### PR TITLE
fix(webapp): branch and warehouse select not showing saved values in edit mode

### DIFF
--- a/packages/webapp/src/containers/Accounting/MakeJournal/utils.tsx
+++ b/packages/webapp/src/containers/Accounting/MakeJournal/utils.tsx
@@ -213,17 +213,17 @@ export const currenciesFieldShouldUpdate = (newProps, oldProps) => {
 
 export const useSetPrimaryBranchToForm = () => {
   const { setFieldValue } = useFormikContext();
-  const { branches, isBranchesSuccess } = useMakeJournalFormContext();
+  const { branches, isBranchesSuccess, isNewMode } = useMakeJournalFormContext();
 
   React.useEffect(() => {
-    if (isBranchesSuccess) {
+    if (isBranchesSuccess && isNewMode) {
       const primaryBranch = branches.find((b) => b.primary) || first(branches);
 
       if (primaryBranch) {
         setFieldValue('branch_id', primaryBranch.id);
       }
     }
-  }, [isBranchesSuccess, setFieldValue, branches]);
+  }, [isBranchesSuccess, setFieldValue, branches, isNewMode]);
 };
 
 export const useManualJournalCreditTotal = () => {

--- a/packages/webapp/src/containers/Expenses/ExpenseForm/utils.tsx
+++ b/packages/webapp/src/containers/Expenses/ExpenseForm/utils.tsx
@@ -152,17 +152,17 @@ export const transformFormValuesToRequest = (values) => {
 
 export const useSetPrimaryBranchToForm = () => {
   const { setFieldValue } = useFormikContext();
-  const { branches, isBranchesSuccess } = useExpenseFormContext();
+  const { branches, isBranchesSuccess, isNewMode } = useExpenseFormContext();
 
   React.useEffect(() => {
-    if (isBranchesSuccess) {
+    if (isBranchesSuccess && isNewMode) {
       const primaryBranch = branches.find((b) => b.primary) || first(branches);
 
       if (primaryBranch) {
         setFieldValue('branch_id', primaryBranch.id);
       }
     }
-  }, [isBranchesSuccess, setFieldValue, branches]);
+  }, [isBranchesSuccess, setFieldValue, branches, isNewMode]);
 };
 
 /**

--- a/packages/webapp/src/containers/Purchases/Bills/BillForm/utils.tsx
+++ b/packages/webapp/src/containers/Purchases/Bills/BillForm/utils.tsx
@@ -231,25 +231,25 @@ export const handleErrors = (errors, { setErrors }) => {
 
 export const useSetPrimaryBranchToForm = () => {
   const { setFieldValue } = useFormikContext();
-  const { branches, isBranchesSuccess } = useBillFormContext();
+  const { branches, isBranchesSuccess, isNewMode } = useBillFormContext();
 
   React.useEffect(() => {
-    if (isBranchesSuccess) {
+    if (isBranchesSuccess && isNewMode) {
       const primaryBranch = branches.find((b) => b.primary) || first(branches);
 
       if (primaryBranch) {
         setFieldValue('branch_id', primaryBranch.id);
       }
     }
-  }, [isBranchesSuccess, setFieldValue, branches]);
+  }, [isBranchesSuccess, setFieldValue, branches, isNewMode]);
 };
 
 export const useSetPrimaryWarehouseToForm = () => {
   const { setFieldValue } = useFormikContext();
-  const { warehouses, isWarehousesSuccess } = useBillFormContext();
+  const { warehouses, isWarehousesSuccess, isNewMode } = useBillFormContext();
 
   React.useEffect(() => {
-    if (isWarehousesSuccess) {
+    if (isWarehousesSuccess && isNewMode) {
       const primaryWarehouse =
         warehouses.find((b) => b.primary) || first(warehouses);
 
@@ -257,7 +257,7 @@ export const useSetPrimaryWarehouseToForm = () => {
         setFieldValue('warehouse_id', primaryWarehouse.id);
       }
     }
-  }, [isWarehousesSuccess, setFieldValue, warehouses]);
+  }, [isWarehousesSuccess, setFieldValue, warehouses, isNewMode]);
 };
 
 /**

--- a/packages/webapp/src/containers/Purchases/CreditNotes/CreditNoteForm/utils.tsx
+++ b/packages/webapp/src/containers/Purchases/CreditNotes/CreditNoteForm/utils.tsx
@@ -156,25 +156,25 @@ export const useObserveVendorCreditNoSettings = (prefix, nextNumber) => {
 
 export const useSetPrimaryBranchToForm = () => {
   const { setFieldValue } = useFormikContext();
-  const { branches, isBranchesSuccess } = useVendorCreditNoteFormContext();
+  const { branches, isBranchesSuccess, isNewMode } = useVendorCreditNoteFormContext();
 
   React.useEffect(() => {
-    if (isBranchesSuccess) {
+    if (isBranchesSuccess && isNewMode) {
       const primaryBranch = branches.find((b) => b.primary) || first(branches);
 
       if (primaryBranch) {
         setFieldValue('branch_id', primaryBranch.id);
       }
     }
-  }, [isBranchesSuccess, setFieldValue, branches]);
+  }, [isBranchesSuccess, setFieldValue, branches, isNewMode]);
 };
 
 export const useSetPrimaryWarehouseToForm = () => {
   const { setFieldValue } = useFormikContext();
-  const { warehouses, isWarehousesSuccess } = useVendorCreditNoteFormContext();
+  const { warehouses, isWarehousesSuccess, isNewMode } = useVendorCreditNoteFormContext();
 
   React.useEffect(() => {
-    if (isWarehousesSuccess) {
+    if (isWarehousesSuccess && isNewMode) {
       const primaryWarehouse =
         warehouses.find((b) => b.primary) || first(warehouses);
 
@@ -182,7 +182,7 @@ export const useSetPrimaryWarehouseToForm = () => {
         setFieldValue('warehouse_id', primaryWarehouse.id);
       }
     }
-  }, [isWarehousesSuccess, setFieldValue, warehouses]);
+  }, [isWarehousesSuccess, setFieldValue, warehouses, isNewMode]);
 };
 
 /**

--- a/packages/webapp/src/containers/Purchases/PaymentsMade/PaymentForm/utils.tsx
+++ b/packages/webapp/src/containers/Purchases/PaymentsMade/PaymentForm/utils.tsx
@@ -115,17 +115,17 @@ export const transformFormToRequest = (form) => {
 
 export const useSetPrimaryBranchToForm = () => {
   const { setFieldValue } = useFormikContext();
-  const { branches, isBranchesSuccess } = usePaymentMadeFormContext();
+  const { branches, isBranchesSuccess, isNewMode } = usePaymentMadeFormContext();
 
   React.useEffect(() => {
-    if (isBranchesSuccess) {
+    if (isBranchesSuccess && isNewMode) {
       const primaryBranch = branches.find((b) => b.primary) || first(branches);
 
       if (primaryBranch) {
         setFieldValue('branch_id', primaryBranch.id);
       }
     }
-  }, [isBranchesSuccess, setFieldValue, branches]);
+  }, [isBranchesSuccess, setFieldValue, branches, isNewMode]);
 };
 
 /**

--- a/packages/webapp/src/containers/Sales/CreditNotes/CreditNoteForm/utils.tsx
+++ b/packages/webapp/src/containers/Sales/CreditNotes/CreditNoteForm/utils.tsx
@@ -148,25 +148,25 @@ export const entriesFieldShouldUpdate = (newProps, oldProps) => {
 
 export const useSetPrimaryBranchToForm = () => {
   const { setFieldValue } = useFormikContext();
-  const { branches, isBranchesSuccess } = useCreditNoteFormContext();
+  const { branches, isBranchesSuccess, isNewMode } = useCreditNoteFormContext();
 
   React.useEffect(() => {
-    if (isBranchesSuccess) {
+    if (isBranchesSuccess && isNewMode) {
       const primaryBranch = branches.find((b) => b.primary) || first(branches);
 
       if (primaryBranch) {
         setFieldValue('branch_id', primaryBranch.id);
       }
     }
-  }, [isBranchesSuccess, setFieldValue, branches]);
+  }, [isBranchesSuccess, setFieldValue, branches, isNewMode]);
 };
 
 export const useSetPrimaryWarehouseToForm = () => {
   const { setFieldValue } = useFormikContext();
-  const { warehouses, isWarehousesSuccess } = useCreditNoteFormContext();
+  const { warehouses, isWarehousesSuccess, isNewMode } = useCreditNoteFormContext();
 
   React.useEffect(() => {
-    if (isWarehousesSuccess) {
+    if (isWarehousesSuccess && isNewMode) {
       const primaryWarehouse =
         warehouses.find((b) => b.primary) || first(warehouses);
 
@@ -174,7 +174,7 @@ export const useSetPrimaryWarehouseToForm = () => {
         setFieldValue('warehouse_id', primaryWarehouse.id);
       }
     }
-  }, [isWarehousesSuccess, setFieldValue, warehouses]);
+  }, [isWarehousesSuccess, setFieldValue, warehouses, isNewMode]);
 };
 
 /**

--- a/packages/webapp/src/containers/Sales/Estimates/EstimateForm/utils.tsx
+++ b/packages/webapp/src/containers/Sales/Estimates/EstimateForm/utils.tsx
@@ -182,10 +182,10 @@ export const transfromsFormValuesToRequest = (values) => {
 
 export const useSetPrimaryWarehouseToForm = () => {
   const { setFieldValue } = useFormikContext();
-  const { warehouses, isWarehousesSuccess } = useEstimateFormContext();
+  const { warehouses, isWarehousesSuccess, isNewMode } = useEstimateFormContext();
 
   React.useEffect(() => {
-    if (isWarehousesSuccess) {
+    if (isWarehousesSuccess && isNewMode) {
       const primaryWarehouse =
         warehouses.find((b) => b.primary) || first(warehouses);
 
@@ -193,22 +193,22 @@ export const useSetPrimaryWarehouseToForm = () => {
         setFieldValue('warehouse_id', primaryWarehouse.id);
       }
     }
-  }, [isWarehousesSuccess, setFieldValue, warehouses]);
+  }, [isWarehousesSuccess, setFieldValue, warehouses, isNewMode]);
 };
 
 export const useSetPrimaryBranchToForm = () => {
   const { setFieldValue } = useFormikContext();
-  const { branches, isBranchesSuccess } = useEstimateFormContext();
+  const { branches, isBranchesSuccess, isNewMode } = useEstimateFormContext();
 
   React.useEffect(() => {
-    if (isBranchesSuccess) {
+    if (isBranchesSuccess && isNewMode) {
       const primaryBranch = branches.find((b) => b.primary) || first(branches);
 
       if (primaryBranch) {
         setFieldValue('branch_id', primaryBranch.id);
       }
     }
-  }, [isBranchesSuccess, setFieldValue, branches]);
+  }, [isBranchesSuccess, setFieldValue, branches, isNewMode]);
 };
 
 /**

--- a/packages/webapp/src/containers/Sales/Invoices/InvoiceForm/InvoiceFormProvider.tsx
+++ b/packages/webapp/src/containers/Sales/Invoices/InvoiceForm/InvoiceFormProvider.tsx
@@ -180,6 +180,7 @@ function InvoiceFormProvider({ invoiceId, baseCurrency, ...props }) {
     isInvoiceStateLoading,
 
     isBootLoading,
+    isNewMode,
   };
 
   return <InvoiceFormContext.Provider value={provider} {...props} />;

--- a/packages/webapp/src/containers/Sales/Invoices/InvoiceForm/InvoiceFormProvider.tsx
+++ b/packages/webapp/src/containers/Sales/Invoices/InvoiceForm/InvoiceFormProvider.tsx
@@ -180,7 +180,6 @@ function InvoiceFormProvider({ invoiceId, baseCurrency, ...props }) {
     isInvoiceStateLoading,
 
     isBootLoading,
-    isNewMode,
   };
 
   return <InvoiceFormContext.Provider value={provider} {...props} />;

--- a/packages/webapp/src/containers/Sales/Invoices/InvoiceForm/utils.tsx
+++ b/packages/webapp/src/containers/Sales/Invoices/InvoiceForm/utils.tsx
@@ -264,10 +264,10 @@ const transformPaymentMethodsToForm = (
 
 export const useSetPrimaryWarehouseToForm = () => {
   const { setFieldValue } = useFormikContext();
-  const { warehouses, isWarehousesSuccess } = useInvoiceFormContext();
+  const { warehouses, isWarehousesSuccess, isNewMode } = useInvoiceFormContext();
 
   React.useEffect(() => {
-    if (isWarehousesSuccess) {
+    if (isWarehousesSuccess && isNewMode) {
       const primaryWarehouse =
         warehouses.find((b) => b.primary) || first(warehouses);
 
@@ -275,22 +275,22 @@ export const useSetPrimaryWarehouseToForm = () => {
         setFieldValue('warehouse_id', primaryWarehouse.id);
       }
     }
-  }, [isWarehousesSuccess, setFieldValue, warehouses]);
+  }, [isWarehousesSuccess, setFieldValue, warehouses, isNewMode]);
 };
 
 export const useSetPrimaryBranchToForm = () => {
   const { setFieldValue } = useFormikContext();
-  const { branches, isBranchesSuccess } = useInvoiceFormContext();
+  const { branches, isBranchesSuccess, isNewMode } = useInvoiceFormContext();
 
   React.useEffect(() => {
-    if (isBranchesSuccess) {
+    if (isBranchesSuccess && isNewMode) {
       const primaryBranch = branches.find((b) => b.primary) || first(branches);
 
       if (primaryBranch) {
         setFieldValue('branch_id', primaryBranch.id);
       }
     }
-  }, [isBranchesSuccess, setFieldValue, branches]);
+  }, [isBranchesSuccess, setFieldValue, branches, isNewMode]);
 };
 
 /**

--- a/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentReceiveForm/utils.tsx
+++ b/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentReceiveForm/utils.tsx
@@ -177,17 +177,17 @@ export const transformFormToRequest = (form) => {
 
 export const useSetPrimaryBranchToForm = () => {
   const { setFieldValue } = useFormikContext();
-  const { branches, isBranchesSuccess } = usePaymentReceiveFormContext();
+  const { branches, isBranchesSuccess, isNewMode } = usePaymentReceiveFormContext();
 
   React.useEffect(() => {
-    if (isBranchesSuccess) {
+    if (isBranchesSuccess && isNewMode) {
       const primaryBranch = branches.find((b) => b.primary) || first(branches);
 
       if (primaryBranch) {
         setFieldValue('branch_id', primaryBranch.id);
       }
     }
-  }, [isBranchesSuccess, setFieldValue, branches]);
+  }, [isBranchesSuccess, setFieldValue, branches, isNewMode]);
 };
 
 /**

--- a/packages/webapp/src/containers/Sales/Receipts/ReceiptForm/utils.tsx
+++ b/packages/webapp/src/containers/Sales/Receipts/ReceiptForm/utils.tsx
@@ -173,10 +173,10 @@ export const transformFormValuesToRequest = (values) => {
 
 export const useSetPrimaryWarehouseToForm = () => {
   const { setFieldValue } = useFormikContext();
-  const { warehouses, isWarehousesSuccess } = useReceiptFormContext();
+  const { warehouses, isWarehousesSuccess, isNewMode } = useReceiptFormContext();
 
   React.useEffect(() => {
-    if (isWarehousesSuccess) {
+    if (isWarehousesSuccess && isNewMode) {
       const primaryWarehouse =
         warehouses.find((b) => b.primary) || first(warehouses);
 
@@ -184,22 +184,22 @@ export const useSetPrimaryWarehouseToForm = () => {
         setFieldValue('warehouse_id', primaryWarehouse.id);
       }
     }
-  }, [isWarehousesSuccess, setFieldValue, warehouses]);
+  }, [isWarehousesSuccess, setFieldValue, warehouses, isNewMode]);
 };
 
 export const useSetPrimaryBranchToForm = () => {
   const { setFieldValue } = useFormikContext();
-  const { branches, isBranchesSuccess } = useReceiptFormContext();
+  const { branches, isBranchesSuccess, isNewMode } = useReceiptFormContext();
 
   React.useEffect(() => {
-    if (isBranchesSuccess) {
+    if (isBranchesSuccess && isNewMode) {
       const primaryBranch = branches.find((b) => b.primary) || first(branches);
 
       if (primaryBranch) {
         setFieldValue('branch_id', primaryBranch.id);
       }
     }
-  }, [isBranchesSuccess, setFieldValue, branches]);
+  }, [isBranchesSuccess, setFieldValue, branches, isNewMode]);
 };
 
 /**


### PR DESCRIPTION
## Summary

Fixed an issue where branch and warehouse select fields were not displaying saved values when editing existing transactions. The l`useSetPrimaryBranchToForm` and `useSetPrimaryWarehouseToForm` hooks were overwriting saved values with primary defaults on every form load.

## Changes

- Added `isNewMode` check to `useSetPrimaryBranchToForm` hook across all forms
- Added `isNewMode` check to `useSetPrimaryWarehouseToForm` hook across all forms  
- Updated `InvoiceFormProvider` to expose `isNewMode` in context

## Affected Forms

**Sales:**
- Invoice
- Estimate
- Receipt
- CreditNote
- PaymentReceived

**Purchases:**
- Bill
- VendorCredit
- PaymentMade

**Other:**
- Expense
- MakeJournal (Manual Journal)

## Test Plan

- [ ] Edit an existing invoice with a non-primary branch/warehouse - verify saved values display correctly
- [ ] Edit an existing estimate with a non-primary branch/warehouse - verify saved values display correctly
- [ ] Edit an existing bill with a non-primary branch/warehouse - verify saved values display correctly
- [ ] Create a new transaction - verify primary branch/warehouse is still auto-selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk UI behavior change, but it touches multiple transaction forms and could affect default branch/warehouse auto-selection if `isNewMode` is mis-set.
> 
> **Overview**
> Stops form initialization hooks from overwriting saved `branch_id`/`warehouse_id` values when editing existing transactions.
> 
> Across sales, purchases, expenses, and manual journals, `useSetPrimaryBranchToForm` and `useSetPrimaryWarehouseToForm` now only apply primary defaults when the form is in *new* mode (`isNewMode`), and the effects’ dependency lists were updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2065afe108adbe237697274ef91cbcb2627793bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->