### PR TITLE
feat(webapp): add blurry background to sticky data table cells

### DIFF
--- a/packages/webapp/src/style/components/DataTable/DataTable.scss
+++ b/packages/webapp/src/style/components/DataTable/DataTable.scss
@@ -390,3 +390,17 @@
     }
   }
 }
+
+// Sticky cells in table body: blurred transparent background so content doesn't show through
+.bigcapital-datatable.has-sticky {
+  &.table-constrant .table .tbody .tr:not(:hover) .td[data-sticky-td],
+  &.table--constrant .table .tbody .tr:not(:hover) .td[data-sticky-td] {
+    background: rgba(255, 255, 255, 0.25);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+
+    body.bp4-dark & {
+      background: rgba(28, 33, 39, 0.6);
+    }
+  }
+}


### PR DESCRIPTION
Add backdrop-filter blur effect to sticky column cells in financial reports to prevent content from showing through during horizontal scrolling.

The effect only applies when rows are not hovered (:not(:hover)) to preserve the hover background interactions.