### PR TITLE
Download attachments (documents) with original filenames

### DIFF
--- a/packages/server/src/api/controllers/Attachments/AttachmentsController.ts
+++ b/packages/server/src/api/controllers/Attachments/AttachmentsController.ts
@@ -250,10 +250,12 @@ export class AttachmentsController extends BaseController {
     res: Response,
     next: NextFunction
   ): Promise<Response | void> {
+    const { tenantId } = req;
     const { id: documentKey } = req.params;
 
     try {
       const presignedUrl = await this.attachmentsApplication.getPresignedUrl(
+        tenantId,
         documentKey
       );
       return res.status(200).send({ presignedUrl });

--- a/packages/server/src/services/Attachments/AttachmentsApplication.ts
+++ b/packages/server/src/services/Attachments/AttachmentsApplication.ts
@@ -96,10 +96,11 @@ export class AttachmentsApplication {
 
   /**
    * Retrieves the presigned url of the given attachment key.
+   * @param {number} tenantId
    * @param {string} key
    * @returns {Promise<string>}
    */
-  public getPresignedUrl(key: string): Promise<string> {
-    return this.getPresignedUrlService.getPresignedUrl(key);
+  public getPresignedUrl(tenantId: number, key: string): Promise<string> {
+    return this.getPresignedUrlService.getPresignedUrl(tenantId, key);
   }
 }

--- a/packages/server/src/services/Attachments/GetAttachmentPresignedUrl.ts
+++ b/packages/server/src/services/Attachments/GetAttachmentPresignedUrl.ts
@@ -1,20 +1,34 @@
-import { Service } from 'typedi';
+import { Inject, Service } from 'typedi';
 import { GetObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { s3 } from '@/lib/S3/S3';
 import config from '@/config';
+import HasTenancyService from '../Tenancy/TenancyService';
 
 @Service()
 export class getAttachmentPresignedUrl {
+  @Inject()
+  private tenancy: HasTenancyService;
+
   /**
-   * Retrieves the presigned url of the given attachment key.
+   * Retrieves the presigned url of the given attachment key with the original filename.
+   * @param {number} tenantId
    * @param {string} key
-   * @returns {Promise<string?>}
+   * @returns {string}
    */
-  async getPresignedUrl(key: string) {
+  async getPresignedUrl(tenantId: number, key: string) {
+    const { Document } = this.tenancy.models(tenantId);
+    const foundDocument = await Document.query().findOne({ key });
+
+    let ResponseContentDisposition = 'attachment';
+    if (foundDocument && foundDocument.originName) {
+      ResponseContentDisposition += `; filename="${foundDocument.originName}"`;
+    }
+
     const command = new GetObjectCommand({
       Bucket: config.s3.bucket,
       Key: key,
+      ResponseContentDisposition,
     });
     const signedUrl = await getSignedUrl(s3, command, { expiresIn: 300 });
 

--- a/packages/webapp/src/hooks/query/attachments.ts
+++ b/packages/webapp/src/hooks/query/attachments.ts
@@ -9,7 +9,7 @@ export function useUploadAttachments(props) {
   const apiRequest = useApiRequest();
 
   return useMutation(
-    (values) => apiRequest.post('/attachments', values),
+    (values) => apiRequest.post('attachments', values),
     props,
   );
 }
@@ -21,7 +21,7 @@ export function useDeleteAttachment(props) {
   const apiRequest = useApiRequest();
 
   return useMutation(
-    (key: string) => apiRequest.delete(`/attachments/${key}`),
+    (key: string) => apiRequest.delete(`attachments/${key}`),
     props,
   );
 }
@@ -35,7 +35,7 @@ export function useGetPresignedUrlAttachment(props) {
   return useMutation(
     (key: string) =>
       apiRequest
-        .get(`/attachments/${key}/presigned-url`)
+        .get(`attachments/${key}/presigned-url`)
         .then((res) => res.data),
     props,
   );


### PR DESCRIPTION
- Fixed double slash in attachments API route
- Download attachments with original filenames