### PR TITLE
fix(organization): align date formats and fix address field naming

### DIFF
--- a/packages/server/src/modules/Organization/Organization.constants.ts
+++ b/packages/server/src/modules/Organization/Organization.constants.ts
@@ -1,18 +1,15 @@
 import currencies from 'js-money/lib/currency';
 
 export const DATE_FORMATS = [
-  'MM.dd.yy',
-  'dd.MM.yy',
-  'yy.MM.dd',
-  'MM.dd.yyyy',
-  'dd.MM.yyyy',
-  'yyyy.MM.dd',
-  'MM/DD/YYYY',
-  'M/D/YYYY',
-  'dd MMM YYYY',
-  'dd MMMM YYYY',
-  'MMMM dd, YYYY',
-  'EEE, MMMM dd, YYYY',
+  'MM/DD/YY',
+  'DD/MM/YY',
+  'YY/MM/DD',
+  'MM/DD/yyyy',
+  'DD/MM/yyyy',
+  'yyyy/MM/DD',
+  'DD MMM YYYY',
+  'DD MMMM YYYY',
+  'MMMM DD, YYYY',
 ];
 export const MONTHS = [
   'january',

--- a/packages/server/src/modules/Organization/Organization.utils.ts
+++ b/packages/server/src/modules/Organization/Organization.utils.ts
@@ -12,6 +12,6 @@ export const transformBuildDto = (
 ): BuildOrganizationDto => {
   return {
     ...buildDTO,
-    dateFormat: defaultTo(buildDTO.dateFormat, 'DD MMM yyyy'),
+    dateFormat: defaultTo(buildDTO.dateFormat, 'DD MMM YYYY'),
   };
 };

--- a/packages/webapp/src/containers/Preferences/General/GeneralForm.tsx
+++ b/packages/webapp/src/containers/Preferences/General/GeneralForm.tsx
@@ -111,12 +111,12 @@ export default function PreferencesGeneralForm({ isSubmitting }) {
       >
         <Stack>
           <FInputGroup
-            name={'address.address_1'}
+            name={'address.address1'}
             placeholder={'Address 1'}
             fastField
           />
           <FInputGroup
-            name={'address.address_2'}
+            name={'address.address2'}
             placeholder={'Address 2'}
             fastField
           />


### PR DESCRIPTION
## Summary

This PR fixes three related issues with organization preferences:

1. **Date format validation mismatch**: The frontend fetched date formats from `/date-formats` (using `Miscellaneous.constants.ts`) with formats like `'MM/DD/YY'`, but the backend DTO validation used `Organization.constants.ts` with different formats like `'MM/DD/YYYY'` and `'MM.dd.yy'`. This caused validation errors when users tried to update their organization.

2. **Default date format casing issue**: The default date format in `Organization.utils.ts` was `'DD MMM yyyy'` (lowercase), but the valid format in `DATE_FORMATS` is `'DD MMM YYYY'` (uppercase). This caused the initial date format value to not be selected when editing organization preferences.

3. **Address field naming inconsistency**: Renamed address fields from `address_1`/`address_2` to `address1`/`address2` in the General preferences form for consistency.

## Changes

- `packages/server/src/modules/Organization/Organization.constants.ts`: Updated `DATE_FORMATS` to match `Miscellaneous.constants.ts`
- `packages/server/src/modules/Organization/Organization.utils.ts`: Fixed default date format casing
- `packages/webapp/src/containers/Preferences/General/GeneralForm.tsx`: Renamed address fields

## Test plan

- [ ] Build organization with initial setup and verify date format is saved correctly
- [ ] Edit organization preferences and verify date format dropdown shows saved value
- [ ] Verify address fields save and load correctly in preferences form
- [ ] Verify PUT /organization endpoint accepts date formats from the dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)