### PR TITLE
Fix ESLint working directories

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,12 +19,12 @@
     ],
     "eslint.alwaysShowStatus": true,
     "eslint.workingDirectories": [
-        "./client",
-        "./server"
+        "./packages/webapp",
+        "./packages/server"
     ],
     "editor.useTabStops": false,
     "editor.tabSize": 2,
     "editor.insertSpaces": true,
     "git.ignoreLimitWarning": true,
-    "god.tsconfig": "./server/tsconfig.json",
+    "god.tsconfig": "./packages/server/tsconfig.json",
 }


### PR DESCRIPTION
Adjust the ESLint working directories in `.vscode/settings.json` to the correct paths.