### PR TITLE
fix(server): localize hardcoded strings in financial reports

### DIFF
--- a/packages/server/src/i18n/en/cash_flow_statement.json
+++ b/packages/server/src/i18n/en/cash_flow_statement.json
@@ -9,5 +9,10 @@
   "net_cash_financing": "Net cash provided by financing activities",
   "cash_beginning_period": "Cash at beginning of period",
   "net_cash_increase": "NET CASH INCREASE FOR PERIOD",
-  "cash_end_period": "CASH AT END OF PERIOD"
+  "cash_end_period": "CASH AT END OF PERIOD",
+  "account_name": "Account name",
+  "total": "Total",
+  "sheet_name": "Statement of Cash Flow",
+  "from_date": "From",
+  "to_date": "To"
 }

--- a/packages/server/src/i18n/en/contact_summary_balance.json
+++ b/packages/server/src/i18n/en/contact_summary_balance.json
@@ -1,0 +1,5 @@
+{
+  "account_name": "Account name",
+  "total": "Total",
+  "percentage_column": "% of Column"
+}

--- a/packages/server/src/i18n/en/inventory_item_details.json
+++ b/packages/server/src/i18n/en/inventory_item_details.json
@@ -1,0 +1,14 @@
+{
+  "opening_balance": "Opening balance",
+  "closing_balance": "Closing balance",
+  "date": "Date",
+  "transaction_type": "Transaction type",
+  "transaction_number": "Transaction #",
+  "quantity": "Quantity",
+  "rate": "Rate",
+  "total": "Total",
+  "value": "Value",
+  "profit_margin": "Profit Margin",
+  "running_quantity": "Running quantity",
+  "running_value": "Running Value"
+}

--- a/packages/server/src/i18n/en/transactions_by_contact.json
+++ b/packages/server/src/i18n/en/transactions_by_contact.json
@@ -1,0 +1,4 @@
+{
+  "opening_balance": "Opening balance",
+  "closing_balance": "Closing balance"
+}

--- a/packages/server/src/i18n/en/trial_balance_sheet.json
+++ b/packages/server/src/i18n/en/trial_balance_sheet.json
@@ -1,0 +1,6 @@
+{
+  "account": "Account",
+  "debit": "Debit",
+  "credit": "Credit",
+  "total": "Total"
+}

