### PR TITLE
Partial Fix: Correctly display the discount percentage on Invoice Creation and discount fix on items

### DIFF
--- a/packages/server/src/services/Sales/Invoices/ItemEntryTransformer.ts
+++ b/packages/server/src/services/Sales/Invoices/ItemEntryTransformer.ts
@@ -38,7 +38,8 @@ export class ItemEntryTransformer extends Transformer {
    * @returns {string}
    */
   protected totalFormatted = (entry: IItemEntry): string => {
-    return formatNumber(entry.total, {
+    const discountedTotal = entry.total - ((entry.total * entry.discount) / 100);
+    return formatNumber(discountedTotal, {
       currencyCode: this.context.currencyCode,
       money: false,
     });

--- a/packages/webapp/src/components/DataTableCells/PercentFieldCell.tsx
+++ b/packages/webapp/src/components/DataTableCells/PercentFieldCell.tsx
@@ -32,7 +32,7 @@ const PercentFieldCell = ({
   return (
     <FormGroup intent={error ? Intent.DANGER : null}>
       <MoneyInputGroup
-        prefix={'%'}
+        suffix={'%'}
         value={value}
         onChange={handleChange}
         onBlurValue={handleBlurChange}

--- a/packages/webapp/src/components/Forms/MoneyInputGroup/CurrencyInputProps.ts
+++ b/packages/webapp/src/components/Forms/MoneyInputGroup/CurrencyInputProps.ts
@@ -86,6 +86,11 @@ export type CurrencyInputProps = Overwrite<
     prefix?: string;
 
     /**
+     * Include a suffix eg. %
+     */
+    suffix?: string;
+
+    /**
      * Incremental value change on arrow down and arrow up key press
      */
     step?: number;

--- a/packages/webapp/src/components/Forms/MoneyInputGroup/index.tsx
+++ b/packages/webapp/src/components/Forms/MoneyInputGroup/index.tsx
@@ -28,6 +28,7 @@ export const CurrencyInput: FC<CurrencyInputProps> = ({
   placeholder,
   precision,
   prefix,
+  suffix,
   step,
   decimalSeparator = '.',
   groupSeparator = ',',
@@ -52,6 +53,7 @@ export const CurrencyInput: FC<CurrencyInputProps> = ({
     groupSeparator,
     turnOffSeparators,
     prefix,
+    suffix,
   };
 
   const cleanValueOptions: Partial<CleanValueOptions> = {
@@ -62,6 +64,7 @@ export const CurrencyInput: FC<CurrencyInputProps> = ({
     allowNegativeValue,
     turnOffAbbreviations,
     prefix,
+    suffix,
   };
 
   const _defaultValue =

--- a/packages/webapp/src/components/Forms/MoneyInputGroup/utils/cleanValue.ts
+++ b/packages/webapp/src/components/Forms/MoneyInputGroup/utils/cleanValue.ts
@@ -13,6 +13,7 @@ export type CleanValueOptions = {
   allowNegativeValue?: boolean;
   turnOffAbbreviations?: boolean;
   prefix?: string;
+  suffix?: string;
 };
 
 /**
@@ -27,12 +28,14 @@ export const cleanValue = ({
   allowNegativeValue = true,
   turnOffAbbreviations = false,
   prefix = '',
+  suffix = '',
 }: CleanValueOptions): string => {
   const abbreviations = turnOffAbbreviations ? [] : ['k', 'm', 'b'];
   const isNegative = value.includes('-');
 
   const [prefixWithValue, preValue] = RegExp(`(\\d+)-?${escapeRegExp(prefix)}`).exec(value) || [];
   const withoutPrefix = prefix ? value.replace(prefixWithValue, '').concat(preValue) : value;
+  // Remove suffix from value
   const withoutSeparators = removeSeparators(withoutPrefix, groupSeparator);
   const withoutInvalidChars = removeInvalidChars(withoutSeparators, [
     groupSeparator,

--- a/packages/webapp/src/components/Forms/MoneyInputGroup/utils/formatValue.ts
+++ b/packages/webapp/src/components/Forms/MoneyInputGroup/utils/formatValue.ts
@@ -34,10 +34,15 @@ type Props = {
    * Prefix
    */
   prefix?: string;
+
+  /**
+   * Suffix
+   */
+  suffix?: string;
 };
 
 /**
- * Format value with decimal separator, group separator and prefix
+ * Format value with decimal separator, group separator, prefix, and suffix
  */
 export const formatValue = (props: Props): string => {
   const {
@@ -46,6 +51,7 @@ export const formatValue = (props: Props): string => {
     decimalSeparator = '.',
     turnOffSeparators = false,
     prefix,
+    suffix,
   } = props;
 
   if (_value === '' || _value === undefined) {
@@ -75,5 +81,7 @@ export const formatValue = (props: Props): string => {
       ? `${decimalSeparator}`
       : '';
 
-  return `${includeNegative}${includePrefix}${formattedInt}${includeDecimals}`;
+  const includeSuffix = suffix ? suffix : '';
+
+  return `${includeNegative}${includePrefix}${formattedInt}${includeDecimals}${includeSuffix}`;
 };


### PR DESCRIPTION
This pull request addresses the issue of displaying the correct percentage charachter at the creation of an invoice. Additionally, addreses a partial bug refered on the issue #556 where the Discount is not being properly applied on the invoices.

Changes:
- suffix: Now displays the percentage character properly on invoice creation
- discountedTotal: Calculates the total discounted amount and formats the Number for every item on invoice.

**Before:**
<img width="972" alt="image" src="https://github.com/user-attachments/assets/c3daf0e4-da63-461c-8b89-b3be7fa97f3e">

<img width="694" alt="image" src="https://github.com/user-attachments/assets/b943e45a-cb9f-462e-a8ad-51a39b2c2129">

**After:**
![image](https://github.com/user-attachments/assets/6b8d4a0f-7efc-47b5-bd88-842afa49366e)

![image](https://github.com/user-attachments/assets/c901140f-d5db-434b-ab38-ff34eaf002eb)

Was not able to fix the invoice ISaleInvoice assign in order to retrieve the discounts and properly dispay them on the frontend. Also, I'm not sure if there's another twerks to be made in order to completely fix the bug.

Keep up with the good work!