### PR TITLE
Added support of path-style S3 endpoints

### DIFF
--- a/packages/server/src/config/index.ts
+++ b/packages/server/src/config/index.ts
@@ -236,6 +236,10 @@ module.exports = {
     secretAccessKey: process.env.S3_SECRET_ACCESS_KEY,
     endpoint: process.env.S3_ENDPOINT,
     bucket: process.env.S3_BUCKET || 'bigcapital-documents',
+    forcePathStyle: parseBoolean(
+      defaultTo(process.env.S3_FORCE_PATH_STYLE, false),
+      false
+    ),
   },
 
   loops: {

--- a/packages/server/src/lib/S3/S3.ts
+++ b/packages/server/src/lib/S3/S3.ts
@@ -8,4 +8,5 @@ export const s3 = new S3Client({
     secretAccessKey: config.s3.secretAccessKey,
   },
   endpoint: config.s3.endpoint,
+  forcePathStyle: config.s3.forcePathStyle,
 });


### PR DESCRIPTION
This can be very useful when using S3-compatible object storages like MinIO. Path-style endpoint means that bucket name will not be prepended to the API endpoint as a subdomain, but added to the path instead.
e.g. `https://bucket-name.my-s3-storage.com/` -> `https://my-s3-storage.com/bucket-name`