### PR TITLE
feat: expand rate limiting of getting org build job endpoint

### DIFF
--- a/packages/server/src/modules/Organization/Organization.controller.ts
+++ b/packages/server/src/modules/Organization/Organization.controller.ts
@@ -17,6 +17,7 @@ import {
   HttpCode,
   Param,
 } from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
 import { BuildOrganizationService } from './commands/BuildOrganization.service';
 import {
   BuildOrganizationDto,
@@ -50,7 +51,7 @@ export class OrganizationController {
     private readonly updateOrganizationService: UpdateOrganizationService,
     private readonly getBuildOrganizationJobService: GetBuildOrganizationBuildJob,
     private readonly orgBaseCurrencyLockingService: OrganizationBaseCurrencyLocking,
-  ) { }
+  ) {}
 
   @Post('build')
   @HttpCode(200)
@@ -77,6 +78,7 @@ export class OrganizationController {
   }
 
   @Get('build/:buildJobId')
+  @Throttle({ default: { limit: 300, ttl: 60000 } }) // 300 req/min
   @ApiParam({
     name: 'buildJobId',
     required: true,


### PR DESCRIPTION
## Summary

Add rate limiting to the organization build job status endpoint (`GET /build/:buildJobId`) to prevent abuse.

## Changes

- Add `@Throttle` decorator to the `getBuildOrganizationJob` method
- Limit set to 300 requests per minute (ttl: 60000ms)

## Rationale

This endpoint is polled by clients to check the status of organization build jobs. Without rate limiting, it could be vulnerable to abuse or accidental flooding.

## Testing

- [ ] Verify the endpoint still works correctly
- [ ] Verify rate limiting is applied after 300 requests in a 60-second window