### PR TITLE
fix(webapp): allow formatted phone numbers in customer and vendor forms

### DIFF
--- a/packages/webapp/src/containers/Customers/CustomerForm/CustomerForm.schema.tsx
+++ b/packages/webapp/src/containers/Customers/CustomerForm/CustomerForm.schema.tsx
@@ -17,8 +17,8 @@ const Schema = Yup.object().shape({
     .label(intl.get('display_name_')),
 
   email: Yup.string().email().nullable(),
-  work_phone: Yup.number(),
-  personal_phone: Yup.number(),
+  work_phone: Yup.string().nullable(),
+  personal_phone: Yup.string().nullable(),
   website: Yup.string().url().nullable(),
 
   active: Yup.boolean(),
@@ -30,7 +30,7 @@ const Schema = Yup.object().shape({
   billing_address_city: Yup.string().trim(),
   billing_address_state: Yup.string().trim(),
   billing_address_postcode: Yup.string().nullable(),
-  billing_address_phone: Yup.number(),
+  billing_address_phone: Yup.string().nullable(),
 
   shipping_address_country: Yup.string().trim(),
   shipping_address_1: Yup.string().trim(),
@@ -38,7 +38,7 @@ const Schema = Yup.object().shape({
   shipping_address_city: Yup.string().trim(),
   shipping_address_state: Yup.string().trim(),
   shipping_address_postcode: Yup.string().nullable(),
-  shipping_address_phone: Yup.number(),
+  shipping_address_phone: Yup.string().nullable(),
 
   opening_balance: Yup.number().nullable(),
   currency_code: Yup.string(),

--- a/packages/webapp/src/containers/Vendors/VendorForm/VendorForm.schema.tsx
+++ b/packages/webapp/src/containers/Vendors/VendorForm/VendorForm.schema.tsx
@@ -10,8 +10,8 @@ const Schema = Yup.object().shape({
   display_name: Yup.string().trim().required().label(intl.get('display_name_')),
 
   email: Yup.string().email().nullable(),
-  work_phone: Yup.number(),
-  personal_phone: Yup.number(),
+  work_phone: Yup.string().nullable(),
+  personal_phone: Yup.string().nullable(),
   website: Yup.string().url().nullable(),
 
   active: Yup.boolean(),
@@ -23,7 +23,7 @@ const Schema = Yup.object().shape({
   billing_address_city: Yup.string().trim(),
   billing_address_state: Yup.string().trim(),
   billing_address_postcode: Yup.string().nullable(),
-  billing_address_phone: Yup.number(),
+  billing_address_phone: Yup.string().nullable(),
 
   shipping_address_country: Yup.string().trim(),
   shipping_address_1: Yup.string().trim(),
@@ -31,7 +31,7 @@ const Schema = Yup.object().shape({
   shipping_address_city: Yup.string().trim(),
   shipping_address_state: Yup.string().trim(),
   shipping_address_postcode: Yup.string().nullable(),
-  shipping_address_phone: Yup.number(),
+  shipping_address_phone: Yup.string().nullable(),
 
   opening_balance: Yup.number().nullable(),
   currency_code: Yup.string(),


### PR DESCRIPTION
## Summary

Fixed phone number validation in Customer and Vendor forms to accept formatted phone numbers (e.g., 555-555-5555, 555.555.5555) that were previously only accepted during import but failed validation when editing through the web interface.

## Problem

- Import validation treated phone fields as text, allowing formats like `555-555-5555`, `555.555.5555`, `555 555 5555`
- Web form validation used `Yup.number()`, which rejected any non-numeric characters
- This caused imported phone numbers to fail validation when users tried to edit them

## Solution

Changed phone field validation from `Yup.number()` to `Yup.string().nullable()` in:
- CustomerForm.schema.tsx
- VendorForm.schema.tsx

## Files Changed

- `packages/webapp/src/containers/Customers/CustomerForm/CustomerForm.schema.tsx`
- `packages/webapp/src/containers/Vendors/VendorForm/VendorForm.schema.tsx`

## Test Plan

- [ ] Import customers/vendors with formatted phone numbers (555-555-5555, 555.555.5555)
- [ ] Edit imported customers/vendors through web interface
- [ ] Verify no validation errors occur
- [ ] Create new customers/vendors with formatted phone numbers
- [ ] Verify phone numbers are saved correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)