### PR TITLE
fix: correct cash flow transaction type naming inconsistencies

### DIFF
--- a/packages/server/src/modules/BankingTransactions/constants.ts
+++ b/packages/server/src/modules/BankingTransactions/constants.ts
@@ -27,7 +27,7 @@ export enum CASHFLOW_DIRECTION {
 }
 
 export enum CASHFLOW_TRANSACTION_TYPE {
-  ONWERS_DRAWING = 'OwnerDrawing',
+  OWNERS_DRAWING = 'OwnerDrawing',
   OWNER_CONTRIBUTION = 'OwnerContribution',
   OTHER_INCOME = 'OtherIncome',
   TRANSFER_FROM_ACCOUNT = 'TransferFromAccount',
@@ -36,7 +36,7 @@ export enum CASHFLOW_TRANSACTION_TYPE {
 }
 
 export const CASHFLOW_TRANSACTION_TYPE_META = {
-  [`${CASHFLOW_TRANSACTION_TYPE.ONWERS_DRAWING}`]: {
+  [`${CASHFLOW_TRANSACTION_TYPE.OWNERS_DRAWING}`]: {
     type: 'OwnerDrawing',
     direction: CASHFLOW_DIRECTION.OUT,
     creditType: [ACCOUNT_TYPE.EQUITY],

--- a/packages/webapp/src/constants/cashflowOptions.tsx
+++ b/packages/webapp/src/constants/cashflowOptions.tsx
@@ -19,7 +19,7 @@ export const getAddMoneyInOptions = () => [
 export const getAddMoneyOutOptions = () => [
   {
     name: intl.get('banking.owner_drawings'),
-    value: 'OwnerDrawing',
+    value: 'owner_drawing',
   },
   {
     name: intl.get('banking.expenses'),
@@ -31,11 +31,11 @@ export const getAddMoneyOutOptions = () => [
   },
 ];
 
-export const TRANSACRIONS_TYPE = [
+export const TRANSACTIONS_TYPE = [
   'OwnerContribution',
   'OtherIncome',
   'TransferFromAccount',
-  'OnwersDrawing',
+  'OwnerDrawing',
   'OtherExpense',
   'TransferToAccount',
 ];

--- a/packages/webapp/src/containers/CashFlow/CategorizeTransaction/drawers/CategorizeTransactionDrawer/CategorizeTransactionFormContent.tsx
+++ b/packages/webapp/src/containers/CashFlow/CategorizeTransaction/drawers/CategorizeTransactionDrawer/CategorizeTransactionFormContent.tsx
@@ -92,7 +92,7 @@ function CategorizeTransactionFormSubContent() {
   } else if (values.transactionType === 'transfer_to_account') {
     return <CategorizeTransactionToAccount />;
     // Owner drawings.
-  } else if (values.transactionType === 'OwnerDrawing') {
+  } else if (values.transactionType === 'owner_drawing') {
     return <CategorizeTransactionOwnerDrawings />;
   }
   return null;

--- a/packages/webapp/src/containers/CashFlow/MoneyInDialog/OtherIncome/OtherIncomeFormFields.tsx
+++ b/packages/webapp/src/containers/CashFlow/MoneyInDialog/OtherIncome/OtherIncomeFormFields.tsx
@@ -23,6 +23,8 @@ import {
   FFormGroup,
   FTextArea,
   FMoneyInputGroup,
+  Icon,
+  FDateInput,
 } from '@/components';
 import { CLASSES, ACCOUNT_TYPE, Features } from '@/constants';
 

--- a/packages/webapp/src/containers/CashFlow/MoneyInDialog/OwnerContribution/OwnerContributionFormFields.tsx
+++ b/packages/webapp/src/containers/CashFlow/MoneyInDialog/OwnerContribution/OwnerContributionFormFields.tsx
@@ -17,6 +17,7 @@ import {
   FTextArea,
   FInputGroup,
   FDateInput,
+  Icon,
 } from '@/components';
 import { ACCOUNT_TYPE, CLASSES, Features } from '@/constants';
 import {

--- a/packages/webapp/src/containers/CashFlow/MoneyInDialog/utils.tsx
+++ b/packages/webapp/src/containers/CashFlow/MoneyInDialog/utils.tsx
@@ -46,4 +46,8 @@ export const BranchRowDivider = styled.div`
   height: 1px;
   background: #ebf1f6;
   margin-bottom: 15px;
+
+  .bp4-dark & {
+    background: var(--color-dark-gray5);
+  }
 `;

--- a/packages/webapp/src/containers/CashFlow/MoneyOutDialog/MoneyOutContentFields.tsx
+++ b/packages/webapp/src/containers/CashFlow/MoneyOutDialog/MoneyOutContentFields.tsx
@@ -17,7 +17,7 @@ function MoneyOutContentFields() {
 
   const transactionType = useMemo(() => {
     switch (values.transaction_type) {
-      case 'OwnerDrawing':
+      case 'owner_drawing':
         return <OwnerDrawingsFormFields />;
 
       case 'other_expense':

--- a/packages/webapp/src/containers/CashFlow/MoneyOutDialog/utils.tsx
+++ b/packages/webapp/src/containers/CashFlow/MoneyOutDialog/utils.tsx
@@ -45,4 +45,8 @@ export const BranchRowDivider = styled.div`
   height: 1px;
   background: #ebf1f6;
   margin-bottom: 15px;
+
+  .bp4-dark & {
+    background: var(--color-dark-gray5);
+  }
 `;


### PR DESCRIPTION
- Fix typo ONWERS_DRAWING -> OWNERS_DRAWING in server constants
- Change OwnerDrawing -> owner_drawing for consistency in webapp
- Fix typo TRANSACRIONS_TYPE -> TRANSACTIONS_TYPE
- Fix typo OnwersDrawing -> OwnerDrawing
- Add missing Icon and FDateInput imports
- Add dark mode styling for BranchRowDivider

Co-Authored-By: Claude Code <noreply@anthropic.com>
