### PR TITLE
Fix Customer and Vendor create and edit forms

### DIFF
--- a/packages/webapp/src/components/Currencies/CurrencySelectList.tsx
+++ b/packages/webapp/src/components/Currencies/CurrencySelectList.tsx
@@ -19,7 +19,7 @@ export function CurrencySelectList({
       name={name}
       items={items}
       textAccessor={'currency_code'}
-      valueAccessor={'id'}
+      valueAccessor={'currency_code'}
       placeholder={placeholder}
       popoverProps={{ minimal: true, usePortal: true, inline: false }}
       {...props}

--- a/packages/webapp/src/containers/Vendors/VendorForm/VendorFinanicalPanelTab.tsx
+++ b/packages/webapp/src/containers/Vendors/VendorForm/VendorFinanicalPanelTab.tsx
@@ -29,7 +29,7 @@ import { useCurrentOrganization } from '@/hooks/state';
  * Vendor Finaniceal Panel Tab.
  */
 export default function VendorFinanicalPanelTab() {
-  const { currencies, branches } = useVendorFormContext();
+  const { currencies, vendorId, branches } = useVendorFormContext();
 
   // Sets the primary branch to form.
   useSetPrimaryBranchToForm();
@@ -48,6 +48,7 @@ export default function VendorFinanicalPanelTab() {
             <CurrencySelectList
               name="currency_code"
               items={currencies}
+	      disabled={vendorId}
             />
           </FFormGroup>
 

--- a/packages/webapp/src/containers/Vendors/VendorForm/VendorFormFormik.tsx
+++ b/packages/webapp/src/containers/Vendors/VendorForm/VendorFormFormik.tsx
@@ -58,12 +58,10 @@ function VendorFormFormik({
   const initialFormValues = useMemo(
     () => ({
       ...defaultInitialValues,
-      ...transformToForm(initialValues, defaultInitialValues),
       currency_code: base_currency,
-      ...transformToForm(vendor, defaultInitialValues),
-      ...transformToForm(contactDuplicate, defaultInitialValues),
+      ...transformToForm(contactDuplicate || vendor, defaultInitialValues),
     }),
-    [vendor, contactDuplicate, base_currency, initialValues],
+    [vendor, contactDuplicate, base_currency],
   );
 
   // Handles the form submit.

--- a/packages/webapp/src/containers/Vendors/VendorForm/VendorFormPage.tsx
+++ b/packages/webapp/src/containers/Vendors/VendorForm/VendorFormPage.tsx
@@ -30,6 +30,8 @@ export default function VendorFormPage() {
   const history = useHistory();
   const { id } = useParams();
 
+  const vendorId = id ? parseInt(id, 10) : null;
+
   // Handle the form submit success.
   const handleSubmitSuccess = (values, formArgs, submitPayload) => {
     if (!submitPayload.noRedirect) {
@@ -42,7 +44,7 @@ export default function VendorFormPage() {
   };
 
   return (
-    <VendorFormProvider vendorId={id}>
+    <VendorFormProvider vendorId={vendorId}>
       <VendorFormPageLoading>
         <DashboardCard page>
           <VendorFormPageFormik

--- a/packages/webapp/src/containers/Vendors/VendorForm/VendorFormProvider.tsx
+++ b/packages/webapp/src/containers/Vendors/VendorForm/VendorFormProvider.tsx
@@ -1,6 +1,5 @@
 // @ts-nocheck
 import React, { useState, createContext } from 'react';
-import { omit } from 'lodash';
 import { useLocation } from 'react-router-dom';
 import {
   useVendor,
@@ -68,7 +67,7 @@ function VendorFormProvider({ query, vendorId, ...props }) {
     currencies,
     vendor,
     branches,
-    contactDuplicate: { ...omit(contactDuplicate, ['opening_balance_at']) },
+    contactDuplicate,
     submitPayload,
 
     isNewMode,


### PR DESCRIPTION
This PR fixes the issues I was facing inside the Customer and Vendor modules.

* fixed Vendor and Customer create, financials tab now displays the correct "Opening Balanch" after selecting the currency.
* fixed Vendor edit, in financials tab the currency dropdown list is now disabled same as what was happening in customer edit.
* fixed Vendor create and edit, the email is saving when created but when you go to the edit page of the vendor its not showing or its displaying the incorrect email if you tried saving different emails each time you edit.