### PR TITLE
Allow non-numeric postal codes

### DIFF
--- a/packages/webapp/src/containers/Customers/CustomerForm/CustomerForm.schema.tsx
+++ b/packages/webapp/src/containers/Customers/CustomerForm/CustomerForm.schema.tsx
@@ -29,7 +29,7 @@ const Schema = Yup.object().shape({
   billing_address_2: Yup.string().trim(),
   billing_address_city: Yup.string().trim(),
   billing_address_state: Yup.string().trim(),
-  billing_address_postcode: Yup.number().nullable(),
+  billing_address_postcode: Yup.string().nullable(),
   billing_address_phone: Yup.number(),
 
   shipping_address_country: Yup.string().trim(),
@@ -37,7 +37,7 @@ const Schema = Yup.object().shape({
   shipping_address_2: Yup.string().trim(),
   shipping_address_city: Yup.string().trim(),
   shipping_address_state: Yup.string().trim(),
-  shipping_address_postcode: Yup.number().nullable(),
+  shipping_address_postcode: Yup.string().nullable(),
   shipping_address_phone: Yup.number(),
 
   opening_balance: Yup.number().nullable(),

--- a/packages/webapp/src/containers/Vendors/VendorForm/VendorForm.schema.tsx
+++ b/packages/webapp/src/containers/Vendors/VendorForm/VendorForm.schema.tsx
@@ -22,7 +22,7 @@ const Schema = Yup.object().shape({
   billing_address_2: Yup.string().trim(),
   billing_address_city: Yup.string().trim(),
   billing_address_state: Yup.string().trim(),
-  billing_address_postcode: Yup.number().nullable(),
+  billing_address_postcode: Yup.string().nullable(),
   billing_address_phone: Yup.number(),
 
   shipping_address_country: Yup.string().trim(),
@@ -30,7 +30,7 @@ const Schema = Yup.object().shape({
   shipping_address_2: Yup.string().trim(),
   shipping_address_city: Yup.string().trim(),
   shipping_address_state: Yup.string().trim(),
-  shipping_address_postcode: Yup.number().nullable(),
+  shipping_address_postcode: Yup.string().nullable(),
   shipping_address_phone: Yup.number(),
 
   opening_balance: Yup.number().nullable(),


### PR DESCRIPTION
In some locales, postal codes are not just digits, they can contain letters as well. In the Netherlands, they look like `1234AB`. The webapp currently only allows numbers for postal codes, which makes it impossible for me to enter this code there when entering customer or supplier contact info.

Since the codes are saved as strings in the database anyway, this PR removes the number validation from the customer/supplier forms and allows the user to enter any string instead. On the backend, everything should work just like it did before.

I ran into this issue while trying to migrate my data into Bigcapital, and since it was a very easy fix, I figured I'd immediately make a pull request out of it. If I missed something or something needs a change, please let me know!