### PR TITLE
[docker] Change BANKING_CONNECT to BANK_FEED_ENABLED

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -93,7 +93,7 @@ services:
       - OPEN_EXCHANGE_RATE_APP_ID-${OPEN_EXCHANGE_RATE_APP_ID}
 
       # Bank Sync
-      - BANKING_CONNECT=${BANKING_CONNECT}
+      - BANK_FEED_ENABLED=${BANK_FEED_ENABLED}
 
       # Plaid
       - PLAID_ENV=${PLAID_ENV}


### PR DESCRIPTION
`BANKING_CONNECT` isn't referenced anywhere in the code base. I'm pretty sure this is supposed to be `BANK_FEED_ENABLED`.