### PR TITLE
Add payment success page

### DIFF
--- a/packages/server/src/modules/PaymentLinks/PaymentLinks.module.ts
+++ b/packages/server/src/modules/PaymentLinks/PaymentLinks.module.ts
@@ -9,6 +9,7 @@ import { StripePaymentModule } from '../StripePayment/StripePayment.module';
 import { SaleInvoicesModule } from '../SaleInvoices/SaleInvoices.module';
 import { GetInvoicePaymentLinkMetadata } from './GetInvoicePaymentLinkMetadata';
 import { TenancyContext } from '../Tenancy/TenancyContext.service';
+import { GenerateShareLink } from '../SaleInvoices/commands/GenerateInvoicePaymentLink.service';
 
 const models = [InjectSystemModel(PaymentLink)];
 
@@ -21,6 +22,7 @@ const models = [InjectSystemModel(PaymentLink)];
     ...models,
     TenancyContext,
     CreateInvoiceCheckoutSession,
+    GenerateShareLink,
     GetPaymentLinkInvoicePdf,
     PaymentLinksApplication,
     GetInvoicePaymentLinkMetadata,

--- a/packages/server/src/modules/SaleInvoices/SaleInvoices.module.ts
+++ b/packages/server/src/modules/SaleInvoices/SaleInvoices.module.ts
@@ -137,6 +137,7 @@ import { ValidateBulkDeleteSaleInvoicesService } from './ValidateBulkDeleteSaleI
     SaleInvoicePdf,
     SaleInvoicesExportable,
     SaleInvoicesImportable,
+    GenerateShareLink,
   ],
 })
 export class SaleInvoicesModule { }

--- a/packages/server/src/modules/SaleInvoices/commands/GenerateInvoicePaymentLink.service.ts
+++ b/packages/server/src/modules/SaleInvoices/commands/GenerateInvoicePaymentLink.service.ts
@@ -74,13 +74,20 @@ export class GenerateShareLink {
           trx,
         },
       );
-      return this.transformer.transform(
-        paymentLink,
-        new GeneratePaymentLinkTransformer(),
-        {
-          baseUrl: this.configService.get('app.baseUrl'),
-        }
-      );
+      return await this.generatePaymentLinkFromModel(paymentLink);
     });
+  }
+
+  /**
+   * Generates a payment link (with URL) for the given payment link model.
+   */
+  generatePaymentLinkFromModel(paymentLink: PaymentLink) {
+    return this.transformer.transform(
+      paymentLink,
+      new GeneratePaymentLinkTransformer(),
+      {
+        baseUrl: this.configService.get('app.baseUrl'),
+      },
+    );
   }
 }

