### PR TITLE
fix: correct queue name, add missing await, and clean up constants

### DIFF
--- a/packages/server/src/modules/SaleEstimates/types/SaleEstimates.types.ts
+++ b/packages/server/src/modules/SaleEstimates/types/SaleEstimates.types.ts
@@ -9,7 +9,7 @@ import { CommonMailOptionsDTO } from '@/modules/MailNotification/MailNotificatio
 import { CommonMailOptions } from '@/modules/MailNotification/MailNotification.types';
 import { EditSaleEstimateDto } from '../dtos/SaleEstimate.dto';
 
-export const SendSaleEstimateMailQueue = 'SendSaleEstimateMailProcessor';
+export const SendSaleEstimateMailQueue = 'SendSaleEstimateMailQueue';
 export const SendSaleEstimateMailJob = 'SendSaleEstimateMailProcess';
 
 export interface ISaleEstimateDTO {

--- a/packages/server/src/modules/SaleInvoices/constants.ts
+++ b/packages/server/src/modules/SaleInvoices/constants.ts
@@ -1,8 +1,5 @@
-// import config from '@/config';
-
 export const SendSaleInvoiceQueue = 'SendSaleInvoiceQueue';
 export const SendSaleInvoiceMailJob = 'SendSaleInvoiceMailJob';
-
 
 export const DEFAULT_INVOICE_MAIL_SUBJECT =
 'Invoice {Invoice Number} from {Company Name} for {Customer Name}';

--- a/packages/server/src/modules/UsersModule/subscribers/InviteSendMailNotification.subscriber.ts
+++ b/packages/server/src/modules/UsersModule/subscribers/InviteSendMailNotification.subscriber.ts
@@ -37,7 +37,7 @@ export default class InviteSendMainNotificationSubscribe {
     const organizationId = tenant.organizationId;
     const userId = authedUser.id;
 
-    this.sendInviteMailQueue.add(SendInviteUserMailJob, {
+    await this.sendInviteMailQueue.add(SendInviteUserMailJob, {
       fromUser: invitingUser,
       invite,
       userId,


### PR DESCRIPTION
## Summary

This PR includes small fixes and cleanup for mail queue handling:

- Fix incorrect queue name constant in SaleEstimates.types.ts (`SendSaleEstimateMailProcessor` → `SendSaleEstimateMailQueue`)
- Add missing `await` for async queue operation in InviteSendMailNotification.subscriber.ts
- Remove commented import and extra blank line in SaleInvoices/constants.ts

## Changes

| File | Change |
|------|--------|
| `SaleEstimates.types.ts` | Fixed queue name constant |
| `InviteSendMailNotification.subscriber.ts` | Added missing `await` |
| `SaleInvoices/constants.ts` | Code cleanup |

pr_agent:summary
pr_agent:walkthrough