### PR TITLE
refactor(server): migrate ExchangeRates module to NestJS

### DIFF
--- a/packages/server/src/modules/App/App.module.ts
+++ b/packages/server/src/modules/App/App.module.ts
@@ -99,6 +99,7 @@ import { UsersModule } from '../UsersModule/Users.module';
 import { ContactsModule } from '../Contacts/Contacts.module';
 import { BankingPlaidModule } from '../BankingPlaid/BankingPlaid.module';
 import { BankingCategorizeModule } from '../BankingCategorize/BankingCategorize.module';
+import { ExchangeRatesModule } from '../ExchangeRates/ExchangeRates.module';
 import { TenantModelsInitializeModule } from '../Tenancy/TenantModelsInitialize.module';
 import { BillLandedCostsModule } from '../BillLandedCosts/BillLandedCosts.module';
 import { SocketModule } from '../Socket/Socket.module';
@@ -256,6 +257,7 @@ import { AppThrottleModule } from './AppThrottle.module';
     UsersModule,
     ContactsModule,
     SocketModule,
+    ExchangeRatesModule,
   ],
   controllers: [AppController],
   providers: [

--- a/packages/server/src/modules/ExchangeRates/ExchangeRates.application.ts
+++ b/packages/server/src/modules/ExchangeRates/ExchangeRates.application.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@nestjs/common';
+import { ExchangeRatesService } from './ExchangeRates.service';
+import { ExchangeRateLatestDTO, EchangeRateLatestPOJO } from './ExchangeRates.types';
+
+@Injectable()
+export class ExchangeRateApplication {
+  constructor(private readonly exchangeRateService: ExchangeRatesService) {}
+
+  /**
+   * Gets the latest exchange rate.
+   * @param {number} tenantId
+   * @param {ExchangeRateLatestDTO} exchangeRateLatestDTO
+   * @returns {Promise<EchangeRateLatestPOJO>}
+   */
+  public latest(
+    tenantId: number,
+    exchangeRateLatestDTO: ExchangeRateLatestDTO,
+  ): Promise<EchangeRateLatestPOJO> {
+    return this.exchangeRateService.latest(tenantId, exchangeRateLatestDTO);
+  }
+}

--- a/packages/server/src/modules/ExchangeRates/ExchangeRates.controller.ts
+++ b/packages/server/src/modules/ExchangeRates/ExchangeRates.controller.ts
@@ -1,0 +1,73 @@
+import {
+  Controller,
+  Get,
+  Query,
+  Req,
+  UsePipes,
+  ValidationPipe,
+} from '@nestjs/common';
+import { Request } from 'express';
+import {
+  ApiOperation,
+  ApiTags,
+  ApiResponse,
+  ApiQuery,
+} from '@nestjs/swagger';
+import { ExchangeRateApplication } from './ExchangeRates.application';
+import { ExchangeRateLatestQueryDto } from './dtos/ExchangeRateLatestQuery.dto';
+import { ExchangeRateLatestResponseDto } from './dtos/ExchangeRateLatestResponse.dto';
+
+interface RequestWithTenantId extends Request {
+  tenantId: number;
+}
+
+@Controller('exchange-rates')
+@ApiTags('Exchange Rates')
+export class ExchangeRatesController {
+  constructor(private readonly exchangeRateApp: ExchangeRateApplication) {}
+
+  @Get('/latest')
+  @UsePipes(
+    new ValidationPipe({
+      transform: true,
+      whitelist: true,
+      forbidNonWhitelisted: true,
+    }),
+  )
+  @ApiOperation({ summary: 'Get the latest exchange rate' })
+  @ApiQuery({
+    name: 'from_currency',
+    description: 'Source currency code (ISO 4217)',
+    required: false,
+    type: String,
+    example: 'USD',
+  })
+  @ApiQuery({
+    name: 'to_currency',
+    description: 'Target currency code (ISO 4217)',
+    required: false,
+    type: String,
+    example: 'EUR',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Successfully retrieved exchange rate',
+    type: ExchangeRateLatestResponseDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Invalid currency code or service error',
+  })
+  async getLatestExchangeRate(
+    @Query() query: ExchangeRateLatestQueryDto,
+    @Req() req: RequestWithTenantId,
+  ): Promise<ExchangeRateLatestResponseDto> {
+    const tenantId = req.tenantId;
+
+    const exchangeRate = await this.exchangeRateApp.latest(tenantId, {
+      fromCurrency: query.from_currency,
+      toCurrency: query.to_currency,
+    });
+    return exchangeRate;
+  }
+}

--- a/packages/server/src/modules/ExchangeRates/ExchangeRates.module.ts
+++ b/packages/server/src/modules/ExchangeRates/ExchangeRates.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { ExchangeRatesController } from './ExchangeRates.controller';
+import { ExchangeRatesService } from './ExchangeRates.service';
+import { ExchangeRateApplication } from './ExchangeRates.application';
+
+@Module({
+  providers: [ExchangeRatesService, ExchangeRateApplication],
+  controllers: [ExchangeRatesController],
+  exports: [ExchangeRatesService, ExchangeRateApplication],
+})
+export class ExchangeRatesModule {}

--- a/packages/server/src/modules/ExchangeRates/ExchangeRates.service.ts
+++ b/packages/server/src/modules/ExchangeRates/ExchangeRates.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@nestjs/common';
+import { ExchangeRate } from './lib/ExchangeRate';
+import { ExchangeRateServiceType } from './lib/types';
+import { TenantMetadata } from '@/modules/System/models/TenantMetadataModel';
+import { ExchangeRateLatestDTO, EchangeRateLatestPOJO } from './ExchangeRates.types';
+
+@Injectable()
+export class ExchangeRatesService {
+  /**
+   * Gets the latest exchange rate.
+   * @param {number} tenantId
+   * @param {ExchangeRateLatestDTO} exchangeRateLatestDTO
+   * @returns {EchangeRateLatestPOJO}
+   */
+  public async latest(
+    tenantId: number,
+    exchangeRateLatestDTO: ExchangeRateLatestDTO,
+  ): Promise<EchangeRateLatestPOJO> {
+    const organization = await TenantMetadata.query().findOne({ tenantId });
+
+    // Assign the organization base currency as a default currency
+    // if no currency is provided
+    const fromCurrency =
+      exchangeRateLatestDTO.fromCurrency || organization.baseCurrency;
+    const toCurrency =
+      exchangeRateLatestDTO.toCurrency || organization.baseCurrency;
+
+    const exchange = new ExchangeRate(ExchangeRateServiceType.OpenExchangeRate);
+    const exchangeRate = await exchange.latest(fromCurrency, toCurrency);
+
+    return {
+      baseCurrency: fromCurrency,
+      toCurrency: exchangeRateLatestDTO.toCurrency || toCurrency,
+      exchangeRate,
+    };
+  }
+}

--- a/packages/server/src/modules/ExchangeRates/ExchangeRates.types.ts
+++ b/packages/server/src/modules/ExchangeRates/ExchangeRates.types.ts
@@ -1,0 +1,10 @@
+export interface ExchangeRateLatestDTO {
+  fromCurrency?: string;
+  toCurrency?: string;
+}
+
+export interface EchangeRateLatestPOJO {
+  baseCurrency: string;
+  toCurrency: string;
+  exchangeRate: number;
+}

--- a/packages/server/src/modules/ExchangeRates/dtos/ExchangeRateLatestQuery.dto.ts
+++ b/packages/server/src/modules/ExchangeRates/dtos/ExchangeRateLatestQuery.dto.ts
@@ -1,0 +1,22 @@
+import { IsOptional, IsString, Length } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class ExchangeRateLatestQueryDto {
+  @ApiPropertyOptional({
+    description: 'The source currency code (ISO 4217)',
+    example: 'USD',
+  })
+  @IsOptional()
+  @IsString()
+  @Length(3, 3, { message: 'Currency code must be 3 characters (ISO 4217)' })
+  from_currency?: string;
+
+  @ApiPropertyOptional({
+    description: 'The target currency code (ISO 4217)',
+    example: 'EUR',
+  })
+  @IsOptional()
+  @IsString()
+  @Length(3, 3, { message: 'Currency code must be 3 characters (ISO 4217)' })
+  to_currency?: string;
+}

--- a/packages/server/src/modules/ExchangeRates/dtos/ExchangeRateLatestResponse.dto.ts
+++ b/packages/server/src/modules/ExchangeRates/dtos/ExchangeRateLatestResponse.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ExchangeRateLatestResponseDto {
+  @ApiProperty({
+    description: 'The base currency code',
+    example: 'USD',
+  })
+  baseCurrency: string;
+
+  @ApiProperty({
+    description: 'The target currency code',
+    example: 'EUR',
+  })
+  toCurrency: string;
+
+  @ApiProperty({
+    description: 'The exchange rate value',
+    example: 0.85,
+  })
+  exchangeRate: number;
+}

--- a/packages/server/src/modules/ExchangeRates/index.ts
+++ b/packages/server/src/modules/ExchangeRates/index.ts
@@ -1,0 +1,7 @@
+export * from './ExchangeRates.module';
+export * from './ExchangeRates.controller';
+export * from './ExchangeRates.service';
+export * from './ExchangeRates.application';
+export * from './dtos/ExchangeRateLatestQuery.dto';
+export * from './dtos/ExchangeRateLatestResponse.dto';
+export * from './lib/types';

--- a/packages/server/src/modules/ExchangeRates/lib/ExchangeRate.ts
+++ b/packages/server/src/modules/ExchangeRates/lib/ExchangeRate.ts
@@ -1,0 +1,45 @@
+import { OpenExchangeRate } from './OpenExchangeRate';
+import { ExchangeRateServiceType, IExchangeRateService } from './types';
+
+export class ExchangeRate {
+  private exchangeRateService: IExchangeRateService;
+  private exchangeRateServiceType: ExchangeRateServiceType;
+
+  /**
+   * Constructor method.
+   * @param {ExchangeRateServiceType} service
+   */
+  constructor(service: ExchangeRateServiceType) {
+    this.exchangeRateServiceType = service;
+    this.initService();
+  }
+
+  /**
+   * Initialize the exchange rate service based on the service type.
+   */
+  private initService() {
+    if (
+      this.exchangeRateServiceType === ExchangeRateServiceType.OpenExchangeRate
+    ) {
+      this.setExchangeRateService(new OpenExchangeRate());
+    }
+  }
+
+  /**
+   * Sets the exchange rate service.
+   * @param {IExchangeRateService} service
+   */
+  private setExchangeRateService(service: IExchangeRateService) {
+    this.exchangeRateService = service;
+  }
+
+  /**
+   * Gets the latest exchange rate.
+   * @param {string} baseCurrency
+   * @param {string} toCurrency
+   * @returns {number}
+   */
+  public latest(baseCurrency: string, toCurrency: string): Promise<number> {
+    return this.exchangeRateService.latest(baseCurrency, toCurrency);
+  }
+}

--- a/packages/server/src/modules/ExchangeRates/lib/OpenExchangeRate.ts
+++ b/packages/server/src/modules/ExchangeRates/lib/OpenExchangeRate.ts
@@ -1,0 +1,85 @@
+import Axios from 'axios';
+import {
+  EchangeRateErrors,
+  IExchangeRateService,
+  OPEN_EXCHANGE_RATE_LATEST_URL,
+} from './types';
+import { ServiceError } from '@/modules/Items/ServiceError';
+
+export class OpenExchangeRate implements IExchangeRateService {
+  private appId: string;
+
+  constructor(appId?: string) {
+    this.appId = appId || process.env.OPEN_EXCHANGE_RATE_APP_ID || '';
+  }
+
+  /**
+   * Gets the latest exchange rate.
+   * @param {string} baseCurrency
+   * @param {string} toCurrency
+   * @returns {Promise<number>}
+   */
+  public async latest(
+    baseCurrency: string,
+    toCurrency: string
+  ): Promise<number> {
+    // Validates the Open Exchange Rate api id early.
+    this.validateApiIdExistance();
+
+    try {
+      const result = await Axios.get(OPEN_EXCHANGE_RATE_LATEST_URL, {
+        params: {
+          app_id: this.appId,
+          base: baseCurrency,
+          symbols: toCurrency,
+        },
+      });
+      return result.data.rates[toCurrency] || (1 as number);
+    } catch (error) {
+      this.handleLatestErrors(error);
+    }
+  }
+
+  /**
+   * Validates the Open Exchange Rate api id.
+   * @throws {ServiceError}
+   */
+  private validateApiIdExistance() {
+    if (!this.appId) {
+      throw new ServiceError(
+        EchangeRateErrors.EX_RATE_SERVICE_API_KEY_REQUIRED,
+        'Invalid App ID provided. Please sign up at https://openexchangerates.org/signup, or contact support@openexchangerates.org.'
+      );
+    }
+  }
+
+  /**
+   * Handles the latest errors.
+   * @param {any} error
+   * @throws {ServiceError}
+   */
+  private handleLatestErrors(error: any) {
+    if (error.response?.data?.message === 'missing_app_id') {
+      throw new ServiceError(
+        EchangeRateErrors.EX_RATE_SERVICE_API_KEY_REQUIRED,
+        'Invalid App ID provided. Please sign up at https://openexchangerates.org/signup, or contact support@openexchangerates.org.'
+      );
+    } else if (error.response?.data?.message === 'invalid_app_id') {
+      throw new ServiceError(
+        EchangeRateErrors.EX_RATE_SERVICE_API_KEY_REQUIRED,
+        'Invalid App ID provided. Please sign up at https://openexchangerates.org/signup, or contact support@openexchangerates.org.'
+      );
+    } else if (error.response?.data?.message === 'not_allowed') {
+      throw new ServiceError(
+        EchangeRateErrors.EX_RATE_SERVICE_NOT_ALLOWED,
+        'Getting the exchange rate from the given base currency to the given currency is not allowed.'
+      );
+    } else if (error.response?.data?.message === 'invalid_base') {
+      throw new ServiceError(
+        EchangeRateErrors.EX_RATE_INVALID_BASE_CURRENCY,
+        'The given base currency is invalid.'
+      );
+    }
+    throw error;
+  }
+}

--- a/packages/server/src/modules/ExchangeRates/lib/types.ts
+++ b/packages/server/src/modules/ExchangeRates/lib/types.ts
@@ -1,0 +1,17 @@
+export interface IExchangeRateService {
+  latest(baseCurrency: string, toCurrency: string): Promise<number>;
+}
+
+export enum ExchangeRateServiceType {
+  OpenExchangeRate = 'OpenExchangeRate',
+}
+
+export enum EchangeRateErrors {
+  EX_RATE_SERVICE_NOT_ALLOWED = 'EX_RATE_SERVICE_NOT_ALLOWED',
+  EX_RATE_LIMIT_EXCEEDED = 'EX_RATE_LIMIT_EXCEEDED',
+  EX_RATE_SERVICE_API_KEY_REQUIRED = 'EX_RATE_SERVICE_API_KEY_REQUIRED',
+  EX_RATE_INVALID_BASE_CURRENCY = 'EX_RATE_INVALID_BASE_CURRENCY',
+}
+
+export const OPEN_EXCHANGE_RATE_LATEST_URL =
+  'https://openexchangerates.org/api/latest.json';

--- a/shared/sdk-ts/src/exchange-rates.ts
+++ b/shared/sdk-ts/src/exchange-rates.ts
@@ -1,0 +1,41 @@
+import type { ApiFetcher } from './fetch-utils';
+
+export const EXCHANGE_RATES_ROUTES = {
+  LATEST: '/api/exchange-rates/latest',
+} as const;
+
+/** Query params for GET /api/exchange-rates/latest */
+export interface ExchangeRateLatestQuery {
+  /** Source currency code (ISO 4217) */
+  from_currency?: string;
+  /** Target currency code (ISO 4217) */
+  to_currency?: string;
+}
+
+/** Response for GET /api/exchange-rates/latest */
+export interface ExchangeRateLatestResponse {
+  /** The base currency code */
+  baseCurrency: string;
+  /** The target currency code */
+  toCurrency: string;
+  /** The exchange rate value */
+  exchangeRate: number;
+}
+
+/**
+ * Fetches the latest exchange rate for the given currency pair.
+ * @param fetcher - The API fetcher instance
+ * @param query - Query parameters containing from_currency and/or to_currency
+ * @returns The exchange rate response with baseCurrency, toCurrency, and exchangeRate
+ */
+export async function fetchLatestExchangeRate(
+  fetcher: ApiFetcher,
+  query?: ExchangeRateLatestQuery,
+): Promise<ExchangeRateLatestResponse> {
+  const get = fetcher
+    .path(EXCHANGE_RATES_ROUTES.LATEST as never)
+    .method('get')
+    .create();
+  const { data } = await get((query ?? {}) as never);
+  return data as ExchangeRateLatestResponse;
+}

--- a/shared/sdk-ts/src/index.ts
+++ b/shared/sdk-ts/src/index.ts
@@ -14,6 +14,7 @@ export * from './bills';
 export * from './items';
 export * from './branches';
 export * from './warehouses';
+export * from './exchange-rates';
 export * from './expenses';
 export * from './import';
 export * from './manual-journals';


### PR DESCRIPTION
## Summary

This PR refactors the ExchangeRates module from the legacy TypeDI/Express pattern to the NestJS framework and adds TypeScript SDK support.

### Server Changes

- **Controller**: Converted from Express router to NestJS `@Controller()` with `@Get()` decorators
- **Services**: Migrated from TypeDI `@Service()` to NestJS `@Injectable()` with constructor injection
- **Validation**: Replaced `express-validator` with `class-validator` DTOs and `ValidationPipe`
- **Documentation**: Added Swagger/OpenAPI decorators (`@ApiOperation`, `@ApiResponse`, etc.)
- **Types**: Created proper TypeScript interfaces for request/response types
- **Module**: Added `ExchangeRatesModule` to `AppModule` imports

### SDK Changes

- Added `exchange-rates.ts` SDK module with `fetchLatestExchangeRate` function
- Added `ExchangeRateLatestQuery` type for query parameters
- Added `ExchangeRateLatestResponse` type for API responses
- Exported new module from SDK index

### Files Added/Modified

**Server:**
- `ExchangeRates.module.ts` - New NestJS module
- `ExchangeRates.controller.ts` - New NestJS controller
- `ExchangeRates.service.ts` - New NestJS service
- `ExchangeRates.application.ts` - Application layer
- `ExchangeRates.types.ts` - Shared TypeScript types
- `dtos/` - Request/response DTOs with validation
- `lib/OpenExchangeRate.ts` - Fixed imports and config handling
- `App.module.ts` - Added ExchangeRatesModule import

**SDK:**
- `shared/sdk-ts/src/exchange-rates.ts` - New SDK module
- `shared/sdk-ts/src/index.ts` - Added export for exchange-rates module

### Removed

- `EchangeRates.controller.ts` (old TypeDI controller)
- `LatestExchangeRate.service.ts` (old TypeDI service)

## Test plan

- [ ] Verify `GET /exchange-rates/latest` endpoint returns correct exchange rate
- [ ] Verify currency validation works (ISO 4217 format)
- [ ] Verify error handling for missing/invalid API key
- [ ] Verify Swagger documentation is generated correctly
- [ ] Verify SDK `fetchLatestExchangeRate` function works correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new NestJS `exchange-rates/latest` API that calls an external provider (OpenExchangeRates) and depends on per-tenant metadata/env configuration, so failures or misconfiguration could impact currency-related flows.
> 
> **Overview**
> Adds a new NestJS `ExchangeRatesModule` (wired into `AppModule`) exposing `GET /exchange-rates/latest` with DTO-based validation and Swagger docs, delegating through an application/service layer to fetch rates and defaulting missing currencies to the tenant base currency.
> 
> Implements an OpenExchangeRates-backed provider (`OPEN_EXCHANGE_RATE_APP_ID`), including explicit error mapping via `ServiceError`, and adds a TypeScript SDK entry (`fetchLatestExchangeRate`) plus exports from the SDK index.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eff5f6b9f7cd1a6e9493dfd36d7f117a89682a68. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->