### PR TITLE
fix(server): add permission guards to credit note and vendor credit controllers

### DIFF
--- a/packages/server/src/modules/CreditNoteRefunds/CreditNoteRefunds.controller.ts
+++ b/packages/server/src/modules/CreditNoteRefunds/CreditNoteRefunds.controller.ts
@@ -1,20 +1,35 @@
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
-import { Body, Controller, Delete, Get, Param, Post } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
 import { ICreditNoteRefundDTO } from '../CreditNotes/types/CreditNotes.types';
 import { CreditNotesRefundsApplication } from './CreditNotesRefundsApplication.service';
 import { RefundCreditNote } from './models/RefundCreditNote';
 import { CreditNoteRefundDto } from './dto/CreditNoteRefund.dto';
 import { ApiCommonHeaders } from '@/common/decorators/ApiCommonHeaders';
+import { RequirePermission } from '@/modules/Roles/RequirePermission.decorator';
+import { PermissionGuard } from '@/modules/Roles/Permission.guard';
+import { AuthorizationGuard } from '@/modules/Roles/Authorization.guard';
+import { AbilitySubject } from '@/modules/Roles/Roles.types';
+import { CreditNoteAction } from '../CreditNotes/types/CreditNotes.types';
 
 @Controller('credit-notes')
 @ApiTags('Credit Note Refunds')
 @ApiCommonHeaders()
