### PR TITLE
fix(accounts): add account settings service

### DIFF
--- a/packages/server/src/modules/Accounts/Accounts.module.ts
+++ b/packages/server/src/modules/Accounts/Accounts.module.ts
@@ -21,6 +21,7 @@ import { AccountsExportable } from './AccountsExportable.service';
 import { AccountsImportable } from './AccountsImportable.service';
 import { BulkDeleteAccountsService } from './BulkDeleteAccounts.service';
 import { ValidateBulkDeleteAccountsService } from './ValidateBulkDeleteAccounts.service';
+import { AccountsSettingsService } from './AccountsSettings.service';
 
 const models = [RegisterTenancyModel(BankAccount)];
 
@@ -29,6 +30,7 @@ const models = [RegisterTenancyModel(BankAccount)];
   controllers: [AccountsController],
   providers: [
     AccountsApplication,
+    AccountsSettingsService,
     CreateAccountService,
     TenancyContext,
     CommandAccountValidators,
@@ -49,9 +51,10 @@ const models = [RegisterTenancyModel(BankAccount)];
   exports: [
     AccountRepository,
     CreateAccountService,
+    AccountsSettingsService,
     ...models,
     AccountsExportable,
-    AccountsImportable
+    AccountsImportable,
   ],
 })
 export class AccountsModule {}

--- a/packages/server/src/modules/Accounts/AccountsSettings.service.ts
+++ b/packages/server/src/modules/Accounts/AccountsSettings.service.ts
@@ -1,0 +1,33 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { SettingsStore } from '../Settings/SettingsStore';
+import { SETTINGS_PROVIDER } from '../Settings/Settings.types';
+
+export interface IAccountsSettings {
+  accountCodeRequired: boolean;
+  accountCodeUnique: boolean;
+}
+
+@Injectable()
+export class AccountsSettingsService {
+  constructor(
+    @Inject(SETTINGS_PROVIDER)
+    private readonly settingsStore: () => SettingsStore,
+  ) {}
+
+  /**
+   * Retrieves account settings (account code required, account code unique).
+   */
+  public async getAccountsSettings(): Promise<IAccountsSettings> {
+    const settingsStore = await this.settingsStore();
+    return {
+      accountCodeRequired: settingsStore.get(
+        { group: 'accounts', key: 'account_code_required' },
+        false,
+      ),
+      accountCodeUnique: settingsStore.get(
+        { group: 'accounts', key: 'account_code_unique' },
+        true,
+      ),
+    };
+  }
+}

