### PR TITLE
fix(server): add attachment support for all transaction types

### DIFF
--- a/packages/server/src/modules/Attachments/Attachment.module.ts
+++ b/packages/server/src/modules/Attachments/Attachment.module.ts
@@ -15,6 +15,8 @@ import { AttachmentsOnPaymentsReceived } from "./events/AttachmentsOnPaymentsRec
 import { AttachmentsOnManualJournals } from "./events/AttachmentsOnManualJournals";
 import { AttachmentsOnVendorCredits } from "./events/AttachmentsOnVendorCredits";
 import { AttachmentsOnSaleInvoiceCreated } from "./events/AttachmentsOnSaleInvoice";
+import { AttachmentsOnSaleReceipt } from "./events/AttachmentsOnSaleReceipts";
+import { AttachmentsOnSaleEstimates } from "./events/AttachmentsOnSaleEstimates";
 import { AttachmentsController } from "./Attachments.controller";
 import { RegisterTenancyModel } from "../Tenancy/TenancyModels/Tenancy.module";
 import { DocumentModel } from "./models/Document.model";
@@ -50,6 +52,8 @@ const models = [
     AttachmentsOnManualJournals,
     AttachmentsOnVendorCredits,
     AttachmentsOnSaleInvoiceCreated,
+    AttachmentsOnSaleReceipt,
+    AttachmentsOnSaleEstimates,
     AttachmentsApplication,
     UploadDocument,
     AttachmentUploadPipeline,

--- a/packages/server/src/modules/Attachments/events/AttachmentsOnPaymentsReceived.ts
+++ b/packages/server/src/modules/Attachments/events/AttachmentsOnPaymentsReceived.ts
@@ -55,7 +55,7 @@ export class AttachmentsOnPaymentsReceived {
     );
     await this.linkAttachmentService.bulkLink(
       keys,
-      'PaymentReceive',
+      'PaymentReceived',
       paymentReceive.id,
       trx,
     );
@@ -76,7 +76,7 @@ export class AttachmentsOnPaymentsReceived {
     );
     await this.unlinkAttachmentService.unlinkUnpresentedKeys(
       keys,
-      'PaymentReceive',
+      'PaymentReceived',
       oldPaymentReceive.id,
       trx,
     );
@@ -100,7 +100,7 @@ export class AttachmentsOnPaymentsReceived {
     );
     await this.linkAttachmentService.bulkLink(
       keys,
-      'PaymentReceive',
+      'PaymentReceived',
       oldPaymentReceive.id,
       trx,
     );
@@ -117,7 +117,7 @@ export class AttachmentsOnPaymentsReceived {
     trx,
   }: IPaymentReceivedDeletingPayload) {
     await this.unlinkAttachmentService.unlinkAllModelKeys(
-      'PaymentReceive',
+      'PaymentReceived',
       oldPaymentReceive.id,
       trx,
     );

--- a/packages/server/src/modules/BillPayments/models/BillPayment.ts
+++ b/packages/server/src/modules/BillPayments/models/BillPayment.ts
@@ -9,7 +9,9 @@ import { BillPaymentMeta } from './BillPayment.meta';
 import { TenantBaseModel } from '@/modules/System/models/TenantBaseModel';
 import { InjectModelDefaultViews } from '@/modules/Views/decorators/InjectModelDefaultViews.decorator';
 import { BillPaymentDefaultViews } from '../constants';
+import { InjectAttachable } from '@/modules/Attachments/decorators/InjectAttachable.decorator';
 
+@InjectAttachable()
 @ImportableModel()
 @ExportableModel()
 @InjectModelMeta(BillPaymentMeta)

--- a/packages/server/src/modules/Bills/models/Bill.ts
+++ b/packages/server/src/modules/Bills/models/Bill.ts
@@ -13,7 +13,9 @@ import { InjectModelMeta } from '@/modules/Tenancy/TenancyModels/decorators/Inje
 import { BillMeta } from './Bill.meta';
 import { InjectModelDefaultViews } from '@/modules/Views/decorators/InjectModelDefaultViews.decorator';
 import { BillDefaultViews } from '../Bills.constants';
+import { InjectAttachable } from '@/modules/Attachments/decorators/InjectAttachable.decorator';
 
+@InjectAttachable()
 @ExportableModel()
 @InjectModelMeta(BillMeta)
 @InjectModelDefaultViews(BillDefaultViews)

--- a/packages/server/src/modules/ChromiumlyTenancy/models/DocumentLink.ts
+++ b/packages/server/src/modules/ChromiumlyTenancy/models/DocumentLink.ts
@@ -28,7 +28,7 @@ export class DocumentLink extends BaseModel{
    * Relationship mapping.
    */
   static get relationMappings() {
-    const Document = require('./Document');
+    const { Document } = require('./Document');
 
     return {
       /**
@@ -36,7 +36,7 @@ export class DocumentLink extends BaseModel{
        */
       document: {
         relation: Model.HasOneRelation,
-        modelClass: Document.default,
+        modelClass: Document,
         join: {
           from: 'document_links.documentId',
           to: 'documents.id',

--- a/packages/server/src/modules/CreditNotes/models/CreditNote.ts
+++ b/packages/server/src/modules/CreditNotes/models/CreditNote.ts
@@ -11,7 +11,9 @@ import { Warehouse } from '@/modules/Warehouses/models/Warehouse.model';
 import { CreditNoteMeta } from './CreditNote.meta';
 import { InjectModelDefaultViews } from '@/modules/Views/decorators/InjectModelDefaultViews.decorator';
 import { CreditNoteDefaultViews } from '../constants';
+import { InjectAttachable } from '@/modules/Attachments/decorators/InjectAttachable.decorator';
 
+@InjectAttachable()
 @ExportableModel()
 @ImportableModel()
 @InjectModelMeta(CreditNoteMeta)

--- a/packages/server/src/modules/Expenses/models/Expense.model.ts
+++ b/packages/server/src/modules/Expenses/models/Expense.model.ts
@@ -9,7 +9,9 @@ import { InjectModelMeta } from '@/modules/Tenancy/TenancyModels/decorators/Inje
 import { ExpenseMeta } from './Expense.meta';
 import { InjectModelDefaultViews } from '@/modules/Views/decorators/InjectModelDefaultViews.decorator';
 import { ExpenseDefaultViews } from '../constants';
+import { InjectAttachable } from '@/modules/Attachments/decorators/InjectAttachable.decorator';
 
+@InjectAttachable()
 @ExportableModel()
 @ImportableModel()
 @InjectModelMeta(ExpenseMeta)

--- a/packages/server/src/modules/ManualJournals/models/ManualJournal.ts
+++ b/packages/server/src/modules/ManualJournals/models/ManualJournal.ts
@@ -8,7 +8,9 @@ import { ManualJournalMeta } from './ManualJournal.meta';
 import { ImportableModel } from '@/modules/Import/decorators/Import.decorator';
 import { InjectModelDefaultViews } from '@/modules/Views/decorators/InjectModelDefaultViews.decorator';
 import { ManualJournalDefaultViews } from '../constants';
+import { InjectAttachable } from '@/modules/Attachments/decorators/InjectAttachable.decorator';
 
+@InjectAttachable()
 @ExportableModel()
 @ImportableModel()
 @InjectModelMeta(ManualJournalMeta)

--- a/packages/server/src/modules/PaymentReceived/models/PaymentReceived.ts
+++ b/packages/server/src/modules/PaymentReceived/models/PaymentReceived.ts
@@ -1,5 +1,6 @@
 import { Model } from 'objection';
 import { PaymentReceivedEntry } from './PaymentReceivedEntry';
+import { Document } from '@/modules/ChromiumlyTenancy/models/Document';
 import { TenantBaseModel } from '@/modules/System/models/TenantBaseModel';
 import { ExportableModel } from '@/modules/Export/decorators/ExportableModel.decorator';
 import { ImportableModel } from '@/modules/Import/decorators/Import.decorator';
@@ -7,7 +8,9 @@ import { InjectModelMeta } from '@/modules/Tenancy/TenancyModels/decorators/Inje
 import { PaymentReceivedMeta } from './PaymentReceived.meta';
 import { InjectModelDefaultViews } from '@/modules/Views/decorators/InjectModelDefaultViews.decorator';
 import { PaymentReceivedDefaultViews } from '../constants';
+import { InjectAttachable } from '@/modules/Attachments/decorators/InjectAttachable.decorator';
 
+@InjectAttachable()
 @ExportableModel()
 @ImportableModel()
 @InjectModelMeta(PaymentReceivedMeta)
@@ -31,6 +34,7 @@ export class PaymentReceived extends TenantBaseModel {
   updatedAt: string;
 
   entries?: PaymentReceivedEntry[];
+  public attachments!: Document[];
 
   /**
    * Table name.
@@ -159,7 +163,7 @@ export class PaymentReceived extends TenantBaseModel {
           to: 'documents.id',
         },
         filter(query) {
-          query.where('model_ref', 'PaymentReceive');
+          query.where('model_ref', 'PaymentReceived');
         },
       },
 

--- a/packages/server/src/modules/PaymentReceived/queries/GetPaymentReceived.service.ts
+++ b/packages/server/src/modules/PaymentReceived/queries/GetPaymentReceived.service.ts
@@ -32,6 +32,7 @@ export class GetPaymentReceivedService {
       .withGraphFetched('entries.invoice')
       .withGraphFetched('transactions')
       .withGraphFetched('branch')
+      .withGraphFetched('attachments')
       .findById(paymentReceiveId);
 
     if (!paymentReceive) {

--- a/packages/server/src/modules/PaymentReceived/queries/PaymentReceivedTransformer.ts
+++ b/packages/server/src/modules/PaymentReceived/queries/PaymentReceivedTransformer.ts
@@ -2,6 +2,7 @@ import { Transformer } from '../../Transformer/Transformer';
 import { PaymentReceived } from '../models/PaymentReceived';
 import { PaymentReceivedEntry } from '../models/PaymentReceivedEntry';
 import { PaymentReceivedEntryTransfromer } from './PaymentReceivedEntryTransformer';
+import { AttachmentTransformer } from '@/modules/Attachments/Attachment.transformer';
 
 export class PaymentReceiveTransfromer extends Transformer {
   /**
@@ -17,6 +18,7 @@ export class PaymentReceiveTransfromer extends Transformer {
       'formattedAmount',
       'formattedExchangeRate',
       'entries',
+      'attachments',
     ];
   };
 
@@ -88,5 +90,14 @@ export class PaymentReceiveTransfromer extends Transformer {
    */
   protected entries = (payment: PaymentReceived): PaymentReceivedEntry[] => {
     return this.item(payment.entries, new PaymentReceivedEntryTransfromer());
+  };
+
+  /**
+   * Retrieves the payment received attachments.
+   * @param {PaymentReceived} payment
+   * @returns
+   */
+  protected attachments = (payment: PaymentReceived) => {
+    return this.item(payment.attachments, new AttachmentTransformer());
   };
 }

--- a/packages/server/src/modules/SaleEstimates/models/SaleEstimate.ts
+++ b/packages/server/src/modules/SaleEstimates/models/SaleEstimate.ts
@@ -12,7 +12,9 @@ import { Customer } from '@/modules/Customers/models/Customer';
 import { DiscountType } from '@/common/types/Discount';
 import { InjectModelDefaultViews } from '@/modules/Views/decorators/InjectModelDefaultViews.decorator';
 import { SaleEstimateDefaultViews } from '../constants';
+import { InjectAttachable } from '@/modules/Attachments/decorators/InjectAttachable.decorator';
 
+@InjectAttachable()
 @ExportableModel()
 @ImportableModel()
 @InjectModelMeta(SaleEstimateMeta)

--- a/packages/server/src/modules/SaleReceipts/models/SaleReceipt.ts
+++ b/packages/server/src/modules/SaleReceipts/models/SaleReceipt.ts
@@ -5,6 +5,7 @@ import { BaseModel } from '@/models/Model';
 import { ItemEntry } from '@/modules/TransactionItemEntry/models/ItemEntry';
 import { Customer } from '@/modules/Customers/models/Customer';
 import { AccountTransaction } from '@/modules/Accounts/models/AccountTransaction.model';
+import { Document } from '@/modules/ChromiumlyTenancy/models/Document';
 import { Branch } from '@/modules/Branches/models/Branch.model';
 import { Warehouse } from '@/modules/Warehouses/models/Warehouse.model';
 import { DiscountType } from '@/common/types/Discount';
@@ -15,6 +16,7 @@ import { SearchableBaseModelMixin } from '@/modules/DynamicListing/models/Search
 import { ExportableModel } from '@/modules/Export/decorators/ExportableModel.decorator';
 import { ImportableModel } from '@/modules/Import/decorators/Import.decorator';
 import { InjectModelMeta } from '@/modules/Tenancy/TenancyModels/decorators/InjectModelMeta.decorator';
+import { InjectAttachable } from '@/modules/Attachments/decorators/InjectAttachable.decorator';
 import { SaleReceiptMeta } from './SaleReceipt.meta';
 import { InjectModelDefaultViews } from '@/modules/Views/decorators/InjectModelDefaultViews.decorator';
 import { SaleReceiptDefaultViews } from '../constants';
@@ -26,6 +28,7 @@ const ExtendedModel = R.pipe(
   MetadataModelMixin,
 )(BaseModel);
 
+@InjectAttachable()
 @ExportableModel()
 @ImportableModel()
 @InjectModelMeta(SaleReceiptMeta)
@@ -58,6 +61,7 @@ export class SaleReceipt extends ExtendedModel {
   public customer!: Customer;
   public entries!: ItemEntry[];
   public transactions!: AccountTransaction[];
+  public attachments!: Document[];
   public branch!: Branch;
   public warehouse!: Warehouse;
 

--- a/packages/server/src/modules/SaleReceipts/queries/SaleReceiptTransformer.ts
+++ b/packages/server/src/modules/SaleReceipts/queries/SaleReceiptTransformer.ts
@@ -139,22 +139,22 @@ export class SaleReceiptTransformer extends Transformer {
   };
 
   /**
-   * Retrieves the entries of the credit note.
-   * @param {ISaleReceipt} credit
+   * Retrieves the entries of the sale receipt.
+   * @param {ISaleReceipt} receipt
    * @returns {}
    */
-  // protected entries = (receipt: SaleReceipt) => {
-  //   return this.item(receipt.entries, new ItemEntryTransformer(), {
-  //     currencyCode: receipt.currencyCode,
-  //   });
-  // };
+  protected entries = (receipt: SaleReceipt) => {
+    return this.item(receipt.entries, new ItemEntryTransformer(), {
+      currencyCode: receipt.currencyCode,
+    });
+  };
 
   /**
    * Retrieves the sale receipt attachments.
    * @param {SaleReceipt} receipt
    * @returns
    */
-  // protected attachments = (receipt: SaleReceipt) => {
-  //   return this.item(receipt.attachments, new AttachmentTransformer());
-  // };
+  protected attachments = (receipt: SaleReceipt) => {
+    return this.item(receipt.attachments, new AttachmentTransformer());
+  };
 }

--- a/packages/server/src/modules/VendorCredit/models/VendorCredit.ts
+++ b/packages/server/src/modules/VendorCredit/models/VendorCredit.ts
@@ -11,7 +11,9 @@ import { InjectModelMeta } from '@/modules/Tenancy/TenancyModels/decorators/Inje
 import { VendorCreditMeta } from './VendorCredit.meta';
 import { InjectModelDefaultViews } from '@/modules/Views/decorators/InjectModelDefaultViews.decorator';
 import { VendorCreditDefaultViews } from '../constants';
+import { InjectAttachable } from '@/modules/Attachments/decorators/InjectAttachable.decorator';
 
+@InjectAttachable()
 @ExportableModel()
 @ImportableModel()
 @InjectModelMeta(VendorCreditMeta)


### PR DESCRIPTION
## Summary

This PR fixes attachments not showing in edit forms for various transaction types. The root causes were missing @InjectAttachable() decorators, incomplete transformers, and inconsistent model reference names.

## Changes

### 1. Added @InjectAttachable() decorator to models:
- `SaleReceipt` - For sale receipts
- `SaleEstimate` - For sale estimates  
- `CreditNote` - For credit notes
- `PaymentReceived` - For payment received
- `Bill` - For bills
- `BillPayment` - For bill payments (payments made)
- `VendorCredit` - For vendor credits
- `ManualJournal` - For manual journals
- `Expense` - For expenses

### 2. Fixed transformers to include attachments:
- `SaleReceiptTransformer` - Uncommented attachments method
- `PaymentReceivedTransformer` - Added attachments method and includeAttributes

### 3. Registered missing event subscribers:
- `AttachmentsOnSaleReceipts` - For sale receipt attachment events
- `AttachmentsOnSaleEstimates` - For sale estimate attachment events

### 4. Fixed DocumentLink model:
- Changed `Document.default` to `Document` for proper ES module export handling

### 5. Fixed PaymentReceived model_ref consistency:
- Changed from 'PaymentReceive' to 'PaymentReceived' to match class name
- Updated event subscriber to use consistent naming

### 6. Fixed GetPaymentReceived service:
- Added missing `.withGraphFetched('attachments')` to query

## Test plan
- [ ] Create a sale receipt with attachment, edit and verify attachment shows
- [ ] Create a sale estimate with attachment, edit and verify attachment shows
- [ ] Create a credit note with attachment, edit and verify attachment shows
- [ ] Create a payment received with attachment, edit and verify attachment shows
- [ ] Create a bill with attachment, edit and verify attachment shows
- [ ] Create a bill payment with attachment, edit and verify attachment shows
- [ ] Create a vendor credit with attachment, edit and verify attachment shows
- [ ] Create a manual journal with attachment, edit and verify attachment shows
- [ ] Create an expense with attachment, edit and verify attachment shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)