### PR TITLE
Update `dev` Script in `package.json` to Use `cross-env`

### DIFF
--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -121,7 +121,7 @@
     "yup": "^0.28.1"
   },
   "scripts": {
-    "dev": "SET PORT=4000 && craco start",
+    "dev": "cross-env PORT=4000 craco start",
     "build": "craco build",
     "test": "node scripts/test.js",
     "storybook": "start-storybook -p 6006"

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -121,7 +121,7 @@
     "yup": "^0.28.1"
   },
   "scripts": {
-    "dev": "PORT=4000 craco start",
+    "dev": "SET PORT=4000 && craco start",
     "build": "craco build",
     "test": "node scripts/test.js",
     "storybook": "start-storybook -p 6006"


### PR DESCRIPTION
**Summary**
This PR updates the dev script in the /webapp/package.json file to ensure cross-platform compatibility for setting environment variables.

**Changes Made**
**Old Script:** `"dev": "PORT=4000 craco start"`

**New Script:** `"dev": "cross-env PORT=4000 craco start"`

**Reason for Change**
The previous method of setting the PORT variable was only compatible with UNIX-like systems. By using cross-env, this change ensures the development server can be started on both Windows and macOS/Linux systems without any issues.