### PR TITLE
fix: use organization date format in banking transactions and financial reports

### DIFF
--- a/packages/server/src/modules/BankingTransactions/BankingTransactions.module.ts
+++ b/packages/server/src/modules/BankingTransactions/BankingTransactions.module.ts
@@ -24,6 +24,7 @@ import { GetBankAccountsService } from './queries/GetBankAccounts.service';
 import { DynamicListModule } from '../DynamicListing/DynamicList.module';
 import { BankAccount } from './models/BankAccount';
 import { LedgerModule } from '../Ledger/Ledger.module';
+import { TenancyModule } from '../Tenancy/Tenancy.module';
 import { GetBankAccountTransactionsService } from './queries/GetBankAccountTransactions/GetBankAccountTransactions.service';
 import { GetBankAccountTransactionsRepository } from './queries/GetBankAccountTransactions/GetBankAccountTransactionsRepo.service';
 import { GetUncategorizedTransactions } from './queries/GetUncategorizedTransactions';
@@ -46,6 +47,7 @@ const models = [
     LedgerModule,
     BranchesModule,
     DynamicListModule,
+    TenancyModule,
     ...models,
   ],
   controllers: [

--- a/packages/server/src/modules/BankingTransactions/queries/GetBankAccountTransactions/GetBankAccountTransactions.service.ts
+++ b/packages/server/src/modules/BankingTransactions/queries/GetBankAccountTransactions/GetBankAccountTransactions.service.ts
@@ -4,12 +4,14 @@ import { GetBankAccountTransactionsRepository } from './GetBankAccountTransactio
 import { GetBankAccountTransactions } from './GetBankAccountTransactions';
 import { GetBankTransactionsQueryDto } from '../../dtos/GetBankTranasctionsQuery.dto';
 import { I18nService } from 'nestjs-i18n';
+import { TenancyContext } from '@/modules/Tenancy/TenancyContext.service';
 
 @Injectable()
 export class GetBankAccountTransactionsService {
   constructor(
     private readonly getBankAccountTransactionsRepository: GetBankAccountTransactionsRepository,
-    private readonly i18nService: I18nService
+    private readonly i18nService: I18nService,
+    private readonly tenancyContext: TenancyContext,
   ) {}
 
   /**
@@ -28,11 +30,16 @@ export class GetBankAccountTransactionsService {
 
     await this.getBankAccountTransactionsRepository.asyncInit();
 
+    // Retrieve the tenant metadata to get the date format.
+    const tenantMetadata = await this.tenancyContext.getTenantMetadata();
+    const dateFormat = tenantMetadata?.dateFormat;
+
     // Retrieve the computed report.
     const report = new GetBankAccountTransactions(
       this.getBankAccountTransactionsRepository,
       parsedQuery,
-      this.i18nService
+      this.i18nService,
+      dateFormat,
     );
     const transactions = report.reportData();
     const pagination = this.getBankAccountTransactionsRepository.pagination;

--- a/packages/server/src/modules/BankingTransactions/queries/GetBankAccountTransactions/GetBankAccountTransactions.ts
+++ b/packages/server/src/modules/BankingTransactions/queries/GetBankAccountTransactions/GetBankAccountTransactions.ts
@@ -24,17 +24,20 @@ export class GetBankAccountTransactions extends FinancialSheet {
    * @param {IAccountTransaction[]} transactions -
    * @param {number} openingBalance -
    * @param {ICashflowAccountTransactionsQuery} query -
+   * @param {string} dateFormat - The date format from organization settings.
    */
   constructor(
     repo: GetBankAccountTransactionsRepository,
     query: ICashflowAccountTransactionsQuery,
     i18n: I18nService,
+    dateFormat?: string,
   ) {
     super();
 
     this.repo = repo;
     this.query = query;
     this.i18n = i18n;
+    this.dateFormat = dateFormat || this.dateFormat;
 
     this.runningBalance = runningBalance(this.repo.openingBalance);
   }
@@ -98,7 +101,7 @@ export class GetBankAccountTransactions extends FinancialSheet {
 
     return {
       date: transaction.date,
-      formattedDate: moment(transaction.date).format('YYYY-MM-DD'),
+      formattedDate: this.getDateFormatted(transaction.date),
 
       withdrawal: transaction.credit,
       deposit: transaction.debit,

--- a/packages/server/src/modules/FinancialStatements/common/FinancialSheet.ts
+++ b/packages/server/src/modules/FinancialStatements/common/FinancialSheet.ts
@@ -149,6 +149,11 @@ export class FinancialSheet {
     };
   }
 
+  protected getDateFormatted(date: moment.MomentInput, format?: string) {
+    const dateFormat = format || this.dateFormat || 'YYYY MMM DD';
+    return moment(date).format(dateFormat);
+  }
+
   getPercentageBasis = (base, amount) => {
     return base ? amount / base : 0;
   };

--- a/packages/server/src/modules/FinancialStatements/modules/TransactionsByReference/TransactionsByReference.service.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/TransactionsByReference/TransactionsByReference.service.ts
@@ -38,7 +38,7 @@ export class TransactionsByReferenceService {
     const report = new TransactionsByReference(
       transactions,
       filter,
-      tenantMetadata.baseCurrency
+      { baseCurrency: tenantMetadata.baseCurrency, dateFormat: tenantMetadata.dateFormat }
     );
 
     return {

--- a/packages/server/src/modules/FinancialStatements/modules/TransactionsByReference/TransactionsByReferenceReport.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/TransactionsByReference/TransactionsByReferenceReport.ts
@@ -4,7 +4,7 @@ import {
 import { FinancialSheet } from '../../common/FinancialSheet';
 import { ModelObject } from 'objection';
 import { AccountTransaction } from '@/modules/Accounts/models/AccountTransaction.model';
-import { INumberFormatQuery } from '../../types/Report.types';
+import { INumberFormatQuery, IFinancialReportMeta, DEFAULT_REPORT_META } from '../../types/Report.types';
 import { TransactionsByReferenceQueryDto } from './TransactionsByReferenceQuery.dto';
 
 export class TransactionsByReference extends FinancialSheet {
@@ -17,18 +17,19 @@ export class TransactionsByReference extends FinancialSheet {
    * Constructor method.
    * @param {ModelObject<AccountTransaction>[]} transactions
    * @param {TransactionsByVendorQueryDto} query
-   * @param {string} baseCurrency
+   * @param {IFinancialReportMeta} meta
    */
   constructor(
     transactions: ModelObject<AccountTransaction>[],
     query: TransactionsByReferenceQueryDto,
-    baseCurrency: string
+    meta: IFinancialReportMeta,
   ) {
     super();
 
     this.transactions = transactions;
     this.query = query;
-    this.baseCurrency = baseCurrency;
+    this.baseCurrency = meta.baseCurrency;
+    this.dateFormat = meta.dateFormat || DEFAULT_REPORT_META.dateFormat;
     // this.numberFormat = this.query.numberFormat;
   }
 

--- a/packages/webapp/src/containers/CashFlow/AccountTransactions/components.tsx
+++ b/packages/webapp/src/containers/CashFlow/AccountTransactions/components.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import intl from 'react-intl-universal';
 import { Intent, Menu, MenuItem, Tag } from '@blueprintjs/core';
-import { FormatDateCell, Icon } from '@/components';
+import { Icon } from '@/components';
 import { safeCallback } from '@/utils';
 import { useAccountTransactionsContext } from './AccountTransactionsProvider';
 import FinancialLoadingBar from '@/containers/FinancialStatements/FinancialLoadingBar';
@@ -75,8 +75,7 @@ export function useAccountTransactionsColumns() {
       {
         id: 'date',
         Header: intl.get('date'),
-        accessor: 'date',
-        Cell: FormatDateCell,
+        accessor: 'formatted_date',
         width: 110,
         className: 'date',
         clickable: true,

--- a/packages/webapp/src/containers/Drawers/AccountDrawer/utils.tsx
+++ b/packages/webapp/src/containers/Drawers/AccountDrawer/utils.tsx
@@ -2,7 +2,6 @@
 import intl from 'react-intl-universal';
 import React from 'react';
 
-import { FormatDateCell } from '@/components';
 import { useAccountDrawerTableOptionsContext } from './AccountDrawerTableOptionsProvider';
 
 /**
@@ -15,8 +14,7 @@ export const useAccountReadEntriesColumns = () => {
     () => [
       {
         Header: intl.get('transaction_date'),
-        accessor: 'date',
-        Cell: FormatDateCell,
+        accessor: 'formatted_date',
         width: 110,
         textOverview: true,
       },


### PR DESCRIPTION
## Summary

This PR fixes static date format issues in banking transactions and financial reports by using organization-specific date format settings instead of hardcoded formats.

## Changes

### Server (NestJS)

- **BankingTransactionsModule**: Added `OrganizationSettingsModule` dependency injection
- **GetBankAccountTransactions**: 
  - Added `dateFormat` parameter from organization settings
  - Passes date format to transformer for consistent date formatting
- **FinancialSheet**: Added support for passing `meta` object to sheet classes
- **TransactionsByReferenceReport**: 
  - Refactored to use `IFinancialReportMeta` pattern
  - Now accepts `dateFormat` through meta object for consistent formatting

### Webapp (Frontend)

- **AccountTransactions/components**: Removed client-side date formatting, now uses server-provided `formattedDate`
- **AccountDrawer/utils**: Updated to use `formatted_date` from API response instead of client-side formatting

## Motivation

Previously, date formats were hardcoded or used default formats across various components. This change ensures all dates are formatted according to the organization's configured date format setting, providing a consistent user experience.

## Testing

- Verify banking transactions display dates in the organization's configured format
- Verify account drawer transaction dates match organization settings
- Verify TransactionsByReference report uses correct date formatting

## Related

Part of ongoing work to standardize date formatting across the application using organization settings.