+@UseGuards(AuthorizationGuard, PermissionGuard)
 export class CreditNoteRefundsController {
   constructor(
     private readonly creditNotesRefundsApplication: CreditNotesRefundsApplication,
   ) {}
 
   @Get(':creditNoteId/refunds')
+  @RequirePermission(CreditNoteAction.View, AbilitySubject.CreditNote)
   @ApiOperation({ summary: 'Retrieve the credit note graph.' })
   getCreditNoteRefunds(@Param('creditNoteId') creditNoteId: number) {
     return this.creditNotesRefundsApplication.getCreditNoteRefunds(
@@ -29,6 +44,7 @@ export class CreditNoteRefundsController {
    * @returns {Promise<RefundCreditNote>}
    */
   @Post(':creditNoteId/refunds')
+  @RequirePermission(CreditNoteAction.Refund, AbilitySubject.CreditNote)
   @ApiOperation({ summary: 'Create a refund for the given credit note.' })
   createRefundCreditNote(
     @Param('creditNoteId') creditNoteId: number,
@@ -46,6 +62,7 @@ export class CreditNoteRefundsController {
    * @returns {Promise<void>}
    */
   @Delete('refunds/:refundCreditId')
+  @RequirePermission(CreditNoteAction.Refund, AbilitySubject.CreditNote)
   @ApiOperation({ summary: 'Delete a refund for the given credit note.' })
   deleteRefundCreditNote(
     @Param('refundCreditId') refundCreditId: number,

--- a/packages/server/src/modules/CreditNotesApplyInvoice/CreditNotesApplyInvoice.controller.ts
+++ b/packages/server/src/modules/CreditNotesApplyInvoice/CreditNotesApplyInvoice.controller.ts
@@ -1,15 +1,31 @@
-import { Body, Controller, Get, Param, Post } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { GetCreditNoteAssociatedAppliedInvoices } from './queries/GetCreditNoteAssociatedAppliedInvoices.service';
+import { ApiCommonHeaders } from '@/common/decorators/ApiCommonHeaders';
+import { RequirePermission } from '@/modules/Roles/RequirePermission.decorator';
+import { PermissionGuard } from '@/modules/Roles/Permission.guard';
+import { AuthorizationGuard } from '@/modules/Roles/Authorization.guard';
+import { AbilitySubject } from '@/modules/Roles/Roles.types';
+import { CreditNoteAction } from '../CreditNotes/types/CreditNotes.types';
 
 @Controller('credit-notes')
 @ApiTags('Credit Notes Apply Invoice')
+@ApiCommonHeaders()
+@UseGuards(AuthorizationGuard, PermissionGuard)
 export class CreditNotesApplyInvoiceController {
   constructor(
     private readonly getCreditNoteAssociatedAppliedInvoicesService: GetCreditNoteAssociatedAppliedInvoices,
   ) {}
 
   @Get(':creditNoteId/applied-invoices')
+  @RequirePermission(CreditNoteAction.View, AbilitySubject.CreditNote)
   @ApiOperation({ summary: 'Applied credit note to invoices' })
   @ApiResponse({
     status: 200,
@@ -24,6 +40,7 @@ export class CreditNotesApplyInvoiceController {
   }
 
   @Post(':creditNoteId/apply-invoices')
+  @RequirePermission(CreditNoteAction.Edit, AbilitySubject.CreditNote)
   @ApiOperation({ summary: 'Apply credit note to invoices' })
   @ApiResponse({
     status: 200,

--- a/packages/server/src/modules/Roles/Authorization.guard.ts
+++ b/packages/server/src/modules/Roles/Authorization.guard.ts
@@ -31,9 +31,10 @@ export class AuthorizationGuard implements CanActivate {
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest<Request>();
     const { user } = request as any;
+    const userId = this.clsService.get('userId');
 
-    if (ABILITIES_CACHE.has(user.id)) {
-      (request as any).ability = ABILITIES_CACHE.get(user.id);
+    if (ABILITIES_CACHE.has(userId)) {
+      (request as any).ability = ABILITIES_CACHE.get(userId);
     } else {
       const ability = await this.getAbilityForUser();
       (request as any).ability = ability;

--- a/packages/server/src/modules/VendorCreditsApplyBills/VendorCreditApplyBills.controller.ts
+++ b/packages/server/src/modules/VendorCreditsApplyBills/VendorCreditApplyBills.controller.ts
@@ -1,16 +1,33 @@
-import { Body, Controller, Delete, Get, Param, Post } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
 import { VendorCreditApplyBillsApplicationService } from './VendorCreditApplyBillsApplication.service';
 import { IVendorCreditApplyToInvoicesDTO } from './types/VendorCreditApplyBills.types';
 import { ApiTags } from '@nestjs/swagger';
+import { ApiCommonHeaders } from '@/common/decorators/ApiCommonHeaders';
+import { RequirePermission } from '@/modules/Roles/RequirePermission.decorator';
+import { PermissionGuard } from '@/modules/Roles/Permission.guard';
+import { AuthorizationGuard } from '@/modules/Roles/Authorization.guard';
+import { AbilitySubject } from '@/modules/Roles/Roles.types';
+import { VendorCreditAction } from '../VendorCredit/types/VendorCredit.types';
 
 @Controller('vendor-credits')
 @ApiTags('Vendor Credits Apply Bills')
+@ApiCommonHeaders()
+@UseGuards(AuthorizationGuard, PermissionGuard)
 export class VendorCreditApplyBillsController {
   constructor(
     private readonly vendorCreditApplyBillsApplication: VendorCreditApplyBillsApplicationService,
   ) {}
 
   @Get(':vendorCreditId/bills-to-apply')
+  @RequirePermission(VendorCreditAction.View, AbilitySubject.VendorCredit)
   async getVendorCreditToApplyBills(
     @Param('vendorCreditId') vendorCreditId: number,
   ) {
@@ -20,6 +37,7 @@ export class VendorCreditApplyBillsController {
   }
 
   @Post(':vendorCreditId/apply-to-bills')
+  @RequirePermission(VendorCreditAction.Edit, AbilitySubject.VendorCredit)
   async applyVendorCreditToBills(
     @Param('vendorCreditId') vendorCreditId: number,
     @Body() applyCreditToBillsDTO: IVendorCreditApplyToInvoicesDTO,
@@ -31,6 +49,7 @@ export class VendorCreditApplyBillsController {
   }
 
   @Delete('applied-bills/:vendorCreditAppliedBillId')
+  @RequirePermission(VendorCreditAction.Edit, AbilitySubject.VendorCredit)
   async deleteAppliedBillToVendorCredit(
     @Param('vendorCreditAppliedBillId') vendorCreditAppliedBillId: number,
   ) {
@@ -40,6 +59,7 @@ export class VendorCreditApplyBillsController {
   }
 
   @Get(':vendorCreditId/applied-bills')
+  @RequirePermission(VendorCreditAction.View, AbilitySubject.VendorCredit)
   async getAppliedBillsToVendorCredit(
     @Param('vendorCreditId') vendorCreditId: number,
   ) {

--- a/packages/server/src/modules/VendorCreditsRefund/VendorCreditsRefund.controller.ts
+++ b/packages/server/src/modules/VendorCreditsRefund/VendorCreditsRefund.controller.ts
@@ -1,11 +1,27 @@
-import { Body, Controller, Delete, Get, Param, Post } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
 import { VendorCreditsRefundApplication } from './VendorCreditsRefund.application';
 import { RefundVendorCredit } from './models/RefundVendorCredit';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { RefundVendorCreditDto } from './dtos/RefundVendorCredit.dto';
+import { ApiCommonHeaders } from '@/common/decorators/ApiCommonHeaders';
+import { RequirePermission } from '@/modules/Roles/RequirePermission.decorator';
+import { PermissionGuard } from '@/modules/Roles/Permission.guard';
+import { AuthorizationGuard } from '@/modules/Roles/Authorization.guard';
+import { AbilitySubject } from '@/modules/Roles/Roles.types';
+import { VendorCreditAction } from '../VendorCredit/types/VendorCredit.types';
 
 @Controller('vendor-credits')
 @ApiTags('Vendor Credits Refunds')
+@ApiCommonHeaders()
+@UseGuards(AuthorizationGuard, PermissionGuard)
 export class VendorCreditsRefundController {
   constructor(
     private readonly vendorCreditsRefundApplication: VendorCreditsRefundApplication,
@@ -17,6 +33,7 @@ export class VendorCreditsRefundController {
    * @returns {Promise<IRefundVendorCreditPOJO[]>}
    */
   @Get(':vendorCreditId/refund')
+  @RequirePermission(VendorCreditAction.View, AbilitySubject.VendorCredit)
   @ApiOperation({ summary: 'Retrieve the vendor credit refunds graph.' })
   public getVendorCreditRefunds(
     @Param('vendorCreditId') vendorCreditId: string,
@@ -33,6 +50,7 @@ export class VendorCreditsRefundController {
    * @returns {Promise<RefundVendorCredit>}
    */
   @Post(':vendorCreditId/refund')
+  @RequirePermission(VendorCreditAction.Refund, AbilitySubject.VendorCredit)
   @ApiOperation({ summary: 'Create a refund for the given vendor credit.' })
   public async createRefundVendorCredit(
     @Param('vendorCreditId') vendorCreditId: string,
@@ -50,6 +68,7 @@ export class VendorCreditsRefundController {
    * @returns {Promise<void>}
    */
   @Delete('refunds/:refundCreditId')
+  @RequirePermission(VendorCreditAction.Refund, AbilitySubject.VendorCredit)
   @ApiOperation({ summary: 'Delete a refund for the given vendor credit.' })
   public async deleteRefundVendorCredit(
     @Param('refundCreditId') refundCreditId: string,


### PR DESCRIPTION
Add AuthorizationGuard and PermissionGuard to the following controllers:
- CreditNoteRefundsController
- CreditNotesApplyInvoiceController
- VendorCreditApplyBillsController
- VendorCreditsRefundController

Add @RequirePermission decorators with appropriate actions:
- View action for GET endpoints
- Edit action for POST/DELETE endpoints
- Refund action for refund-related operations

Also fixes AuthorizationGuard to use userId from clsService instead of user.id from request for consistency with the abilities cache.