--- a/packages/webapp/src/components/App.tsx
+++ b/packages/webapp/src/components/App.tsx
@@ -32,8 +32,11 @@ const RegisterVerify = lazy(
 const OneClickDemoPage = lazy(
   () => import('@/containers/OneClickDemo/OneClickDemoPage'),
 );
-const PaymentPortalPage = lazy(
-  () => import('@/containers/PaymentPortal/PaymentPortalPage'),
+const PaymentInvoicePage = lazy(
+  () => import('@/containers/PaymentPortal/PaymentInvoicePage'),
+);
+const PaymentSuccessPage = lazy(
+  () => import('@/containers/PaymentPortal/PaymentSuccessPage'),
 );
 
 /**
@@ -61,8 +64,12 @@ function AppInsider({ history }) {
               />
               <Route path={'/auth'} children={<AuthenticationPage />} />
               <Route
+                path={'/payment/:linkId/success/:stripeSessionId'}
+                children={<PaymentSuccessPage />}
+              />
+              <Route
                 path={'/payment/:linkId'}
-                children={<PaymentPortalPage />}
+                children={<PaymentInvoicePage />}
               />
               <Route path={'/'} children={<DashboardPrivatePages />} />
             </Switch>

--- a/packages/webapp/src/containers/PaymentPortal/DownloadInvoiceButton.tsx
+++ b/packages/webapp/src/containers/PaymentPortal/DownloadInvoiceButton.tsx
@@ -1,0 +1,44 @@
+import { Button, Intent } from '@blueprintjs/core';
+import clsx from 'classnames';
+import { AppToaster } from '@/components';
+import { useGeneratePaymentLinkInvoicePdf } from '@/hooks/query/payment-link';
+import { usePaymentPortalBoot } from './PaymentPortalBoot';
+import { downloadFile } from '@/hooks/useDownloadFile';
+import styles from './PaymentPortal.module.scss';
+
+export function DownloadInvoiceButton() {
+  const { sharableLinkMeta, linkId } = usePaymentPortalBoot();
+  const {
+    mutateAsync: generatePaymentLinkInvoice,
+    isLoading: isInvoiceGenerating,
+  } = useGeneratePaymentLinkInvoicePdf();
+
+  // Handles invoice download button click.
+  function onClick() {
+    generatePaymentLinkInvoice({ paymentLinkId: linkId })
+      .then((data) => {
+        downloadFile(
+          data,
+          `Invoice ${sharableLinkMeta?.invoiceNo}`,
+          'application/pdf',
+        );
+      })
+      .catch(() => {
+        AppToaster.show({
+          intent: Intent.DANGER,
+          message: 'Something went wrong.',
+        });
+      });
+  }
+
+  return (
+    <Button
+      minimal
+      className={clsx(styles.footerButton, styles.downloadInvoiceButton)}
+      onClick={onClick}
+      loading={isInvoiceGenerating}
+    >
+      Download Invoice
+    </Button>
+  );
+}

--- a/packages/webapp/src/containers/PaymentPortal/PaymentPortalInvoiceHeader.tsx
+++ b/packages/webapp/src/containers/PaymentPortal/PaymentPortalInvoiceHeader.tsx
@@ -1,0 +1,54 @@
+import { Text, Classes } from '@blueprintjs/core';
+import clsx from 'classnames';
+import { Box, Group, Stack } from '@/components';
+import { usePaymentPortalBoot } from './PaymentPortalBoot';
+import styles from './PaymentPortal.module.scss';
+
+export function PaymentPortalInvoiceHeader() {
+  const { sharableLinkMeta } = usePaymentPortalBoot();
+  return (
+    <>
+      <Group spacing={10}>
+        {sharableLinkMeta?.brandingTemplate?.companyLogoUri && (
+          <Box
+            className={styles.companyLogoWrap}
+            style={{
+              backgroundImage: `url(${sharableLinkMeta?.brandingTemplate?.companyLogoUri})`,
+            }}
+          ></Box>
+        )}
+        <Text>{sharableLinkMeta?.organization?.name}</Text>
+      </Group>
+
+      <Stack spacing={6}>
+        <h1 className={styles.bigTitle}>
+          {sharableLinkMeta?.organization?.name} Sent an Invoice for{' '}
+          {sharableLinkMeta?.totalFormatted}
+        </h1>
+        <Group spacing={10}>
+          <Text className={clsx(Classes.TEXT_MUTED, styles.invoiceDueDate)}>
+            Invoice due {sharableLinkMeta?.dueDateFormatted}{' '}
+          </Text>
+        </Group>
+      </Stack>
+
+      <Stack className={styles.address} spacing={2}>
+        <Box className={styles.customerName}>
+          {sharableLinkMeta?.customerName}
+        </Box>
+
+        {sharableLinkMeta?.formattedCustomerAddress && (
+          <Box
+            dangerouslySetInnerHTML={{
+              __html: sharableLinkMeta?.formattedCustomerAddress,
+            }}
+          />
+        )}
+      </Stack>
+
+      <h2 className={styles.invoiceNumber}>
+        Invoice {sharableLinkMeta?.invoiceNo}
+      </h2>
+    </>
+  );
+}

--- a/packages/webapp/src/containers/PaymentPortal/PaymentPortalPage.tsx
+++ b/packages/webapp/src/containers/PaymentPortal/PaymentPortalPage.tsx
@@ -1,25 +1,25 @@
-import { useParams } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
 import BodyClassName from 'react-body-classname';
-import { PaymentPortal } from './PaymentPortal';
-import { PaymentPortalBoot, usePaymentPortalBoot } from './PaymentPortalBoot';
-import { PaymentInvoicePreviewDrawer } from './drawers/PaymentInvoicePreviewDrawer/PaymentInvoicePreviewDrawer';
-import { DRAWERS } from '@/constants/drawers';
 import styles from './PaymentPortal.module.scss';
-import { useEffect } from 'react';
+import { ReactNode, useEffect } from 'react';
 import { hsl, lighten, parseToHsl } from 'polished';
+import { Box } from '@/components';
+import { usePaymentPortalBoot } from './PaymentPortalBoot';
 
-export default function PaymentPortalPage() {
-  const { linkId } = useParams<{ linkId: string }>();
-
+export default function PaymentPortalPage({
+  children,
+}: {
+  children: ReactNode;
+}) {
   return (
     <BodyClassName className={styles.rootBodyPage}>
-      <PaymentPortalBoot linkId={linkId}>
+      <>
         <PaymentPortalHelmet />
         <PaymentPortalCssVariables />
-        <PaymentPortal />
-        <PaymentInvoicePreviewDrawer name={DRAWERS.PAYMENT_INVOICE_PREVIEW} />
-      </PaymentPortalBoot>
+        <Box className={styles.root} my={'40px'} mx={'auto'}>
+          {children}
+        </Box>
+      </>
     </BodyClassName>
   );
 }

--- a/packages/webapp/src/containers/PaymentPortal/PaymentSuccessPage.tsx
+++ b/packages/webapp/src/containers/PaymentPortal/PaymentSuccessPage.tsx
@@ -1,0 +1,35 @@
+import { useParams } from 'react-router-dom';
+import { Callout, Intent } from '@blueprintjs/core';
+
+import PaymentPortalPage from './PaymentPortalPage';
+import { PaymentPortalBoot } from './PaymentPortalBoot';
+import { Stack } from '@/components';
+import { PaymentPortalInvoiceHeader } from './PaymentPortalInvoiceHeader';
+import styles from './PaymentPortal.module.scss';
+import { DownloadInvoiceButton } from './DownloadInvoiceButton';
+
+function PaymentSuccessPage() {
+  return (
+    <PaymentPortalPage>
+      <Stack spacing={0} className={styles.body}>
+        <Stack>
+          <PaymentPortalInvoiceHeader />
+          <Callout intent={Intent.SUCCESS} title="Payment Successful">
+            Thank you. Your payment was successfully received.
+          </Callout>
+          <DownloadInvoiceButton />
+        </Stack>
+      </Stack>
+    </PaymentPortalPage>
+  );
+}
+
+export default function PaymentSuccessPageWrapper() {
+  const { linkId } = useParams<{ linkId: string }>();
+
+  return (
+    <PaymentPortalBoot linkId={linkId}>
+      <PaymentSuccessPage />
+    </PaymentPortalBoot>
+  );
+}


### PR DESCRIPTION
*This is a port of https://github.com/Daniel15/DanCapital/pull/3 from v0.22.0 to the latest develop branch. Unfortunately I can't fully test it since I'm hitting errors when trying to create a new invoice.*

___

Adds a new payment success page that Stripe can redirect to after a successful payment.

 - Split `PaymentPortal` into several files: `PaymentPortalPage` and `PaymentPortalInvoiceHeader` with the reusable parts, and `PaymentInvoicePage` for stuff that's specific to the current invoice page
 - Add new route for Stripe success_url: `https://example.com/payment/{paymentLinkID}/success/{stripeCheckoutSessionID}`. Currently the Stripe checkout session ID is not used, but it could be used to load details about the payment.
 - Remove hard-coded `localhost` `success_url` and `cancel_url`s and replace them with proper URLs: `success_url` goes to the new page, and `cancel_url` just goes back to the invoice.

<img width="1096" height="733" alt="Screenshot_20251116_170653" src="https://github.com/user-attachments/assets/9b470ceb-eb1f-4d57-bf7c-73c1491687cf" />

Closes #849
