### PR TITLE
fix(accounts): add missing dynamic list filter properties to GetAccountsQueryDto

### DIFF
--- a/packages/server/src/modules/Accounts/dtos/GetAccountsQuery.dto.ts
+++ b/packages/server/src/modules/Accounts/dtos/GetAccountsQuery.dto.ts
@@ -1,8 +1,10 @@
-import { IsBoolean, IsEnum, IsOptional } from 'class-validator';
+import { IsArray, IsBoolean, IsEnum, IsInt, IsOptional, IsString, Min } from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
 import { parseBoolean } from '@/utils/parse-boolean';
 import { IAccountsStructureType } from '../Accounts.types';
+import { IFilterRole, ISortOrder } from '@/modules/DynamicListing/DynamicFilter/DynamicFilter.types';
+import { ToNumber } from '@/common/decorators/Validators';
 
 export class GetAccountsQueryDto {
   @ApiPropertyOptional({
@@ -23,5 +25,93 @@ export class GetAccountsQueryDto {
   @IsOptional()
   @IsEnum(IAccountsStructureType)
   structure?: IAccountsStructureType;
+
+  @ApiPropertyOptional({
+    description: 'Custom view ID',
+    type: Number,
+    example: 1,
+  })
+  @IsOptional()
+  @ToNumber()
+  @IsInt()
+  customViewId?: number;
+
+  @ApiPropertyOptional({
+    description: 'Filter roles array',
+    type: Array,
+    isArray: true,
+  })
+  @IsArray()
+  @IsOptional()
+  filterRoles?: IFilterRole[];
+
+  @ApiPropertyOptional({
+    description: 'Column to sort by',
+    type: String,
+    example: 'created_at',
+  })
+  @IsOptional()
+  @IsString()
+  columnSortBy?: string;
+
+  @ApiPropertyOptional({
+    description: 'Sort order',
+    enum: ISortOrder,
+    example: ISortOrder.DESC,
+  })
+  @IsOptional()
+  @IsEnum(ISortOrder)
+  sortOrder?: string;
+
+  @ApiPropertyOptional({
+    description: 'Stringified filter roles',
+    type: String,
+    example: '{"fieldKey":"root_type","value":"asset"}',
+  })
+  @IsOptional()
+  @IsString()
+  stringifiedFilterRoles?: string;
+
+  @ApiPropertyOptional({
+    description: 'Search keyword',
+    type: String,
+    example: 'bank account',
+  })
+  @IsOptional()
+  @IsString()
+  searchKeyword?: string;
+
+  @ApiPropertyOptional({
+    description: 'View slug',
+    type: String,
+    example: 'assets',
+  })
+  @IsOptional()
+  @IsString()
+  viewSlug?: string;
+
+  @ApiPropertyOptional({
+    description: 'Page number',
+    type: Number,
+    example: 1,
+    minimum: 1,
+  })
+  @IsOptional()
+  @ToNumber()
+  @IsInt()
+  @Min(1)
+  page?: number;
+
+  @ApiPropertyOptional({
+    description: 'Page size',
+    type: Number,
+    example: 25,
+    minimum: 1,
+  })
+  @IsOptional()
+  @ToNumber()
+  @IsInt()
+  @Min(1)
+  pageSize?: number;
 }
 


### PR DESCRIPTION
## Summary

This PR fixes issue #1023 where selecting a Table View (e.g., \"Expenses\") on the Accounts Chart page was not filtering results. The API call included `view_slug=expenses` but `stringified_filter_roles=[]` was empty, so the server returned all accounts unfiltered.

## Root Cause

The `GetAccountsQueryDto` class was missing the properties needed for dynamic list filtering that other similar DTOs (like `BankAccountsQueryDto`) have. The DTO only had `onlyInactive` and `structure` properties.

## Changes

Added the following properties to `GetAccountsQueryDto`:

- `viewSlug` - to identify the selected view (e.g., \"expenses\", \"assets\")
- `stringifiedFilterRoles` - to pass custom filter roles
- `filterRoles` - for structured filter roles
- `searchKeyword` - for keyword search
- `columnSortBy` / `sortOrder` - for sorting
- `customViewId` - for custom view ID
- `page` / `pageSize` - for pagination

## How It Works Now

1. Frontend sends `view_slug=expenses` with the API request
2. `GetAccountsQueryDto` accepts `viewSlug` as a valid property
3. `GetAccountsService.getAccountsList()` passes the filter to `DynamicListService`
4. `DynamicListService.dynamicList()` detects `viewSlug` and calls `DynamicListCustomView.dynamicListCustomView()`
5. This retrieves the view definition from `AccountDefaultViews` (which has the `root_type` filter roles)
6. `DynamicFilterViews` applies these filter roles to the query, filtering accounts by their root type

## Testing

- [ ] Go to Accounts Chart
- [ ] Click \"Table Views\" dropdown
- [ ] Select any view (Assets, Liabilities, Equity, Income, or Expenses)
- [ ] Verify only accounts matching the view's root_type are displayed

## Related Issues

Fixes #1023

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)