### PR TITLE
fix(payment-received): allow decimal amounts in paymentAmount validation

### DIFF
--- a/packages/server/src/modules/PaymentReceived/dtos/PaymentReceived.dto.ts
+++ b/packages/server/src/modules/PaymentReceived/dtos/PaymentReceived.dto.ts
@@ -35,7 +35,7 @@ export class PaymentReceivedEntryDto {
   invoiceId: number;
 
   @ToNumber()
-  @IsInt()
+  @IsNumber()
   @IsNotEmpty()
   paymentAmount: number;
 }


### PR DESCRIPTION
## Summary

Fixed the validation for `paymentAmount` field in PaymentReceivedEntryDto that was rejecting decimal amounts.

## Issue

Recording a payment received for an invoice with a non-integer amount (e.g. $1,679.80) was failing with \"paymentAmount must be an integer number\".

## Changes

- Changed `@IsInt()` to `@IsNumber()` for `paymentAmount` field in `PaymentReceivedEntryDto`
- This allows recording payments with cents/decimal values

## Test plan

- [ ] Record a payment with decimal amount (e.g., $1,679.80) via API
- [ ] Record a payment with decimal amount via Quick Receive Payment modal in UI
- [ ] Verify integer amounts still work correctly

## Closing issues

Fixes #1016

🤖 Generated with [Claude Code](https://claude.com/claude-code)