### PR TITLE
feat(server): add Query DTOs for consistent filtering across modules

### DIFF
--- a/packages/server/src/modules/Bills/Bills.application.ts
+++ b/packages/server/src/modules/Bills/Bills.application.ts
@@ -2,7 +2,8 @@ import { CreateBill } from './commands/CreateBill.service';
 import { EditBillService } from './commands/EditBill.service';
 import { GetBill } from './queries/GetBill';
 import { DeleteBill } from './commands/DeleteBill.service';
-import { IBillDTO, IBillEditDTO, IBillsFilter } from './Bills.types';
+import { IBillDTO, IBillEditDTO } from './Bills.types';
+import { GetBillsQueryDto } from './dtos/GetBillsQuery.dto';
 import { GetDueBills } from './queries/GetDueBills.service';
 import { OpenBillService } from './commands/OpenBill.service';
 import { Injectable } from '@nestjs/common';
@@ -78,9 +79,9 @@ export class BillsApplication {
 
   /**
    * Retrieve bills data table list.
-   * @param {IBillsFilter} billsFilter -
+   * @param {GetBillsQueryDto} filterDTO -
    */
-  public getBills(filterDTO: Partial<IBillsFilter>) {
+  public getBills(filterDTO: GetBillsQueryDto) {
     return this.getBillsService.getBills(filterDTO);
   }
 

--- a/packages/server/src/modules/Bills/Bills.controller.ts
+++ b/packages/server/src/modules/Bills/Bills.controller.ts
@@ -21,8 +21,8 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { BillsApplication } from './Bills.application';
-import { IBillsFilter } from './Bills.types';
 import { CreateBillDto, EditBillDto } from './dtos/Bill.dto';
+import { GetBillsQueryDto } from './dtos/GetBillsQuery.dto';
 import { BillResponseDto } from './dtos/BillResponse.dto';
 import { PaginatedResponseDto } from '@/common/dtos/PaginatedResults.dto';
 import { ApiCommonHeaders } from '@/common/decorators/ApiCommonHeaders';
@@ -141,7 +141,7 @@ export class BillsController {
     type: Number,
     description: 'The bill id',
   })
-  getBills(@Query() filterDTO: Partial<IBillsFilter>) {
+  getBills(@Query() filterDTO: GetBillsQueryDto) {
     return this.billsApplication.getBills(filterDTO);
   }
 

--- a/packages/server/src/modules/Bills/dtos/GetBillsQuery.dto.ts
+++ b/packages/server/src/modules/Bills/dtos/GetBillsQuery.dto.ts
@@ -1,0 +1,3 @@
+import { DynamicFilterQueryDto } from '@/modules/DynamicListing/dtos/DynamicFilterQuery.dto';
+
+export class GetBillsQueryDto extends DynamicFilterQueryDto {}

--- a/packages/server/src/modules/Bills/queries/GetBills.service.ts
+++ b/packages/server/src/modules/Bills/queries/GetBills.service.ts
@@ -22,7 +22,7 @@ export class GetBillsService {
    * @param {GetBillsQueryDto} filterDTO -
    */
   public async getBills(filterDTO: GetBillsQueryDto): Promise<{
-    data: Bill[];
+    bills: Bill[];
     pagination: IPaginationMeta;
     filterMeta: IFilterMeta;
   }> {

--- a/packages/server/src/modules/Bills/queries/GetBills.service.ts
+++ b/packages/server/src/modules/Bills/queries/GetBills.service.ts
@@ -5,7 +5,7 @@ import { DynamicListService } from '@/modules/DynamicListing/DynamicList.service
 import { Bill } from '../models/Bill';
 import { IFilterMeta, IPaginationMeta } from '@/interfaces/Model';
 import { BillTransformer } from './Bill.transformer';
-import { IBillsFilter } from '../Bills.types';
+import { GetBillsQueryDto } from '../dtos/GetBillsQuery.dto';
 import { TenantModelProxy } from '@/modules/System/models/TenantBaseModel';
 
 @Injectable()
@@ -19,10 +19,10 @@ export class GetBillsService {
 
   /**
    * Retrieve bills data table list.
-   * @param {IBillsFilter} billsFilter -
+   * @param {GetBillsQueryDto} filterDTO -
    */
-  public async getBills(filterDTO: Partial<IBillsFilter>): Promise<{
-    bills: Bill;
+  public async getBills(filterDTO: GetBillsQueryDto): Promise<{
+    data: Bill[];
     pagination: IPaginationMeta;
     filterMeta: IFilterMeta;
   }> {

--- a/packages/server/src/modules/CreditNotes/CreditNoteApplication.service.ts
+++ b/packages/server/src/modules/CreditNotes/CreditNoteApplication.service.ts
@@ -4,9 +4,9 @@ import { DeleteCreditNoteService } from './commands/DeleteCreditNote.service';
 import { EditCreditNoteService } from './commands/EditCreditNote.service';
 import { OpenCreditNoteService } from './commands/OpenCreditNote.service';
 import { GetCreditNotePdf } from './queries/GetCreditNotePdf.serivce';
-import { ICreditNotesQueryDTO } from './types/CreditNotes.types';
 import { GetCreditNotesService } from './queries/GetCreditNotes.service';
 import { CreateCreditNoteDto, EditCreditNoteDto } from './dtos/CreditNote.dto';
+import { GetCreditNotesQueryDto } from './dtos/GetCreditNotesQuery.dto';
 import { GetCreditNoteState } from './queries/GetCreditNoteState.service';
 import { GetCreditNoteService } from './queries/GetCreditNote.service';
 import { BulkDeleteCreditNotesService } from './BulkDeleteCreditNotes.service';
@@ -78,10 +78,10 @@ export class CreditNoteApplication {
 
   /**
    * Retrieves the credit notes list.
-   * @param {ICreditNotesQueryDTO} creditNotesQuery
+   * @param {GetCreditNotesQueryDto} creditNotesQuery
    * @returns {Promise<GetCreditNotesResponse>}
    */
-  getCreditNotes(creditNotesQuery: ICreditNotesQueryDTO) {
+  getCreditNotes(creditNotesQuery: GetCreditNotesQueryDto) {
     return this.getCreditNotesService.getCreditNotesList(creditNotesQuery);
   }
 

--- a/packages/server/src/modules/CreditNotes/CreditNotes.controller.ts
+++ b/packages/server/src/modules/CreditNotes/CreditNotes.controller.ts
@@ -21,8 +21,8 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { CreditNoteApplication } from './CreditNoteApplication.service';
-import { ICreditNotesQueryDTO } from './types/CreditNotes.types';
 import { CreateCreditNoteDto, EditCreditNoteDto } from './dtos/CreditNote.dto';
+import { GetCreditNotesQueryDto } from './dtos/GetCreditNotesQuery.dto';
 import { CreditNoteResponseDto } from './dtos/CreditNoteResponse.dto';
 import { CreditNoteStateResponseDto } from './dtos/CreditNoteStateResponse.dto';
 import { PaginatedResponseDto } from '@/common/dtos/PaginatedResults.dto';
@@ -126,7 +126,7 @@ export class CreditNotesController {
       ],
     },
   })
-  getCreditNotes(@Query() creditNotesQuery: ICreditNotesQueryDTO) {
+  getCreditNotes(@Query() creditNotesQuery: GetCreditNotesQueryDto) {
     return this.creditNoteApplication.getCreditNotes(creditNotesQuery);
   }
 

--- a/packages/server/src/modules/CreditNotes/dtos/GetCreditNotesQuery.dto.ts
+++ b/packages/server/src/modules/CreditNotes/dtos/GetCreditNotesQuery.dto.ts
@@ -1,0 +1,3 @@
+import { DynamicFilterQueryDto } from '@/modules/DynamicListing/dtos/DynamicFilterQuery.dto';
+
+export class GetCreditNotesQueryDto extends DynamicFilterQueryDto {}

--- a/packages/server/src/modules/CreditNotes/queries/GetCreditNotes.service.ts
+++ b/packages/server/src/modules/CreditNotes/queries/GetCreditNotes.service.ts
@@ -2,10 +2,8 @@ import { Inject, Injectable } from '@nestjs/common';
 import * as R from 'ramda';
 import { TransformerInjectable } from '@/modules/Transformer/TransformerInjectable.service';
 import { DynamicListService } from '@/modules/DynamicListing/DynamicList.service';
-import {
-  GetCreditNotesResponse,
-  ICreditNotesQueryDTO,
-} from '../types/CreditNotes.types';
+import { GetCreditNotesResponse } from '../types/CreditNotes.types';
+import { GetCreditNotesQueryDto } from '../dtos/GetCreditNotesQuery.dto';
 import { CreditNote } from '../models/CreditNote';
 import { CreditNoteTransformer } from './CreditNoteTransformer';
 import { TenantModelProxy } from '@/modules/System/models/TenantBaseModel';
@@ -32,10 +30,10 @@ export class GetCreditNotesService {
   /**
    * Retrieves the paginated and filterable credit notes list.
    * @param {number} tenantId -
-   * @param {ICreditNotesQueryDTO} creditNotesQuery -
+   * @param {GetCreditNotesQueryDto} creditNotesQuery -
    */
   public async getCreditNotesList(
-    filterDto: ICreditNotesQueryDTO,
+    filterDto: GetCreditNotesQueryDto,
   ): Promise<GetCreditNotesResponse> {
     const _filterDto = {
       sortOrder: 'desc',

--- a/packages/server/src/modules/DynamicListing/dtos/DynamicFilterQuery.dto.ts
+++ b/packages/server/src/modules/DynamicListing/dtos/DynamicFilterQuery.dto.ts
@@ -1,33 +1,46 @@
 import { ToNumber } from '@/common/decorators/Validators';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import { IsArray, IsOptional, IsString } from 'class-validator';
 import { IFilterRole, ISortOrder } from '../DynamicFilter/DynamicFilter.types';
 
 export class DynamicFilterQueryDto {
+  @ApiPropertyOptional({ description: 'Custom view ID', type: Number })
   @IsOptional()
   @ToNumber()
   customViewId?: number;
 
+  @ApiPropertyOptional({ description: 'Filter roles', type: Array })
   @IsArray()
   @IsOptional()
   filterRoles?: IFilterRole[];
 
+  @ApiPropertyOptional({ description: 'Column to sort by', type: String })
   @IsOptional()
   @IsString()
   columnSortBy: string;
 
+  @ApiPropertyOptional({ description: 'Sort order (asc/desc)', type: String })
   @IsString()
   @IsOptional()
   sortOrder: ISortOrder;
 
+  @ApiPropertyOptional({
+    description: 'Stringified filter roles',
+    type: String,
+  })
   @IsString()
   @IsOptional()
   stringifiedFilterRoles?: string;
 
+  @ApiPropertyOptional({ description: 'Search keyword', type: String })
   @IsString()
   @IsOptional()
   searchKeyword?: string;
 
+  @ApiPropertyOptional({ description: 'View slug', type: String })
   @IsString()
   @IsOptional()
   viewSlug?: string;
+
+  filterQuery?: (query: any) => void;
 }

--- a/packages/server/src/modules/Expenses/Expenses.controller.ts
+++ b/packages/server/src/modules/Expenses/Expenses.controller.ts
@@ -10,7 +10,7 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { ExpensesApplication } from './ExpensesApplication.service';
-import { IExpensesFilter } from './Expenses.types';
+import { GetExpensesQueryDto } from './dtos/GetExpensesQuery.dto';
 import {
   ApiExtraModels,
   ApiOperation,
@@ -151,7 +151,7 @@ export class ExpensesController {
       ],
     },
   })
-  public getExpenses(@Query() filterDTO: IExpensesFilter) {
+  public getExpenses(@Query() filterDTO: GetExpensesQueryDto) {
     return this.expensesApplication.getExpenses(filterDTO);
   }
 

--- a/packages/server/src/modules/Expenses/ExpensesApplication.service.ts
+++ b/packages/server/src/modules/Expenses/ExpensesApplication.service.ts
@@ -7,6 +7,7 @@ import { GetExpenseService } from './queries/GetExpense.service';
 import { IExpensesFilter } from './interfaces/Expenses.interface';
 import { GetExpensesService } from './queries/GetExpenses.service';
 import { CreateExpenseDto, EditExpenseDto } from './dtos/Expense.dto';
+import { GetExpensesQueryDto } from './dtos/GetExpensesQuery.dto';
 import { BulkDeleteExpensesService } from './BulkDeleteExpenses.service';
 import { ValidateBulkDeleteExpensesService } from './ValidateBulkDeleteExpenses.service';
 
@@ -95,9 +96,9 @@ export class ExpensesApplication {
 
   /**
    * Retrieve expenses paginated list.
-   * @param  {IExpensesFilter} expensesFilter
+   * @param  {GetExpensesQueryDto} filterDTO
    */
-  public getExpenses(filterDTO: Partial<IExpensesFilter>) {
+  public getExpenses(filterDTO: GetExpensesQueryDto) {
     return this.getExpensesService.getExpensesList(filterDTO);
   }
 }

--- a/packages/server/src/modules/Expenses/ExpensesExportable.ts
+++ b/packages/server/src/modules/Expenses/ExpensesExportable.ts
@@ -2,9 +2,10 @@ import { Exportable } from '../Export/Exportable';
 import { ExpensesApplication } from './ExpensesApplication.service';
 import { EXPORT_SIZE_LIMIT } from '../Export/constants';
 import { Injectable } from '@nestjs/common';
-import { IExpensesFilter } from './Expenses.types';
 import { ExportableService } from '../Export/decorators/ExportableModel.decorator';
 import { Expense } from './models/Expense.model';
+import { GetExpensesQueryDto } from './dtos/GetExpensesQuery.dto';
+import { ISortOrder } from '@/modules/DynamicListing/DynamicFilter/DynamicFilter.types';
 
 @Injectable()
 @ExportableService({ name: Expense.name })
@@ -17,20 +18,20 @@ export class ExpensesExportable extends Exportable {
 
   /**
    * Retrieves the accounts data to exportable sheet.
-   * @param {IExpensesFilter}
+   * @param {GetExpensesQueryDto} query
    */
-  public exportable(query: IExpensesFilter) {
+  public exportable(query: GetExpensesQueryDto) {
     const filterQuery = (query) => {
       query.withGraphFetched('branch');
     };
     const parsedQuery = {
-      sortOrder: 'desc',
+      sortOrder: 'desc' as ISortOrder,
       columnSortBy: 'created_at',
       ...query,
       page: 1,
       pageSize: EXPORT_SIZE_LIMIT,
       filterQuery,
-    } as IExpensesFilter;
+    } as GetExpensesQueryDto;
 
     return this.expensesApplication
       .getExpenses(parsedQuery)

--- a/packages/server/src/modules/Expenses/dtos/GetExpensesQuery.dto.ts
+++ b/packages/server/src/modules/Expenses/dtos/GetExpensesQuery.dto.ts
@@ -1,0 +1,3 @@
+import { DynamicFilterQueryDto } from '@/modules/DynamicListing/dtos/DynamicFilterQuery.dto';
+
+export class GetExpensesQueryDto extends DynamicFilterQueryDto {}

--- a/packages/server/src/modules/Expenses/queries/GetExpenses.service.ts
+++ b/packages/server/src/modules/Expenses/queries/GetExpenses.service.ts
@@ -3,7 +3,8 @@ import { ExpenseTransfromer } from './Expense.transformer';
 import { DynamicListService } from '@/modules/DynamicListing/DynamicList.service';
 import { TransformerInjectable } from '@/modules/Transformer/TransformerInjectable.service';
 import { Inject, Injectable } from '@nestjs/common';
-import { IExpensesFilter, IPaginationMeta } from '../Expenses.types';
+import { IPaginationMeta } from '../Expenses.types';
+import { GetExpensesQueryDto } from '../dtos/GetExpensesQuery.dto';
 import { Expense } from '../models/Expense.model';
 import { IFilterMeta } from '@/interfaces/Model';
 import { TenantModelProxy } from '@/modules/System/models/TenantBaseModel';
@@ -20,11 +21,11 @@ export class GetExpensesService {
 
   /**
    * Retrieve expenses paginated list.
-   * @param  {IExpensesFilter} expensesFilter
+   * @param  {GetExpensesQueryDto} filterDTO
    * @return {IExpense[]}
    */
-  public async getExpensesList(filterDto: Partial<IExpensesFilter>): Promise<{
-    expenses: Expense[];
+  public async getExpensesList(filterDTO: GetExpensesQueryDto): Promise<{
+    data: Expense[];
     pagination: IPaginationMeta;
     filterMeta: IFilterMeta;
   }> {
@@ -33,7 +34,7 @@ export class GetExpensesService {
       columnSortBy: 'created_at',
       page: 1,
       pageSize: 12,
-      ...filterDto,
+      ...filterDTO,
     };
     // Parses list filter DTO.
     const filter = this.parseListFilterDTO(_filterDto);

--- a/packages/server/src/modules/Expenses/queries/GetExpenses.service.ts
+++ b/packages/server/src/modules/Expenses/queries/GetExpenses.service.ts
@@ -25,7 +25,7 @@ export class GetExpensesService {
    * @return {IExpense[]}
    */
   public async getExpensesList(filterDTO: GetExpensesQueryDto): Promise<{
-    data: Expense[];
+    expenses: Expense[];
     pagination: IPaginationMeta;
     filterMeta: IFilterMeta;
   }> {

--- a/packages/server/src/modules/ItemCategories/ItemCategory.application.ts
+++ b/packages/server/src/modules/ItemCategories/ItemCategory.application.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@nestjs/common';
 import {
-  IItemCategoriesFilter,
   IItemCategoryOTD,
 } from './ItemCategory.interfaces';
+import { GetItemCategoriesQueryDto } from './dtos/GetItemCategoriesQuery.dto';
 import { CreateItemCategoryService } from './commands/CreateItemCategory.service';
 import { DeleteItemCategoryService } from './commands/DeleteItemCategory.service';
 import { EditItemCategoryService } from './commands/EditItemCategory.service';
@@ -75,10 +75,10 @@ export class ItemCategoryApplication {
 
   /**
    * Retrieves the item categories list.
-   * @param {IItemCategoriesFilter} filterDTO - The item categories filter DTO.
+   * @param {GetItemCategoriesQueryDto} filterDTO - The item categories filter DTO.
    * @returns {Promise<GetItemCategoriesResponse>}
    */
-  public getItemCategories(filterDTO: Partial<IItemCategoriesFilter>) {
+  public getItemCategories(filterDTO: GetItemCategoriesQueryDto) {
     return this.getItemCategoriesService.getItemCategories(filterDTO);
   }
 }

--- a/packages/server/src/modules/ItemCategories/ItemCategory.controller.ts
+++ b/packages/server/src/modules/ItemCategories/ItemCategory.controller.ts
@@ -9,10 +9,7 @@ import {
   Query,
 } from '@nestjs/common';
 import { ItemCategoryApplication } from './ItemCategory.application';
-import {
-  GetItemCategoriesResponse,
-  IItemCategoriesFilter,
-} from './ItemCategory.interfaces';
+import { GetItemCategoriesResponse } from './ItemCategory.interfaces';
 import {
   ApiExtraModels,
   ApiOperation,
@@ -24,6 +21,7 @@ import {
   CreateItemCategoryDto,
   EditItemCategoryDto,
 } from './dtos/ItemCategory.dto';
+import { GetItemCategoriesQueryDto } from './dtos/GetItemCategoriesQuery.dto';
 import { ItemCategoryResponseDto } from './dtos/ItemCategoryResponse.dto';
 import { ApiCommonHeaders } from '@/common/decorators/ApiCommonHeaders';
 
@@ -53,7 +51,7 @@ export class ItemCategoryController {
     },
   })
   async getItemCategories(
-    @Query() filterDTO: Partial<IItemCategoriesFilter>,
+    @Query() filterDTO: GetItemCategoriesQueryDto,
   ): Promise<GetItemCategoriesResponse> {
     return this.itemCategoryApplication.getItemCategories(filterDTO);
   }

--- a/packages/server/src/modules/ItemCategories/dtos/GetItemCategoriesQuery.dto.ts
+++ b/packages/server/src/modules/ItemCategories/dtos/GetItemCategoriesQuery.dto.ts
@@ -1,0 +1,3 @@
+import { DynamicFilterQueryDto } from '@/modules/DynamicListing/dtos/DynamicFilterQuery.dto';
+
+export class GetItemCategoriesQueryDto extends DynamicFilterQueryDto {}

--- a/packages/server/src/modules/ItemCategories/queries/GetItemCategories.service.ts
+++ b/packages/server/src/modules/ItemCategories/queries/GetItemCategories.service.ts
@@ -2,10 +2,8 @@ import * as R from 'ramda';
 import { DynamicListService } from '@/modules/DynamicListing/DynamicList.service';
 import { ItemCategory } from '../models/ItemCategory.model';
 import { Inject } from '@nestjs/common';
-import {
-  GetItemCategoriesResponse,
-  IItemCategoriesFilter,
-} from '../ItemCategory.interfaces';
+import { GetItemCategoriesResponse } from '../ItemCategory.interfaces';
+import { GetItemCategoriesQueryDto } from '../dtos/GetItemCategoriesQuery.dto';
 import { TenantModelProxy } from '@/modules/System/models/TenantBaseModel';
 import { ISortOrder } from '@/modules/DynamicListing/DynamicFilter/DynamicFilter.types';
 
@@ -31,11 +29,11 @@ export class GetItemCategoriesService {
 
   /**
    * Retrieve item categories list.
-   * @param {IItemCategoriesFilter} filterDTO
+   * @param {GetItemCategoriesQueryDto} filterDTO
    * @returns {Promise<GetItemCategoriesResponse>}
    */
   public async getItemCategories(
-    filterDto: Partial<IItemCategoriesFilter>,
+    filterDto: GetItemCategoriesQueryDto,
   ): Promise<GetItemCategoriesResponse> {
     const _filterDto = {
       sortOrder: ISortOrder.ASC,

--- a/packages/server/src/modules/ManualJournals/ManualJournals.controller.ts
+++ b/packages/server/src/modules/ManualJournals/ManualJournals.controller.ts
@@ -23,7 +23,7 @@ import {
   CreateManualJournalDto,
   EditManualJournalDto,
 } from './dtos/ManualJournal.dto';
-import { IManualJournalsFilter } from './types/ManualJournals.types';
+import { GetManualJournalsQueryDto } from './dtos/GetManualJournalsQuery.dto';
 import { ManualJournalResponseDto } from './dtos/ManualJournalResponse.dto';
 import { ApiCommonHeaders } from '@/common/decorators/ApiCommonHeaders';
 import {
@@ -194,7 +194,7 @@ export class ManualJournalsController {
     },
   })
   @ApiResponse({ status: 404, description: 'The manual journal not found.' })
-  public getManualJournals(@Query() filterDto: Partial<IManualJournalsFilter>) {
+  public getManualJournals(@Query() filterDto: GetManualJournalsQueryDto) {
     return this.manualJournalsApplication.getManualJournals(filterDto);
   }
 }

--- a/packages/server/src/modules/ManualJournals/ManualJournalsApplication.service.ts
+++ b/packages/server/src/modules/ManualJournals/ManualJournalsApplication.service.ts
@@ -4,11 +4,11 @@ import { EditManualJournal } from './commands/EditManualJournal.service';
 import { PublishManualJournal } from './commands/PublishManualJournal.service';
 import { GetManualJournal } from './queries/GetManualJournal.service';
 import { DeleteManualJournalService } from './commands/DeleteManualJournal.service';
-import { IManualJournalsFilter } from './types/ManualJournals.types';
 import {
   CreateManualJournalDto,
   EditManualJournalDto,
 } from './dtos/ManualJournal.dto';
+import { GetManualJournalsQueryDto } from './dtos/GetManualJournalsQuery.dto';
 import { GetManualJournals } from './queries/GetManualJournals.service';
 import { BulkDeleteManualJournalsService } from './BulkDeleteManualJournals.service';
 import { ValidateBulkDeleteManualJournalsService } from './ValidateBulkDeleteManualJournals.service';
@@ -105,9 +105,9 @@ export class ManualJournalsApplication {
 
   /**
    * Retrieves the paginated manual journals.
-   * @param {IManualJournalsFilter} filterDTO
+   * @param {GetManualJournalsQueryDto} filterDTO
    */
-  public getManualJournals = (filterDTO: Partial<IManualJournalsFilter>) => {
+  public getManualJournals = (filterDTO: GetManualJournalsQueryDto) => {
     return this.getManualJournalsService.getManualJournals(filterDTO);
   };
 }

--- a/packages/server/src/modules/ManualJournals/dtos/GetManualJournalsQuery.dto.ts
+++ b/packages/server/src/modules/ManualJournals/dtos/GetManualJournalsQuery.dto.ts
@@ -1,0 +1,3 @@
+import { DynamicFilterQueryDto } from '@/modules/DynamicListing/dtos/DynamicFilterQuery.dto';
+
+export class GetManualJournalsQueryDto extends DynamicFilterQueryDto {}

--- a/packages/server/src/modules/ManualJournals/queries/GetManualJournals.service.ts
+++ b/packages/server/src/modules/ManualJournals/queries/GetManualJournals.service.ts
@@ -5,7 +5,7 @@ import { TransformerInjectable } from '@/modules/Transformer/TransformerInjectab
 import { DynamicListService } from '@/modules/DynamicListing/DynamicList.service';
 import { ManualJournal } from '../models/ManualJournal';
 import { IFilterMeta, IPaginationMeta } from '@/interfaces/Model';
-import { IManualJournalsFilter } from '../types/ManualJournals.types';
+import { GetManualJournalsQueryDto } from '../dtos/GetManualJournalsQuery.dto';
 import { TenantModelProxy } from '@/modules/System/models/TenantBaseModel';
 
 @Injectable()
@@ -28,10 +28,10 @@ export class GetManualJournals {
 
   /**
    * Retrieve manual journals datatable list.
-   * @param {IManualJournalsFilter} filter -
+   * @param {GetManualJournalsQueryDto} filter -
    */
   public getManualJournals = async (
-    filterDTO: Partial<IManualJournalsFilter>,
+    filterDTO: GetManualJournalsQueryDto,
   ): Promise<{
     manualJournals: ManualJournal[];
     pagination: IPaginationMeta;

--- a/packages/server/src/modules/PaymentReceived/PaymentReceived.application.ts
+++ b/packages/server/src/modules/PaymentReceived/PaymentReceived.application.ts
@@ -1,7 +1,5 @@
-import {
-  IPaymentsReceivedFilter,
-  PaymentReceiveMailOptsDTO,
-} from './types/PaymentReceived.types';
+import { PaymentReceiveMailOptsDTO } from './types/PaymentReceived.types';
+import { GetPaymentsReceivedQueryDto } from './dtos/GetPaymentsReceivedQuery.dto';
 import { Injectable } from '@nestjs/common';
 import { CreatePaymentReceivedService } from './commands/CreatePaymentReceived.serivce';
 import { EditPaymentReceivedService } from './commands/EditPaymentReceived.service';
@@ -103,11 +101,11 @@ export class PaymentReceivesApplication {
   /**
    * Retrieve payment receives paginated and filterable.
    * @param {number} tenantId
-   * @param {IPaymentsReceivedFilter} filterDTO
+   * @param {GetPaymentsReceivedQueryDto} filterDTO
    * @returns
    */
   public async getPaymentsReceived(
-    filterDTO: Partial<IPaymentsReceivedFilter>,
+    filterDTO: GetPaymentsReceivedQueryDto,
   ) {
     return this.getPaymentsReceivedService.getPaymentReceives(filterDTO);
   }

--- a/packages/server/src/modules/PaymentReceived/PaymentsReceived.controller.ts
+++ b/packages/server/src/modules/PaymentReceived/PaymentsReceived.controller.ts
@@ -23,9 +23,9 @@ import {
 } from '@nestjs/common';
 import { PaymentReceivesApplication } from './PaymentReceived.application';
 import {
-  IPaymentsReceivedFilter,
   PaymentReceiveMailOptsDTO,
 } from './types/PaymentReceived.types';
+import { GetPaymentsReceivedQueryDto } from './dtos/GetPaymentsReceivedQuery.dto';
 import {
   CreatePaymentReceivedDto,
   EditPaymentReceivedDto,
@@ -156,7 +156,7 @@ export class PaymentReceivesController {
     },
   })
   public getPaymentsReceived(
-    @Query() filterDTO: Partial<IPaymentsReceivedFilter>,
+    @Query() filterDTO: GetPaymentsReceivedQueryDto,
   ) {
     return this.paymentReceivesApplication.getPaymentsReceived(filterDTO);
   }

--- a/packages/server/src/modules/PaymentReceived/dtos/GetPaymentsReceivedQuery.dto.ts
+++ b/packages/server/src/modules/PaymentReceived/dtos/GetPaymentsReceivedQuery.dto.ts
@@ -1,0 +1,3 @@
+import { DynamicFilterQueryDto } from '@/modules/DynamicListing/dtos/DynamicFilterQuery.dto';
+
+export class GetPaymentsReceivedQueryDto extends DynamicFilterQueryDto {}

--- a/packages/server/src/modules/PaymentReceived/queries/GetPaymentsReceived.service.ts
+++ b/packages/server/src/modules/PaymentReceived/queries/GetPaymentsReceived.service.ts
@@ -5,7 +5,7 @@ import { TransformerInjectable } from '@/modules/Transformer/TransformerInjectab
 import { DynamicListService } from '@/modules/DynamicListing/DynamicList.service';
 import { PaymentReceived } from '../models/PaymentReceived';
 import { IFilterMeta, IPaginationMeta } from '@/interfaces/Model';
-import { IPaymentsReceivedFilter } from '../types/PaymentReceived.types';
+import { GetPaymentsReceivedQueryDto } from '../dtos/GetPaymentsReceivedQuery.dto';
 import { TenantModelProxy } from '@/modules/System/models/TenantBaseModel';
 
 @Injectable()
@@ -22,10 +22,10 @@ export class GetPaymentsReceivedService {
 
   /**
    * Retrieve payment receives paginated and filterable list.
-   * @param {IPaymentsReceivedFilter} filterDTO
+   * @param {GetPaymentsReceivedQueryDto} filterDTO
    */
   public async getPaymentReceives(
-    filterDTO: Partial<IPaymentsReceivedFilter>,
+    filterDTO: GetPaymentsReceivedQueryDto,
   ): Promise<{
     paymentReceives: PaymentReceived[];
     pagination: IPaginationMeta;

--- a/packages/server/src/modules/SaleEstimates/SaleEstimates.controller.ts
+++ b/packages/server/src/modules/SaleEstimates/SaleEstimates.controller.ts
@@ -22,10 +22,7 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { SaleEstimatesApplication } from './SaleEstimates.application';
-import {
-  ISalesEstimatesFilter,
-  SaleEstimateMailOptionsDTO,
-} from './types/SaleEstimates.types';
+import { SaleEstimateMailOptionsDTO } from './types/SaleEstimates.types';
 import { SaleEstimate } from './models/SaleEstimate';
 import {
   CreateSaleEstimateDto,
@@ -34,6 +31,7 @@ import {
 import { AcceptType } from '@/constants/accept-type';
 import { Response } from 'express';
 import { SaleEstimateResponseDto } from './dtos/SaleEstimateResponse.dto';
+import { GetSaleEstimatesQueryDto } from './dtos/GetSaleEstimatesQuery.dto';
 import { PaginatedResponseDto } from '@/common/dtos/PaginatedResults.dto';
 import { SaleEstiamteStateResponseDto } from './dtos/SaleEstimateStateResponse.dto';
 import { ApiCommonHeaders } from '@/common/decorators/ApiCommonHeaders';
@@ -198,7 +196,7 @@ export class SaleEstimatesController {
       ],
     },
   })
-  public getSaleEstimates(@Query() filterDTO: ISalesEstimatesFilter) {
+  public getSaleEstimates(@Query() filterDTO: GetSaleEstimatesQueryDto) {
     return this.saleEstimatesApplication.getSaleEstimates(filterDTO);
   }
 

--- a/packages/server/src/modules/SaleEstimates/dtos/GetSaleEstimatesQuery.dto.ts
+++ b/packages/server/src/modules/SaleEstimates/dtos/GetSaleEstimatesQuery.dto.ts
@@ -1,0 +1,3 @@
+import { DynamicFilterQueryDto } from '@/modules/DynamicListing/dtos/DynamicFilterQuery.dto';
+
+export class GetSaleEstimatesQueryDto extends DynamicFilterQueryDto {}

--- a/packages/server/src/modules/SaleInvoices/SaleInvoices.application.ts
+++ b/packages/server/src/modules/SaleInvoices/SaleInvoices.application.ts
@@ -12,10 +12,10 @@ import { GetSaleInvoiceState } from './queries/GetSaleInvoiceState.service';
 import { GetSaleInvoiceMailState } from './queries/GetSaleInvoiceMailState.service';
 import {
   ISaleInvoiceWriteoffDTO,
-  ISalesInvoicesFilter,
   SaleInvoiceMailState,
   SendInvoiceMailDTO,
 } from './SaleInvoice.types';
+import { GetSaleInvoicesQueryDto } from './dtos/GetSaleInvoicesQuery.dto';
 import { GetSaleInvoicesService } from './queries/GetSaleInvoices';
 import { SendSaleInvoiceMail } from './commands/SendSaleInvoiceMail';
 import {
@@ -112,7 +112,7 @@ export class SaleInvoiceApplication {
    * @param {ISalesInvoicesFilter} filterDTO
    * @returns {Promise<{ salesInvoices: SaleInvoice[]; pagination: IPaginationMeta; filterMeta: IFilterMeta; }>}
    */
-  public getSaleInvoices(filterDTO: Partial<ISalesInvoicesFilter>) {
+  public getSaleInvoices(filterDTO: GetSaleInvoicesQueryDto) {
     return this.getSaleInvoicesService.getSaleInvoices(filterDTO);
   }
 

--- a/packages/server/src/modules/SaleInvoices/SaleInvoices.controller.ts
+++ b/packages/server/src/modules/SaleInvoices/SaleInvoices.controller.ts
@@ -16,7 +16,6 @@ import {
 } from '@nestjs/common';
 import {
   ISaleInvoiceWriteoffDTO,
-  ISalesInvoicesFilter,
   SaleInvoiceMailState,
   SendInvoiceMailDTO,
 } from './SaleInvoice.types';
@@ -34,6 +33,7 @@ import {
   CreateSaleInvoiceDto,
   EditSaleInvoiceDto,
 } from './dtos/SaleInvoice.dto';
+import { GetSaleInvoicesQueryDto } from './dtos/GetSaleInvoicesQuery.dto';
 import { AcceptType } from '@/constants/accept-type';
 import { SaleInvoiceResponseDto } from './dtos/SaleInvoiceResponse.dto';
 import { PaginatedResponseDto } from '@/common/dtos/PaginatedResults.dto';
@@ -262,7 +262,7 @@ export class SaleInvoicesController {
       ],
     },
   })
-  getSaleInvoices(@Query() filterDTO: Partial<ISalesInvoicesFilter>) {
+  getSaleInvoices(@Query() filterDTO: GetSaleInvoicesQueryDto) {
     return this.saleInvoiceApplication.getSaleInvoices(filterDTO);
   }
 

--- a/packages/server/src/modules/SaleInvoices/dtos/GetSaleInvoicesQuery.dto.ts
+++ b/packages/server/src/modules/SaleInvoices/dtos/GetSaleInvoicesQuery.dto.ts
@@ -1,0 +1,3 @@
+import { DynamicFilterQueryDto } from '@/modules/DynamicListing/dtos/DynamicFilterQuery.dto';
+
+export class GetSaleInvoicesQueryDto extends DynamicFilterQueryDto {}

--- a/packages/server/src/modules/SaleInvoices/queries/GetSaleInvoices.ts
+++ b/packages/server/src/modules/SaleInvoices/queries/GetSaleInvoices.ts
@@ -6,7 +6,7 @@ import { TransformerInjectable } from '@/modules/Transformer/TransformerInjectab
 import { DynamicListService } from '@/modules/DynamicListing/DynamicList.service';
 import { IFilterMeta, IPaginationMeta } from '@/interfaces/Model';
 import { SaleInvoice } from '../models/SaleInvoice';
-import { ISalesInvoicesFilter } from '../SaleInvoice.types';
+import { GetSaleInvoicesQueryDto } from '../dtos/GetSaleInvoicesQuery.dto';
 import { TenantModelProxy } from '@/modules/System/models/TenantBaseModel';
 
 @Injectable()
@@ -21,11 +21,11 @@ export class GetSaleInvoicesService {
 
   /**
    * Retrieve sales invoices filterable and paginated list.
-   * @param {ISalesInvoicesFilter} filterDTO -
-   * @returns {Promise<{ salesInvoices: SaleInvoice[]; pagination: IPaginationMeta; filterMeta: IFilterMeta; }>}
+   * @param {GetSaleInvoicesQueryDto} filterDTO -
+   * @returns {Promise<{ data: SaleInvoice[]; pagination: IPaginationMeta; filterMeta: IFilterMeta; }>}
    */
   public async getSaleInvoices(
-    filterDTO: Partial<ISalesInvoicesFilter>,
+    filterDTO: GetSaleInvoicesQueryDto,
   ): Promise<{
     salesInvoices: SaleInvoice[];
     pagination: IPaginationMeta;

--- a/packages/server/src/modules/SaleReceipts/SaleReceiptApplication.service.ts
+++ b/packages/server/src/modules/SaleReceipts/SaleReceiptApplication.service.ts
@@ -9,10 +9,10 @@ import { GetSaleReceipt } from './queries/GetSaleReceipt.service';
 import { EditSaleReceipt } from './commands/EditSaleReceipt.service';
 import {
   ISaleReceiptState,
-  ISalesReceiptsFilter,
   SaleReceiptMailOpts,
   SaleReceiptMailOptsDTO,
 } from './types/SaleReceipts.types';
+import { GetSaleReceiptsQueryDto } from './dtos/GetSaleReceiptsQuery.dto';
 import { GetSaleReceiptsService } from './queries/GetSaleReceipts.service';
 import { SaleReceipt } from './models/SaleReceipt';
 import { IFilterMeta, IPaginationMeta } from '@/interfaces/Model';
@@ -115,10 +115,10 @@ export class SaleReceiptApplication {
 
   /**
    * Retrieve sales receipts paginated and filterable list.
-   * @param {ISalesReceiptsFilter} filterDTO
+   * @param {GetSaleReceiptsQueryDto} filterDTO
    * @returns
    */
-  public async getSaleReceipts(filterDTO: ISalesReceiptsFilter): Promise<{
+  public async getSaleReceipts(filterDTO: GetSaleReceiptsQueryDto): Promise<{
     data: SaleReceipt[];
     pagination: IPaginationMeta;
     filterMeta: IFilterMeta;

--- a/packages/server/src/modules/SaleReceipts/SaleReceipts.controller.ts
+++ b/packages/server/src/modules/SaleReceipts/SaleReceipts.controller.ts
@@ -25,8 +25,8 @@ import {
   CreateSaleReceiptDto,
   EditSaleReceiptDto,
 } from './dtos/SaleReceipt.dto';
+import { GetSaleReceiptsQueryDto } from './dtos/GetSaleReceiptsQuery.dto';
 import {
-  ISalesReceiptsFilter,
   SaleReceiptMailOptsDTO,
 } from './types/SaleReceipts.types';
 import { AcceptType } from '@/constants/accept-type';
@@ -206,7 +206,7 @@ export class SaleReceiptsController {
       ],
     },
   })
-  getSaleReceipts(@Query() filterDTO: Partial<ISalesReceiptsFilter>) {
+  getSaleReceipts(@Query() filterDTO: GetSaleReceiptsQueryDto) {
     return this.saleReceiptApplication.getSaleReceipts(filterDTO);
   }
 

--- a/packages/server/src/modules/SaleReceipts/commands/SaleReceiptsExportable.ts
+++ b/packages/server/src/modules/SaleReceipts/commands/SaleReceiptsExportable.ts
@@ -1,8 +1,9 @@
 import { Exportable } from '@/modules/Export/Exportable';
 import { Injectable } from '@nestjs/common';
 import { SaleReceiptApplication } from '../SaleReceiptApplication.service';
-import { ISalesReceiptsFilter } from '../types/SaleReceipts.types';
 import { EXPORT_SIZE_LIMIT } from '@/modules/Export/constants';
+import { GetSaleReceiptsQueryDto } from '../dtos/GetSaleReceiptsQuery.dto';
+import { ISortOrder } from '@/modules/DynamicListing/DynamicFilter/DynamicFilter.types';
 
 @Injectable()
 export class SaleReceiptsExportable extends Exportable {
@@ -12,21 +13,21 @@ export class SaleReceiptsExportable extends Exportable {
 
   /**
    * Retrieves the accounts data to exportable sheet.
-   * @param {ISalesReceiptsFilter} query -
+   * @param {GetSaleReceiptsQueryDto} query -
    */
-  public exportable(query: ISalesReceiptsFilter) {
+  public exportable(query: GetSaleReceiptsQueryDto) {
     const filterQuery = (query) => {
       query.withGraphFetched('branch');
       query.withGraphFetched('warehouse');
     };
     const parsedQuery = {
-      sortOrder: 'desc',
+      sortOrder: 'desc' as ISortOrder,
       columnSortBy: 'created_at',
       ...query,
       page: 1,
       pageSize: EXPORT_SIZE_LIMIT,
       filterQuery,
-    } as ISalesReceiptsFilter;
+    } as GetSaleReceiptsQueryDto;
 
     return this.saleReceiptsApp
       .getSaleReceipts(parsedQuery)

--- a/packages/server/src/modules/SaleReceipts/dtos/GetSaleReceiptsQuery.dto.ts
+++ b/packages/server/src/modules/SaleReceipts/dtos/GetSaleReceiptsQuery.dto.ts
@@ -1,0 +1,3 @@
+import { DynamicFilterQueryDto } from '@/modules/DynamicListing/dtos/DynamicFilterQuery.dto';
+
+export class GetSaleReceiptsQueryDto extends DynamicFilterQueryDto {}

--- a/packages/server/src/modules/SaleReceipts/queries/GetSaleReceipts.service.ts
+++ b/packages/server/src/modules/SaleReceipts/queries/GetSaleReceipts.service.ts
@@ -4,7 +4,7 @@ import { SaleReceiptTransformer } from './SaleReceiptTransformer';
 import { TransformerInjectable } from '@/modules/Transformer/TransformerInjectable.service';
 import { DynamicListService } from '@/modules/DynamicListing/DynamicList.service';
 import { IFilterMeta, IPaginationMeta } from '@/interfaces/Model';
-import { ISalesReceiptsFilter } from '../types/SaleReceipts.types';
+import { GetSaleReceiptsQueryDto } from '../dtos/GetSaleReceiptsQuery.dto';
 import { SaleReceipt } from '../models/SaleReceipt';
 import { TenantModelProxy } from '@/modules/System/models/TenantBaseModel';
 
@@ -23,9 +23,9 @@ export class GetSaleReceiptsService {
 
   /**
    * Retrieve sales receipts paginated and filterable list.
-   * @param {ISalesReceiptsFilter} salesReceiptsFilter - Sales receipts filter.
+   * @param {GetSaleReceiptsQueryDto} filterDTO - Sales receipts filter.
    */
-  public async getSaleReceipts(filterDTO: ISalesReceiptsFilter): Promise<{
+  public async getSaleReceipts(filterDTO: GetSaleReceiptsQueryDto): Promise<{
     data: SaleReceipt[];
     pagination: IPaginationMeta;
     filterMeta: IFilterMeta;

--- a/packages/server/src/modules/VendorCredit/VendorCredits.controller.ts
+++ b/packages/server/src/modules/VendorCredit/VendorCredits.controller.ts
@@ -10,7 +10,7 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { VendorCreditsApplicationService } from './VendorCreditsApplication.service';
-import { IVendorCreditsQueryDTO } from './types/VendorCredit.types';
+import { GetVendorCreditsQueryDto } from './dtos/GetVendorCreditsQuery.dto';
 import {
   ApiExtraModels,
   ApiOperation,
@@ -98,7 +98,7 @@ export class VendorCreditsController {
   @Get()
   @RequirePermission(VendorCreditAction.View, AbilitySubject.VendorCredit)
   @ApiOperation({ summary: 'Retrieves the vendor credits.' })
-  async getVendorCredits(@Query() filterDTO: IVendorCreditsQueryDTO) {
+  async getVendorCredits(@Query() filterDTO: GetVendorCreditsQueryDto) {
     return this.vendorCreditsApplication.getVendorCredits(filterDTO);
   }
 

--- a/packages/server/src/modules/VendorCredit/VendorCreditsApplication.service.ts
+++ b/packages/server/src/modules/VendorCredit/VendorCreditsApplication.service.ts
@@ -5,9 +5,9 @@ import { EditVendorCreditService } from './commands/EditVendorCredit.service';
 import { GetVendorCreditService } from './queries/GetVendorCredit.service';
 import {
   IVendorCreditEditDTO,
-  IVendorCreditsQueryDTO,
 } from './types/VendorCredit.types';
 import { IVendorCreditCreateDTO } from './types/VendorCredit.types';
+import { GetVendorCreditsQueryDto } from './dtos/GetVendorCreditsQuery.dto';
 import { Injectable } from '@nestjs/common';
 import { OpenVendorCreditService } from './commands/OpenVendorCredit.service';
 import { GetVendorCreditsService } from './queries/GetVendorCredits.service';
@@ -95,10 +95,10 @@ export class VendorCreditsApplicationService {
 
   /**
    * Retrieves the paginated filterable vendor credits list.
-   * @param {IVendorCreditsQueryDTO} query 
+   * @param {GetVendorCreditsQueryDto} query
    * @returns {}
    */
-  getVendorCredits(query: IVendorCreditsQueryDTO) {
+  getVendorCredits(query: GetVendorCreditsQueryDto) {
     return this.getVendorCreditsService.getVendorCredits(query);
   }
 

--- a/packages/server/src/modules/VendorCredit/dtos/GetVendorCreditsQuery.dto.ts
+++ b/packages/server/src/modules/VendorCredit/dtos/GetVendorCreditsQuery.dto.ts
@@ -1,0 +1,3 @@
+import { DynamicFilterQueryDto } from '@/modules/DynamicListing/dtos/DynamicFilterQuery.dto';
+
+export class GetVendorCreditsQueryDto extends DynamicFilterQueryDto {}

--- a/packages/server/src/modules/VendorCredit/queries/GetVendorCredits.service.ts
+++ b/packages/server/src/modules/VendorCredit/queries/GetVendorCredits.service.ts
@@ -4,7 +4,7 @@ import { VendorCreditTransformer } from './VendorCreditTransformer';
 import { DynamicListService } from '@/modules/DynamicListing/DynamicList.service';
 import { TransformerInjectable } from '@/modules/Transformer/TransformerInjectable.service';
 import { VendorCredit } from '../models/VendorCredit';
-import { IVendorCreditsQueryDTO } from '../types/VendorCredit.types';
+import { GetVendorCreditsQueryDto } from '../dtos/GetVendorCreditsQuery.dto';
 import { TenantModelProxy } from '@/modules/System/models/TenantBaseModel';
 
 @Injectable()
@@ -19,19 +19,19 @@ export class GetVendorCreditsService {
 
   /**
    * Parses the sale invoice list filter DTO.
-   * @param {IVendorCreditsQueryDTO} filterDTO
+   * @param {GetVendorCreditsQueryDto} filterDTO
    * @returns
    */
-  private parseListFilterDTO = (filterDTO: IVendorCreditsQueryDTO) => {
+  private parseListFilterDTO = (filterDTO: GetVendorCreditsQueryDto) => {
     return R.compose(this.dynamicListService.parseStringifiedFilter)(filterDTO);
   };
 
   /**
    * Retrieve the vendor credits list.
-   * @param {IVendorCreditsQueryDTO} vendorCreditQuery -
+   * @param {GetVendorCreditsQueryDto} vendorCreditQuery -
    */
   public getVendorCredits = async (
-    vendorCreditQuery: IVendorCreditsQueryDTO,
+    vendorCreditQuery: GetVendorCreditsQueryDto,
   ) => {
     const filterDto = {
       sortOrder: 'desc',
@@ -58,7 +58,7 @@ export class GetVendorCreditsService {
         // Gives ability to inject custom query to filter results.
         filterDto?.filterQuery && filterDto?.filterQuery(builder);
       })
-      .pagination(filter.page - 1, filter.pageSize);
+      .pagination(filterDto.page - 1, filterDto.pageSize);
 
     // Transformes the vendor credits models to POJO.
     const vendorCredits = await this.transformer.transform(

--- a/shared/sdk-ts/openapi.json
+++ b/shared/sdk-ts/openapi.json
@@ -399,6 +399,76 @@
             }
           },
           {
+            "name": "customViewId",
+            "required": false,
+            "in": "query",
+            "description": "Custom view ID for filtering",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "filterRoles",
+            "required": false,
+            "in": "query",
+            "description": "Array of filter roles",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "columnSortBy",
+            "required": false,
+            "in": "query",
+            "description": "Column sort direction",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortOrder",
+            "required": false,
+            "in": "query",
+            "description": "Sort order direction",
+            "schema": {
+              "enum": [
+                "DESC",
+                "ASC"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "name": "stringifiedFilterRoles",
+            "required": false,
+            "in": "query",
+            "description": "Stringified filter roles",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "searchKeyword",
+            "required": false,
+            "in": "query",
+            "description": "Search keyword",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "viewSlug",
+            "required": false,
+            "in": "query",
+            "description": "View slug for filtering",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "inactiveMode",
             "required": false,
             "in": "query",
@@ -421,76 +491,6 @@
             "required": false,
             "in": "query",
             "description": "Page number for pagination",
-            "schema": {
-              "type": "number"
-            }
-          },
-          {
-            "name": "viewSlug",
-            "required": false,
-            "in": "query",
-            "description": "View slug for filtering",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "searchKeyword",
-            "required": false,
-            "in": "query",
-            "description": "Search keyword",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "stringifiedFilterRoles",
-            "required": false,
-            "in": "query",
-            "description": "Stringified filter roles",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "sortOrder",
-            "required": false,
-            "in": "query",
-            "description": "Sort order direction",
-            "schema": {
-              "enum": [
-                "DESC",
-                "ASC"
-              ],
-              "type": "string"
-            }
-          },
-          {
-            "name": "columnSortBy",
-            "required": false,
-            "in": "query",
-            "description": "Column sort direction",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "filterRoles",
-            "required": false,
-            "in": "query",
-            "description": "Array of filter roles",
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "name": "customViewId",
-            "required": false,
-            "in": "query",
-            "description": "Custom view ID for filtering",
             "schema": {
               "type": "number"
             }
@@ -2998,6 +2998,72 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "customViewId",
+            "required": false,
+            "in": "query",
+            "description": "Custom view ID",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "filterRoles",
+            "required": false,
+            "in": "query",
+            "description": "Filter roles",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "columnSortBy",
+            "required": false,
+            "in": "query",
+            "description": "Column to sort by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortOrder",
+            "required": false,
+            "in": "query",
+            "description": "Sort order (asc/desc)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "stringifiedFilterRoles",
+            "required": false,
+            "in": "query",
+            "description": "Stringified filter roles",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "searchKeyword",
+            "required": false,
+            "in": "query",
+            "description": "Search keyword",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "viewSlug",
+            "required": false,
+            "in": "query",
+            "description": "View slug",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -4781,6 +4847,72 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "customViewId",
+            "required": false,
+            "in": "query",
+            "description": "Custom view ID",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "filterRoles",
+            "required": false,
+            "in": "query",
+            "description": "Filter roles",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "columnSortBy",
+            "required": false,
+            "in": "query",
+            "description": "Column to sort by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortOrder",
+            "required": false,
+            "in": "query",
+            "description": "Sort order (asc/desc)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "stringifiedFilterRoles",
+            "required": false,
+            "in": "query",
+            "description": "Stringified filter roles",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "searchKeyword",
+            "required": false,
+            "in": "query",
+            "description": "Search keyword",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "viewSlug",
+            "required": false,
+            "in": "query",
+            "description": "View slug",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -5831,6 +5963,72 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "customViewId",
+            "required": false,
+            "in": "query",
+            "description": "Custom view ID",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "filterRoles",
+            "required": false,
+            "in": "query",
+            "description": "Filter roles",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "columnSortBy",
+            "required": false,
+            "in": "query",
+            "description": "Column to sort by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortOrder",
+            "required": false,
+            "in": "query",
+            "description": "Sort order (asc/desc)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "stringifiedFilterRoles",
+            "required": false,
+            "in": "query",
+            "description": "Stringified filter roles",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "searchKeyword",
+            "required": false,
+            "in": "query",
+            "description": "Search keyword",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "viewSlug",
+            "required": false,
+            "in": "query",
+            "description": "View slug",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -6155,6 +6353,72 @@
             "in": "header",
             "description": "Required if Authorization is a JWT token. The organization ID to operate within.",
             "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "customViewId",
+            "required": false,
+            "in": "query",
+            "description": "Custom view ID",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "filterRoles",
+            "required": false,
+            "in": "query",
+            "description": "Filter roles",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "columnSortBy",
+            "required": false,
+            "in": "query",
+            "description": "Column to sort by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortOrder",
+            "required": false,
+            "in": "query",
+            "description": "Sort order (asc/desc)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "stringifiedFilterRoles",
+            "required": false,
+            "in": "query",
+            "description": "Stringified filter roles",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "searchKeyword",
+            "required": false,
+            "in": "query",
+            "description": "Search keyword",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "viewSlug",
+            "required": false,
+            "in": "query",
+            "description": "View slug",
             "schema": {
               "type": "string"
             }
@@ -6875,6 +7139,72 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "customViewId",
+            "required": false,
+            "in": "query",
+            "description": "Custom view ID",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "filterRoles",
+            "required": false,
+            "in": "query",
+            "description": "Filter roles",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "columnSortBy",
+            "required": false,
+            "in": "query",
+            "description": "Column to sort by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortOrder",
+            "required": false,
+            "in": "query",
+            "description": "Sort order (asc/desc)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "stringifiedFilterRoles",
+            "required": false,
+            "in": "query",
+            "description": "Stringified filter roles",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "searchKeyword",
+            "required": false,
+            "in": "query",
+            "description": "Search keyword",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "viewSlug",
+            "required": false,
+            "in": "query",
+            "description": "View slug",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -7124,6 +7454,72 @@
             "in": "header",
             "description": "Required if Authorization is a JWT token. The organization ID to operate within.",
             "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "customViewId",
+            "required": false,
+            "in": "query",
+            "description": "Custom view ID",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "filterRoles",
+            "required": false,
+            "in": "query",
+            "description": "Filter roles",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "columnSortBy",
+            "required": false,
+            "in": "query",
+            "description": "Column to sort by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortOrder",
+            "required": false,
+            "in": "query",
+            "description": "Sort order (asc/desc)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "stringifiedFilterRoles",
+            "required": false,
+            "in": "query",
+            "description": "Stringified filter roles",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "searchKeyword",
+            "required": false,
+            "in": "query",
+            "description": "Search keyword",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "viewSlug",
+            "required": false,
+            "in": "query",
+            "description": "View slug",
             "schema": {
               "type": "string"
             }
@@ -7627,6 +8023,72 @@
             "in": "header",
             "description": "Required if Authorization is a JWT token. The organization ID to operate within.",
             "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "customViewId",
+            "required": false,
+            "in": "query",
+            "description": "Custom view ID",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "filterRoles",
+            "required": false,
+            "in": "query",
+            "description": "Filter roles",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "columnSortBy",
+            "required": false,
+            "in": "query",
+            "description": "Column to sort by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortOrder",
+            "required": false,
+            "in": "query",
+            "description": "Sort order (asc/desc)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "stringifiedFilterRoles",
+            "required": false,
+            "in": "query",
+            "description": "Stringified filter roles",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "searchKeyword",
+            "required": false,
+            "in": "query",
+            "description": "Search keyword",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "viewSlug",
+            "required": false,
+            "in": "query",
+            "description": "View slug",
             "schema": {
               "type": "string"
             }
@@ -8332,6 +8794,72 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "customViewId",
+            "required": false,
+            "in": "query",
+            "description": "Custom view ID",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "filterRoles",
+            "required": false,
+            "in": "query",
+            "description": "Filter roles",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "columnSortBy",
+            "required": false,
+            "in": "query",
+            "description": "Column to sort by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortOrder",
+            "required": false,
+            "in": "query",
+            "description": "Sort order (asc/desc)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "stringifiedFilterRoles",
+            "required": false,
+            "in": "query",
+            "description": "Stringified filter roles",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "searchKeyword",
+            "required": false,
+            "in": "query",
+            "description": "Search keyword",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "viewSlug",
+            "required": false,
+            "in": "query",
+            "description": "View slug",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -8853,6 +9381,72 @@
             "in": "header",
             "description": "Required if Authorization is a JWT token. The organization ID to operate within.",
             "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "customViewId",
+            "required": false,
+            "in": "query",
+            "description": "Custom view ID",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "filterRoles",
+            "required": false,
+            "in": "query",
+            "description": "Filter roles",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "columnSortBy",
+            "required": false,
+            "in": "query",
+            "description": "Column to sort by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortOrder",
+            "required": false,
+            "in": "query",
+            "description": "Sort order (asc/desc)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "stringifiedFilterRoles",
+            "required": false,
+            "in": "query",
+            "description": "Stringified filter roles",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "searchKeyword",
+            "required": false,
+            "in": "query",
+            "description": "Search keyword",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "viewSlug",
+            "required": false,
+            "in": "query",
+            "description": "View slug",
             "schema": {
               "type": "string"
             }
@@ -9519,6 +10113,72 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "customViewId",
+            "required": false,
+            "in": "query",
+            "description": "Custom view ID",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "filterRoles",
+            "required": false,
+            "in": "query",
+            "description": "Filter roles",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "columnSortBy",
+            "required": false,
+            "in": "query",
+            "description": "Column to sort by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortOrder",
+            "required": false,
+            "in": "query",
+            "description": "Sort order (asc/desc)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "stringifiedFilterRoles",
+            "required": false,
+            "in": "query",
+            "description": "Stringified filter roles",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "searchKeyword",
+            "required": false,
+            "in": "query",
+            "description": "Search keyword",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "viewSlug",
+            "required": false,
+            "in": "query",
+            "description": "View slug",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -9825,6 +10485,72 @@
             "in": "header",
             "description": "Required if Authorization is a JWT token. The organization ID to operate within.",
             "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "customViewId",
+            "required": false,
+            "in": "query",
+            "description": "Custom view ID",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "filterRoles",
+            "required": false,
+            "in": "query",
+            "description": "Filter roles",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "columnSortBy",
+            "required": false,
+            "in": "query",
+            "description": "Column to sort by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortOrder",
+            "required": false,
+            "in": "query",
+            "description": "Sort order (asc/desc)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "stringifiedFilterRoles",
+            "required": false,
+            "in": "query",
+            "description": "Stringified filter roles",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "searchKeyword",
+            "required": false,
+            "in": "query",
+            "description": "Search keyword",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "viewSlug",
+            "required": false,
+            "in": "query",
+            "description": "View slug",
             "schema": {
               "type": "string"
             }
@@ -10788,6 +11514,72 @@
             "in": "header",
             "description": "Required if Authorization is a JWT token. The organization ID to operate within.",
             "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "customViewId",
+            "required": false,
+            "in": "query",
+            "description": "Custom view ID",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "filterRoles",
+            "required": false,
+            "in": "query",
+            "description": "Filter roles",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "columnSortBy",
+            "required": false,
+            "in": "query",
+            "description": "Column to sort by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortOrder",
+            "required": false,
+            "in": "query",
+            "description": "Sort order (asc/desc)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "stringifiedFilterRoles",
+            "required": false,
+            "in": "query",
+            "description": "Stringified filter roles",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "searchKeyword",
+            "required": false,
+            "in": "query",
+            "description": "Search keyword",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "viewSlug",
+            "required": false,
+            "in": "query",
+            "description": "View slug",
             "schema": {
               "type": "string"
             }
@@ -22953,6 +23745,52 @@
         },
         "tags": [
           "Contacts"
+        ]
+      }
+    },
+    "/api/exchange-rates/latest": {
+      "get": {
+        "operationId": "ExchangeRatesController_getLatestExchangeRate",
+        "summary": "Get the latest exchange rate",
+        "parameters": [
+          {
+            "name": "from_currency",
+            "required": false,
+            "in": "query",
+            "description": "Source currency code (ISO 4217)",
+            "schema": {
+              "example": "USD",
+              "type": "string"
+            }
+          },
+          {
+            "name": "to_currency",
+            "required": false,
+            "in": "query",
+            "description": "Target currency code (ISO 4217)",
+            "schema": {
+              "example": "EUR",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved exchange rate",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExchangeRateLatestResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid currency code or service error"
+          }
+        },
+        "tags": [
+          "Exchange Rates"
         ]
       }
     }
@@ -38997,6 +39835,31 @@
           "firstName",
           "lastName",
           "password"
+        ]
+      },
+      "ExchangeRateLatestResponseDto": {
+        "type": "object",
+        "properties": {
+          "baseCurrency": {
+            "type": "string",
+            "description": "The base currency code",
+            "example": "USD"
+          },
+          "toCurrency": {
+            "type": "string",
+            "description": "The target currency code",
+            "example": "EUR"
+          },
+          "exchangeRate": {
+            "type": "number",
+            "description": "The exchange rate value",
+            "example": 0.85
+          }
+        },
+        "required": [
+          "baseCurrency",
+          "toCurrency",
+          "exchangeRate"
         ]
       }
     }

--- a/shared/sdk-ts/src/sale-estimates.ts
+++ b/shared/sdk-ts/src/sale-estimates.ts
@@ -1,6 +1,6 @@
 import type { ApiFetcher } from './fetch-utils';
 import { paths } from './schema';
-import { OpForPath, OpRequestBody, OpResponseBody } from './utils';
+import { OpForPath, OpQueryParams, OpRequestBody, OpResponseBody } from './utils';
 
 export const SALE_ESTIMATES_ROUTES = {
   LIST: '/api/sale-estimates',
@@ -20,10 +20,14 @@ export type SaleEstimatesListResponse = OpResponseBody<OpForPath<typeof SALE_EST
 export type SaleEstimate = OpResponseBody<OpForPath<typeof SALE_ESTIMATES_ROUTES.BY_ID, 'get'>>;
 export type CreateSaleEstimateBody = OpRequestBody<OpForPath<typeof SALE_ESTIMATES_ROUTES.LIST, 'post'>>;
 export type EditSaleEstimateBody = OpRequestBody<OpForPath<typeof SALE_ESTIMATES_ROUTES.BY_ID, 'put'>>;
+export type GetSaleEstimatesQuery = OpQueryParams<OpForPath<typeof SALE_ESTIMATES_ROUTES.LIST, 'get'>>;
 
-export async function fetchSaleEstimates(fetcher: ApiFetcher): Promise<SaleEstimatesListResponse> {
+export async function fetchSaleEstimates(
+  fetcher: ApiFetcher,
+  query?: GetSaleEstimatesQuery
+): Promise<SaleEstimatesListResponse> {
   const get = fetcher.path(SALE_ESTIMATES_ROUTES.LIST).method('get').create();
-  const { data } = await get({});
+  const { data } = await get(query || {});
   return data;
 }
 

--- a/shared/sdk-ts/src/schema.ts
+++ b/shared/sdk-ts/src/schema.ts
@@ -4643,6 +4643,23 @@ export interface paths {
         patch: operations["ContactsController_inactivateContact"];
         trace?: never;
     };
+    "/api/exchange-rates/latest": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get the latest exchange rate */
+        get: operations["ExchangeRatesController_getLatestExchangeRate"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -14155,6 +14172,23 @@ export interface components {
              */
             password: string;
         };
+        ExchangeRateLatestResponseDto: {
+            /**
+             * @description The base currency code
+             * @example USD
+             */
+            baseCurrency: string;
+            /**
+             * @description The target currency code
+             * @example EUR
+             */
+            toCurrency: string;
+            /**
+             * @description The exchange rate value
+             * @example 0.85
+             */
+            exchangeRate: number;
+        };
     };
     responses: never;
     parameters: never;
@@ -14444,26 +14478,26 @@ export interface operations {
     ItemsController_getItems: {
         parameters: {
             query?: {
+                /** @description Custom view ID for filtering */
+                customViewId?: number;
+                /** @description Array of filter roles */
+                filterRoles?: string[];
+                /** @description Column sort direction */
+                columnSortBy?: string;
+                /** @description Sort order direction */
+                sortOrder?: "DESC" | "ASC";
+                /** @description Stringified filter roles */
+                stringifiedFilterRoles?: string;
+                /** @description Search keyword */
+                searchKeyword?: string;
+                /** @description View slug for filtering */
+                viewSlug?: string;
                 /** @description Filter for inactive items */
                 inactiveMode?: boolean;
                 /** @description Number of items per page */
                 pageSize?: number;
                 /** @description Page number for pagination */
                 page?: number;
-                /** @description View slug for filtering */
-                viewSlug?: string;
-                /** @description Search keyword */
-                searchKeyword?: string;
-                /** @description Stringified filter roles */
-                stringifiedFilterRoles?: string;
-                /** @description Sort order direction */
-                sortOrder?: "DESC" | "ASC";
-                /** @description Column sort direction */
-                columnSortBy?: string;
-                /** @description Array of filter roles */
-                filterRoles?: string[];
-                /** @description Custom view ID for filtering */
-                customViewId?: number;
             };
             header: {
                 /** @description Value must be 'Bearer <token>' where <token> is an API key prefixed with 'bc_' or a JWT token. */
@@ -15918,7 +15952,22 @@ export interface operations {
     };
     SaleInvoicesController_getSaleInvoices: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Custom view ID */
+                customViewId?: number;
+                /** @description Filter roles */
+                filterRoles?: string[];
+                /** @description Column to sort by */
+                columnSortBy?: string;
+                /** @description Sort order (asc/desc) */
+                sortOrder?: string;
+                /** @description Stringified filter roles */
+                stringifiedFilterRoles?: string;
+                /** @description Search keyword */
+                searchKeyword?: string;
+                /** @description View slug */
+                viewSlug?: string;
+            };
             header: {
                 /** @description Value must be 'Bearer <token>' where <token> is an API key prefixed with 'bc_' or a JWT token. */
                 Authorization: string;
@@ -17030,7 +17079,22 @@ export interface operations {
     };
     PaymentReceivesController_getPaymentsReceived: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Custom view ID */
+                customViewId?: number;
+                /** @description Filter roles */
+                filterRoles?: string[];
+                /** @description Column to sort by */
+                columnSortBy?: string;
+                /** @description Sort order (asc/desc) */
+                sortOrder?: string;
+                /** @description Stringified filter roles */
+                stringifiedFilterRoles?: string;
+                /** @description Search keyword */
+                searchKeyword?: string;
+                /** @description View slug */
+                viewSlug?: string;
+            };
             header: {
                 /** @description Value must be 'Bearer <token>' where <token> is an API key prefixed with 'bc_' or a JWT token. */
                 Authorization: string;
@@ -17675,7 +17739,22 @@ export interface operations {
     };
     ItemCategoryController_getItemCategories: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Custom view ID */
+                customViewId?: number;
+                /** @description Filter roles */
+                filterRoles?: string[];
+                /** @description Column to sort by */
+                columnSortBy?: string;
+                /** @description Sort order (asc/desc) */
+                sortOrder?: string;
+                /** @description Stringified filter roles */
+                stringifiedFilterRoles?: string;
+                /** @description Search keyword */
+                searchKeyword?: string;
+                /** @description View slug */
+                viewSlug?: string;
+            };
             header: {
                 /** @description Value must be 'Bearer <token>' where <token> is an API key prefixed with 'bc_' or a JWT token. */
                 Authorization: string;
@@ -17861,7 +17940,22 @@ export interface operations {
     };
     ExpensesController_getExpenses: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Custom view ID */
+                customViewId?: number;
+                /** @description Filter roles */
+                filterRoles?: string[];
+                /** @description Column to sort by */
+                columnSortBy?: string;
+                /** @description Sort order (asc/desc) */
+                sortOrder?: string;
+                /** @description Stringified filter roles */
+                stringifiedFilterRoles?: string;
+                /** @description Search keyword */
+                searchKeyword?: string;
+                /** @description View slug */
+                viewSlug?: string;
+            };
             header: {
                 /** @description Value must be 'Bearer <token>' where <token> is an API key prefixed with 'bc_' or a JWT token. */
                 Authorization: string;
@@ -18285,7 +18379,22 @@ export interface operations {
     };
     CustomersController_getCustomers: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Custom view ID */
+                customViewId?: number;
+                /** @description Filter roles */
+                filterRoles?: string[];
+                /** @description Column to sort by */
+                columnSortBy?: string;
+                /** @description Sort order (asc/desc) */
+                sortOrder?: string;
+                /** @description Stringified filter roles */
+                stringifiedFilterRoles?: string;
+                /** @description Search keyword */
+                searchKeyword?: string;
+                /** @description View slug */
+                viewSlug?: string;
+            };
             header: {
                 /** @description Value must be 'Bearer <token>' where <token> is an API key prefixed with 'bc_' or a JWT token. */
                 Authorization: string;
@@ -18426,7 +18535,22 @@ export interface operations {
     };
     VendorsController_getVendors: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Custom view ID */
+                customViewId?: number;
+                /** @description Filter roles */
+                filterRoles?: string[];
+                /** @description Column to sort by */
+                columnSortBy?: string;
+                /** @description Sort order (asc/desc) */
+                sortOrder?: string;
+                /** @description Stringified filter roles */
+                stringifiedFilterRoles?: string;
+                /** @description Search keyword */
+                searchKeyword?: string;
+                /** @description View slug */
+                viewSlug?: string;
+            };
             header: {
                 /** @description Value must be 'Bearer <token>' where <token> is an API key prefixed with 'bc_' or a JWT token. */
                 Authorization: string;
@@ -18690,7 +18814,22 @@ export interface operations {
     };
     SaleEstimatesController_getSaleEstimates: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Custom view ID */
+                customViewId?: number;
+                /** @description Filter roles */
+                filterRoles?: string[];
+                /** @description Column to sort by */
+                columnSortBy?: string;
+                /** @description Sort order (asc/desc) */
+                sortOrder?: string;
+                /** @description Stringified filter roles */
+                stringifiedFilterRoles?: string;
+                /** @description Search keyword */
+                searchKeyword?: string;
+                /** @description View slug */
+                viewSlug?: string;
+            };
             header: {
                 /** @description Value must be 'Bearer <token>' where <token> is an API key prefixed with 'bc_' or a JWT token. */
                 Authorization: string;
@@ -19099,7 +19238,22 @@ export interface operations {
     };
     SaleReceiptsController_getSaleReceipts: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Custom view ID */
+                customViewId?: number;
+                /** @description Filter roles */
+                filterRoles?: string[];
+                /** @description Column to sort by */
+                columnSortBy?: string;
+                /** @description Sort order (asc/desc) */
+                sortOrder?: string;
+                /** @description Stringified filter roles */
+                stringifiedFilterRoles?: string;
+                /** @description Search keyword */
+                searchKeyword?: string;
+                /** @description View slug */
+                viewSlug?: string;
+            };
             header: {
                 /** @description Value must be 'Bearer <token>' where <token> is an API key prefixed with 'bc_' or a JWT token. */
                 Authorization: string;
@@ -19397,7 +19551,22 @@ export interface operations {
     };
     BillsController_getBills: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Custom view ID */
+                customViewId?: number;
+                /** @description Filter roles */
+                filterRoles?: string[];
+                /** @description Column to sort by */
+                columnSortBy?: string;
+                /** @description Sort order (asc/desc) */
+                sortOrder?: string;
+                /** @description Stringified filter roles */
+                stringifiedFilterRoles?: string;
+                /** @description Search keyword */
+                searchKeyword?: string;
+                /** @description View slug */
+                viewSlug?: string;
+            };
             header: {
                 /** @description Value must be 'Bearer <token>' where <token> is an API key prefixed with 'bc_' or a JWT token. */
                 Authorization: string;
@@ -19770,7 +19939,22 @@ export interface operations {
     };
     ManualJournalsController_getManualJournals: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Custom view ID */
+                customViewId?: number;
+                /** @description Filter roles */
+                filterRoles?: string[];
+                /** @description Column to sort by */
+                columnSortBy?: string;
+                /** @description Sort order (asc/desc) */
+                sortOrder?: string;
+                /** @description Stringified filter roles */
+                stringifiedFilterRoles?: string;
+                /** @description Search keyword */
+                searchKeyword?: string;
+                /** @description View slug */
+                viewSlug?: string;
+            };
             header: {
                 /** @description Value must be 'Bearer <token>' where <token> is an API key prefixed with 'bc_' or a JWT token. */
                 Authorization: string;
@@ -19973,7 +20157,22 @@ export interface operations {
     };
     CreditNotesController_getCreditNotes: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Custom view ID */
+                customViewId?: number;
+                /** @description Filter roles */
+                filterRoles?: string[];
+                /** @description Column to sort by */
+                columnSortBy?: string;
+                /** @description Sort order (asc/desc) */
+                sortOrder?: string;
+                /** @description Stringified filter roles */
+                stringifiedFilterRoles?: string;
+                /** @description Search keyword */
+                searchKeyword?: string;
+                /** @description View slug */
+                viewSlug?: string;
+            };
             header: {
                 /** @description Value must be 'Bearer <token>' where <token> is an API key prefixed with 'bc_' or a JWT token. */
                 Authorization: string;
@@ -20580,7 +20779,22 @@ export interface operations {
     };
     VendorCreditsController_getVendorCredits: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Custom view ID */
+                customViewId?: number;
+                /** @description Filter roles */
+                filterRoles?: string[];
+                /** @description Column to sort by */
+                columnSortBy?: string;
+                /** @description Sort order (asc/desc) */
+                sortOrder?: string;
+                /** @description Stringified filter roles */
+                stringifiedFilterRoles?: string;
+                /** @description Search keyword */
+                searchKeyword?: string;
+                /** @description View slug */
+                viewSlug?: string;
+            };
             header: {
                 /** @description Value must be 'Bearer <token>' where <token> is an API key prefixed with 'bc_' or a JWT token. */
                 Authorization: string;
@@ -28764,6 +28978,38 @@ export interface operations {
         requestBody?: never;
         responses: {
             200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    ExchangeRatesController_getLatestExchangeRate: {
+        parameters: {
+            query?: {
+                /** @description Source currency code (ISO 4217) */
+                from_currency?: string;
+                /** @description Target currency code (ISO 4217) */
+                to_currency?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successfully retrieved exchange rate */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ExchangeRateLatestResponseDto"];
+                };
+            };
+            /** @description Invalid currency code or service error */
+            400: {
                 headers: {
                     [name: string]: unknown;
                 };


### PR DESCRIPTION
## Summary

This PR adds Query DTOs (Data Transfer Objects) for consistent filtering across multiple server modules. The changes standardize how query parameters are handled in controllers and services.

### Changes

- **New Query DTOs added:**
  - `GetBillsQuery.dto.ts` - Bills module filtering
  - `GetCreditNotesQuery.dto.ts` - Credit notes filtering
  - `GetExpensesQuery.dto.ts` - Expenses filtering
  - `GetItemCategoriesQuery.dto.ts` - Item categories filtering
  - `GetManualJournalsQuery.dto.ts` - Manual journals filtering
  - `GetPaymentsReceivedQuery.dto.ts` - Payments received filtering
  - `GetSaleEstimatesQuery.dto.ts` - Sale estimates filtering
  - `GetSaleInvoicesQuery.dto.ts` - Sale invoices filtering
  - `GetSaleReceiptsQuery.dto.ts` - Sale receipts filtering
  - `GetVendorCreditsQuery.dto.ts` - Vendor credits filtering

- **Updated `DynamicFilterQuery.dto.ts`** with enhanced filter options
- **Refactored controllers and services** to use the new Query DTOs
- **Updated SDK schema and types** (`sale-estimates.ts`, `schema.ts`, `openapi.json`)

### Test plan

- [ ] Verify all endpoints accept query parameters correctly
- [ ] Ensure backward compatibility with existing API consumers
- [ ] Test filtering functionality across affected modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)