### PR TITLE
fix(server): add missing S3_FORCE_PATH_STYLE environment variable

### DIFF
--- a/packages/server/src/common/config/s3.ts
+++ b/packages/server/src/common/config/s3.ts
@@ -6,4 +6,5 @@ export default registerAs('s3', () => ({
   secretAccessKey: process.env.S3_SECRET_ACCESS_KEY,
   endpoint: process.env.S3_ENDPOINT,
   bucket: process.env.S3_BUCKET,
+  forcePathStyle: process.env.S3_FORCE_PATH_STYLE === 'true',
 }));


### PR DESCRIPTION
## Summary

This PR fixes the missing `S3_FORCE_PATH_STYLE` environment variable configuration that was referenced in the S3 module but never actually being read from the environment.

## Issue

As reported in #940, the `S3.module.ts` was trying to use `config.forcePathStyle` but the value was never being set in `s3.ts` config file.

## Changes

- Added `forcePathStyle: process.env.S3_FORCE_PATH_STYLE === 'true'` to the S3 configuration

## Test plan

- [ ] Set `S3_FORCE_PATH_STYLE=true` in environment variables
- [ ] Verify S3 client uses path-style URLs when enabled

## Related Issues

Closes #940