--- a/packages/server/src/modules/FinancialStatements/modules/CashFlowStatement/CashFlowTable.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/CashFlowStatement/CashFlowTable.ts
@@ -239,7 +239,7 @@ export class CashFlowTable {
     section: ICashFlowStatementSection,
   ): ICashFlowStatementSection => {
     const label = section.footerLabel
-      ? section.footerLabel
+      ? this.i18n.t(section.footerLabel)
       : this.i18n.t('financial_sheet.total_row', {
           args: { value: section.label },
         });
@@ -302,7 +302,7 @@ export class CashFlowTable {
    * @returns {ITableColumn}
    */
   private totalColumns = (): ITableColumn[] => {
-    return [{ key: 'total', label: this.i18n.t('Total') }];
+    return [{ key: 'total', label: this.i18n.t('cash_flow_statement.total') }];
   };
 
   /**
@@ -366,7 +366,7 @@ export class CashFlowTable {
    */
   public tableColumns = (): ITableColumn[] => {
     return R.compose(
-      R.concat([{ key: 'name', label: this.i18n.t('Account name') }]),
+      R.concat([{ key: 'name', label: this.i18n.t('cash_flow_statement.account_name') }]),
       R.when(
         R.always(this.isDisplayColumnsBy(DISPLAY_COLUMNS_BY.DATE_PERIODS)),
         R.concat(this.datePeriodsColumns()),

--- a/packages/server/src/modules/FinancialStatements/modules/CashFlowStatement/CashflowSheetMeta.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/CashFlowStatement/CashflowSheetMeta.ts
@@ -1,5 +1,6 @@
 import * as moment from 'moment';
 import { Injectable } from '@nestjs/common';
+import { I18nService } from 'nestjs-i18n';
 import { FinancialSheetMeta } from '../../common/FinancialSheetMeta';
 import {
   ICashFlowStatementMeta,
@@ -8,7 +9,10 @@ import {
 
 @Injectable()
 export class CashflowSheetMeta {
-  constructor(private readonly financialSheetMeta: FinancialSheetMeta) {}
+  constructor(
+    private readonly financialSheetMeta: FinancialSheetMeta,
+    private readonly i18n: I18nService,
+  ) {}
 
   /**
    * Cashflow sheet meta.
@@ -21,9 +25,11 @@ export class CashflowSheetMeta {
     const meta = await this.financialSheetMeta.meta();
     const formattedToDate = moment(query.toDate).format('YYYY/MM/DD');
     const formattedFromDate = moment(query.fromDate).format('YYYY/MM/DD');
-    const formattedDateRange = `From ${formattedFromDate} | To ${formattedToDate}`;
+    const fromLabel = this.i18n.t('cash_flow_statement.from_date');
+    const toLabel = this.i18n.t('cash_flow_statement.to_date');
+    const formattedDateRange = `${fromLabel} ${formattedFromDate} | ${toLabel} ${formattedToDate}`;
 
-    const sheetName = 'Statement of Cash Flow';
+    const sheetName = this.i18n.t('cash_flow_statement.sheet_name');
 
     return {
       ...meta,

--- a/packages/server/src/modules/FinancialStatements/modules/CustomerBalanceSummary/CustomerBalanceSummaryTableRows.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/CustomerBalanceSummary/CustomerBalanceSummaryTableRows.ts
@@ -91,7 +91,7 @@ export class CustomerBalanceSummaryTable {
    */
   private getTotalColumnsAccessor = (): IColumnMapperMeta[] => {
     const columns = [
-      { key: 'name', value: this.i18n.t('Total') },
+      { key: 'name', value: this.i18n.t('contact_summary_balance.total') },
       { key: 'total', accessor: 'total.formattedAmount' },
     ];
     // @ts-ignore

--- a/packages/server/src/modules/FinancialStatements/modules/InventoryItemDetails/InventoryItemDetailsTable.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/InventoryItemDetails/InventoryItemDetailsTable.ts
@@ -93,7 +93,7 @@ export class InventoryItemDetailsTable {
   ): ITableRow => {
     const columns: Array<IColumnMapperMeta> = [
       { key: 'date', accessor: 'date.formattedDate' },
-      { key: 'closing', value: this.i18n.t('Opening balance') },
+      { key: 'closing', value: this.i18n.t('inventory_item_details.opening_balance') },
       { key: 'empty', value: '' },
       { key: 'quantity', accessor: 'quantity.formattedNumber' },
       { key: 'empty', value: '' },
@@ -115,7 +115,7 @@ export class InventoryItemDetailsTable {
   ): ITableRow => {
     const columns: Array<IColumnMapperMeta> = [
       { key: 'date', accessor: 'date.formattedDate' },
-      { key: 'closing', value: this.i18n.t('Closing balance') },
+      { key: 'closing', value: this.i18n.t('inventory_item_details.closing_balance') },
       { key: 'empty', value: '' },
       { key: 'quantity', accessor: 'quantity.formattedNumber' },
       { key: 'empty', value: '' },
@@ -193,16 +193,16 @@ export class InventoryItemDetailsTable {
    */
   public tableColumns = (): ITableColumn[] => {
     return [
-      { key: 'date', label: this.i18n.t('Date') },
-      { key: 'transaction_type', label: this.i18n.t('Transaction type') },
-      { key: 'transaction_id', label: this.i18n.t('Transaction #') },
-      { key: 'quantity', label: this.i18n.t('Quantity') },
-      { key: 'rate', label: this.i18n.t('Rate') },
-      { key: 'total', label: this.i18n.t('Total') },
-      { key: 'value', label: this.i18n.t('Value') },
-      { key: 'profit_margin', label: this.i18n.t('Profit Margin') },
-      { key: 'running_quantity', label: this.i18n.t('Running quantity') },
-      { key: 'running_value', label: this.i18n.t('Running Value') },
+      { key: 'date', label: this.i18n.t('inventory_item_details.date') },
+      { key: 'transaction_type', label: this.i18n.t('inventory_item_details.transaction_type') },
+      { key: 'transaction_id', label: this.i18n.t('inventory_item_details.transaction_number') },
+      { key: 'quantity', label: this.i18n.t('inventory_item_details.quantity') },
+      { key: 'rate', label: this.i18n.t('inventory_item_details.rate') },
+      { key: 'total', label: this.i18n.t('inventory_item_details.total') },
+      { key: 'value', label: this.i18n.t('inventory_item_details.value') },
+      { key: 'profit_margin', label: this.i18n.t('inventory_item_details.profit_margin') },
+      { key: 'running_quantity', label: this.i18n.t('inventory_item_details.running_quantity') },
+      { key: 'running_value', label: this.i18n.t('inventory_item_details.running_value') },
     ];
   };
 }

--- a/packages/server/src/modules/FinancialStatements/modules/TransactionsByContact/TransactionsByContactTableRows.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/TransactionsByContact/TransactionsByContactTableRows.ts
@@ -52,7 +52,7 @@ export class TransactionsByContactsTableRows {
     const columns = [
       {
         key: 'openingBalanceLabel',
-        value: this.i18n.t('Opening balance') as string,
+        value: this.i18n.t('transactions_by_contact.opening_balance') as string,
       },
       ...R.repeat({ key: 'empty', value: '' }, 5),
       {
@@ -76,7 +76,7 @@ export class TransactionsByContactsTableRows {
     const columns = [
       {
         key: 'closingBalanceLabel',
-        value: this.i18n.t('Closing balance') as string,
+        value: this.i18n.t('transactions_by_contact.closing_balance') as string,
       },
       ...R.repeat({ key: 'empty', value: '' }, 5),
       {

--- a/packages/server/src/modules/FinancialStatements/modules/TrialBalanceSheet/TrialBalanceSheetTable.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/TrialBalanceSheet/TrialBalanceSheetTable.ts
@@ -141,10 +141,10 @@ export class TrialBalanceSheetTable extends R.compose(
     return R.compose(
       this.tableColumnsCellIndexing,
       R.concat([
-        { key: 'account', label: 'Account' },
-        { key: 'debit', label: 'Debit' },
-        { key: 'credit', label: 'Credit' },
-        { key: 'total', label: 'Total' },
+        { key: 'account', label: this.i18n.t('trial_balance_sheet.account') },
+        { key: 'debit', label: this.i18n.t('trial_balance_sheet.debit') },
+        { key: 'credit', label: this.i18n.t('trial_balance_sheet.credit') },
+        { key: 'total', label: this.i18n.t('trial_balance_sheet.total') },
       ]),
     )([]);
   };

--- a/packages/server/src/modules/FinancialStatements/modules/VendorBalanceSummary/VendorBalanceSummaryTableRows.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/VendorBalanceSummary/VendorBalanceSummaryTableRows.ts
@@ -91,7 +91,7 @@ export class VendorBalanceSummaryTable {
    */
   private getTotalColumnsAccessor = (): IColumnMapperMeta[] => {
     const columns = [
-      { key: 'name', value: this.i18n.t('Total') },
+      { key: 'name', value: this.i18n.t('contact_summary_balance.total') },
       { key: 'total', accessor: 'total.formattedAmount' },
     ];
     return R.compose(


### PR DESCRIPTION
## Summary

This PR fixes multiple localization issues in financial reports where hardcoded English strings were used instead of translatable keys.

### Changes Made

#### Cash Flow Statement
- Fixed \`net_cash_investing\` not being localized in the footer label
- Added translation keys for: account_name, total, sheet_name, from_date, to_date
- Localized sheet name and date range formatting in CashflowSheetMeta

#### New Translation Files Created
- \`contact_summary_balance.json\` - For Customer/Vendor Balance Summary
- \`trial_balance_sheet.json\` - For Trial Balance Sheet columns  
- \`inventory_item_details.json\` - For Inventory Item Details
- \`transactions_by_contact.json\` - For Transactions by Contact

#### Fixed Hardcoded Strings
- TrialBalanceSheetTable: Account, Debit, Credit, Total column labels
- CustomerBalanceSummaryTableRows: Total row label
- VendorBalanceSummaryTableRows: Total row label
- InventoryItemDetailsTable: All column headers (Date, Transaction type, Quantity, etc.)
- TransactionsByContactTableRows: Opening/Closing balance labels

## Test plan
- [ ] Verify Cash Flow Statement displays localized labels correctly
- [ ] Verify Trial Balance Sheet columns are localized
- [ ] Verify Inventory Item Details columns are localized
- [ ] Verify Customer/Vendor Balance Summary total row is localized
- [ ] Verify Transactions by Contact opening/closing balance labels are localized

🤖 Generated with [Claude Code](https://claude.com/claude-code)