### PR TITLE
fix(server): Fix UnlinkAttachment model reference bug

### DIFF
--- a/packages/server/src/modules/Attachments/UnlinkAttachment.ts
+++ b/packages/server/src/modules/Attachments/UnlinkAttachment.ts
@@ -44,7 +44,7 @@ export class UnlinkAttachment {
     validateLinkModelExists(attachableModel);
 
     const LinkModel = this.moduleRef.get(modelRef, { strict: false });
-    const foundLinkModel = await LinkModel.query(trx).findById(modelId);
+    const foundLinkModel = await LinkModel().query(trx).findById(modelId);
     validateLinkModelEntryExists(foundLinkModel);
 
     const document = await this.documentModel().query(trx).findOne('key', filekey);


### PR DESCRIPTION
## Summary

Fixes a bug in the UnlinkAttachment service where the LinkModel was not being invoked as a function before calling the query method. This caused failures when trying to unlink attachments from transactions.

## Changes

- Added missing function invocation parentheses to `LinkModel` in `UnlinkAttachment.ts`
- Changed `LinkModel.query(trx)` to `LinkModel().query(trx)` to match the pattern used elsewhere in the codebase

## Test Plan

- [ ] Test unlinking attachments from payments/transactions
- [ ] Verify the attachment is properly unlinked without errors
- [ ] Confirm the document link record is deleted from the database

## Related Issues

Fixes attachment unlinking failure when deleting transactions that have linked attachments.

## pr_agent:summary

## pr_agent:walkthrough