### PR TITLE
fix: Multiline details for Estimates, Invoices, Receipts, and Credit Notes

### DIFF
--- a/packages/server/resources/css/modules/credit-rtl.css
+++ b/packages/server/resources/css/modules/credit-rtl.css
@@ -547,6 +547,7 @@ html[lang^=en] body {
 }
 .credit__conditions p, .credit__notes p {
   margin: 0;
+  white-space: pre-line;
 }
 .credit__conditions + .credit__notes {
   margin-top: 20px;

--- a/packages/server/resources/css/modules/credit.css
+++ b/packages/server/resources/css/modules/credit.css
@@ -547,6 +547,7 @@ html[lang^=en] body {
 }
 .credit__conditions p, .credit__notes p {
   margin: 0;
+  white-space: pre-line;
 }
 .credit__conditions + .credit__notes {
   margin-top: 20px;

--- a/packages/server/resources/css/modules/estimate-rtl.css
+++ b/packages/server/resources/css/modules/estimate-rtl.css
@@ -541,4 +541,5 @@ html[lang^=en] body {
 }
 .estimate__conditions p, .estimate__notes p {
   margin: 0 0 20px;
+  white-space: pre-line;
 }

--- a/packages/server/resources/css/modules/estimate.css
+++ b/packages/server/resources/css/modules/estimate.css
@@ -541,4 +541,5 @@ html[lang^=en] body {
 }
 .estimate__conditions p, .estimate__notes p {
   margin: 0 0 20px;
+  white-space: pre-line;
 }

--- a/packages/server/resources/css/modules/invoice-rtl.css
+++ b/packages/server/resources/css/modules/invoice-rtl.css
@@ -547,6 +547,7 @@ html[lang^=en] body {
 }
 .invoice__conditions p, .invoice__notes p {
   margin: 0;
+  white-space: pre-line;
 }
 .invoice__conditions + .invoice__notes {
   margin-top: 20px;

--- a/packages/server/resources/css/modules/invoice.css
+++ b/packages/server/resources/css/modules/invoice.css
@@ -547,6 +547,7 @@ html[lang^=en] body {
 }
 .invoice__conditions p, .invoice__notes p {
   margin: 0;
+  white-space: pre-line;
 }
 .invoice__conditions + .invoice__notes {
   margin-top: 20px;

--- a/packages/server/resources/css/modules/payment-rtl.css
+++ b/packages/server/resources/css/modules/payment-rtl.css
@@ -547,6 +547,7 @@ html[lang^=en] body {
 }
 .payment__conditions p, .payment__notes p {
   margin: 0;
+  white-space: pre-line;
 }
 .payment__conditions + .payment__notes {
   margin-top: 20px;

--- a/packages/server/resources/css/modules/payment.css
+++ b/packages/server/resources/css/modules/payment.css
@@ -547,6 +547,7 @@ html[lang^=en] body {
 }
 .payment__conditions p, .payment__notes p {
   margin: 0;
+  white-space: pre-line;
 }
 .payment__conditions + .payment__notes {
   margin-top: 20px;

--- a/packages/server/resources/css/modules/receipt-rtl.css
+++ b/packages/server/resources/css/modules/receipt-rtl.css
@@ -543,4 +543,5 @@ html[lang^=en] body {
 }
 .receipt__conditions p, .receipt__notes p {
   margin: 0 0 20px;
+  white-space: pre-line;
 }

--- a/packages/server/resources/css/modules/receipt.css
+++ b/packages/server/resources/css/modules/receipt.css
@@ -543,4 +543,5 @@ html[lang^=en] body {
 }
 .receipt__conditions p, .receipt__notes p {
   margin: 0 0 20px;
+  white-space: pre-line;
 }

--- a/packages/server/resources/locales/ar.json
+++ b/packages/server/resources/locales/ar.json
@@ -227,7 +227,7 @@
   "credit.paper.remaining": "رصيد المتبقي",
   "credit.paper.billed_to": "إيصال إلي",
   "credit.paper.credit_date": "تاريخ الاشعار",
-  "credit.paper.terms_conditions": "الشروط والاحكام",
+  "credit.paper.conditions_title": "الشروط والاحكام",
   "credit.paper.notes": "ملاحظات",
   "credit.paper.total": "إجمالي",
   "credit.paper.credits_used": "قيمة المستخدمه",

--- a/packages/server/resources/scss/modules/credit.scss
+++ b/packages/server/resources/scss/modules/credit.scss
@@ -184,6 +184,7 @@
 
     p {
       margin: 0;
+      white-space: pre-line;
     }
   }
 

--- a/packages/server/resources/scss/modules/estimate.scss
+++ b/packages/server/resources/scss/modules/estimate.scss
@@ -169,6 +169,7 @@
     }
     p {
       margin: 0 0 20px;
+      white-space: pre-line;
     }
   }
 }

--- a/packages/server/resources/scss/modules/invoice.scss
+++ b/packages/server/resources/scss/modules/invoice.scss
@@ -175,6 +175,7 @@
     }
     p{
       margin: 0;
+      white-space: pre-line;
     }
   }
   &__conditions + &__notes{

--- a/packages/server/resources/scss/modules/payment.scss
+++ b/packages/server/resources/scss/modules/payment.scss
@@ -170,6 +170,7 @@
     }
     p{
       margin: 0;
+      white-space: pre-line;
     }
   }
   &__conditions + &__notes{

--- a/packages/server/resources/scss/modules/receipt.scss
+++ b/packages/server/resources/scss/modules/receipt.scss
@@ -180,6 +180,7 @@
 
     p {
       margin: 0 0 20px;
+      white-space: pre-line;
     }
   }
 }

