### PR TITLE
Change email to Base64 Encoding

### DIFF
--- a/packages/server/src/modules/Mail/Mail.ts
+++ b/packages/server/src/modules/Mail/Mail.ts
@@ -28,6 +28,7 @@ export class Mail {
       html: this.html,
       attachments: this.attachments,
       replyTo: this.replyTo,
+      textEncoding: 'base64' as const,
     };
   }
 


### PR DESCRIPTION
set encoding to base64 - Helps with email formatting particularly when using SMTP to API