### PR TITLE
fix(server): fix Docker healthcheck endpoint

### DIFF
--- a/packages/server/src/modules/System/SystemDB/SystemDB.controller.ts
+++ b/packages/server/src/modules/System/SystemDB/SystemDB.controller.ts
@@ -1,12 +1,14 @@
-import { Controller, Get, Post } from '@nestjs/common';
+import { Controller, Get, HttpCode } from '@nestjs/common';
+import { PublicRoute } from '@/modules/Auth/guards/jwt.guard';
 
-@Controller('/system_db')
+@Controller('system_db')
+@PublicRoute()
 export class SystemDatabaseController {
   constructor() {}
 
-  @Post()
   @Get()
-  ping(){
-    
+  @HttpCode(200)
+  ping() {
+    return { status: 'ok' };
   }
 }

--- a/packages/server/src/modules/System/SystemDB/SystemDB.module.ts
+++ b/packages/server/src/modules/System/SystemDB/SystemDB.module.ts
@@ -6,6 +6,7 @@ import {
   SystemKnexConnectionConfigure,
 } from './SystemDB.constants';
 import { knexSnakeCaseMappers } from 'objection';
+import { SystemDatabaseController } from './SystemDB.controller';
 
 const providers = [
   {
@@ -42,6 +43,7 @@ const providers = [
 
 @Global()
 @Module({
+  controllers: [SystemDatabaseController],
   providers: [...providers],
   exports: [...providers],
 })


### PR DESCRIPTION
## Summary

This PR fixes the Docker healthcheck that was failing with 404 Not Found errors. The healthcheck in the Dockerfile calls \`http://localhost:3000/api/system_db\`, but the endpoint was not properly registered.

## Changes

- **SystemDB.module.ts**: Registered \`SystemDatabaseController\` in the module's controllers array
- **SystemDB.controller.ts**: 
  - Added \`PublicRoute()\` decorator to bypass authentication (was returning 401 Unauthorized)
  - Updated \`ping()\` method to return \`{ status: 'ok' }\` with HTTP 200
  - Removed unused \`@Post()\` decorator
  - Fixed controller path (removed leading slash)

## Problem

The Docker image has a built-in healthcheck that calls \`/api/system_db\`, but:
1. The controller was defined but never registered in the module
2. The endpoint was protected by authentication guards

## Solution

1. Register the controller in \`SystemDatabaseModule\`
2. Add \`@PublicRoute()\` decorator to allow unauthenticated access for healthchecks

## Test Plan

- [ ] Build the Docker image locally
- [ ] Run the container
- [ ] Verify healthcheck returns 200: \`docker exec bigcapital-server wget -qO- http://localhost:3000/api/system_db\`
- [ ] Verify container status shows \"healthy\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)