### PR TITLE
feat: add credit note status translations and manual journal default views

### DIFF
--- a/packages/server/src/i18n/en/credit_note.json
+++ b/packages/server/src/i18n/en/credit_note.json
@@ -1,4 +1,9 @@
 {
+  "view.draft": "Draft",
+  "view.published": "Published",
+  "view.open": "Open",
+  "view.closed": "Closed",
+
   "field.customer": "Customer",
   "field.exchange_rate": "Exchange Rate",
   "field.credit_note_date": "Credit Note Date",

--- a/packages/server/src/modules/ManualJournals/constants.ts
+++ b/packages/server/src/modules/ManualJournals/constants.ts
@@ -28,7 +28,28 @@ export const CONTACTS_CONFIG = [
   },
 ];
 
-export const ManualJournalDefaultViews = [];
+export const DEFAULT_VIEW_COLUMNS = [];
+
+export const ManualJournalDefaultViews = [
+  {
+    name: 'Draft',
+    slug: 'draft',
+    rolesLogicExpression: '1',
+    roles: [
+      { index: 1, fieldKey: 'status', comparator: 'equals', value: 'draft' },
+    ],
+    columns: DEFAULT_VIEW_COLUMNS,
+  },
+  {
+    name: 'Published',
+    slug: 'published',
+    rolesLogicExpression: '1',
+    roles: [
+      { index: 1, fieldKey: 'status', comparator: 'equals', value: 'published' },
+    ],
+    columns: DEFAULT_VIEW_COLUMNS,
+  },
+];
 
 export const ManualJournalsSampleData = [
   {


### PR DESCRIPTION
## Summary

- Added credit note status translation keys (`view.draft`, `view.published`, `view.open`, `view.closed`) to `credit_note.json`
- Added Manual Journal default views for Draft and Published statuses
- Added `DEFAULT_VIEW_COLUMNS` constant for reusability

## Changes

### Credit Notes
- Added missing translation keys for status views in `packages/server/src/i18n/en/credit_note.json`

### Manual Journals
- Added `DEFAULT_VIEW_COLUMNS` constant in `constants.ts`
- Implemented `ManualJournalDefaultViews` with Draft and Published views
- Each view filters by status field with appropriate comparator