### PR TITLE
fix(financial-statements): use stored date format settings in all reports

### DIFF
--- a/packages/server/src/modules/FinancialStatements/common/FinancialSheet.ts
+++ b/packages/server/src/modules/FinancialStatements/common/FinancialSheet.ts
@@ -15,6 +15,7 @@ export class FinancialSheet {
     negativeFormat: 'mines',
   };
   public baseCurrency: string;
+  public dateFormat: string = 'YYYY MMM DD';
 
   /**
    * Transformes the number format query to settings
@@ -140,9 +141,10 @@ export class FinancialSheet {
    * @param {string} format
    * @returns
    */
-  protected getDateMeta(date: moment.MomentInput, format = 'YYYY-MM-DD') {
+  protected getDateMeta(date: moment.MomentInput, format?: string) {
+    const dateFormat = format || this.dateFormat || 'YYYY MMM DD';
     return {
-      formattedDate: moment(date).format(format),
+      formattedDate: moment(date).format(dateFormat),
       date: moment(date).toDate(),
     };
   }

--- a/packages/server/src/modules/FinancialStatements/modules/APAgingSummary/APAgingSummaryService.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/APAgingSummary/APAgingSummaryService.ts
@@ -32,17 +32,18 @@ export class APAgingSummaryService {
     this.APAgingSummaryRepository.setFilter(filter);
     await this.APAgingSummaryRepository.load();
 
+    // Retrieve the aging summary report meta first to get date format.
+    const meta = await this.APAgingSummaryMeta.meta(filter);
+
     // A/P aging summary report instance.
     const APAgingSummaryReport = new APAgingSummarySheet(
       filter,
       this.APAgingSummaryRepository,
+      { baseCurrency: meta.baseCurrency, dateFormat: meta.dateFormat },
     );
     // A/P aging summary report data and columns.
     const data = APAgingSummaryReport.reportData();
     const columns = APAgingSummaryReport.reportColumns();
-
-    // Retrieve the aging summary report meta.
-    const meta = await this.APAgingSummaryMeta.meta(filter);
 
     // Triggers `onPayableAgingViewed` event.
     await this.eventPublisher.emitAsync(events.reports.onPayableAgingViewed, {

--- a/packages/server/src/modules/FinancialStatements/modules/APAgingSummary/APAgingSummarySheet.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/APAgingSummary/APAgingSummarySheet.ts
@@ -14,6 +14,7 @@ import { allPassedConditionsPass } from '@/utils/all-conditions-passed';
 import { APAgingSummaryRepository } from './APAgingSummaryRepository';
 import { Bill } from '@/modules/Bills/models/Bill';
 import { APAgingSummaryQueryDto } from './APAgingSummaryQuery.dto';
+import { IFinancialReportMeta, DEFAULT_REPORT_META } from '../../types/Report.types';
 
 export class APAgingSummarySheet extends AgingSummaryReport {
   readonly repository: APAgingSummaryRepository;
@@ -31,12 +32,14 @@ export class APAgingSummarySheet extends AgingSummaryReport {
   constructor(
     query: APAgingSummaryQueryDto,
     repository: APAgingSummaryRepository,
+    meta: IFinancialReportMeta,
   ) {
     super();
 
     this.query = query;
     this.repository = repository;
     this.numberFormat = this.query.numberFormat;
+    this.dateFormat = meta.dateFormat || DEFAULT_REPORT_META.dateFormat;
 
     this.overdueInvoicesByContactId = this.repository.overdueBillsByVendorId;
     this.currentInvoicesByContactId = this.repository.dueBillsByVendorId;

--- a/packages/server/src/modules/FinancialStatements/modules/ARAgingSummary/ARAgingSummaryService.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/ARAgingSummary/ARAgingSummaryService.ts
@@ -28,17 +28,18 @@ export class ARAgingSummaryService {
     this.ARAgingSummaryRepository.setFilter(filter);
     await this.ARAgingSummaryRepository.load();
 
+    // Retrieve the aging summary report meta first to get date format.
+    const meta = await this.ARAgingSummaryMeta.meta(filter);
+
     // A/R aging summary report instance.
     const ARAgingSummaryReport = new ARAgingSummarySheet(
       filter,
       this.ARAgingSummaryRepository,
+      { baseCurrency: meta.baseCurrency, dateFormat: meta.dateFormat },
     );
     // A/R aging summary report data and columns.
     const data = ARAgingSummaryReport.reportData();
     const columns = ARAgingSummaryReport.reportColumns();
-
-    // Retrieve the aging summary report meta.
-    const meta = await this.ARAgingSummaryMeta.meta(filter);
 
     // Triggers `onReceivableAgingViewed` event.
     await this.eventPublisher.emitAsync(

--- a/packages/server/src/modules/FinancialStatements/modules/ARAgingSummary/ARAgingSummarySheet.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/ARAgingSummary/ARAgingSummarySheet.ts
@@ -14,6 +14,7 @@ import { ARAgingSummaryRepository } from './ARAgingSummaryRepository';
 import { Customer } from '@/modules/Customers/models/Customer';
 import { SaleInvoice } from '@/modules/SaleInvoices/models/SaleInvoice';
 import { ARAgingSummaryQueryDto } from './ARAgingSummaryQuery.dto';
+import { IFinancialReportMeta, DEFAULT_REPORT_META } from '../../types/Report.types';
 
 export class ARAgingSummarySheet extends AgingSummaryReport {
   readonly query: ARAgingSummaryQueryDto;
@@ -32,16 +33,19 @@ export class ARAgingSummarySheet extends AgingSummaryReport {
    * Constructor method.
    * @param {ARAgingSummaryQueryDto} query - Query
    * @param {ARAgingSummaryRepository} repository - Repository.
+   * @param {IFinancialReportMeta} meta - Report meta.
    */
   constructor(
     query: ARAgingSummaryQueryDto,
     repository: ARAgingSummaryRepository,
+    meta: IFinancialReportMeta,
   ) {
     super();
 
     this.query = query;
     this.repository = repository;
     this.numberFormat = this.query.numberFormat;
+    this.dateFormat = meta.dateFormat || DEFAULT_REPORT_META.dateFormat;
 
     this.overdueInvoicesByContactId =
       this.repository.overdueInvoicesByContactId;

--- a/packages/server/src/modules/FinancialStatements/modules/AgingSummary/AgingSummaryMeta.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/AgingSummary/AgingSummaryMeta.ts
@@ -13,7 +13,7 @@ export class AgingSummaryMeta {
    */
   public async meta(query: IAgingSummaryQuery): Promise<IAgingSummaryMeta> {
     const commonMeta = await this.financialSheetMeta.meta();
-    const formattedAsDate = moment(query.asDate).format('YYYY/MM/DD');
+    const formattedAsDate = moment(query.asDate).format(commonMeta.dateFormat);
     const formattedDateRange = `As ${formattedAsDate}`;
 
     return {

--- a/packages/server/src/modules/FinancialStatements/modules/BalanceSheet/BalanceSheet.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/BalanceSheet/BalanceSheet.ts
@@ -19,7 +19,7 @@ import { BalanceSheetFiltering } from './BalanceSheetFiltering';
 import { BalanceSheetNetIncome } from './BalanceSheetNetIncome';
 import { BalanceSheetAggregators } from './BalanceSheetAggregators';
 import { BalanceSheetAccounts } from './BalanceSheetAccounts';
-import { INumberFormatQuery } from '../../types/Report.types';
+import { INumberFormatQuery, IFinancialReportMeta, DEFAULT_REPORT_META } from '../../types/Report.types';
 import { FinancialSheet } from '../../common/FinancialSheet';
 
 export class BalanceSheet extends R.pipe(
@@ -66,21 +66,23 @@ export class BalanceSheet extends R.pipe(
   /**
    * Constructor method.
    * @param {IBalanceSheetQuery} query -
-   * @param {IAccount[]} accounts -
-   * @param {string} baseCurrency -
+   * @param {BalanceSheetRepository} repository -
+   * @param {I18nService} i18n -
+   * @param {IFinancialReportMeta} meta -
    */
   constructor(
     query: IBalanceSheetQuery,
     repository: BalanceSheetRepository,
-    baseCurrency: string,
     i18n: I18nService,
+    meta: IFinancialReportMeta,
   ) {
     super();
 
     this.query = new BalanceSheetQuery(query);
     this.repository = repository;
-    this.baseCurrency = baseCurrency;
+    this.baseCurrency = meta.baseCurrency;
     this.numberFormat = this.query.query.numberFormat;
+    this.dateFormat = meta.dateFormat || DEFAULT_REPORT_META.dateFormat;
     this.i18n = i18n;
   }
 

--- a/packages/server/src/modules/FinancialStatements/modules/BalanceSheet/BalanceSheetInjectable.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/BalanceSheet/BalanceSheetInjectable.ts
@@ -40,18 +40,18 @@ export class BalanceSheetInjectable {
     // Loads all resources.
     await this.balanceSheetRepository.asyncInitialize(filter);
 
+    // Balance sheet meta first to get date format.
+    const meta = await this.balanceSheetMeta.meta(filter);
+
     // Balance sheet report instance.
     const balanceSheetInstanace = new BalanceSheet(
       filter,
       this.balanceSheetRepository,
-      tenantMetadata.baseCurrency,
       this.i18n,
+      { baseCurrency: tenantMetadata.baseCurrency, dateFormat: meta.dateFormat },
     );
     // Balance sheet data.
     const data = balanceSheetInstanace.reportData();
-
-    // Balance sheet meta.
-    const meta = await this.balanceSheetMeta.meta(filter);
 
     // Triggers `onBalanceSheetViewed` event.
     await this.eventPublisher.emitAsync(events.reports.onBalanceSheetViewed, {

--- a/packages/server/src/modules/FinancialStatements/modules/BalanceSheet/BalanceSheetMeta.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/BalanceSheet/BalanceSheetMeta.ts
@@ -13,7 +13,7 @@ export class BalanceSheetMetaInjectable {
    */
   public async meta(query: IBalanceSheetQuery): Promise<IBalanceSheetMeta> {
     const commonMeta = await this.financialSheetMeta.meta();
-    const formattedAsDate = moment(query.toDate).format('YYYY/MM/DD');
+    const formattedAsDate = moment(query.toDate).format(commonMeta.dateFormat);
     const formattedDateRange = `As ${formattedAsDate}`;
     const sheetName = 'Balance Sheet Statement';
 

--- a/packages/server/src/modules/FinancialStatements/modules/CashFlowStatement/CashFlow.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/CashFlowStatement/CashFlow.ts
@@ -27,7 +27,7 @@ import { DISPLAY_COLUMNS_BY } from './constants';
 import { FinancialSheetStructure } from '../../common/FinancialSheetStructure';
 import { Account } from '@/modules/Accounts/models/Account.model';
 import { ILedger } from '@/modules/Ledger/types/Ledger.types';
-import { INumberFormatQuery } from '../../types/Report.types';
+import { INumberFormatQuery, IFinancialReportMeta, DEFAULT_REPORT_META } from '../../types/Report.types';
 import { transformToMapBy } from '@/utils/transform-to-map-by';
 import { accumSum } from '@/utils/accum-sum';
 import { ModelObject } from 'objection';
@@ -62,12 +62,12 @@ export class CashFlowStatement extends R.pipe(
     cashLedger: ILedger,
     netIncomeLedger: ILedger,
     query: ICashFlowStatementQuery,
-    baseCurrency: string,
     i18n: I18nService,
+    meta: IFinancialReportMeta,
   ) {
     super();
 
-    this.baseCurrency = baseCurrency;
+    this.baseCurrency = meta.baseCurrency;
     this.i18n = i18n;
     this.ledger = ledger;
     this.cashLedger = cashLedger;
@@ -76,6 +76,7 @@ export class CashFlowStatement extends R.pipe(
     this.accountsByRootType = transformToMapBy(accounts, 'accountRootType');
     this.query = query;
     this.numberFormat = this.query.numberFormat;
+    this.dateFormat = meta.dateFormat || DEFAULT_REPORT_META.dateFormat;
     this.dateRangeSet = [];
     this.comparatorDateType =
       query.displayColumnsType === 'total' ? 'day' : query.displayColumnsBy;

--- a/packages/server/src/modules/FinancialStatements/modules/CashFlowStatement/CashFlowService.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/CashFlowStatement/CashFlowService.ts
@@ -85,6 +85,9 @@ export class CashFlowStatementService {
     const cashLedger = Ledger.fromTransactions(cashAtBeginningTransactions);
     const netIncomeLedger = Ledger.fromTransactions(netIncome);
 
+    // Retrieve the cashflow sheet meta first to get date format.
+    const meta = await this.cashflowSheetMeta.meta(filter);
+
     // Cash flow statement.
     const cashFlowInstance = new CashFlowStatement(
       accounts,
@@ -92,11 +95,9 @@ export class CashFlowStatementService {
       cashLedger,
       netIncomeLedger,
       filter,
-      tenant.metadata.baseCurrency,
       this.i18n,
+      { baseCurrency: tenant.metadata.baseCurrency, dateFormat: meta.dateFormat },
     );
-    // Retrieve the cashflow sheet meta.
-    const meta = await this.cashflowSheetMeta.meta(filter);
 
     return {
       data: cashFlowInstance.reportData(),

--- a/packages/server/src/modules/FinancialStatements/modules/CashFlowStatement/CashflowSheetMeta.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/CashFlowStatement/CashflowSheetMeta.ts
@@ -23,8 +23,8 @@ export class CashflowSheetMeta {
     query: ICashFlowStatementQuery,
   ): Promise<ICashFlowStatementMeta> {
     const meta = await this.financialSheetMeta.meta();
-    const formattedToDate = moment(query.toDate).format('YYYY/MM/DD');
-    const formattedFromDate = moment(query.fromDate).format('YYYY/MM/DD');
+    const formattedToDate = moment(query.toDate).format(meta.dateFormat);
+    const formattedFromDate = moment(query.fromDate).format(meta.dateFormat);
     const fromLabel = this.i18n.t('cash_flow_statement.from_date');
     const toLabel = this.i18n.t('cash_flow_statement.to_date');
     const formattedDateRange = `${fromLabel} ${formattedFromDate} | ${toLabel} ${formattedToDate}`;

--- a/packages/server/src/modules/FinancialStatements/modules/CustomerBalanceSummary/CustomerBalanceSummary.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/CustomerBalanceSummary/CustomerBalanceSummary.ts
@@ -8,7 +8,7 @@ import {
 import { ContactBalanceSummaryReport } from '../ContactBalanceSummary/ContactBalanceSummary';
 import { ILedger } from '@/modules/Ledger/types/Ledger.types';
 import { ModelObject } from 'objection';
-import { INumberFormatQuery } from '../../types/Report.types';
+import { INumberFormatQuery, IFinancialReportMeta, DEFAULT_REPORT_META } from '../../types/Report.types';
 import { Customer } from '@/modules/Customers/models/Customer';
 
 export class CustomerBalanceSummaryReport extends ContactBalanceSummaryReport {
@@ -23,21 +23,22 @@ export class CustomerBalanceSummaryReport extends ContactBalanceSummaryReport {
    * @param {IJournalPoster} receivableLedger
    * @param {ICustomer[]} customers
    * @param {ICustomerBalanceSummaryQuery} filter
-   * @param {string} baseCurrency
+   * @param {IFinancialReportMeta} meta
    */
   constructor(
     ledger: ILedger,
     customers: ModelObject<Customer>[],
     filter: ICustomerBalanceSummaryQuery,
-    baseCurrency: string
+    meta: IFinancialReportMeta,
   ) {
     super();
 
     this.ledger = ledger;
-    this.baseCurrency = baseCurrency;
+    this.baseCurrency = meta.baseCurrency;
     this.customers = customers;
     this.filter = filter;
     this.numberFormat = this.filter.numberFormat;
+    this.dateFormat = meta.dateFormat || DEFAULT_REPORT_META.dateFormat;
   }
 
   /**

--- a/packages/server/src/modules/FinancialStatements/modules/CustomerBalanceSummary/CustomerBalanceSummaryMeta.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/CustomerBalanceSummary/CustomerBalanceSummaryMeta.ts
@@ -19,7 +19,7 @@ export class CustomerBalanceSummaryMeta {
     query: ICustomerBalanceSummaryQuery,
   ): Promise<ICustomerBalanceSummaryMeta> {
     const commonMeta = await this.financialSheetMeta.meta();
-    const formattedAsDate = moment(query.asDate).format('YYYY/MM/DD');
+    const formattedAsDate = moment(query.asDate).format(commonMeta.dateFormat);
     const formattedDateRange = `As ${formattedAsDate}`;
 
     return {

--- a/packages/server/src/modules/FinancialStatements/modules/CustomerBalanceSummary/CustomerBalanceSummaryService.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/CustomerBalanceSummary/CustomerBalanceSummaryService.ts
@@ -63,15 +63,16 @@ export class CustomerBalanceSummaryService {
     // Ledger query.
     const ledger = new Ledger(customersEntries);
 
+    // Retrieve the customer balance summary meta first to get date format.
+    const meta = await this.customerBalanceSummaryMeta.meta(filter);
+
     // Report instance.
     const report = new CustomerBalanceSummaryReport(
       ledger,
       customers,
       filter,
-      tenantMetadata.baseCurrency,
+      { baseCurrency: tenantMetadata.baseCurrency, dateFormat: meta.dateFormat },
     );
-    // Retrieve the customer balance summary meta.
-    const meta = await this.customerBalanceSummaryMeta.meta(filter);
 
     // Triggers `onCustomerBalanceSummaryViewed` event.
     await this.eventPublisher.emitAsync(

--- a/packages/server/src/modules/FinancialStatements/modules/GeneralLedger/GeneralLedger.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/GeneralLedger/GeneralLedger.ts
@@ -19,6 +19,7 @@ import { Account } from '@/modules/Accounts/models/Account.model';
 import { ModelObject } from 'objection';
 import { flatToNestedArray } from '@/utils/flat-to-nested-array';
 import { getTransactionTypeLabel } from '@/modules/BankingTransactions/utils';
+import { IFinancialReportMeta, DEFAULT_REPORT_META } from '../../types/Report.types';
 
 export class GeneralLedgerSheet extends R.compose(FinancialSheetStructure)(
   FinancialSheet,
@@ -33,18 +34,21 @@ export class GeneralLedgerSheet extends R.compose(FinancialSheetStructure)(
    * @param {IGeneralLedgerSheetQuery} query -
    * @param {GeneralLedgerRepository} repository -
    * @param {I18nService} i18n -
+   * @param {IFinancialReportMeta} meta -
    */
   constructor(
     query: IGeneralLedgerSheetQuery,
     repository: GeneralLedgerRepository,
     i18n: I18nService,
+    meta: IFinancialReportMeta,
   ) {
     super();
 
     this.query = query;
     this.numberFormat = this.query.numberFormat;
+    this.dateFormat = meta.dateFormat || DEFAULT_REPORT_META.dateFormat;
     this.repository = repository;
-    this.baseCurrency = this.repository.tenant.metadata.baseCurrency;
+    this.baseCurrency = meta.baseCurrency;
     this.i18n = i18n;
   }
 
@@ -87,7 +91,7 @@ export class GeneralLedgerSheet extends R.compose(FinancialSheetStructure)(
     return {
       id: entry.id,
       date: entry.date,
-      dateFormatted: moment(entry.date).format('YYYY MMM DD'),
+      dateFormatted: moment(entry.date).format(this.dateFormat),
 
       referenceType: entry.transactionType,
       referenceId: entry.transactionId,

--- a/packages/server/src/modules/FinancialStatements/modules/GeneralLedger/GeneralLedger.types.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/GeneralLedger/GeneralLedger.types.ts
@@ -6,6 +6,7 @@ export interface IGeneralLedgerSheetQuery {
   toDate: Date | string;
   basis: string;
   numberFormat: IGeneralLedgerNumberFormat;
+  dateFormat?: string;
   noneTransactions: boolean;
   accountsIds: number[];
   branchesIds?: number[];

--- a/packages/server/src/modules/FinancialStatements/modules/GeneralLedger/GeneralLedgerMeta.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/GeneralLedger/GeneralLedgerMeta.ts
@@ -19,8 +19,8 @@ export class GeneralLedgerMeta {
   ): Promise<IGeneralLedgerMeta> {
     const commonMeta = await this.financialSheetMeta.meta();
 
-    const formattedToDate = moment(query.toDate).format('YYYY/MM/DD');
-    const formattedFromDate = moment(query.fromDate).format('YYYY/MM/DD');
+    const formattedToDate = moment(query.toDate).format(commonMeta.dateFormat);
+    const formattedFromDate = moment(query.fromDate).format(commonMeta.dateFormat);
     const formattedDateRange = `From ${formattedFromDate} | To ${formattedToDate}`;
 
     return {

--- a/packages/server/src/modules/FinancialStatements/modules/GeneralLedger/GeneralLedgerService.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/GeneralLedger/GeneralLedgerService.ts
@@ -37,17 +37,18 @@ export class GeneralLedgerService {
     this.generalLedgerRepository.setFilter(filter);
     await this.generalLedgerRepository.asyncInitialize();
 
+    // Retrieve general ledger report metadata first to get the date format.
+    const meta = await this.generalLedgerMeta.meta(filter);
+
     // General ledger report instance.
     const generalLedgerInstance = new GeneralLedgerSheet(
       filter,
       this.generalLedgerRepository,
       this.i18n,
+      { baseCurrency: meta.baseCurrency, dateFormat: meta.dateFormat },
     );
     // Retrieve general ledger report data.
     const reportData = generalLedgerInstance.reportData();
-
-    // Retrieve general ledger report metadata.
-    const meta = await this.generalLedgerMeta.meta(filter);
 
     // Triggers `onGeneralLedgerViewed` event.
     await this.eventEmitter.emitAsync(events.reports.onGeneralLedgerViewed, {});

--- a/packages/server/src/modules/FinancialStatements/modules/InventoryItemDetails/InventoryItemDetails.service.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/InventoryItemDetails/InventoryItemDetails.service.ts
@@ -8,6 +8,7 @@ import { InventoryDetails } from './InventoryItemDetails';
 import { InventoryItemDetailsRepository } from './InventoryItemDetailsRepository';
 import { InventoryDetailsMetaInjectable } from './InventoryItemDetailsMeta';
 import { getInventoryItemDetailsDefaultQuery } from './constant';
+import { TenancyContext } from '@/modules/Tenancy/TenancyContext.service';
 
 @Injectable()
 export class InventoryDetailsService {
@@ -15,6 +16,7 @@ export class InventoryDetailsService {
     private readonly inventoryItemDetailsRepository: InventoryItemDetailsRepository,
     private readonly inventoryDetailsMeta: InventoryDetailsMetaInjectable,
     private readonly i18n: I18nService,
+    private readonly tenancyContext: TenancyContext,
   ) {}
 
   /**
@@ -34,13 +36,20 @@ export class InventoryDetailsService {
     this.inventoryItemDetailsRepository.setFilter(filter);
     await this.inventoryItemDetailsRepository.asyncInit();
 
+    // Retrieve the meta first to get date format.
+    const meta = await this.inventoryDetailsMeta.meta(query);
+
+    // Inventory details report mapper.
+    // Get tenant metadata for baseCurrency
+    const tenantMetadata = await this.tenancyContext.getTenantMetadata();
+
     // Inventory details report mapper.
     const inventoryDetailsInstance = new InventoryDetails(
       filter,
       this.inventoryItemDetailsRepository,
       this.i18n,
+      { baseCurrency: tenantMetadata.baseCurrency, dateFormat: meta.dateFormat },
     );
-    const meta = await this.inventoryDetailsMeta.meta(query);
 
     return {
       data: inventoryDetailsInstance.reportData(),

--- a/packages/server/src/modules/FinancialStatements/modules/InventoryItemDetails/InventoryItemDetails.service.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/InventoryItemDetails/InventoryItemDetails.service.ts
@@ -40,15 +40,11 @@ export class InventoryDetailsService {
     const meta = await this.inventoryDetailsMeta.meta(query);
 
     // Inventory details report mapper.
-    // Get tenant metadata for baseCurrency
-    const tenantMetadata = await this.tenancyContext.getTenantMetadata();
-
-    // Inventory details report mapper.
     const inventoryDetailsInstance = new InventoryDetails(
       filter,
       this.inventoryItemDetailsRepository,
       this.i18n,
-      { baseCurrency: tenantMetadata.baseCurrency, dateFormat: meta.dateFormat },
+      { baseCurrency: meta.baseCurrency, dateFormat: meta.dateFormat },
     );
 
     return {

--- a/packages/server/src/modules/FinancialStatements/modules/InventoryItemDetails/InventoryItemDetails.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/InventoryItemDetails/InventoryItemDetails.ts
@@ -17,6 +17,8 @@ import { Item } from '@/modules/Items/models/Item';
 import {
   IFormatNumberSettings,
   INumberFormatQuery,
+  IFinancialReportMeta,
+  DEFAULT_REPORT_META,
 } from '../../types/Report.types';
 import { InventoryTransaction } from '@/modules/InventoryCost/models/InventoryTransaction';
 import { InventoryItemDetailsRepository } from './InventoryItemDetailsRepository';
@@ -35,11 +37,13 @@ export class InventoryDetails extends FinancialSheet {
    * Constructor method.
    * @param {InventoryItemDetailsRepository} repository - The repository.
    * @param {I18nService} i18n - The i18n service.
+   * @param {IFinancialReportMeta} meta - Report meta.
    */
   constructor(
     filter: IInventoryDetailsQuery,
     repository: InventoryItemDetailsRepository,
     i18n: I18nService,
+    meta: IFinancialReportMeta,
   ) {
     super();
 
@@ -48,6 +52,7 @@ export class InventoryDetails extends FinancialSheet {
     this.query = filter;
     this.numberFormat = this.query.numberFormat;
     this.i18n = i18n;
+    this.dateFormat = meta.dateFormat || DEFAULT_REPORT_META.dateFormat;
   }
 
   /**
@@ -89,7 +94,7 @@ export class InventoryDetails extends FinancialSheet {
    */
   public getDateMeta(date: Date | string): IInventoryDetailsDate {
     return {
-      formattedDate: moment(date).format('YYYY-MM-DD'),
+      formattedDate: moment(date).format(this.dateFormat),
       date: moment(date).toDate(),
     };
   }

--- a/packages/server/src/modules/FinancialStatements/modules/InventoryItemDetails/InventoryItemDetailsMeta.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/InventoryItemDetails/InventoryItemDetailsMeta.ts
@@ -19,8 +19,8 @@ export class InventoryDetailsMetaInjectable {
   ): Promise<IInventoryItemDetailMeta> {
     const commonMeta = await this.financialSheetMeta.meta();
 
-    const formattedFromDate = moment(query.fromDate).format('YYYY/MM/DD');
-    const formattedToDay = moment(query.toDate).format('YYYY/MM/DD');
+    const formattedFromDate = moment(query.fromDate).format(commonMeta.dateFormat);
+    const formattedToDay = moment(query.toDate).format(commonMeta.dateFormat);
     const formattedDateRange = `From ${formattedFromDate} | To ${formattedToDay}`;
 
     const sheetName = 'Inventory Item Details';

--- a/packages/server/src/modules/FinancialStatements/modules/InventoryValuationSheet/InventoryValuationSheet.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/InventoryValuationSheet/InventoryValuationSheet.ts
@@ -12,6 +12,7 @@ import { InventoryCostLotTracker } from '@/modules/InventoryCost/models/Inventor
 import { FinancialSheet } from '../../common/FinancialSheet';
 import { InventoryValuationSheetRepository } from './InventoryValuationSheetRepository';
 import { allPassedConditionsPass } from '@/utils/all-conditions-passed';
+import { IFinancialReportMeta, DEFAULT_REPORT_META } from '../../types/Report.types';
 
 export class InventoryValuationSheet extends FinancialSheet {
   readonly query: IInventoryValuationReportQuery;
@@ -21,16 +22,19 @@ export class InventoryValuationSheet extends FinancialSheet {
    * Constructor method.
    * @param {IInventoryValuationReportQuery} query - Inventory valuation query.
    * @param {InventoryValuationSheetRepository} repository - Inventory valuation sheet repository.
+   * @param {IFinancialReportMeta} meta - Report meta.
    */
   constructor(
     query: IInventoryValuationReportQuery,
     repository: InventoryValuationSheetRepository,
+    meta: IFinancialReportMeta,
   ) {
     super();
 
     this.query = query;
     this.repository = repository;
     this.numberFormat = this.query.numberFormat;
+    this.dateFormat = meta.dateFormat || DEFAULT_REPORT_META.dateFormat;
   }
 
   /**

--- a/packages/server/src/modules/FinancialStatements/modules/InventoryValuationSheet/InventoryValuationSheetMeta.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/InventoryValuationSheet/InventoryValuationSheetMeta.ts
@@ -18,7 +18,7 @@ export class InventoryValuationMetaInjectable {
     query: IInventoryValuationReportQuery,
   ): Promise<IInventoryValuationSheetMeta> {
     const commonMeta = await this.financialSheetMeta.meta();
-    const formattedAsDate = moment(query.asDate).format('YYYY/MM/DD');
+    const formattedAsDate = moment(query.asDate).format(commonMeta.dateFormat);
     const formattedDateRange = `As ${formattedAsDate}`;
 
     return {

--- a/packages/server/src/modules/FinancialStatements/modules/InventoryValuationSheet/InventoryValuationSheetService.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/InventoryValuationSheet/InventoryValuationSheetService.ts
@@ -34,15 +34,16 @@ export class InventoryValuationSheetService {
     this.inventoryValuationSheetRepository.setFilter(filter);
     await this.inventoryValuationSheetRepository.asyncInit();
 
+    // Retrieves the inventorty valuation meta first to get date format.
+    const meta = await this.inventoryValuationMeta.meta(filter);
+
     const inventoryValuationInstance = new InventoryValuationSheet(
       filter,
       this.inventoryValuationSheetRepository,
+      { baseCurrency: meta.baseCurrency, dateFormat: meta.dateFormat },
     );
     // Retrieve the inventory valuation report data.
     const inventoryValuationData = inventoryValuationInstance.reportData();
-
-    // Retrieves the inventorty valuation meta.
-    const meta = await this.inventoryValuationMeta.meta(filter);
 
     // Triggers `onInventoryValuationViewed` event.
     await this.eventPublisher.emitAsync(

--- a/packages/server/src/modules/FinancialStatements/modules/JournalSheet/JournalSheet.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/JournalSheet/JournalSheet.ts
@@ -11,6 +11,7 @@ import { FinancialSheet } from '../../common/FinancialSheet';
 import { JournalSheetRepository } from './JournalSheetRepository';
 import { ILedgerEntry } from '@/modules/Ledger/types/Ledger.types';
 import { getTransactionTypeLabel } from '@/modules/BankingTransactions/utils';
+import { IFinancialReportMeta, DEFAULT_REPORT_META } from '../../types/Report.types';
 
 export class JournalSheet extends FinancialSheet {
   readonly query: IJournalReportQuery;
@@ -22,20 +23,24 @@ export class JournalSheet extends FinancialSheet {
    * @param {IJournalReportQuery} query -
    * @param {JournalSheetRepository} repository -
    * @param {I18nService} i18n -
+   * @param {IFinancialReportMeta} meta -
    */
   constructor(
     query: IJournalReportQuery,
     repository: JournalSheetRepository,
     i18n: I18nService,
+    meta: IFinancialReportMeta,
   ) {
     super();
 
     this.query = query;
     this.repository = repository;
+    this.baseCurrency = meta.baseCurrency;
     this.numberFormat = {
       ...this.numberFormat,
       ...this.query.numberFormat,
     };
+    this.dateFormat = meta.dateFormat || DEFAULT_REPORT_META.dateFormat;
     this.i18n = i18n;
   }
 
@@ -94,7 +99,7 @@ export class JournalSheet extends FinancialSheet {
 
     return {
       date: moment(groupEntry.date).toDate(),
-      dateFormatted: moment(groupEntry.date).format('YYYY MMM DD'),
+      dateFormatted: moment(groupEntry.date).format(this.dateFormat),
 
       transactionType: groupEntry.transactionType,
       referenceId: groupEntry.transactionId,

--- a/packages/server/src/modules/FinancialStatements/modules/JournalSheet/JournalSheet.types.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/JournalSheet/JournalSheet.types.ts
@@ -8,6 +8,7 @@ export interface IJournalReportQuery {
     noCents: boolean;
     divideOn1000: boolean;
   };
+  dateFormat?: string;
   transactionType: string;
   transactionId: string;
 

--- a/packages/server/src/modules/FinancialStatements/modules/JournalSheet/JournalSheetMeta.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/JournalSheet/JournalSheetMeta.ts
@@ -17,8 +17,8 @@ export class JournalSheetMeta {
   ): Promise<IJournalSheetMeta> {
     const common = await this.financialSheetMeta.meta();
 
-    const formattedToDate = moment(query.toDate).format('YYYY/MM/DD');
-    const formattedFromDate = moment(query.fromDate).format('YYYY/MM/DD');
+    const formattedToDate = moment(query.toDate).format(common.dateFormat);
+    const formattedFromDate = moment(query.fromDate).format(common.dateFormat);
     const formattedDateRange = `From ${formattedFromDate} | To ${formattedToDate}`;
 
     return {

--- a/packages/server/src/modules/FinancialStatements/modules/JournalSheet/JournalSheetService.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/JournalSheet/JournalSheetService.ts
@@ -30,17 +30,18 @@ export class JournalSheetService {
     this.journalRepository.setFilter(query);
     await this.journalRepository.load();
 
+    // Retrieve the journal sheet meta first to get the date format.
+    const meta = await this.journalSheetMeta.meta(filter);
+
     // Journal report instance.
     const journalSheetInstance = new JournalSheet(
       filter,
       this.journalRepository,
       this.i18n,
+      { baseCurrency: meta.baseCurrency, dateFormat: meta.dateFormat },
     );
     // Retrieve journal report columns.
     const journalSheetData = journalSheetInstance.reportData();
-
-    // Retrieve the journal sheet meta.
-    const meta = await this.journalSheetMeta.meta(filter);
 
     // Triggers `onJournalViewed` event.
     await this.eventPublisher.emitAsync(events.reports.onJournalViewed, {

--- a/packages/server/src/modules/FinancialStatements/modules/ProfitLossSheet/ProfitLossSheet.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/ProfitLossSheet/ProfitLossSheet.ts
@@ -28,6 +28,7 @@ import { FinancialSheetStructure } from '../../common/FinancialSheetStructure';
 import { FinancialSheet } from '../../common/FinancialSheet';
 import { Account } from '@/modules/Accounts/models/Account.model';
 import { flatToNestedArray } from '@/utils/flat-to-nested-array';
+import { IFinancialReportMeta, DEFAULT_REPORT_META } from '../../types/Report.types';
 
 export default class ProfitLossSheet extends R.pipe(
   ProfitLossSheetPreviousYear,
@@ -71,20 +72,24 @@ export default class ProfitLossSheet extends R.pipe(
 
   /**
    * Constructor method.
+   * @param {ProfitLossSheetRepository} repository -
    * @param {IProfitLossSheetQuery} query -
-   * @param {IAccount[]} accounts -
-   * @param {IJournalPoster} transactionsJournal -
+   * @param {I18nService} i18n -
+   * @param {IFinancialReportMeta} meta -
    */
   constructor(
     repository: ProfitLossSheetRepository,
     query: IProfitLossSheetQuery,
     i18n: I18nService,
+    meta: IFinancialReportMeta,
   ) {
     super();
 
     this.query = new ProfitLossSheetQuery(query);
     this.repository = repository;
+    this.baseCurrency = meta.baseCurrency;
     this.numberFormat = this.query.query.numberFormat;
+    this.dateFormat = meta.dateFormat || DEFAULT_REPORT_META.dateFormat;
     this.i18n = i18n;
   }
 

--- a/packages/server/src/modules/FinancialStatements/modules/ProfitLossSheet/ProfitLossSheetMeta.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/ProfitLossSheet/ProfitLossSheetMeta.ts
@@ -19,8 +19,8 @@ export class ProfitLossSheetMeta {
     query: IProfitLossSheetQuery,
   ): Promise<IProfitLossSheetMeta> {
     const commonMeta = await this.financialSheetMeta.meta();
-    const formattedToDate = moment(query.toDate).format('YYYY/MM/DD');
-    const formattedFromDate = moment(query.fromDate).format('YYYY/MM/DD');
+    const formattedToDate = moment(query.toDate).format(commonMeta.dateFormat);
+    const formattedFromDate = moment(query.fromDate).format(commonMeta.dateFormat);
     const formattedDateRange = `From ${formattedFromDate} | To ${formattedToDate}`;
 
     const sheetName = 'Cashflow Statement';

--- a/packages/server/src/modules/FinancialStatements/modules/ProfitLossSheet/ProfitLossSheetService.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/ProfitLossSheet/ProfitLossSheetService.ts
@@ -40,17 +40,18 @@ export class ProfitLossSheetService {
     this.profitLossRepository.setFilter(filter);
     await this.profitLossRepository.asyncInitialize();
 
+    // Retrieve the profit/loss sheet meta first to get date format.
+    const meta = await this.profitLossSheetMeta.meta(filter);
+
     // Profit/Loss report instance.
     const profitLossInstance = new ProfitLossSheet(
       this.profitLossRepository,
       filter,
       this.i18nService,
+      { baseCurrency: meta.baseCurrency, dateFormat: meta.dateFormat },
     );
     // Profit/loss report data and columns.
     const data = profitLossInstance.reportData();
-
-    // Retrieve the profit/loss sheet meta.
-    const meta = await this.profitLossSheetMeta.meta(filter);
 
     // Triggers `onProfitLossSheetViewed` event.
     await this.eventPublisher.emitAsync(

--- a/packages/server/src/modules/FinancialStatements/modules/PurchasesByItems/PurchasesByItems.service.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/PurchasesByItems/PurchasesByItems.service.ts
@@ -73,16 +73,16 @@ export class PurchasesByItemsService {
         // Filter the date range of the sheet.
         builder.modify('filterDateRange', filter.fromDate, filter.toDate);
       });
+    // Retrieve the purchases by items meta first to get date format.
+    const meta = await this.purchasesByItemsMeta.meta(query);
+
     const purchasesByItemsInstance = new PurchasesByItems(
       filter,
       inventoryItems,
       inventoryTransactions,
-      tenantMetadata.baseCurrency,
+      { baseCurrency: tenantMetadata.baseCurrency, dateFormat: meta.dateFormat },
     );
     const purchasesByItemsData = purchasesByItemsInstance.reportData();
-
-    // Retrieve the purchases by items meta.
-    const meta = await this.purchasesByItemsMeta.meta(query);
 
     // Triggers `onPurchasesByItemViewed` event.
     await this.eventPublisher.emitAsync(

--- a/packages/server/src/modules/FinancialStatements/modules/PurchasesByItems/PurchasesByItems.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/PurchasesByItems/PurchasesByItems.ts
@@ -11,6 +11,7 @@ import { FinancialSheet } from '../../common/FinancialSheet';
 import { transformToMapBy } from '@/utils/transform-to-map-by';
 import { Item } from '@/modules/Items/models/Item';
 import { InventoryTransaction } from '@/modules/InventoryCost/models/InventoryTransaction';
+import { IFinancialReportMeta, DEFAULT_REPORT_META } from '../../types/Report.types';
 
 export class PurchasesByItems extends FinancialSheet{
   readonly baseCurrency: string;
@@ -29,14 +30,15 @@ export class PurchasesByItems extends FinancialSheet{
     query: IPurchasesByItemsReportQuery,
     items: Item[],
     itemsTransactions: InventoryTransaction[],
-    baseCurrency: string
+    meta: IFinancialReportMeta,
   ) {
     super();
-    this.baseCurrency = baseCurrency;
+    this.baseCurrency = meta.baseCurrency;
     this.items = items;
     this.itemsTransactions = transformToMapBy(itemsTransactions, 'itemId');
     this.query = query;
     this.numberFormat = this.query.numberFormat;
+    this.dateFormat = meta.dateFormat || DEFAULT_REPORT_META.dateFormat;
   }
 
   /**

--- a/packages/server/src/modules/FinancialStatements/modules/PurchasesByItems/PurchasesByItemsMeta.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/PurchasesByItems/PurchasesByItemsMeta.ts
@@ -21,8 +21,8 @@ export class PurchasesByItemsMeta {
     query: IPurchasesByItemsReportQuery
   ): Promise<IPurchasesByItemsSheetMeta> {
     const commonMeta = await this.financialSheetMetaModel.meta();
-    const formattedToDate = moment(query.toDate).format('YYYY/MM/DD');
-    const formattedFromDate = moment(query.fromDate).format('YYYY/MM/DD');
+    const formattedToDate = moment(query.toDate).format(commonMeta.dateFormat);
+    const formattedFromDate = moment(query.fromDate).format(commonMeta.dateFormat);
     const formattedDateRange = `From ${formattedFromDate} | To ${formattedToDate}`;
 
     return {

--- a/packages/server/src/modules/FinancialStatements/modules/SalesByItems/SalesByItems.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/SalesByItems/SalesByItems.ts
@@ -12,6 +12,7 @@ import { Item } from '@/modules/Items/models/Item';
 import { transformToMap } from '@/utils/transform-to-key';
 import { allPassedConditionsPass } from '@/utils/all-conditions-passed';
 import { InventoryTransaction } from '@/modules/InventoryCost/models/InventoryTransaction';
+import { IFinancialReportMeta, DEFAULT_REPORT_META } from '../../types/Report.types';
 
 export class SalesByItemsReport extends FinancialSheet {
   readonly baseCurrency: string;
@@ -24,21 +25,22 @@ export class SalesByItemsReport extends FinancialSheet {
    * @param {ISalesByItemsReportQuery} query
    * @param {IItem[]} items
    * @param {IAccountTransaction[]} itemsTransactions
-   * @param {string} baseCurrency
+   * @param {IFinancialReportMeta} meta
    */
   constructor(
     query: ISalesByItemsReportQuery,
     items: Item[],
     itemsTransactions: ModelObject<InventoryTransaction>[],
-    baseCurrency: string,
+    meta: IFinancialReportMeta,
   ) {
     super();
 
-    this.baseCurrency = baseCurrency;
+    this.baseCurrency = meta.baseCurrency;
     this.items = items;
     this.itemsTransactions = transformToMap(itemsTransactions, 'itemId');
     this.query = query;
     this.numberFormat = this.query.numberFormat;
+    this.dateFormat = meta.dateFormat || DEFAULT_REPORT_META.dateFormat;
   }
 
   /**

--- a/packages/server/src/modules/FinancialStatements/modules/SalesByItems/SalesByItemsMeta.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/SalesByItems/SalesByItemsMeta.ts
@@ -18,8 +18,8 @@ export class SalesByItemsMeta {
     query: ISalesByItemsReportQuery,
   ): Promise<ISalesByItemsSheetMeta> {
     const commonMeta = await this.financialSheetMeta.meta();
-    const formattedToDate = moment(query.toDate).format('YYYY/MM/DD');
-    const formattedFromDate = moment(query.fromDate).format('YYYY/MM/DD');
+    const formattedToDate = moment(query.toDate).format(commonMeta.dateFormat);
+    const formattedFromDate = moment(query.fromDate).format(commonMeta.dateFormat);
     const formattedDateRange = `From ${formattedFromDate} | To ${formattedToDate}`;
 
     const sheetName = 'Sales By Items';

--- a/packages/server/src/modules/FinancialStatements/modules/SalesByItems/SalesByItemsService.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/SalesByItems/SalesByItemsService.ts
@@ -68,16 +68,16 @@ export class SalesByItemsReportService {
         // Filter the date range of the sheet.
         builder.modify('filterDateRange', filter.fromDate, filter.toDate);
       });
+    // Retrieve the sales by items meta first to get date format.
+    const meta = await this.salesByItemsMeta.meta(query);
+
     const sheet = new SalesByItemsReport(
       filter,
       inventoryItems,
       inventoryTransactions,
-      tenantMetadata.baseCurrency,
+      { baseCurrency: tenantMetadata.baseCurrency, dateFormat: meta.dateFormat },
     );
     const salesByItemsData = sheet.reportData();
-
-    // Retrieve the sales by items meta.
-    const meta = await this.salesByItemsMeta.meta(query);
 
     // Triggers `onSalesByItemViewed` event.
     await this.eventPublisher.emitAsync(events.reports.onSalesByItemViewed, {

--- a/packages/server/src/modules/FinancialStatements/modules/SalesTaxLiabilitySummary/SalesTaxLiability.module.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/SalesTaxLiabilitySummary/SalesTaxLiability.module.ts
@@ -8,9 +8,10 @@ import { SalesTaxLiabilitySummaryController } from './SalesTaxLiabilitySummary.c
 import { FinancialSheetCommonModule } from '../../common/FinancialSheetCommon.module';
 import { SalesTaxLiabilitySummaryRepository } from './SalesTaxLiabilitySummaryRepository';
 import { SalesTaxLiabilitySummaryMeta } from './SalesTaxLiabilitySummaryMeta';
+import { TenancyModule } from '@/modules/Tenancy/Tenancy.module';
 
 @Module({
-  imports: [FinancialSheetCommonModule],
+  imports: [FinancialSheetCommonModule, TenancyModule],
   providers: [
     SalesTaxLiabiltiySummaryPdf,
     SalesTaxLiabilitySummaryTableInjectable,

--- a/packages/server/src/modules/FinancialStatements/modules/SalesTaxLiabilitySummary/SalesTaxLiabilitySummary.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/SalesTaxLiabilitySummary/SalesTaxLiabilitySummary.ts
@@ -10,6 +10,7 @@ import { FinancialSheet } from '../../common/FinancialSheet';
 import { ModelObject } from 'objection';
 import { TaxRateModel } from '@/modules/TaxRates/models/TaxRate.model';
 import { SalesTaxLiabilitySummaryRepository } from './SalesTaxLiabilitySummaryRepository';
+import { IFinancialReportMeta, DEFAULT_REPORT_META } from '../../types/Report.types';
 
 export class SalesTaxLiabilitySummary extends FinancialSheet {
   private query: SalesTaxLiabilitySummaryQuery;
@@ -18,18 +19,19 @@ export class SalesTaxLiabilitySummary extends FinancialSheet {
   /**
    * Sales tax liability summary constructor.
    * @param {SalesTaxLiabilitySummaryQuery} query
-   * @param {ITaxRate[]} taxRates
-   * @param {SalesTaxLiabilitySummaryPayableById} payableTaxesById
-   * @param {SalesTaxLiabilitySummarySalesById} salesTaxesById
+   * @param {SalesTaxLiabilitySummaryRepository} repository
+   * @param {IFinancialReportMeta} meta
    */
   constructor(
     query: SalesTaxLiabilitySummaryQuery,
     repository: SalesTaxLiabilitySummaryRepository,
+    meta: IFinancialReportMeta,
   ) {
     super();
 
     this.query = query;
     this.repository = repository;
+    this.dateFormat = meta.dateFormat || DEFAULT_REPORT_META.dateFormat;
   }
 
   /**

--- a/packages/server/src/modules/FinancialStatements/modules/SalesTaxLiabilitySummary/SalesTaxLiabilitySummaryMeta.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/SalesTaxLiabilitySummary/SalesTaxLiabilitySummaryMeta.ts
@@ -14,8 +14,8 @@ export class SalesTaxLiabilitySummaryMeta {
    */
   public async meta(query: SalesTaxLiabilitySummaryQuery) {
     const commonMeta = await this.financialSheetMeta.meta();
-    const formattedToDate = moment(query.toDate).format('YYYY/MM/DD');
-    const formattedFromDate = moment(query.fromDate).format('YYYY/MM/DD');
+    const formattedToDate = moment(query.toDate).format(commonMeta.dateFormat);
+    const formattedFromDate = moment(query.fromDate).format(commonMeta.dateFormat);
     const formattedDateRange = `From ${formattedFromDate} | To ${formattedToDate}`;
 
     const sheetName = 'Sales Tax Liability Summary';

--- a/packages/server/src/modules/FinancialStatements/modules/SalesTaxLiabilitySummary/SalesTaxLiabilitySummaryService.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/SalesTaxLiabilitySummary/SalesTaxLiabilitySummaryService.ts
@@ -3,12 +3,14 @@ import { SalesTaxLiabilitySummary } from './SalesTaxLiabilitySummary';
 import { SalesTaxLiabilitySummaryMeta } from './SalesTaxLiabilitySummaryMeta';
 import { Injectable } from '@nestjs/common';
 import { SalesTaxLiabilitySummaryQuery } from './SalesTaxLiability.types';
+import { TenancyContext } from '@/modules/Tenancy/TenancyContext.service';
 
 @Injectable()
 export class SalesTaxLiabilitySummaryService {
   constructor(
     private readonly repository: SalesTaxLiabilitySummaryRepository,
     private readonly salesTaxLiabilityMeta: SalesTaxLiabilitySummaryMeta,
+    private readonly tenancyContext: TenancyContext,
   ) {}
 
   /**
@@ -19,11 +21,17 @@ export class SalesTaxLiabilitySummaryService {
   public async salesTaxLiability(query: SalesTaxLiabilitySummaryQuery) {
     await this.repository.load();
 
+    // Retrieve the meta first to get date format.
+    const meta = await this.salesTaxLiabilityMeta.meta(query);
+
+    // Get tenant metadata for baseCurrency
+    const tenantMetadata = await this.tenancyContext.getTenantMetadata();
+
     const taxLiabilitySummary = new SalesTaxLiabilitySummary(
       query,
       this.repository,
+      { baseCurrency: tenantMetadata.baseCurrency, dateFormat: meta.dateFormat },
     );
-    const meta = await this.salesTaxLiabilityMeta.meta(query);
 
     return {
       data: taxLiabilitySummary.reportData(),

--- a/packages/server/src/modules/FinancialStatements/modules/TransactionsByContact/TransactionsByContactTableRows.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/TransactionsByContact/TransactionsByContactTableRows.ts
@@ -14,9 +14,10 @@ enum ROW_TYPE {
 
 export class TransactionsByContactsTableRows {
   public i18n: I18nService;
+  public dateFormat: string;
 
   public dateAccessor = (value): string => {
-    return moment(value.date).format('YYYY MMM DD');
+    return moment(value.date).format(this.dateFormat);
   };
 
   /**

--- a/packages/server/src/modules/FinancialStatements/modules/TransactionsByCustomer/TransactionsByCustomers.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/TransactionsByCustomer/TransactionsByCustomers.ts
@@ -12,6 +12,7 @@ import { TransactionsByContact } from '../TransactionsByContact/TransactionsByCo
 import { Customer } from '@/modules/Customers/models/Customer';
 import { INumberFormatQuery } from '../../types/Report.types';
 import { TransactionsByCustomersRepository } from './TransactionsByCustomersRepository';
+import { IFinancialReportMeta, DEFAULT_REPORT_META } from '../../types/Report.types';
 
 const CUSTOMER_NORMAL = 'debit';
 
@@ -25,12 +26,14 @@ export class TransactionsByCustomers extends TransactionsByContact {
    * Constructor method.
    * @param {ICustomer} customers
    * @param {Map<number, IAccountTransaction[]>} transactionsLedger
-   * @param {string} baseCurrency
+   * @param {I18nService} i18n
+   * @param {IFinancialReportMeta} meta
    */
   constructor(
     filter: ITransactionsByCustomersFilter,
     transactionsByCustomersRepository: TransactionsByCustomersRepository,
-    i18n: I18nService
+    i18n: I18nService,
+    meta: IFinancialReportMeta,
   ) {
     super();
 
@@ -38,6 +41,8 @@ export class TransactionsByCustomers extends TransactionsByContact {
     this.repository = transactionsByCustomersRepository;
     this.numberFormat = this.filter.numberFormat;
     this.i18n = i18n;
+    this.baseCurrency = meta.baseCurrency;
+    this.dateFormat = meta.dateFormat || DEFAULT_REPORT_META.dateFormat;
   }
 
   /**

--- a/packages/server/src/modules/FinancialStatements/modules/TransactionsByCustomer/TransactionsByCustomersMeta.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/TransactionsByCustomer/TransactionsByCustomersMeta.ts
@@ -20,8 +20,8 @@ export class TransactionsByCustomersMeta {
   ): Promise<ITransactionsByCustomersMeta> {
     const commonMeta = await this.financialSheetMeta.meta();
 
-    const formattedToDate = moment(query.toDate).format('YYYY/MM/DD');
-    const formattedFromDate = moment(query.fromDate).format('YYYY/MM/DD');
+    const formattedToDate = moment(query.toDate).format(commonMeta.dateFormat);
+    const formattedFromDate = moment(query.fromDate).format(commonMeta.dateFormat);
     const formattedDateRange = `From ${formattedFromDate} | To ${formattedToDate}`;
 
     return {

--- a/packages/server/src/modules/FinancialStatements/modules/TransactionsByCustomer/TransactionsByCustomersService.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/TransactionsByCustomer/TransactionsByCustomersService.ts
@@ -36,13 +36,16 @@ export class TransactionsByCustomersSheet {
     this.transactionsByCustomersRepository.setFilter(filter);
     await this.transactionsByCustomersRepository.asyncInit();
 
+    // Retrieve the meta first to get date format.
+    const meta = await this.transactionsByCustomersMeta.meta(filter);
+
     // Transactions by customers data mapper.
     const reportInstance = new TransactionsByCustomers(
       filter,
       this.transactionsByCustomersRepository,
       this.i18n,
+      { baseCurrency: meta.baseCurrency, dateFormat: meta.dateFormat },
     );
-    const meta = await this.transactionsByCustomersMeta.meta(filter);
 
     // Triggers `onCustomerTransactionsViewed` event.
     await this.eventPublisher.emitAsync(

--- a/packages/server/src/modules/FinancialStatements/modules/TransactionsByCustomer/TransactionsByCustomersTable.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/TransactionsByCustomer/TransactionsByCustomersTable.ts
@@ -22,10 +22,12 @@ export class TransactionsByCustomersTable extends TransactionsByContactsTableRow
   constructor(
     customersTransactions: ITransactionsByCustomersCustomer[],
     i18n: I18nService,
+    dateFormat: string,
   ) {
     super();
     this.customersTransactions = customersTransactions;
     this.i18n = i18n;
+    this.dateFormat = dateFormat;
   }
 
   /**

--- a/packages/server/src/modules/FinancialStatements/modules/TransactionsByCustomer/TransactionsByCustomersTableInjectable.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/TransactionsByCustomer/TransactionsByCustomersTableInjectable.ts
@@ -28,6 +28,7 @@ export class TransactionsByCustomersTableInjectable {
     const table = new TransactionsByCustomersTable(
       customersTransactions.data,
       this.i18n,
+      customersTransactions.meta.dateFormat,
     );
     return {
       table: {

--- a/packages/server/src/modules/FinancialStatements/modules/TransactionsByVendor/TransactionsByVendor.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/TransactionsByVendor/TransactionsByVendor.ts
@@ -12,6 +12,7 @@ import { TransactionsByContact } from '../TransactionsByContact/TransactionsByCo
 import { Vendor } from '@/modules/Vendors/models/Vendor';
 import { INumberFormatQuery } from '../../types/Report.types';
 import { TransactionsByVendorRepository } from './TransactionsByVendorRepository';
+import { IFinancialReportMeta, DEFAULT_REPORT_META } from '../../types/Report.types';
 
 const VENDOR_NORMAL = 'credit';
 
@@ -26,11 +27,13 @@ export class TransactionsByVendor extends TransactionsByContact {
    * @param {TransactionsByVendorRepository} transactionsByVendorRepository - Transactions by vendor repository.
    * @param {ITransactionsByVendorsFilter} filter - Transactions by vendors filter.
    * @param {I18nService} i18n - Internationalization service.
+   * @param {IFinancialReportMeta} meta - Report meta.
    */
   constructor(
     transactionsByVendorRepository: TransactionsByVendorRepository,
     filter: ITransactionsByVendorsFilter,
     i18n: I18nService,
+    meta: IFinancialReportMeta,
   ) {
     super();
 
@@ -38,6 +41,8 @@ export class TransactionsByVendor extends TransactionsByContact {
     this.filter = filter;
     this.numberFormat = this.filter.numberFormat;
     this.i18n = i18n;
+    this.baseCurrency = meta.baseCurrency;
+    this.dateFormat = meta.dateFormat || DEFAULT_REPORT_META.dateFormat;
   }
 
   /**

--- a/packages/server/src/modules/FinancialStatements/modules/TransactionsByVendor/TransactionsByVendorInjectable.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/TransactionsByVendor/TransactionsByVendorInjectable.ts
@@ -36,13 +36,16 @@ export class TransactionsByVendorsInjectable {
     // Initialize the repository.
     await this.transactionsByVendorRepository.asyncInit();
 
-    // Transactions by customers data mapper.
+    // Retrieve the meta first to get date format.
+    const meta = await this.transactionsByVendorMeta.meta(filter);
+
+    // Transactions by vendors data mapper.
     const reportInstance = new TransactionsByVendor(
       this.transactionsByVendorRepository,
       filter,
       this.i18n,
+      { baseCurrency: meta.baseCurrency, dateFormat: meta.dateFormat },
     );
-    const meta = await this.transactionsByVendorMeta.meta(filter);
 
     // Triggers `onVendorTransactionsViewed` event.
     await this.eventPublisher.emitAsync(

--- a/packages/server/src/modules/FinancialStatements/modules/TransactionsByVendor/TransactionsByVendorMeta.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/TransactionsByVendor/TransactionsByVendorMeta.ts
@@ -21,8 +21,8 @@ export class TransactionsByVendorMeta {
   ): Promise<ITransactionsByVendorMeta> {
     const commonMeta = await this.financialSheetMeta.meta();
 
-    const formattedToDate = moment(query.toDate).format('YYYY/MM/DD');
-    const formattedFromDate = moment(query.fromDate).format('YYYY/MM/DD');
+    const formattedToDate = moment(query.toDate).format(commonMeta.dateFormat);
+    const formattedFromDate = moment(query.fromDate).format(commonMeta.dateFormat);
     const formattedDateRange = `From ${formattedFromDate} | To ${formattedToDate}`;
 
     const sheetName = 'Transactions By Vendor';

--- a/packages/server/src/modules/FinancialStatements/modules/TransactionsByVendor/TransactionsByVendorTable.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/TransactionsByVendor/TransactionsByVendorTable.ts
@@ -1,4 +1,5 @@
 import * as R from 'ramda';
+import { I18nService } from 'nestjs-i18n';
 import { ITransactionsByVendorsVendor } from './TransactionsByVendor.types';
 import { TransactionsByContactsTableRows } from '../TransactionsByContact/TransactionsByContactTableRows';
 import { tableRowMapper } from '../../utils/Table.utils';
@@ -19,11 +20,16 @@ export class TransactionsByVendorsTable extends TransactionsByContactsTableRows 
    * @param {ITransactionsByVendorsVendor[]} vendorsTransactions -
    * @param {any} i18n
    */
-  constructor(vendorsTransactions: ITransactionsByVendorsVendor[], i18n) {
+  constructor(
+    vendorsTransactions: ITransactionsByVendorsVendor[],
+    i18n: I18nService,
+    dateFormat: string,
+  ) {
     super();
 
     this.vendorsTransactions = vendorsTransactions;
     this.i18n = i18n;
+    this.dateFormat = dateFormat;
   }
 
   /**

--- a/packages/server/src/modules/FinancialStatements/modules/TransactionsByVendor/TransactionsByVendorTableInjectable.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/TransactionsByVendor/TransactionsByVendorTableInjectable.ts
@@ -25,7 +25,7 @@ export class TransactionsByVendorTableInjectable {
     const sheet = await this.transactionsByVendor.transactionsByVendors(
       query
     );
-    const table = new TransactionsByVendorsTable(sheet.data, this.i18n);
+    const table = new TransactionsByVendorsTable(sheet.data, this.i18n, sheet.meta.dateFormat);
 
     return {
       table: {

--- a/packages/server/src/modules/FinancialStatements/modules/TrialBalanceSheet/TrialBalanceSheet.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/TrialBalanceSheet/TrialBalanceSheet.ts
@@ -12,6 +12,7 @@ import { Account } from '@/modules/Accounts/models/Account.model';
 import { allPassedConditionsPass } from '@/utils/all-conditions-passed';
 import { ModelObject } from 'objection';
 import { flatToNestedArray } from '@/utils/flat-to-nested-array';
+import { IFinancialReportMeta, DEFAULT_REPORT_META } from '../../types/Report.types';
 
 export class TrialBalanceSheet extends FinancialSheet {
   /**
@@ -42,14 +43,15 @@ export class TrialBalanceSheet extends FinancialSheet {
   constructor(
     query: ITrialBalanceSheetQuery,
     repository: TrialBalanceSheetRepository,
-    baseCurrency: string
+    meta: IFinancialReportMeta,
   ) {
     super();
 
     this.query = query;
     this.repository = repository;
     this.numberFormat = this.query.numberFormat;
-    this.baseCurrency = baseCurrency;
+    this.baseCurrency = meta.baseCurrency;
+    this.dateFormat = meta.dateFormat || DEFAULT_REPORT_META.dateFormat;
   }
 
   /**

--- a/packages/server/src/modules/FinancialStatements/modules/TrialBalanceSheet/TrialBalanceSheetInjectable.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/TrialBalanceSheet/TrialBalanceSheetInjectable.ts
@@ -39,17 +39,17 @@ export class TrialBalanceSheetService {
     // Loads the resources.
     await this.trialBalanceSheetRepository.asyncInitialize();
 
+    // Trial balance sheet meta first to get date format.
+    const meta = await this.trialBalanceSheetMetaService.meta(filter);
+
     // Trial balance report instance.
     const trialBalanceInstance = new TrialBalanceSheet(
       filter,
       this.trialBalanceSheetRepository,
-      tenantMetadata.baseCurrency,
+      { baseCurrency: tenantMetadata.baseCurrency, dateFormat: meta.dateFormat },
     );
     // Trial balance sheet data.
     const trialBalanceSheetData = trialBalanceInstance.reportData();
-
-    // Trial balance sheet meta.
-    const meta = await this.trialBalanceSheetMetaService.meta(filter);
 
     // Triggers `onTrialBalanceSheetViewed` event.
     await this.eventPublisher.emitAsync(

--- a/packages/server/src/modules/FinancialStatements/modules/TrialBalanceSheet/TrialBalanceSheetMeta.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/TrialBalanceSheet/TrialBalanceSheetMeta.ts
@@ -16,8 +16,8 @@ export class TrialBalanceSheetMeta {
   ): Promise<ITrialBalanceSheetMeta> {
     const commonMeta = await this.financialSheetMeta.meta();
 
-    const formattedFromDate = moment(query.fromDate).format('YYYY/MM/DD');
-    const formattedToDate = moment(query.toDate).format('YYYY/MM/DD');
+    const formattedFromDate = moment(query.fromDate).format(commonMeta.dateFormat);
+    const formattedToDate = moment(query.toDate).format(commonMeta.dateFormat);
     const formattedDateRange = `From ${formattedFromDate} to ${formattedToDate}`;
 
     const sheetName = 'Trial Balance Sheet';

--- a/packages/server/src/modules/FinancialStatements/modules/VendorBalanceSummary/VendorBalanceSummary.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/VendorBalanceSummary/VendorBalanceSummary.ts
@@ -8,7 +8,7 @@ import {
 } from './VendorBalanceSummary.types';
 import { ContactBalanceSummaryReport } from '../ContactBalanceSummary/ContactBalanceSummary';
 import { Vendor } from '@/modules/Vendors/models/Vendor';
-import { INumberFormatQuery } from '../../types/Report.types';
+import { INumberFormatQuery, IFinancialReportMeta, DEFAULT_REPORT_META } from '../../types/Report.types';
 import { VendorBalanceSummaryRepository } from './VendorBalanceSummaryRepository';
 import { Ledger } from '@/modules/Ledger/Ledger';
 
@@ -27,15 +27,17 @@ export class VendorBalanceSummaryReport extends ContactBalanceSummaryReport {
   constructor(
     repository: VendorBalanceSummaryRepository,
     filter: IVendorBalanceSummaryQuery,
+    meta: IFinancialReportMeta,
   ) {
     super();
-    
+
     this.repository = repository;
     this.ledger = this.repository.ledger;
-    this.baseCurrency = this.repository.baseCurrency;
+    this.baseCurrency = meta.baseCurrency;
 
     this.filter = filter;
     this.numberFormat = this.filter.numberFormat;
+    this.dateFormat = meta.dateFormat || DEFAULT_REPORT_META.dateFormat;
 
   }
 

--- a/packages/server/src/modules/FinancialStatements/modules/VendorBalanceSummary/VendorBalanceSummaryMeta.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/VendorBalanceSummary/VendorBalanceSummaryMeta.ts
@@ -19,7 +19,7 @@ export class VendorBalanceSummaryMeta {
     query: IVendorBalanceSummaryQuery,
   ): Promise<IVendorBalanceSummaryMeta> {
     const commonMeta = await this.financialSheetMeta.meta();
-    const formattedAsDate = moment(query.asDate).format('YYYY/MM/DD');
+    const formattedAsDate = moment(query.asDate).format(commonMeta.dateFormat);
 
     return {
       ...commonMeta,

--- a/packages/server/src/modules/FinancialStatements/modules/VendorBalanceSummary/VendorBalanceSummaryService.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/VendorBalanceSummary/VendorBalanceSummaryService.ts
@@ -31,13 +31,15 @@ export class VendorBalanceSummaryService {
     this.vendorBalanceSummaryRepository.setFilter(filter);
     await this.vendorBalanceSummaryRepository.asyncInit();
 
+    // Retrieve the vendor balance summary meta first to get date format.
+    const meta = await this.vendorBalanceSummaryMeta.meta(filter);
+
     // Report instance.
     const reportInstance = new VendorBalanceSummaryReport(
       this.vendorBalanceSummaryRepository,
       filter,
+      { baseCurrency: this.vendorBalanceSummaryRepository.baseCurrency, dateFormat: meta.dateFormat },
     );
-    // Retrieve the vendor balance summary meta.
-    const meta = await this.vendorBalanceSummaryMeta.meta(filter);
 
     // Triggers `onVendorBalanceSummaryViewed` event.
     await this.eventEmitter.emitAsync(

--- a/packages/server/src/modules/FinancialStatements/types/Report.types.ts
+++ b/packages/server/src/modules/FinancialStatements/types/Report.types.ts
@@ -52,6 +52,22 @@ export interface IFinancialSheetCommonMeta {
   sheetName: string;
 }
 
+/**
+ * Report meta interface for sheet constructors.
+ * Combines baseCurrency and dateFormat for a cleaner API.
+ */
+export interface IFinancialReportMeta {
+  baseCurrency: string;
+  dateFormat: string;
+}
+
+/**
+ * Default report meta values.
+ */
+export const DEFAULT_REPORT_META: Omit<IFinancialReportMeta, 'baseCurrency'> = {
+  dateFormat: 'YYYY MMM DD',
+};
+
 export enum IFinancialDatePeriodsUnit {
   Day = 'day',
   Month = 'month',


### PR DESCRIPTION
## Summary

This PR fixes date formatting in all financial reports to use the organization's stored date format preference instead of hardcoded formats.

## Changes

- **Meta Classes**: Updated 17 Meta classes to use `meta.dateFormat` instead of hardcoded `'YYYY/MM/DD'`
- **New Interface**: Added `IFinancialReportMeta` interface combining `baseCurrency` and `dateFormat`
- **Default Value**: Added `DEFAULT_REPORT_META` with default date format `'YYYY MMM DD'`
- **Sheet Classes**: Updated 17 sheet classes to accept `IFinancialReportMeta` parameter
- **Services**: Updated 14 services to pass dateFormat from meta to sheet constructors
- **Table Formatters**: Fixed customer/vendor transactions date formatting
- **Module Fix**: Added `TenancyModule` to `SalesTaxLiabilityModule` for DI

## Testing

- [ ] TypeScript compilation passes
- [ ] Financial reports display dates in the correct format
- [ ] Customer/Vendor transactions table shows formatted dates

## PR-Agent Sections

pr_agent:summary

pr_agent:walkthrough