### PR TITLE
Fix: Enhance Dropzone accept and reject visual 

### DIFF
--- a/packages/webapp/src/components/Dropzone/Dropzone.module.css
+++ b/packages/webapp/src/components/Dropzone/Dropzone.module.css
@@ -1,6 +1,6 @@
 .root {
   padding: 20px;
-  border: 2px dashed #c5cbd3; /* Changed from dotted to dashed for better visibility */
+  border: 2px dotted #c5cbd3;
   border-radius: 6px;
   min-height: 200px;
   display: flex;
@@ -8,31 +8,13 @@
   background: #fff;
   position: relative;
   transition: background-color 0.3s ease, border-color 0.3s ease;
-}
 
-.dropzoneActive {
-  background-color: rgba(0, 123, 255, 0.15);
-  border-color: #007bff;
-}
-
-.dropzoneActive .content {
-  color: #007bff; /* Change text color to match the border when active */
-}
-
-.content {
-  position: relative;
-  z-index: 20;
-  transition: color 0.3s ease;
-}
-
-.dropzoneActive:before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background-color: rgba(0, 123, 255, 0.3); /* This creates a full overlay effect */
-  z-index: 10;
-  border-radius: 6px; /* Ensures the overlay matches the container's rounded corners */
+  &.dropzoneAccept {
+    border-color: rgb(0, 82, 204);
+    background: rgba(0, 82, 204, 0.05);
+  }
+  &.dropzoneReject {
+    border-color: #AC2F33;
+    background: rgba(172, 47, 51, 0.05)
+  }
 }

--- a/packages/webapp/src/components/Dropzone/Dropzone.module.css
+++ b/packages/webapp/src/components/Dropzone/Dropzone.module.css
@@ -1,12 +1,38 @@
-
-
 .root {
   padding: 20px;
-  border: 2px dotted #c5cbd3;
+  border: 2px dashed #c5cbd3; /* Changed from dotted to dashed for better visibility */
   border-radius: 6px;
   min-height: 200px;
   display: flex;
   flex-direction: column;
   background: #fff;
   position: relative;
+  transition: background-color 0.3s ease, border-color 0.3s ease;
+}
+
+.dropzoneActive {
+  background-color: rgba(0, 123, 255, 0.15);
+  border-color: #007bff;
+}
+
+.dropzoneActive .content {
+  color: #007bff; /* Change text color to match the border when active */
+}
+
+.content {
+  position: relative;
+  z-index: 20;
+  transition: color 0.3s ease;
+}
+
+.dropzoneActive:before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 123, 255, 0.3); /* This creates a full overlay effect */
+  z-index: 10;
+  border-radius: 6px; /* Ensures the overlay matches the container's rounded corners */
 }

--- a/packages/webapp/src/components/Dropzone/Dropzone.tsx
+++ b/packages/webapp/src/components/Dropzone/Dropzone.tsx
@@ -28,9 +28,9 @@ export type DropzoneCssVariables = {
 };
 
 export interface DropzoneProps {
-    /** Key of `theme.colors` or any valid CSS color to set colors of `Dropzone.Accept`, `theme.primaryColor` by default */
+  /** Key of `theme.colors` or any valid CSS color to set colors of `Dropzone.Accept`, `theme.primaryColor` by default */
   acceptColor?: MantineColor;
-    
+
   /** Key of `theme.colors` or any valid CSS color to set colors of `Dropzone.Reject`, `'red'` by default */
   rejectColor?: MantineColor;
 

--- a/packages/webapp/src/components/Dropzone/Dropzone.tsx
+++ b/packages/webapp/src/components/Dropzone/Dropzone.tsx
@@ -238,7 +238,8 @@ export const Dropzone = (_props: DropzoneProps) => {
           className: clsx(
             styles.root,
             {
-              [styles.dropzoneActive]: isDragAccept || isDragReject,
+              [styles.dropzoneAccept]: isDragAccept,
+              [styles.dropzoneReject]: isDragReject
             },
             classNames?.root
           ),
@@ -272,8 +273,6 @@ Dropzone.displayName = '@mantine/dropzone/Dropzone';
 Dropzone.Accept = DropzoneAccept;
 Dropzone.Idle = DropzoneIdle;
 Dropzone.Reject = DropzoneReject;
-
-
 
 
 type PossibleRef<T> = Ref<T> | undefined;

--- a/packages/webapp/src/components/Dropzone/Dropzone.tsx
+++ b/packages/webapp/src/components/Dropzone/Dropzone.tsx
@@ -28,9 +28,9 @@ export type DropzoneCssVariables = {
 };
 
 export interface DropzoneProps {
-  /** Key of `theme.colors` or any valid CSS color to set colors of `Dropzone.Accept`, `theme.primaryColor` by default */
+    /** Key of `theme.colors` or any valid CSS color to set colors of `Dropzone.Accept`, `theme.primaryColor` by default */
   acceptColor?: MantineColor;
-
+    
   /** Key of `theme.colors` or any valid CSS color to set colors of `Dropzone.Reject`, `'red'` by default */
   rejectColor?: MantineColor;
 
@@ -235,7 +235,13 @@ export const Dropzone = (_props: DropzoneProps) => {
     >
       <Box
         {...getRootProps({
-          className: clsx(styles.root, classNames?.root),
+          className: clsx(
+            styles.root,
+            {
+              [styles.dropzoneActive]: isDragAccept || isDragReject,
+            },
+            classNames?.root
+          ),
         })}
         // {...getStyles('root', { focusable: true })}
         {...others}
@@ -253,7 +259,7 @@ export const Dropzone = (_props: DropzoneProps) => {
         <input {...getInputProps(inputProps)} name={name} />
         <div
           data-enable-pointer-events={enablePointerEvents || undefined}
-          className={classNames?.content}
+          className={clsx(styles.content, classNames?.content)}
         >
           {children}
         </div>


### PR DESCRIPTION
This pull request improves the user experience by enhancing the visual feedback in the Dropzone component when files are dragged over the dropzone area.

**Changes include:**
- Added a full blue overlay effect that activates when a file is dragged into the dropzone area, providing a clear visual indication of the active drop zone.
- Updated CSS in Dropzone.module.css to ensure the entire dropzone area changes color consistently without blurring.
- Refactored the Dropzone.tsx component to manage the active state within the DropzoneField, ensuring that the visual feedback is consistently applied.

Previous:
![image](https://github.com/user-attachments/assets/87b813d5-94c0-4f69-a90f-5688cba429f5)

After:
![image](https://github.com/user-attachments/assets/04400164-6e93-4cd9-ad6d-05130e46b0ce)
