### PR TITLE
fix: correct config key for base URL in email services

### DIFF
--- a/packages/server/src/modules/Auth/AuthMailMessages.esrvice.ts
+++ b/packages/server/src/modules/Auth/AuthMailMessages.esrvice.ts
@@ -20,7 +20,7 @@ export class AuthenticationMailMesssages {
    * @returns {Mail}
    */
   resetPasswordMessage(user: ModelObject<SystemUser>, token: string) {
-    const baseURL = this.configService.get('baseURL');
+    const baseURL = this.configService.get('app.baseUrl');
 
     return new Mail()
       .setSubject('Bigcapital - Password Reset')
@@ -54,7 +54,7 @@ export class AuthenticationMailMesssages {
    * @returns {Mail}
    */
   signupVerificationMail(email: string, fullName: string, token: string) {
-    const baseURL = this.configService.get('baseURL');
+    const baseURL = this.configService.get('app.baseUrl');
     const verifyUrl = `${baseURL}/auth/email_confirmation?token=${token}&email=${email}`;
 
     return new Mail()

--- a/packages/server/src/modules/UsersModule/commands/SendInviteUsersMailMessage.service.ts
+++ b/packages/server/src/modules/UsersModule/commands/SendInviteUsersMailMessage.service.ts
@@ -28,7 +28,7 @@ export class SendInviteUsersMailMessage {
   ) {
     const tenant = await this.tenancyContext.getTenant(true);
     const root = path.join(global.__images_dirname, '/bigcapital.png');
-    const baseURL = this.configService.get('baseURL');
+    const baseURL = this.configService.get('app.baseUrl');
 
     const mail = new Mail()
       .setSubject(`${fromUser.firstName} has invited you to join a Bigcapital`)


### PR DESCRIPTION
## Summary

Fixes #966 - Undefined URL when clicking "Accept Invitation" and "Verify Email Address" buttons in emails.

The config key used to retrieve the base URL was incorrect. The config is registered as \`app.baseUrl\` (namespace + camelCase) but the code was using \`baseURL\`.

## Changes

- \`SendInviteUsersMailMessage.service.ts\`: Changed config key from \`baseURL\` to \`app.baseUrl\`
- \`AuthMailMessages.esrvice.ts\`: Changed config key from \`baseURL\` to \`app.baseUrl\` in two locations

This fixes the undefined URL in:
- "Accept Invitation" emails
- "Verify Email Address" emails  
- Password reset emails

## Test plan

- [ ] Send user invitation email and verify the "Accept Invitation" link works
- [ ] Sign up a new user and verify the "Verify Email Address" link works
- [ ] Request password reset and verify the reset link works

🤖 Generated with [Claude Code](https://claude.com/claude-code)