### PR TITLE
fix: correct trial balance sheet filtering logic

### DIFF
--- a/packages/server/src/modules/FinancialStatements/modules/TrialBalanceSheet/TrialBalanceSheet.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/TrialBalanceSheet/TrialBalanceSheet.ts
@@ -172,8 +172,11 @@ export class TrialBalanceSheet extends FinancialSheet {
   private filterNoneTransactions = (
     accountNode: ITrialBalanceAccount
   ): boolean => {
-    const accountLedger = this.repository.totalAccountsLedger.whereAccountId(
-      accountNode.id,
+    const depsAccountsIds =
+      this.repository.accountsDepGraph.dependenciesOf(accountNode.id);
+
+    const accountLedger = this.repository.totalAccountsLedger.whereAccountsIds(
+      [accountNode.id, ...depsAccountsIds]
     );
     return !accountLedger.isEmpty();
   };
@@ -241,8 +244,8 @@ export class TrialBalanceSheet extends FinancialSheet {
    */
   private accountsSection(accounts: ModelObject<Account>[]) {
     return R.compose(
-      this.nestedAccountsNode,
       this.accountsFilter,
+      this.nestedAccountsNode,
       this.accountsMapper
     )(accounts);
   }
@@ -250,7 +253,6 @@ export class TrialBalanceSheet extends FinancialSheet {
   /**
    * Retrieve trial balance sheet statement data.
    * Note: Retruns null in case there is no transactions between the given date periods.
-   *
    * @return {ITrialBalanceSheetData}
    */
   public reportData(): ITrialBalanceSheetData {


### PR DESCRIPTION
## Summary

This PR fixes the trial balance sheet filtering logic to correctly handle parent accounts with child transactions.

## Changes

- Include child account transactions when filtering parent accounts by using `dependenciesOf` to get all dependent account IDs
- Fix the order of operations in `accountsSection` method - apply filtering after nesting accounts (not before)
- Ensure accounts with child transactions are not incorrectly filtered out when using the "Hide accounts with no transactions" option

## Rationale

Previously, parent accounts with no direct transactions but with child accounts that had transactions were being incorrectly filtered out. The fix ensures that when checking if an account has transactions, we also consider transactions from all its child (dependent) accounts.

## Testing

- [ ] Test trial balance sheet with nested accounts
- [ ] Verify accounts with child transactions are displayed when "Hide accounts with no transactions" is enabled
- [ ] Confirm correct balance calculations for parent accounts

## Related Issues

N/A

## Screenshots/Videos

N/A

## Checklist

- [ ] I have tested these changes locally
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)