### PR TITLE
fix: universal search API endpoint errors

### DIFF
--- a/packages/server/src/modules/Items/models/Item.ts
+++ b/packages/server/src/modules/Items/models/Item.ts
@@ -71,6 +71,16 @@ export class Item extends TenantBaseModel {
   }
 
   /**
+   * Model search roles.
+   */
+  static get searchRoles() {
+    return [
+      { condition: 'or', fieldKey: 'name', comparator: 'contains' },
+      { condition: 'or', fieldKey: 'code', comparator: 'like' },
+    ];
+  }
+
+  /**
    * Relationship mapping.
    */
   static get relationMappings() {

--- a/packages/webapp/src/hooks/query/GenericResource/index.tsx
+++ b/packages/webapp/src/hooks/query/GenericResource/index.tsx
@@ -32,19 +32,19 @@ export function useResourceData(type, query, props) {
  */
 function getResourceUrlFromType(type) {
   const config = {
-    [RESOURCES_TYPES.INVOICE]: '/sales/invoices',
-    [RESOURCES_TYPES.ESTIMATE]: '/sales/estimates',
+    [RESOURCES_TYPES.INVOICE]: '/sale-invoices',
+    [RESOURCES_TYPES.ESTIMATE]: '/sale-estimates',
     [RESOURCES_TYPES.ITEM]: '/items',
-    [RESOURCES_TYPES.RECEIPT]: '/sales/receipts',
-    [RESOURCES_TYPES.BILL]: '/purchases/bills',
-    [RESOURCES_TYPES.PAYMENT_RECEIVE]: '/sales/payment_receives',
-    [RESOURCES_TYPES.PAYMENT_MADE]: '/purchases/bill_payments',
+    [RESOURCES_TYPES.RECEIPT]: '/sale-receipts',
+    [RESOURCES_TYPES.BILL]: '/bills',
+    [RESOURCES_TYPES.PAYMENT_RECEIVE]: '/payments-received',
+    [RESOURCES_TYPES.PAYMENT_MADE]: '/bill-payments',
     [RESOURCES_TYPES.CUSTOMER]: '/customers',
     [RESOURCES_TYPES.VENDOR]: '/vendors',
     [RESOURCES_TYPES.MANUAL_JOURNAL]: '/manual-journals',
     [RESOURCES_TYPES.ACCOUNT]: '/accounts',
-    [RESOURCES_TYPES.CREDIT_NOTE]: '/sales/credit_notes',
-    [RESOURCES_TYPES.VENDOR_CREDIT]: '/purchases/vendor-credit',
+    [RESOURCES_TYPES.CREDIT_NOTE]: '/credit-notes',
+    [RESOURCES_TYPES.VENDOR_CREDIT]: '/vendor-credits',
   };
   return config[type] || '';
 }


### PR DESCRIPTION
## Summary

Fixes 404 and 500 errors in the universal/global search functionality.

## Changes

### Frontend (webapp)
- Corrected API endpoint URLs to match backend NestJS controller routes:
  - `/sales/invoices` → `/sale-invoices`
  - `/sales/estimates` → `/sale-estimates`
  - `/sales/receipts` → `/sale-receipts`
  - `/purchases/bills` → `/bills`
  - `/sales/payment_receives` → `/payments-received`
  - `/purchases/bill_payments` → `/bill-payments`
  - `/sales/credit_notes` → `/credit-notes`
  - `/purchases/vendor-credit` → `/vendor-credits`

### Backend (server)
- Added missing `searchRoles` static property to the `Item` model to enable searching by name and code
- This fixes the 500 Internal Server Error when searching items via `/api/items?search_keyword=...`

## Test plan
- [ ] Test universal search for invoices
- [ ] Test universal search for estimates
- [ ] Test universal search for receipts
- [ ] Test universal search for bills
- [ ] Test universal search for payment receives
- [ ] Test universal search for payments made
- [ ] Test universal search for credit notes
- [ ] Test universal search for vendor credits
- [ ] Test universal search for items

🤖 Generated with [Claude Code](https://claude.com/claude-code)