### PR TITLE
fix: Credit and debit totals not balancing when decimal values are used

### DIFF
--- a/packages/server/src/services/ManualJournals/CommandManualJournalValidators.ts
+++ b/packages/server/src/services/ManualJournals/CommandManualJournalValidators.ts
@@ -33,6 +33,10 @@ export class CommandManualJournalValidators {
     if (totalCredit <= 0 || totalDebit <= 0) {
       throw new ServiceError(ERRORS.CREDIT_DEBIT_NOT_EQUAL_ZERO);
     }
+
+    if (totalCredit !== totalDebit) {
+      throw new ServiceError(ERRORS.CREDIT_DEBIT_NOT_EQUAL);
+    }
   }
 
   private roundToTwoDecimals(value: number): number {

--- a/packages/server/src/services/ManualJournals/CommandManualJournalValidators.ts
+++ b/packages/server/src/services/ManualJournals/CommandManualJournalValidators.ts
@@ -23,23 +23,20 @@ export class CommandManualJournalValidators {
    * @param {IManualJournalDTO} manualJournalDTO
    */
   public valdiateCreditDebitTotalEquals(manualJournalDTO: IManualJournalDTO) {
-    let totalCredit = 0;
-    let totalDebit = 0;
+    const totalCredit = this.roundToTwoDecimals(
+      manualJournalDTO.entries.reduce((sum, entry) => sum + (entry.credit || 0), 0)
+    );
+    const totalDebit = this.roundToTwoDecimals(
+      manualJournalDTO.entries.reduce((sum, entry) => sum + (entry.debit || 0), 0)
+    );
 
-    manualJournalDTO.entries.forEach((entry) => {
-      if (entry.credit > 0) {
-        totalCredit += entry.credit;
-      }
-      if (entry.debit > 0) {
-        totalDebit += entry.debit;
-      }
-    });
     if (totalCredit <= 0 || totalDebit <= 0) {
       throw new ServiceError(ERRORS.CREDIT_DEBIT_NOT_EQUAL_ZERO);
     }
-    if (totalCredit !== totalDebit) {
-      throw new ServiceError(ERRORS.CREDIT_DEBIT_NOT_EQUAL);
-    }
+  }
+
+  private roundToTwoDecimals(value: number): number {
+    return Math.round(value * 100) / 100;
   }
 
   /**
@@ -308,3 +305,4 @@ export class CommandManualJournalValidators {
     }
   };
 }
+

--- a/packages/server/src/services/ManualJournals/CommandManualJournalValidators.ts
+++ b/packages/server/src/services/ManualJournals/CommandManualJournalValidators.ts
@@ -1,4 +1,4 @@
-import { difference, isEmpty } from 'lodash';
+import { difference, isEmpty, round, sumBy } from 'lodash';
 import { Service, Inject } from 'typedi';
 import { ServiceError } from '@/exceptions';
 import {
@@ -23,13 +23,14 @@ export class CommandManualJournalValidators {
    * @param {IManualJournalDTO} manualJournalDTO
    */
   public valdiateCreditDebitTotalEquals(manualJournalDTO: IManualJournalDTO) {
-    const totalCredit = this.roundToTwoDecimals(
-      manualJournalDTO.entries.reduce((sum, entry) => sum + (entry.credit || 0), 0)
+    const totalCredit = round(
+      sumBy(manualJournalDTO.entries, (entry) => entry.credit || 0),
+      2
     );
-    const totalDebit = this.roundToTwoDecimals(
-      manualJournalDTO.entries.reduce((sum, entry) => sum + (entry.debit || 0), 0)
+    const totalDebit = round(
+      sumBy(manualJournalDTO.entries, (entry) => entry.debit || 0),
+      2
     );
-
     if (totalCredit <= 0 || totalDebit <= 0) {
       throw new ServiceError(ERRORS.CREDIT_DEBIT_NOT_EQUAL_ZERO);
     }
@@ -37,10 +38,6 @@ export class CommandManualJournalValidators {
     if (totalCredit !== totalDebit) {
       throw new ServiceError(ERRORS.CREDIT_DEBIT_NOT_EQUAL);
     }
-  }
-
-  private roundToTwoDecimals(value: number): number {
-    return Math.round(value * 100) / 100;
   }
 
   /**
@@ -309,4 +306,3 @@ export class CommandManualJournalValidators {
     }
   };
 }
-

--- a/packages/webapp/src/containers/Accounting/MakeJournal/MakeJournalEntriesForm.tsx
+++ b/packages/webapp/src/containers/Accounting/MakeJournal/MakeJournalEntriesForm.tsx
@@ -4,7 +4,7 @@ import { Formik, Form } from 'formik';
 import { Intent } from '@blueprintjs/core';
 import intl from 'react-intl-universal';
 import * as R from 'ramda';
-import { isEmpty, omit } from 'lodash';
+import { sumBy, round, isEmpty, omit } from 'lodash';
 import classNames from 'classnames';
 import { useHistory } from 'react-router-dom';
 
@@ -67,17 +67,17 @@ function MakeJournalEntriesForm({
     () => ({
       ...(!isEmpty(manualJournal)
         ? {
-          ...transformToEditForm(manualJournal),
-        }
+            ...transformToEditForm(manualJournal),
+          }
         : {
-          ...defaultManualJournal,
-          // If the auto-increment mode is enabled, take the next journal
-          // number from the settings.
-          ...(journalAutoIncrement && {
-            journal_number: journalNumber,
+            ...defaultManualJournal,
+            // If the auto-increment mode is enabled, take the next journal
+            // number from the settings.
+            ...(journalAutoIncrement && {
+              journal_number: journalNumber,
+            }),
+            currency_code: base_currency,
           }),
-          currency_code: base_currency,
-        }),
     }),
     [manualJournal, base_currency, journalNumber, journalAutoIncrement],
   );
@@ -88,15 +88,13 @@ function MakeJournalEntriesForm({
     const entries = values.entries.filter(
       (entry) => entry.debit || entry.credit,
     );
-
-    // Updated getTotal function
+    // Updated getTotal function using lodash
     const getTotal = (type = 'credit') => {
-      return entries.reduce((total, item) => {
-        const value = item[type] ? parseFloat(item[type]) : 0;
-        return Math.round((total + value) * 100) / 100;
-      }, 0);
+      return round(
+        sumBy(entries, (entry) => parseFloat(entry[type] || 0)),
+        2,
+      );
     };
-
     const totalCredit = getTotal('credit');
     const totalDebit = getTotal('debit');
 

--- a/packages/webapp/src/containers/Accounting/MakeJournal/MakeJournalEntriesForm.tsx
+++ b/packages/webapp/src/containers/Accounting/MakeJournal/MakeJournalEntriesForm.tsx
@@ -67,17 +67,17 @@ function MakeJournalEntriesForm({
     () => ({
       ...(!isEmpty(manualJournal)
         ? {
-            ...transformToEditForm(manualJournal),
-          }
+          ...transformToEditForm(manualJournal),
+        }
         : {
-            ...defaultManualJournal,
-            // If the auto-increment mode is enabled, take the next journal
-            // number from the settings.
-            ...(journalAutoIncrement && {
-              journal_number: journalNumber,
-            }),
-            currency_code: base_currency,
+          ...defaultManualJournal,
+          // If the auto-increment mode is enabled, take the next journal
+          // number from the settings.
+          ...(journalAutoIncrement && {
+            journal_number: journalNumber,
           }),
+          currency_code: base_currency,
+        }),
     }),
     [manualJournal, base_currency, journalNumber, journalAutoIncrement],
   );
@@ -88,15 +88,19 @@ function MakeJournalEntriesForm({
     const entries = values.entries.filter(
       (entry) => entry.debit || entry.credit,
     );
+
+    // Updated getTotal function
     const getTotal = (type = 'credit') => {
       return entries.reduce((total, item) => {
-        return item[type] ? item[type] + total : total;
+        const value = item[type] ? parseFloat(item[type]) : 0;
+        return Math.round((total + value) * 100) / 100;
       }, 0);
     };
+
     const totalCredit = getTotal('credit');
     const totalDebit = getTotal('debit');
 
-    // Validate the total credit should be eqials total debit.
+    // Validate the total credit should be equals total debit.
     if (totalCredit !== totalDebit) {
       AppToaster.show({
         message: intl.get('should_total_of_credit_and_debit_be_equal'),


### PR DESCRIPTION
This pull request addresses the issue where debit and credit totals are not balanced when decimal values are used. 

**Changes made**:
- Refactored valdiateCreditDebitTotalEquals inside file CommandManualJournalValidators.ts
- Refactored the totalCredit and totalDebit values in MakeJournalEntriesForm.tsx by parsing them and rounding them to 2dp for more accurate calculations

Let me know if any further adjustments are required after reviewing the changes. Thanks.