--- a/packages/server/src/modules/Accounts/CommandAccountValidators.service.ts
+++ b/packages/server/src/modules/Accounts/CommandAccountValidators.service.ts
@@ -107,6 +107,20 @@ export class CommandAccountValidators {
   }
 
   /**
+   * Throws error if account code is missing or blank when required.
+   * @param {string|undefined} code - Account code.
+   */
+  public validateAccountCodeRequiredOrThrow(code: string | undefined) {
+    const trimmed = typeof code === 'string' ? code.trim() : '';
+    if (!trimmed) {
+      throw new ServiceError(
+        ERRORS.ACCOUNT_CODE_REQUIRED,
+        'Account code is required.',
+      );
+    }
+  }
+
+  /**
    * Validates the account name uniquiness.
    * @param {string} accountName - Account name.
    * @param {number} notAccountId - Ignore the account id.

--- a/packages/server/src/modules/Accounts/CreateAccount.service.ts
+++ b/packages/server/src/modules/Accounts/CreateAccount.service.ts
@@ -15,6 +15,7 @@ import { events } from '@/common/events/events';
 import { CreateAccountDTO } from './CreateAccount.dto';
 import { PartialModelObject } from 'objection';
 import { TenantModelProxy } from '../System/models/TenantBaseModel';
+import { AccountsSettingsService } from './AccountsSettings.service';
 
 @Injectable()
 export class CreateAccountService {
@@ -32,6 +33,7 @@ export class CreateAccountService {
     private readonly uow: UnitOfWork,
     private readonly validator: CommandAccountValidators,
     private readonly tenancyContext: TenancyContext,
+    private readonly accountsSettings: AccountsSettingsService,
   ) {}
 
   /**
@@ -43,13 +45,20 @@ export class CreateAccountService {
     baseCurrency: string,
     params?: CreateAccountParams,
   ) => {
+    const { accountCodeRequired, accountCodeUnique } =
+      await this.accountsSettings.getAccountsSettings();
+
+    // Validate account code required when setting is enabled.
+    if (accountCodeRequired) {
+      this.validator.validateAccountCodeRequiredOrThrow(accountDTO.code);
+    }
+    // Validate the account code uniquiness when setting is enabled.
+    if (accountCodeUnique && accountDTO.code?.trim()) {
+      await this.validator.isAccountCodeUniqueOrThrowError(accountDTO.code);
+    }
     // Validate account name uniquiness.
     if (!params.ignoreUniqueName) {
       await this.validator.validateAccountNameUniquiness(accountDTO.name);
-    }
-    // Validate the account code uniquiness.
-    if (accountDTO.code) {
-      await this.validator.isAccountCodeUniqueOrThrowError(accountDTO.code);
     }
     // Retrieve the account type meta or throw service error if not found.
     this.validator.getAccountTypeOrThrowError(accountDTO.accountType);

--- a/packages/server/src/modules/Accounts/EditAccount.service.ts
+++ b/packages/server/src/modules/Accounts/EditAccount.service.ts
@@ -7,6 +7,7 @@ import { UnitOfWork } from '../Tenancy/TenancyDB/UnitOfWork.service';
 import { events } from '@/common/events/events';
 import { EditAccountDTO } from './EditAccount.dto';
 import { TenantModelProxy } from '../System/models/TenantBaseModel';
+import { AccountsSettingsService } from './AccountsSettings.service';
 
 @Injectable()
 export class EditAccount {
@@ -17,7 +18,8 @@ export class EditAccount {
 
     @Inject(Account.name)
     private readonly accountModel: TenantModelProxy<typeof Account>,
-  ) { }
+    private readonly accountsSettings: AccountsSettingsService,
+  ) {}
 
   /**
    * Authorize the account editing.
@@ -30,6 +32,24 @@ export class EditAccount {
     accountDTO: EditAccountDTO,
     oldAccount: Account,
   ) => {
+    const { accountCodeRequired, accountCodeUnique } =
+      await this.accountsSettings.getAccountsSettings();
+
+    // Validate account code required when setting is enabled.
+    if (accountCodeRequired) {
+      this.validator.validateAccountCodeRequiredOrThrow(accountDTO.code);
+    }
+    // Validate the account code uniquiness when setting is enabled.
+    if (
+      accountCodeUnique &&
+      accountDTO.code?.trim() &&
+      accountDTO.code !== oldAccount.code
+    ) {
+      await this.validator.isAccountCodeUniqueOrThrowError(
+        accountDTO.code,
+        oldAccount.id,
+      );
+    }
     // Validate account name uniquiness.
     await this.validator.validateAccountNameUniquiness(
       accountDTO.name,
@@ -40,13 +60,6 @@ export class EditAccount {
       oldAccount,
       accountDTO,
     );
-    // Validate the account code not exists on the storage.
-    if (accountDTO.code && accountDTO.code !== oldAccount.code) {
-      await this.validator.isAccountCodeUniqueOrThrowError(
-        accountDTO.code,
-        oldAccount.id,
-      );
-    }
     // Retrieve the parent account of throw not found service error.
     if (accountDTO.parentAccountId) {
       const parentAccount = await this.validator.getParentAccountOrThrowError(

--- a/packages/server/src/modules/Accounts/constants.ts
+++ b/packages/server/src/modules/Accounts/constants.ts
@@ -3,6 +3,7 @@ export const ERRORS = {
   ACCOUNT_TYPE_NOT_FOUND: 'account_type_not_found',
   PARENT_ACCOUNT_NOT_FOUND: 'parent_account_not_found',
   ACCOUNT_CODE_NOT_UNIQUE: 'account_code_not_unique',
+  ACCOUNT_CODE_REQUIRED: 'account_code_required',
   ACCOUNT_NAME_NOT_UNIQUE: 'account_name_not_unqiue',
   PARENT_ACCOUNT_HAS_DIFFERENT_TYPE: 'parent_has_different_type',
   ACCOUNT_TYPE_NOT_ALLOWED_TO_CHANGE: 'account_type_not_allowed_to_changed',

--- a/packages/webapp/src/containers/Dialogs/AccountDialog/utils.tsx
+++ b/packages/webapp/src/containers/Dialogs/AccountDialog/utils.tsx
@@ -15,10 +15,16 @@ export const AccountDialogAction = {
  */
 export const transformApiErrors = (errors) => {
   const fields = {};
+  if (errors.find((e) => e.type === 'account_code_required')) {
+    fields.code = intl.get('account_code_is_required');
+  }
   if (errors.find((e) => e.type === 'NOT_UNIQUE_CODE')) {
     fields.code = intl.get('account_code_is_not_unique');
   }
-  if (errors.find((e) => e.type === 'ACCOUNT.NAME.NOT.UNIQUE')) {
+  if (errors.find((e) => e.type === 'account_code_not_unique')) {
+    fields.code = intl.get('account_code_is_not_unique');
+  }
+  if (errors.find((e) => e.type === 'account_name_not_unqiue')) {
     fields.name = intl.get('account_name_is_already_used');
   }
   if (

--- a/packages/webapp/src/lang/en/index.json
+++ b/packages/webapp/src/lang/en/index.json
@@ -462,6 +462,7 @@
   "should_total_of_credit_and_debit_be_equal": "Should total of credit and debit be equal.",
   "no_accounts": "No Accounts",
   "the_accounts_have_been_successfully_inactivated": "The accounts have been successfully inactivated.",
+  "account_code_is_required": "Account code is required.",
   "account_code_is_not_unique": "Account code is not unique.",
   "are_sure_to_publish_this_expense": "Are you sure you want to publish this expense?",
   "once_delete_these_journals_you_will_not_able_restore_them": "Once you delete these journals, you won't be able to retrieve them later. Are you sure you want to delete them?",


### PR DESCRIPTION
## Summary

This PR introduces a new `AccountsSettingsService` for managing account-related settings and updates the account module to utilize these settings.

## Changes

- **New Service**: Added `AccountsSettingsService` to handle account configuration settings
- **Validators**: Updated `CommandAccountValidators.service.ts` to use settings service
- **Create/Edit Services**: Modified `CreateAccount.service.ts` and `EditAccount.service.ts` to integrate with settings
- **Constants**: Added new constants for account configuration in `constants.ts`
- **Module**: Updated `Accounts.module.ts` to include the new service
- **Frontend**: Updated account dialog utils and translations

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Testing

- [ ] Test account creation with new settings integration
- [ ] Test account editing with settings validation
- [ ] Verify frontend account dialog functionality

pr_agent:summary

pr_agent:walkthrough

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)