### PR TITLE
fix(server): re-recognize transactions when bank rule is edited

### DIFF
--- a/packages/server/src/modules/BankingTranasctionsRegonize/_types.ts
+++ b/packages/server/src/modules/BankingTranasctionsRegonize/_types.ts
@@ -15,8 +15,13 @@ export const RecognizeUncategorizedTransactionsJob =
 export const RecognizeUncategorizedTransactionsQueue =
   'recognize-uncategorized-transactions-queue';
 
-
 export interface RecognizeUncategorizedTransactionsJobPayload extends TenantJobPayload {
   ruleId: number,
-  transactionsCriteria: any;
+  transactionsCriteria?: RecognizeTransactionsCriteria;
+  /**
+   * When true, first reverts recognized transactions before recognizing again.
+   * Used when a bank rule is edited to ensure transactions previously recognized
+   * by lower-priority rules are re-evaluated against the updated rule.
+   */
+  shouldRevert?: boolean;
 }

--- a/packages/server/src/modules/BankingTranasctionsRegonize/commands/RecognizeTranasctions.service.ts
+++ b/packages/server/src/modules/BankingTranasctionsRegonize/commands/RecognizeTranasctions.service.ts
@@ -93,6 +93,10 @@ export class RecognizeTranasctionsService {
           q.whereIn('id', rulesIds);
         }
         q.withGraphFetched('conditions');
+
+        // Order by the 'order' field to ensure higher priority rules (lower order values)
+        // are matched first.
+        q.orderBy('order', 'asc');
       });
 
     const bankRulesByAccountId = transformToMapBy(

--- a/packages/server/src/modules/BankingTranasctionsRegonize/events/TriggerRecognizedTransactions.ts
+++ b/packages/server/src/modules/BankingTranasctionsRegonize/events/TriggerRecognizedTransactions.ts
@@ -69,10 +69,13 @@ export class TriggerRecognizedTransactionsSubscriber {
     const tenantPayload = await this.tenancyContect.getTenantJobPayload();
     const payload = {
       ruleId: bankRule.id,
+      shouldRevert: true,
       ...tenantPayload,
     } as RecognizeUncategorizedTransactionsJobPayload;
 
     // Re-recognize the transactions based on the new rules.
+    // Setting shouldRevert to true ensures that transactions previously recognized
+    // by this or lower-priority rules are re-evaluated against the updated rule.
     await this.recognizeTransactionsQueue.add(
       RecognizeUncategorizedTransactionsJob,
       payload,

--- a/packages/server/src/modules/BankingTranasctionsRegonize/jobs/RecognizeTransactionsJob.ts
+++ b/packages/server/src/modules/BankingTranasctionsRegonize/jobs/RecognizeTransactionsJob.ts
@@ -3,6 +3,7 @@ import { Processor, WorkerHost } from '@nestjs/bullmq';
 import { Scope } from '@nestjs/common';
 import { ClsService, UseCls } from 'nestjs-cls';
 import { RecognizeTranasctionsService } from '../commands/RecognizeTranasctions.service';
+import { RevertRecognizedTransactionsService } from '../commands/RevertRecognizedTransactions.service';
 import {
   RecognizeUncategorizedTransactionsJobPayload,
   RecognizeUncategorizedTransactionsQueue,
@@ -15,10 +16,12 @@ import {
 export class RegonizeTransactionsPrcessor extends WorkerHost {
   /**
    * @param {RecognizeTranasctionsService} recognizeTranasctionsService -
+   * @param {RevertRecognizedTransactionsService} revertRecognizedTransactionsService -
    * @param {ClsService} clsService -
    */
   constructor(
     private readonly recognizeTranasctionsService: RecognizeTranasctionsService,
+    private readonly revertRecognizedTransactionsService: RevertRecognizedTransactionsService,
     private readonly clsService: ClsService,
   ) {
     super();
@@ -29,12 +32,21 @@ export class RegonizeTransactionsPrcessor extends WorkerHost {
    */
   @UseCls()
   async process(job: Job<RecognizeUncategorizedTransactionsJobPayload>) {
-    const { ruleId, transactionsCriteria } = job.data;
+    const { ruleId, transactionsCriteria, shouldRevert } = job.data;
 
     this.clsService.set('organizationId', job.data.organizationId);
     this.clsService.set('userId', job.data.userId);
 
     try {
+      // If shouldRevert is true, first revert recognized transactions before re-recognizing.
+      // This is used when a bank rule is edited to ensure transactions previously recognized
+      // by lower-priority rules are re-evaluated against the updated rule.
+      if (shouldRevert) {
+        await this.revertRecognizedTransactionsService.revertRecognizedTransactions(
+          ruleId,
+          transactionsCriteria,
+        );
+      }
       await this.recognizeTranasctionsService.recognizeTransactions(
         ruleId,
         transactionsCriteria,


### PR DESCRIPTION
## Summary

Fixes #809 - When a bank rule is edited (especially its priority/order), transactions already recognized by lower-priority rules are now re-matched against the updated rule.

## Problem

Previously, when a bank rule was edited:
- Only unrecognized transactions were processed
- Already recognized transactions were never re-evaluated
- This meant that if a rule's priority was increased, transactions that should now match the higher-priority rule would remain matched to lower-priority rules

## Solution

1. Added `shouldRevert` flag to the recognition job payload
2. When a rule is edited, the job now:
   - First reverts all recognized transactions for the affected rule (unlinking them)
   - Then runs recognition again, matching transactions with the updated rules
3. Added sorting by `order` field when querying bank rules to ensure higher priority rules (lower order values) are matched first

## Changes

- `RecognizeTransactionsJob.ts`: Added `RevertRecognizedTransactionsService` injection and `shouldRevert` handling
- `_types.ts`: Added `shouldRevert` optional property to job payload
- `TriggerRecognizedTransactions.ts`: Pass `shouldRevert: true` when rule is edited
- `RecognizeTranasctions.service.ts`: Added `orderBy('order', 'asc')` for proper priority handling

## Test plan

- [ ] Edit a bank rule's priority (order) to be higher than other rules
- [ ] Verify transactions previously recognized by lower-priority rules are re-recognized by the updated rule
- [ ] Verify transactions that don't match the updated rule remain unrecognized or match other appropriate rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)