### PR TITLE
fix(webapp): account delete error handling response types

### DIFF
--- a/packages/webapp/src/containers/Accounts/utils.tsx
+++ b/packages/webapp/src/containers/Accounts/utils.tsx
@@ -8,6 +8,11 @@ import { If, AppToaster } from '@/components';
 import { NormalCell, BalanceCell, BankBalanceCell } from './components';
 import { transformTableStateToQuery, isBlank } from '@/utils';
 
+export const DeleteAccountTypeError = {
+  AccountPredefined: 'account_predefined',
+  AccountHasAssociatedTransactions: 'account_has_associated_transactions',
+};
+
 /**
  * Account name accessor.
  */
@@ -26,13 +31,13 @@ export const accountNameAccessor = (account) => {
  * Handle delete errors in bulk and singular.
  */
 export const handleDeleteErrors = (errors) => {
-  if (errors.find((e) => e.type === 'ACCOUNT.PREDEFINED')) {
+  if (errors.find((e) => e.type === DeleteAccountTypeError.AccountPredefined)) {
     AppToaster.show({
       message: intl.get('cannot_delete_predefined_accounts'),
       intent: Intent.DANGER,
     });
   }
-  if (errors.find((e) => e.type === 'ACCOUNT.HAS.ASSOCIATED.TRANSACTIONS')) {
+  if (errors.find((e) => e.type === DeleteAccountTypeError.AccountHasAssociatedTransactions)) {
     AppToaster.show({
       message: intl.get('cannot_delete_account_has_associated_transactions'),
       intent: Intent.DANGER,


### PR DESCRIPTION
## Summary

Fixed account deletion error handling that was not working due to API response format changes.

## Changes

- Updated error type strings to match server response format (lowercase with underscores)
- Added  constant for better maintainability
- Changed constant keys from UPPERCASE to PascalCase

## Error Types Fixed

-  → 
-  → 

The frontend now correctly displays error toasts when:
- Trying to delete predefined accounts
- Trying to delete accounts with associated transactions