### PR TITLE
fix(server): allow 'payee' field in bank rule conditions validation

### DIFF
--- a/packages/server/src/modules/BankRules/dtos/BankRule.dto.ts
+++ b/packages/server/src/modules/BankRules/dtos/BankRule.dto.ts
@@ -16,7 +16,7 @@ import { ToNumber } from '@/common/decorators/Validators';
 
 class BankRuleConditionDto {
   @IsNotEmpty()
-  @IsIn(['description', 'amount'])
+  @IsIn(['description', 'amount', 'payee'])
   field: string;
 
   @IsNotEmpty()


### PR DESCRIPTION
## Summary

Fixes a validation error when creating bank rules with 'payee' as a condition field.

## Problem

The `BankRuleConditionDto` validation only allowed 'description' and 'amount' fields:

```typescript
@IsIn(['description', 'amount'])
field: string;
```

However, the frontend UI offers three field options (description, amount, payee), causing a 400 Bad Request error when users try to create rules with 'payee' conditions.

## Solution

Added 'payee' to the allowed values in the validation decorator:

```typescript
@IsIn(['description', 'amount', 'payee'])
field: string;
```

## Changes

- Updated `packages/server/src/modules/BankRules/dtos/BankRule.dto.ts` to include 'payee' in the `@IsIn` validator

## Test plan

- [x] Create a new bank rule with 'payee' as the condition field
- [x] Verify the rule is created successfully without validation errors
- [x] Verify existing rules with 'description' and 'amount' fields still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)