### PR TITLE
fix: Lock pnpm to v9 in Dockerfile

### DIFF
--- a/packages/webapp/Dockerfile
+++ b/packages/webapp/Dockerfile
@@ -15,7 +15,7 @@ RUN apk add python3 build-base chromium
 ENV PYTHON=/usr/bin/python3
 
 # Install pnpm packages dependencies
-RUN npm install -g pnpm
+RUN npm install -g pnpm@9
 RUN pnpm install
 
 # Build webapp package


### PR DESCRIPTION
Bigcapital doesn't seem to build properly with pnpm 10, and it's locked to 9 elsewhere.