### PR TITLE
fix(webapp): account type not pre-selected when editing from banking page

### DIFF
--- a/packages/webapp/src/containers/CashFlow/CashFlowAccounts/CashflowAccountsGrid.tsx
+++ b/packages/webapp/src/containers/CashFlow/CashFlowAccounts/CashflowAccountsGrid.tsx
@@ -82,7 +82,7 @@ function CashflowBankAccount({
   const handleEditAccount = () => {
     openDialog(DialogsName.AccountForm, {
       action: AccountDialogAction.Edit,
-      id: account.id,
+      accountId: account.id,
     });
   };
   // Handle money in menu item actions.


### PR DESCRIPTION
## Summary

Fixed an issue where the account type field was not pre-selected when editing an account from the Banking/Cash Flow page. The field was correctly disabled but appeared empty instead of showing the account's type.

## Root Cause

The Banking page was passing `id` in the dialog payload, but the `AccountDialogProvider` expects `accountId` to fetch account details. This mismatch prevented the account data from being fetched, so the form couldn't populate the account type field.

## Changes

- **CashflowAccountsGrid.tsx**: Changed `id: account.id` to `accountId: account.id` in the `handleEditAccount` function

## Testing

1. Navigate to Banking/Cash Flow page
2. Click on any account's context menu (three dots)
3. Click "Edit Account"
4. Verify that the account type field is pre-selected and disabled (matching Accounts Chart behavior)

## Related

- Accounts Chart uses `accountId`: `packages/webapp/src/containers/Accounts/AccountsDataTable.tsx`
- Account Dialog Provider expects `accountId`: `packages/webapp/src/containers/Dialogs/AccountDialog/AccountDialogProvider.tsx`