### PR TITLE
Fix balance calculation

### DIFF
--- a/packages/server/src/services/Sales/Invoices/CommandSaleInvoiceDTOTransformer.ts
+++ b/packages/server/src/services/Sales/Invoices/CommandSaleInvoiceDTOTransformer.ts
@@ -154,6 +154,9 @@ export class CommandSaleInvoiceDTOTransformer {
    * @returns {number}
    */
   private getDueBalanceItemEntries = (entries: ItemEntry[]) => {
-    return sumBy(entries, (e) => e.total);
+    return sumBy(entries, (e) => {
+      if (e.total) return e.total;
+      return e.quantity * e.rate;
+    });
   };
 }


### PR DESCRIPTION
This PR fixes an issue I had where editing an invoice for a service that uses `rate` and `quantity` will fail because there is no `total` value. This will result in a `NaN` being used to update the db causing a 500 failure on the server.

I'm not sure if this is happening to anyone else. But the reproduction steps for me.

1. Create an invoice for a service with a product with a rate. 
2. Try to edit the invoice in any way.
3. Save the invoice.