### PR TITLE
fix: rename prepaid expenses account name

### DIFF
--- a/packages/server/src/database/seeds/data/accounts.js
+++ b/packages/server/src/database/seeds/data/accounts.js
@@ -31,7 +31,7 @@ export const UnearnedRevenueAccount = {
   predefined: true,
 };
 
-export const PrepardExpenses = {
+export const PrepaidExpenses = {
   name: 'Prepaid Expenses',
   slug: 'prepaid-expenses',
   account_type: 'other-current-asset',
@@ -388,7 +388,7 @@ export default [
     predefined: 0,
   },
   UnearnedRevenueAccount,
-  PrepardExpenses,
+  PrepaidExpenses,
   DiscountExpenseAccount,
   PurchaseDiscountAccount,
   OtherChargesAccount,

--- a/packages/server/src/repositories/AccountRepository.ts
+++ b/packages/server/src/repositories/AccountRepository.ts
@@ -6,7 +6,7 @@ import {
   DiscountExpenseAccount,
   OtherChargesAccount,
   OtherExpensesAccount,
-  PrepardExpenses,
+  PrepaidExpenses,
   PurchaseDiscountAccount,
   StripeClearingAccount,
   TaxPayableAccount,
@@ -222,12 +222,12 @@ export default class AccountRepository extends TenantRepository {
   }
 
   /**
-   * Finds or creates the prepard expenses account.
+   * Finds or creates the prepaid expenses account.
    * @param {Record<string, string>} extraAttrs
    * @param {Knex.Transaction} trx
    * @returns
    */
-  public async findOrCreatePrepardExpenses(
+  public async findOrCreatePrepaidExpenses(
     extraAttrs: Record<string, string> = {},
     trx?: Knex.Transaction
   ) {
@@ -242,11 +242,11 @@ export default class AccountRepository extends TenantRepository {
 
     let result = await this.model
       .query(trx)
-      .findOne({ slug: PrepardExpenses.slug, ..._extraAttrs });
+      .findOne({ slug: PrepaidExpenses.slug, ..._extraAttrs });
 
     if (!result) {
       result = await this.model.query(trx).insertAndFetch({
-        ...PrepardExpenses,
+        ...PrepaidExpenses,
         ..._extraAttrs,
       });
     }


### PR DESCRIPTION
This PR renames `PrepaidExpenses` variable name. Initially it was written as `PrepardExpenses`