--- a/packages/server/resources/views/modules/credit-note-standard.pug
+++ b/packages/server/resources/views/modules/credit-note-standard.pug
@@ -72,7 +72,7 @@ block content
   div.credit__footer        
     if creditNote.termsConditions
      div.credit__conditions
-      h3 #{__("credit.paper.terms_conditions")}
+      h3 #{__("credit.paper.conditions_title")}
       p #{creditNote.termsConditions}
 
     if creditNote.note

--- a/packages/webapp/src/components/Details/index.tsx
+++ b/packages/webapp/src/components/Details/index.tsx
@@ -66,7 +66,11 @@ export function DetailItem({ label, children, name, align, className }) {
       >
         {label}
       </div>
-      <div>{children}</div>
+      <div
+        class='detail-item__children'
+       >
+        {children}
+       </div>
     </div>
   );
 }

--- a/packages/webapp/src/containers/Drawers/CreditNoteDetailDrawer/CreditNoteDetailFooter.tsx
+++ b/packages/webapp/src/containers/Drawers/CreditNoteDetailDrawer/CreditNoteDetailFooter.tsx
@@ -21,13 +21,12 @@ export default function CreditNoteDetailFooter() {
     <CommercialDocFooter>
       <DetailsMenu direction={'horizantal'} minLabelSize={'180px'}>
         <If condition={creditNote.terms_conditions}>
-          <DetailItem label={<T id={'note'} />} children={creditNote.note} />
-        </If>
-
-        <If condition={creditNote.terms_conditions}>
           <DetailItem label={<T id={'terms_conditions'} />}>
             {creditNote.terms_conditions}
           </DetailItem>
+        </If>
+        <If condition={creditNote.note}>
+          <DetailItem label={<T id={'note'} />} children={creditNote.note} />
         </If>
       </DetailsMenu>
     </CommercialDocFooter>

--- a/packages/webapp/src/containers/Preferences/CreditNotes/PreferencesCreditNotesForm.tsx
+++ b/packages/webapp/src/containers/Preferences/CreditNotes/PreferencesCreditNotesForm.tsx
@@ -19,20 +19,6 @@ export function PreferencesCreditNotesForm({ isSubmitting }) {
 
   return (
     <Form>
-      {/* ---------- Customer Notes ----------  */}
-      <FFormGroup
-        name={'customerNotes'}
-        label={<T id={'pref.creditNotes.customerNotes.field'} />}
-        fastField={true}
-      >
-        <FTextArea
-          medium={'true'}
-          name={'customerNotes'}
-          fastField={true}
-          fill={true}
-        />
-      </FFormGroup>
-
       {/* ---------- Terms & Conditions ----------  */}
       <FFormGroup
         name={'termsConditions'}
@@ -42,6 +28,20 @@ export function PreferencesCreditNotesForm({ isSubmitting }) {
         <FTextArea
           medium={'true'}
           name={'termsConditions'}
+          fastField={true}
+          fill={true}
+        />
+      </FFormGroup>
+
+      {/* ---------- Customer Notes ----------  */}
+      <FFormGroup
+        name={'customerNotes'}
+        label={<T id={'pref.creditNotes.customerNotes.field'} />}
+        fastField={true}
+      >
+        <FTextArea
+          medium={'true'}
+          name={'customerNotes'}
           fastField={true}
           fill={true}
         />

--- a/packages/webapp/src/containers/Preferences/Estimates/PreferencesEstimatesForm.tsx
+++ b/packages/webapp/src/containers/Preferences/Estimates/PreferencesEstimatesForm.tsx
@@ -19,20 +19,6 @@ export function PreferencesEstimatesForm({ isSubmitting }) {
 
   return (
     <Form>
-      {/* ---------- Customer Notes ----------  */}
-      <FFormGroup
-        name={'customerNotes'}
-        label={<T id={'pref.estimates.customerNotes.field'} />}
-        fastField={true}
-      >
-        <FTextArea
-          medium={'true'}
-          name={'customerNotes'}
-          fastField={true}
-          fill={true}
-        />
-      </FFormGroup>
-
       {/* ---------- Terms & Conditions ----------  */}
       <FFormGroup
         name={'termsConditions'}
@@ -42,6 +28,20 @@ export function PreferencesEstimatesForm({ isSubmitting }) {
         <FTextArea
           medium={'true'}
           name={'termsConditions'}
+          fastField={true}
+          fill={true}
+        />
+      </FFormGroup>
+
+      {/* ---------- Customer Notes ----------  */}
+      <FFormGroup
+        name={'customerNotes'}
+        label={<T id={'pref.estimates.customerNotes.field'} />}
+        fastField={true}
+      >
+        <FTextArea
+          medium={'true'}
+          name={'customerNotes'}
           fastField={true}
           fill={true}
         />

--- a/packages/webapp/src/containers/Preferences/Invoices/PreferencesInvoicesForm.tsx
+++ b/packages/webapp/src/containers/Preferences/Invoices/PreferencesInvoicesForm.tsx
@@ -19,20 +19,6 @@ export function PreferencesInvoicesForm({ isSubmitting }) {
 
   return (
     <Form>
-      {/* ---------- Customer Notes ----------  */}
-      <FFormGroup
-        name={'customerNotes'}
-        label={<T id={'pref.invoices.customerNotes.field'} />}
-        fastField={true}
-      >
-        <FTextArea
-          medium={'true'}
-          name={'customerNotes'}
-          fastField={true}
-          fill={true}
-        />
-      </FFormGroup>
-
       {/* ---------- Terms & Conditions ----------  */}
       <FFormGroup
         name={'termsConditions'}
@@ -42,6 +28,20 @@ export function PreferencesInvoicesForm({ isSubmitting }) {
         <FTextArea
           medium={'true'}
           name={'termsConditions'}
+          fastField={true}
+          fill={true}
+        />
+      </FFormGroup>
+
+      {/* ---------- Customer Notes ----------  */}
+      <FFormGroup
+        name={'customerNotes'}
+        label={<T id={'pref.invoices.customerNotes.field'} />}
+        fastField={true}
+      >
+        <FTextArea
+          medium={'true'}
+          name={'customerNotes'}
           fastField={true}
           fill={true}
         />

--- a/packages/webapp/src/containers/Preferences/Receipts/PreferencesReceiptsForm.tsx
+++ b/packages/webapp/src/containers/Preferences/Receipts/PreferencesReceiptsForm.tsx
@@ -19,15 +19,15 @@ export function PreferencesReceiptsForm({ isSubmitting }) {
 
   return (
     <Form>
-      {/* ---------- Terms & Conditions ----------  */}
+      {/* ---------- Statement ----------  */}
       <FFormGroup
-        name={'termsConditions'}
-        label={<T id={'pref.receipts.termsConditions.field'} />}
+        name={'statement'}
+        label={<T id={'pref.receipts.statement.field'} />}
         fastField={true}
       >
         <FTextArea
           medium={'true'}
-          name={'termsConditions'}
+          name={'statement'}
           fastField={true}
           fill={true}
         />

--- a/packages/webapp/src/containers/Preferences/Receipts/PreferencesReceiptsForm.tsx
+++ b/packages/webapp/src/containers/Preferences/Receipts/PreferencesReceiptsForm.tsx
@@ -19,20 +19,6 @@ export function PreferencesReceiptsForm({ isSubmitting }) {
 
   return (
     <Form>
-      {/* ---------- Customer Notes ----------  */}
-      <FFormGroup
-        name={'receiptMessage'}
-        label={<T id={'pref.receipts.receiptMessage.field'} />}
-        fastField={true}
-      >
-        <FTextArea
-          medium={'true'}
-          name={'receiptMessage'}
-          fastField={true}
-          fill={true}
-        />
-      </FFormGroup>
-
       {/* ---------- Terms & Conditions ----------  */}
       <FFormGroup
         name={'termsConditions'}
@@ -42,6 +28,20 @@ export function PreferencesReceiptsForm({ isSubmitting }) {
         <FTextArea
           medium={'true'}
           name={'termsConditions'}
+          fastField={true}
+          fill={true}
+        />
+      </FFormGroup>
+
+      {/* ---------- Customer Notes ----------  */}
+      <FFormGroup
+        name={'receiptMessage'}
+        label={<T id={'pref.receipts.receiptMessage.field'} />}
+        fastField={true}
+      >
+        <FTextArea
+          medium={'true'}
+          name={'receiptMessage'}
           fastField={true}
           fill={true}
         />

--- a/packages/webapp/src/containers/Purchases/Bills/BillForm/BillFormFooterLeft.tsx
+++ b/packages/webapp/src/containers/Purchases/Bills/BillForm/BillFormFooterLeft.tsx
@@ -15,6 +15,7 @@ export function BillFormFooterLeft() {
         <FEditableText
           name={'note'}
           placeholder={intl.get('bill_form.label.note.placeholder')}
+          multiline={true}
         />
       </TermsConditsFormGroup>
     </React.Fragment>

--- a/packages/webapp/src/containers/Purchases/CreditNotes/CreditNoteForm/VendorCreditNoteFormFooterLeft.tsx
+++ b/packages/webapp/src/containers/Purchases/CreditNotes/CreditNoteForm/VendorCreditNoteFormFooterLeft.tsx
@@ -15,6 +15,7 @@ export function VendorCreditNoteFormFooterLeft() {
         <FEditableText
           name={'note'}
           placeholder={intl.get('vendor_credit_form.note.placeholder')}
+          multiline={true}
         />
       </TermsConditsFormGroup>
     </React.Fragment>

--- a/packages/webapp/src/containers/Purchases/PaymentMades/PaymentForm/PaymentMadeFormFooterLeft.tsx
+++ b/packages/webapp/src/containers/Purchases/PaymentMades/PaymentForm/PaymentMadeFormFooterLeft.tsx
@@ -21,6 +21,7 @@ export function PaymentMadeFormFooterLeft() {
           name={'statement'}
           placeholder={intl.get('payment_made.form.internal_note.placeholder')}
           fastField={true}
+          multiline={true}
         />
       </InternalNoteFormGroup>
     </React.Fragment>

--- a/packages/webapp/src/containers/Sales/CreditNotes/CreditNoteForm/CreditNoteFormFooterLeft.tsx
+++ b/packages/webapp/src/containers/Sales/CreditNotes/CreditNoteForm/CreditNoteFormFooterLeft.tsx
@@ -7,17 +7,6 @@ import { FFormGroup, FEditableText, FormattedMessage as T } from '@/components';
 export function CreditNoteFormFooterLeft() {
   return (
     <React.Fragment>
-      {/* --------- Customer notes --------- */}
-      <CreditNoteMsgFormGroup
-        name={'note'}
-        label={<T id={'credit_note.label_customer_note'} />}
-      >
-        <FEditableText
-          name={'note'}
-          placeholder={intl.get('credit_note.label_customer_note.placeholder')}
-          multiline={true}
-        />
-      </CreditNoteMsgFormGroup>
       {/* --------- Terms and conditions --------- */}
       <TermsConditsFormGroup
         label={<T id={'credit_note.label_terms_conditions'} />}
@@ -31,6 +20,17 @@ export function CreditNoteFormFooterLeft() {
           multiline={true}
         />
       </TermsConditsFormGroup>
+      {/* --------- Customer notes --------- */}
+      <CreditNoteMsgFormGroup
+        name={'note'}
+        label={<T id={'credit_note.label_customer_note'} />}
+      >
+        <FEditableText
+          name={'note'}
+          placeholder={intl.get('credit_note.label_customer_note.placeholder')}
+          multiline={true}
+        />
+      </CreditNoteMsgFormGroup>
     </React.Fragment>
   );
 }

--- a/packages/webapp/src/containers/Sales/CreditNotes/CreditNoteForm/CreditNoteFormFooterLeft.tsx
+++ b/packages/webapp/src/containers/Sales/CreditNotes/CreditNoteForm/CreditNoteFormFooterLeft.tsx
@@ -15,6 +15,7 @@ export function CreditNoteFormFooterLeft() {
         <FEditableText
           name={'note'}
           placeholder={intl.get('credit_note.label_customer_note.placeholder')}
+          multiline={true}
         />
       </CreditNoteMsgFormGroup>
       {/* --------- Terms and conditions --------- */}
@@ -27,6 +28,7 @@ export function CreditNoteFormFooterLeft() {
           placeholder={intl.get(
             'credit_note.label_terms_and_conditions.placeholder',
           )}
+          multiline={true}
         />
       </TermsConditsFormGroup>
     </React.Fragment>

--- a/packages/webapp/src/containers/Sales/Estimates/EstimateForm/EstimateFormFooterLeft.tsx
+++ b/packages/webapp/src/containers/Sales/Estimates/EstimateForm/EstimateFormFooterLeft.tsx
@@ -7,6 +7,18 @@ import { FFormGroup, FEditableText, FormattedMessage as T } from '@/components';
 export function EstimateFormFooterLeft() {
   return (
     <React.Fragment>
+      {/* --------- Terms and conditions --------- */}
+      <TermsConditsFormGroup
+        label={<T id={'estimate_form.label.terms_conditions'} />}
+        name={'terms_conditions'}
+      >
+        <FEditableText
+          name={'terms_conditions'}
+          placeholder={intl.get('estimate_form.terms_and_conditions.placeholder')}
+          multiline={true}
+        />
+      </TermsConditsFormGroup>
+
       {/* --------- Customer Note --------- */}
       <EstimateMsgFormGroup
         name={'note'}
@@ -19,18 +31,6 @@ export function EstimateFormFooterLeft() {
           multiline={true}
         />
       </EstimateMsgFormGroup>
-
-      {/* --------- Terms and conditions --------- */}
-      <TermsConditsFormGroup
-        label={<T id={'estimate_form.label.terms_conditions'} />}
-        name={'terms_conditions'}
-      >
-        <FEditableText
-          name={'terms_conditions'}
-          placeholder={intl.get('estimate_form.terms_and_conditions.placeholder')}
-          multiline={true}
-        />
-      </TermsConditsFormGroup>
     </React.Fragment>
   );
 }

--- a/packages/webapp/src/containers/Sales/Estimates/EstimateForm/EstimateFormFooterLeft.tsx
+++ b/packages/webapp/src/containers/Sales/Estimates/EstimateForm/EstimateFormFooterLeft.tsx
@@ -16,6 +16,7 @@ export function EstimateFormFooterLeft() {
         <FEditableText
           name={'note'}
           placeholder={intl.get('estimate_form.customer_note.placeholder')}
+          multiline={true}
         />
       </EstimateMsgFormGroup>
 
@@ -27,6 +28,7 @@ export function EstimateFormFooterLeft() {
         <FEditableText
           name={'terms_conditions'}
           placeholder={intl.get('estimate_form.terms_and_conditions.placeholder')}
+          multiline={true}
         />
       </TermsConditsFormGroup>
     </React.Fragment>

--- a/packages/webapp/src/containers/Sales/Invoices/InvoiceForm/InvoiceFormFooterLeft.tsx
+++ b/packages/webapp/src/containers/Sales/Invoices/InvoiceForm/InvoiceFormFooterLeft.tsx
@@ -7,18 +7,6 @@ import { FFormGroup, FEditableText, FormattedMessage as T } from '@/components';
 export function InvoiceFormFooterLeft() {
   return (
     <React.Fragment>
-      {/* --------- Invoice message --------- */}
-      <InvoiceMsgFormGroup
-        name={'invoice_message'}
-        label={<T id={'invoice_message'} />}
-      >
-        <FEditableText
-          name={'invoice_message'}
-          placeholder={intl.get('invoice_form.invoice_message.placeholder')}
-          multiline={true}
-        />
-      </InvoiceMsgFormGroup>
-
       {/* --------- Terms and conditions --------- */}
       <TermsConditsFormGroup
         label={<T id={'invoice_form.label.terms_conditions'} />}
@@ -32,6 +20,18 @@ export function InvoiceFormFooterLeft() {
           multiline={true}
         />
       </TermsConditsFormGroup>
+
+      {/* --------- Invoice message --------- */}
+      <InvoiceMsgFormGroup
+        name={'invoice_message'}
+        label={<T id={'invoice_message'} />}
+      >
+        <FEditableText
+          name={'invoice_message'}
+          placeholder={intl.get('invoice_form.invoice_message.placeholder')}
+          multiline={true}
+        />
+      </InvoiceMsgFormGroup>
     </React.Fragment>
   );
 }

--- a/packages/webapp/src/containers/Sales/Invoices/InvoiceForm/InvoiceFormFooterLeft.tsx
+++ b/packages/webapp/src/containers/Sales/Invoices/InvoiceForm/InvoiceFormFooterLeft.tsx
@@ -15,6 +15,7 @@ export function InvoiceFormFooterLeft() {
         <FEditableText
           name={'invoice_message'}
           placeholder={intl.get('invoice_form.invoice_message.placeholder')}
+          multiline={true}
         />
       </InvoiceMsgFormGroup>
 
@@ -28,6 +29,7 @@ export function InvoiceFormFooterLeft() {
           placeholder={intl.get(
             'invoice_form.terms_and_conditions.placeholder',
           )}
+          multiline={true}
         />
       </TermsConditsFormGroup>
     </React.Fragment>

--- a/packages/webapp/src/containers/Sales/PaymentReceives/PaymentReceiveForm/PaymentReceiveFormFootetLeft.tsx
+++ b/packages/webapp/src/containers/Sales/PaymentReceives/PaymentReceiveForm/PaymentReceiveFormFootetLeft.tsx
@@ -19,6 +19,7 @@ export function PaymentReceiveFormFootetLeft() {
             'payment_receive_form.internal_note.placeholder',
           )}
           fastField={true}
+          multiline={true}
         />
       </TermsConditsFormGroup>
     </React.Fragment>

--- a/packages/webapp/src/containers/Sales/Receipts/ReceiptForm/ReceiptForm.tsx
+++ b/packages/webapp/src/containers/Sales/Receipts/ReceiptForm/ReceiptForm.tsx
@@ -83,7 +83,7 @@ function ReceiptForm({
           entries: orderingLinesIndexes(defaultReceipt.entries),
           currency_code: base_currency,
           receipt_message: receiptMessage,
-          terms_conditions: receiptTermsConditions,
+          statement: receiptTermsConditions,
         }),
   };
   // Handle the form submit.

--- a/packages/webapp/src/containers/Sales/Receipts/ReceiptForm/ReceiptFormFooterLeft.tsx
+++ b/packages/webapp/src/containers/Sales/Receipts/ReceiptForm/ReceiptFormFooterLeft.tsx
@@ -7,19 +7,19 @@ import { FFormGroup, FEditableText, FormattedMessage as T } from '@/components';
 export function ReceiptFormFooterLeft() {
   return (
     <React.Fragment>
-      {/* --------- Terms and conditions --------- */}
-      <TermsConditsFormGroup
-        label={<T id={'receipt_form.label.terms_conditions'} />}
-        name={'terms_conditions'}
+      {/* --------- Statement --------- */}
+      <StatementFormGroup
+        label={<T id={'receipt_form.label.statement'} />}
+        name={'statement'}
       >
         <FEditableText
-          name={'terms_conditions'}
+          name={'statement'}
           placeholder={intl.get(
-            'receipt_form.terms_and_conditions.placeholder',
+            'receipt_form.statement.placeholder',
           )}
           multiline={true}
         />
-      </TermsConditsFormGroup>
+      </StatementFormGroup>
 
       {/* --------- Receipt message --------- */}
       <ReceiptMsgFormGroup
@@ -51,7 +51,7 @@ const ReceiptMsgFormGroup = styled(FFormGroup)`
   }
 `;
 
-const TermsConditsFormGroup = styled(FFormGroup)`
+const StatementFormGroup = styled(FFormGroup)`
   &.bp4-form-group {
     .bp4-label {
       font-size: 12px;

--- a/packages/webapp/src/containers/Sales/Receipts/ReceiptForm/ReceiptFormFooterLeft.tsx
+++ b/packages/webapp/src/containers/Sales/Receipts/ReceiptForm/ReceiptFormFooterLeft.tsx
@@ -16,6 +16,7 @@ export function ReceiptFormFooterLeft() {
         <FEditableText
           name={'receipt_message'}
           placeholder={intl.get('receipt_form.receipt_message.placeholder')}
+          multiline={true}
         />
       </ReceiptMsgFormGroup>
 
@@ -29,6 +30,7 @@ export function ReceiptFormFooterLeft() {
           placeholder={intl.get(
             'receipt_form.terms_and_conditions.placeholder',
           )}
+          multiline={true}
         />
       </TermsConditsFormGroup>
     </React.Fragment>

--- a/packages/webapp/src/containers/Sales/Receipts/ReceiptForm/ReceiptFormFooterLeft.tsx
+++ b/packages/webapp/src/containers/Sales/Receipts/ReceiptForm/ReceiptFormFooterLeft.tsx
@@ -7,19 +7,6 @@ import { FFormGroup, FEditableText, FormattedMessage as T } from '@/components';
 export function ReceiptFormFooterLeft() {
   return (
     <React.Fragment>
-      {/* --------- Receipt message --------- */}
-      <ReceiptMsgFormGroup
-        name={'receipt_message'}
-        label={<T id={'receipt_form.label.receipt_message'} />}
-        hintText={'Will be displayed on the Receipt'}
-      >
-        <FEditableText
-          name={'receipt_message'}
-          placeholder={intl.get('receipt_form.receipt_message.placeholder')}
-          multiline={true}
-        />
-      </ReceiptMsgFormGroup>
-
       {/* --------- Terms and conditions --------- */}
       <TermsConditsFormGroup
         label={<T id={'receipt_form.label.terms_conditions'} />}
@@ -33,6 +20,19 @@ export function ReceiptFormFooterLeft() {
           multiline={true}
         />
       </TermsConditsFormGroup>
+
+      {/* --------- Receipt message --------- */}
+      <ReceiptMsgFormGroup
+        name={'receipt_message'}
+        label={<T id={'receipt_form.label.receipt_message'} />}
+        hintText={'Will be displayed on the Receipt'}
+      >
+        <FEditableText
+          name={'receipt_message'}
+          placeholder={intl.get('receipt_form.receipt_message.placeholder')}
+          multiline={true}
+        />
+      </ReceiptMsgFormGroup>
     </React.Fragment>
   );
 }

--- a/packages/webapp/src/containers/Sales/Receipts/ReceiptForm/utils.tsx
+++ b/packages/webapp/src/containers/Sales/Receipts/ReceiptForm/utils.tsx
@@ -53,7 +53,7 @@ export const defaultReceipt = {
   receipt_date: moment(new Date()).format('YYYY-MM-DD'),
   reference_no: '',
   receipt_message: '',
-  terms_conditions: '',
+  statement: '',
   closed: '',
   branch_id: '',
   warehouse_id: '',

--- a/packages/webapp/src/lang/en/index.json
+++ b/packages/webapp/src/lang/en/index.json
@@ -1952,8 +1952,8 @@
   "receipt_form.label.payment_amount": "Payment amount",
   "receipt_form.label.receipt_message": "Receipt Message",
   "receipt_form.receipt_message.placeholder": "This message will be displayed on the receipt.",
-  "receipt_form.label.terms_conditions": "Terms & Conditions",
-  "receipt_form.terms_and_conditions.placeholder": "Enter the terms and conditions of your business to be displayed on the receipt.",
+  "receipt_form.label.statement": "Statement",
+  "receipt_form.statement.placeholder": "Enter the statement to be displayed on the receipt.",
   "payment_receive_form.label.note": "Note",
   "payment_receive_form.internal_note.placeholder": "Internal notes (Not visible to the customer).",
   "payment_receive_form.message.label": "Payment Message",
@@ -2260,7 +2260,7 @@
   "pref.estimates.termsConditions.field": "Terms & Conditions",
   "pref.estimates.customerNotes.field": "Customer Notes",
 
-  "pref.receipts.termsConditions.field": "Terms & Conditions",
+  "pref.receipts.statement.field": "Statement",
   "pref.receipts.receiptMessage.field": "Receipt Message",
 
   "preferences.invoices": "Invoices",

--- a/packages/webapp/src/style/components/Details.scss
+++ b/packages/webapp/src/style/components/Details.scss
@@ -48,6 +48,10 @@
     &__content {
       text-transform: capitalize;
     }
+
+    &__children {
+      white-space: pre-line;
+    }
   }
 
   + .details-menu{


### PR DESCRIPTION
- The settings page in WebApp provides the ability to enter multiline text for notes field and terms and conditions field for Estimates, Invoices, Receipts, and Credit Notes, but this text was rendered in a single line in preview page, edit page and PDF output.
- Reordered these fields to always be in the same order 1 - Terms and conditions, 2 - Notes/Message in Settings, Preview, Edit and PDF
- Renamed Receipt's terms to statements. SalesReceipts model on server has only 'statement' field but not 'terms and conditions'.