### PR TITLE
Fix: Correctly display Date, Published At, and Created At in ExpenseDrawerHeader

### DIFF
--- a/packages/server/src/services/Expenses/CRUD/ExpenseTransformer.ts
+++ b/packages/server/src/services/Expenses/CRUD/ExpenseTransformer.ts
@@ -16,6 +16,7 @@ export class ExpenseTransfromer extends Transformer {
       'formattedAllocatedCostAmount',
       'formattedDate',
       'formattedCreatedAt',
+      'formattedPublishedAt',
       'categories',
       'attachments',
     ];
@@ -91,4 +92,13 @@ export class ExpenseTransfromer extends Transformer {
   protected attachments = (expense: IExpense) => {
     return this.item(expense.attachments, new AttachmentTransformer());
   };
+
+  /**
+   * Retrieve formatted published at date.
+   * @param {IExpense} expense 
+   * @returns {string}
+   */
+  protected formattedPublishedAt = (expense: IExpense): string => {
+    return this.formatDate(expense.publishedAt);
+  }
 }

--- a/packages/webapp/src/containers/Drawers/ExpenseDrawer/ExpenseDrawerHeader.tsx
+++ b/packages/webapp/src/containers/Drawers/ExpenseDrawer/ExpenseDrawerHeader.tsx
@@ -40,7 +40,7 @@ export default function ExpenseDrawerHeader() {
         <Col xs={6}>
           <DetailsMenu direction={'horizantal'} minLabelSize={'180px'}>
             <DetailItem name={'date'} label={<T id={'date'} />}>
-              {expense.formatted_date || '—'}
+              {expense.formatted_date}
             </DetailItem>
 
             <DetailItem name={'reference'} label={<T id={'reference_no'} />}>
@@ -68,7 +68,7 @@ export default function ExpenseDrawerHeader() {
             </DetailItem>
 
             <DetailItem label={<T id={'created_at'} />}>
-              {expense.formatted_created_at || '—'}
+              {expense.formatted_created_at} 
             </DetailItem>
           </DetailsMenu>
         </Col>

--- a/packages/webapp/src/containers/Drawers/ExpenseDrawer/ExpenseDrawerHeader.tsx
+++ b/packages/webapp/src/containers/Drawers/ExpenseDrawer/ExpenseDrawerHeader.tsx
@@ -10,7 +10,6 @@ import {
   Col,
   DetailItem,
   DetailsMenu,
-  FormatDate,
   ExchangeRateDetailItem,
   FormattedMessage as T,
 } from '@/components';
@@ -41,7 +40,7 @@ export default function ExpenseDrawerHeader() {
         <Col xs={6}>
           <DetailsMenu direction={'horizantal'} minLabelSize={'180px'}>
             <DetailItem name={'date'} label={<T id={'date'} />}>
-              {expense.formatted_payment_date}
+              {expense.formatted_date || '—'}
             </DetailItem>
 
             <DetailItem name={'reference'} label={<T id={'reference_no'} />}>
@@ -65,11 +64,11 @@ export default function ExpenseDrawerHeader() {
             minLabelSize={'180px'}
           >
             <DetailItem label={<T id={'published_at'} />}>
-              {expense.formatted_date}
+              {expense.formatted_published_at || '—'}
             </DetailItem>
 
             <DetailItem label={<T id={'created_at'} />}>
-              {expense.formatted_created_at}
+              {expense.formatted_created_at || '—'}
             </DetailItem>
           </DetailsMenu>
         </Col>


### PR DESCRIPTION
This pull request addresses the issue of displaying the correct date fields in the ExpenseDrawerHeader component. Specifically:

- Date: Now displays the formatted_date field under the "Date" label.
- Published At: Displays the formatted_published_at field under the "Published At" label.
- Created At: Displays the formatted_created_at field under the "Created At" label.

**Changes:**

- Updated ExpenseDrawerHeader.tsx to correctly reference and display the formatted_date, formatted_published_at, and formatted_created_at fields.
- Added fallbacks for empty values, displaying — when data is unavailable.
- Updated ExpenseTransformer.ts to create the attribute formattedPublishedAt in order to be able to display the date with the correct format.

Before:
![image](https://github.com/user-attachments/assets/12bcd22d-35a6-41ac-bf8e-8f41b957081d)

After:
![image](https://github.com/user-attachments/assets/f25059d3-1284-47a4-88d6-9ad0a91a6726)

Please review the changes and let me know if any further adjustments are needed.
Thanks.