### PR TITLE
Fix Expense Details drawer

### DIFF
--- a/packages/webapp/src/containers/Drawers/ExpenseDrawer/ExpenseDrawerFooter.tsx
+++ b/packages/webapp/src/containers/Drawers/ExpenseDrawer/ExpenseDrawerFooter.tsx
@@ -22,12 +22,22 @@ export default function ExpenseDrawerFooter() {
       <ExpenseTotalLines labelColWidth={'180px'} amountColWidth={'180px'}>
         <TotalLine
           title={<T id={'expense.details.subtotal'} />}
-          value={<FormatNumber value={expense.total_amount} />}
+          value={
+            <FormatNumber
+              value={expense.total_amount}
+              currency={expense.currency_code}
+            />
+          }
           borderStyle={TotalLineBorderStyle.SingleDark}
         />
         <TotalLine
           title={<T id={'expense.details.total'} />}
-          value={<FormatNumber value={expense.formatted_amount} />}
+          value={
+            <FormatNumber
+              value={expense.formatted_amount}
+              currency={expense.currency_code}
+            />
+          }
           borderStyle={TotalLineBorderStyle.DoubleDark}
           textStyle={TotalLineTextStyle.Bold}
         />

--- a/packages/webapp/src/containers/Drawers/ExpenseDrawer/ExpenseDrawerTable.tsx
+++ b/packages/webapp/src/containers/Drawers/ExpenseDrawer/ExpenseDrawerTable.tsx
@@ -12,11 +12,13 @@ import { TableStyle } from '@/constants';
  * Expense details table.
  */
 export default function ExpenseDrawerTable() {
-  // Expense readonly entries columns.
-  const columns = useExpenseReadEntriesColumns();
-
   // Expense drawer context.
   const { expense } = useExpenseDrawerContext();
+
+  // Expense readonly entries columns.
+  const columns = useExpenseReadEntriesColumns({
+    currency: expense.currency_code,
+  });
 
   return (
     <CommercialDocEntriesTable

--- a/packages/webapp/src/containers/Drawers/ExpenseDrawer/utils.tsx
+++ b/packages/webapp/src/containers/Drawers/ExpenseDrawer/utils.tsx
@@ -9,7 +9,7 @@ import { getColumnWidth } from '@/utils';
 /**
  * Retrieve expense readonly details entries table columns.
  */
-export const useExpenseReadEntriesColumns = () => {
+export const useExpenseReadEntriesColumns = ({ currency }) => {
   // Expense drawer context.
   const {
     expense: { categories },
@@ -38,6 +38,7 @@ export const useExpenseReadEntriesColumns = () => {
         Header: intl.get('amount'),
         accessor: 'amount',
         Cell: FormatNumberCell,
+        formatNumber: { currency },
         width: getColumnWidth(categories, 'amount', {
           minWidth: 60,
           magicSpacing: 5,
@@ -47,6 +48,6 @@ export const useExpenseReadEntriesColumns = () => {
         align: 'right',
       },
     ],
-    [],
+    [currency],
   );
 };


### PR DESCRIPTION
Add currency prop to `useExpenseReadEntriesColumns`
Add missing currency field to `FormatNumber`

Resolves #320 