### PR TITLE
fix(currency): use currency_code instead of id in CurrencySelectList

### DIFF
--- a/packages/webapp/src/components/Currencies/CurrencySelectList.tsx
+++ b/packages/webapp/src/components/Currencies/CurrencySelectList.tsx
@@ -19,7 +19,7 @@ export function CurrencySelectList({
       name={name}
       items={items}
       textAccessor={'currency_code'}
-      valueAccessor={'id'}
+      valueAccessor={'currency_code'}
       placeholder={placeholder}
       popoverProps={{ minimal: true, usePortal: true, inline: false }}
       {...props}


### PR DESCRIPTION
## Summary

Fixes #1025 - Currency dropdowns in Vendor and Customer forms were sending wrong values (numeric IDs instead of currency codes).

## Problem

The "CurrencySelectList" component was using 'id' as the valueAccessor, which caused the component to return the numeric currency ID (e.g., 1007) instead of the currency code string (e.g., 'THB').

This caused 400 Bad Request errors because the backend expects @IsString() for the currencyCode field in CreateVendorDto and CreateCustomerDto.

## Solution

Changed the valueAccessor from 'id' to 'currency_code' in CurrencySelectList.tsx so that the currency code string is correctly sent to the backend.

## Affected Forms

- Vendor form (/vendors/new) - Currency dropdown
- Customer form (/customers/new) - Currency dropdown

## Changes

- packages/webapp/src/components/Currencies/CurrencySelectList.tsx: Changed valueAccessor from {'id'} to {'currency_code'}

## Test Plan

- [ ] Go to /vendors/new
- [ ] Fill in display name, select a currency (e.g., 'THB')
- [ ] Click Save → Should create vendor successfully without 400 error
- [ ] Go to /customers/new  
- [ ] Fill in display name, select a currency
- [ ] Click Save → Should create customer successfully without 400 error

## Related Issues

Fixes #1025