### PR TITLE
fix(server): branches activation not marking bills and payments with primary branch

### DIFF
--- a/packages/server/src/modules/Bills/dtos/BillResponse.dto.ts
+++ b/packages/server/src/modules/Bills/dtos/BillResponse.dto.ts
@@ -1,6 +1,8 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
 import { ItemEntryDto } from '@/modules/TransactionItemEntry/dto/ItemEntry.dto';
 import { AttachmentLinkDto } from '@/modules/Attachments/dtos/Attachment.dto';
+import { BranchResponseDto } from '@/modules/Branches/dtos/BranchResponse.dto';
 import { DiscountType } from '@/common/types/Discount';
 
 export class BillResponseDto {
@@ -88,6 +90,14 @@ export class BillResponseDto {
     required: false,
   })
   branchId?: number;
+
+  @ApiProperty({
+    description: 'Branch details',
+    type: () => BranchResponseDto,
+    required: false,
+  })
+  @Type(() => BranchResponseDto)
+  branch?: BranchResponseDto;
 
   @ApiProperty({
     description: 'The ID of the project',

--- a/packages/server/src/modules/Bills/queries/Bill.transformer.ts
+++ b/packages/server/src/modules/Bills/queries/Bill.transformer.ts
@@ -30,6 +30,7 @@ export class BillTransformer extends Transformer {
       'taxes',
       'entries',
       'attachments',
+      'branch',
     ];
   };
 

--- a/packages/server/src/modules/Branches/Branches.module.ts
+++ b/packages/server/src/modules/Branches/Branches.module.ts
@@ -31,6 +31,12 @@ import { ValidateBranchExistance } from './integrations/ValidateBranchExistance'
 import { ManualJournalBranchesValidator } from './integrations/ManualJournals/ManualJournalsBranchesValidator';
 import { CashflowTransactionsActivateBranches } from './integrations/Cashflow/CashflowActivateBranches';
 import { ExpensesActivateBranches } from './integrations/Expense/ExpensesActivateBranches';
+import { BillActivateBranches } from './integrations/Purchases/BillBranchesActivate';
+import { VendorCreditActivateBranches } from './integrations/Purchases/VendorCreditBranchesActivate';
+import { BillPaymentsActivateBranches } from './integrations/Purchases/PaymentMadeBranchesActivate';
+import { BillBranchesActivateSubscriber } from './subscribers/Activate/BillBranchesActivateSubscriber';
+import { VendorCreditBranchesActivateSubscriber } from './subscribers/Activate/VendorCreditBranchesActivateSubscriber';
+import { PaymentMadeActivateBranchesSubscriber } from './subscribers/Activate/PaymentMadeBranchesActivateSubscriber';
 import { FeaturesModule } from '../Features/Features.module';
 
 @Module({
@@ -66,7 +72,13 @@ import { FeaturesModule } from '../Features/Features.module';
     ValidateBranchExistance,
     ManualJournalBranchesValidator,
     CashflowTransactionsActivateBranches,
-    ExpensesActivateBranches
+    ExpensesActivateBranches,
+    BillActivateBranches,
+    VendorCreditActivateBranches,
+    BillPaymentsActivateBranches,
+    BillBranchesActivateSubscriber,
+    VendorCreditBranchesActivateSubscriber,
+    PaymentMadeActivateBranchesSubscriber
   ],
   exports: [
     BranchesSettingsService,

--- a/packages/server/src/modules/Branches/integrations/Purchases/BillBranchesActivate.ts
+++ b/packages/server/src/modules/Branches/integrations/Purchases/BillBranchesActivate.ts
@@ -1,11 +1,14 @@
 import { Knex } from 'knex';
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { TenantModelProxy } from '@/modules/System/models/TenantBaseModel';
 import { Bill } from '@/modules/Bills/models/Bill';
 
 @Injectable()
 export class BillActivateBranches {
-  constructor(private readonly billModel: TenantModelProxy<typeof Bill>) {}
+  constructor(
+    @Inject(Bill.name)
+    private readonly billModel: TenantModelProxy<typeof Bill>,
+  ) {}
 
   /**
    * Updates all bills transactions with the primary branch.
@@ -17,7 +20,7 @@ export class BillActivateBranches {
     primaryBranchId: number,
     trx?: Knex.Transaction,
   ) => {
-    // Updates the sale invoice with primary branch.
-    await Bill.query(trx).update({ branchId: primaryBranchId });
+    // Updates the bills with primary branch.
+    await this.billModel().query(trx).update({ branchId: primaryBranchId });
   };
 }

--- a/packages/server/src/modules/Branches/integrations/Purchases/PaymentMadeBranchesActivate.ts
+++ b/packages/server/src/modules/Branches/integrations/Purchases/PaymentMadeBranchesActivate.ts
@@ -1,11 +1,12 @@
 import { Knex } from 'knex';
+import { Inject, Injectable } from '@nestjs/common';
 import { TenantModelProxy } from '@/modules/System/models/TenantBaseModel';
 import { BillPayment } from '@/modules/BillPayments/models/BillPayment';
-import { Injectable } from '@nestjs/common';
 
 @Injectable()
 export class BillPaymentsActivateBranches {
   constructor(
+    @Inject(BillPayment.name)
     private readonly billPaymentModel: TenantModelProxy<typeof BillPayment>,
   ) {}
 

--- a/packages/server/src/modules/Branches/integrations/Purchases/VendorCreditBranchesActivate.ts
+++ b/packages/server/src/modules/Branches/integrations/Purchases/VendorCreditBranchesActivate.ts
@@ -1,11 +1,12 @@
 import { Knex } from 'knex';
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { TenantModelProxy } from '@/modules/System/models/TenantBaseModel';
 import { VendorCredit } from '@/modules/VendorCredit/models/VendorCredit';
 
 @Injectable()
 export class VendorCreditActivateBranches {
   constructor(
+    @Inject(VendorCredit.name)
     private readonly vendorCreditModel: TenantModelProxy<typeof VendorCredit>,
   ) {}
 

--- a/packages/server/src/modules/Branches/subscribers/Activate/BillBranchesActivateSubscriber.ts
+++ b/packages/server/src/modules/Branches/subscribers/Activate/BillBranchesActivateSubscriber.ts
@@ -1,0 +1,28 @@
+import { IBranchesActivatedPayload } from '../../Branches.types';
+import { events } from '@/common/events/events';
+import { Injectable } from '@nestjs/common';
+import { BillActivateBranches } from '../../integrations/Purchases/BillBranchesActivate';
+import { OnEvent } from '@nestjs/event-emitter';
+
+@Injectable()
+export class BillBranchesActivateSubscriber {
+  constructor(
+    private readonly billActivateBranches: BillActivateBranches,
+  ) { }
+
+  /**
+   * Updates bills transactions with the primary branch once
+   * the multi-branches is activated.
+   * @param {IBranchesActivatedPayload}
+   */
+  @OnEvent(events.branch.onActivated)
+  async updateBillsWithBranchOnActivated({
+    primaryBranch,
+    trx,
+  }: IBranchesActivatedPayload) {
+    await this.billActivateBranches.updateBillsWithBranch(
+      primaryBranch.id,
+      trx,
+    );
+  }
+}

--- a/packages/server/src/modules/Branches/subscribers/Activate/VendorCreditBranchesActivateSubscriber.ts
+++ b/packages/server/src/modules/Branches/subscribers/Activate/VendorCreditBranchesActivateSubscriber.ts
@@ -1,0 +1,28 @@
+import { IBranchesActivatedPayload } from '../../Branches.types';
+import { events } from '@/common/events/events';
+import { Injectable } from '@nestjs/common';
+import { VendorCreditActivateBranches } from '../../integrations/Purchases/VendorCreditBranchesActivate';
+import { OnEvent } from '@nestjs/event-emitter';
+
+@Injectable()
+export class VendorCreditBranchesActivateSubscriber {
+  constructor(
+    private readonly vendorCreditActivateBranches: VendorCreditActivateBranches,
+  ) { }
+
+  /**
+   * Updates vendor credits transactions with the primary branch once
+   * the multi-branches is activated.
+   * @param {IBranchesActivatedPayload}
+   */
+  @OnEvent(events.branch.onActivated)
+  async updateVendorCreditsWithBranchOnActivated({
+    primaryBranch,
+    trx,
+  }: IBranchesActivatedPayload) {
+    await this.vendorCreditActivateBranches.updateVendorCreditsWithBranch(
+      primaryBranch.id,
+      trx,
+    );
+  }
+}


### PR DESCRIPTION
## Summary

When activating the multi-branches feature, existing bills, vendor credits, and bill payments were not being marked with the default primary branch. This PR fixes the issue by:

## Changes

### Services
- **BillActivateBranches**: Added missing \`@Inject(Bill.name)\` decorator
- **VendorCreditActivateBranches**: Added missing \`@Inject(VendorCredit.name)\` decorator  
- **BillPaymentsActivateBranches**: Added missing \`@Inject(BillPayment.name)\` decorator

### Subscribers (NEW)
- **BillBranchesActivateSubscriber**: Listens to \`onActivated\` event and updates all bills with primary branch
- **VendorCreditBranchesActivateSubscriber**: Listens to \`onActivated\` event and updates all vendor credits with primary branch

### Module Registration
- Registered \`BillActivateBranches\`, \`VendorCreditActivateBranches\`, \`BillPaymentsActivateBranches\` services
- Registered \`BillBranchesActivateSubscriber\`, \`VendorCreditBranchesActivateSubscriber\`, \`PaymentMadeActivateBranchesSubscriber\` in BranchesModule

### API Response
- Added \`branch\` object to \`BillResponseDto\` for proper API responses
- Added \`branch\` to \`BillTransformer\` includeAttributes

## Testing

1. Create bills without branches feature enabled
2. Activate multi-branches feature
3. Verify all existing bills are assigned to the primary branch
4. Verify bill API responses include branch object

Fixes: #935