### PR TITLE
fix(accounts): correct typos in account type constants

### DIFF
--- a/packages/server/src/constants/accounts.ts
+++ b/packages/server/src/constants/accounts.ts
@@ -5,7 +5,7 @@ export const ACCOUNT_TYPE = {
   INVENTORY: 'inventory',
   OTHER_CURRENT_ASSET: 'other-current-asset',
   FIXED_ASSET: 'fixed-asset',
-  NON_CURRENT_ASSET: 'none-current-asset',
+  NON_CURRENT_ASSET: 'non-current-asset',
 
   ACCOUNTS_PAYABLE: 'accounts-payable',
   CREDIT_CARD: 'credit-card',

--- a/packages/server/src/database/tenant/migrations/20260316000000_fix_account_type_typos.ts
+++ b/packages/server/src/database/tenant/migrations/20260316000000_fix_account_type_typos.ts
@@ -1,0 +1,19 @@
+/**
+ * Fix account type typos in the database.
+ *
+ * This migration corrects the following typos:
+ * - 'none-current-asset' -> 'non-current-asset'
+ *
+ * Related GitHub issue: #1041
+ */
+exports.up = function (knex) {
+  return knex('accounts')
+    .where('account_type', 'none-current-asset')
+    .update({ account_type: 'non-current-asset' });
+};
+
+exports.down = function (knex) {
+  return knex('accounts')
+    .where('account_type', 'non-current-asset')
+    .update({ account_type: 'none-current-asset' });
+};

--- a/packages/server/src/modules/Accounts/Accounts.constants.ts
+++ b/packages/server/src/modules/Accounts/Accounts.constants.ts
@@ -412,7 +412,7 @@ export const ACCOUNT_TYPE = {
   INVENTORY: 'inventory',
   OTHER_CURRENT_ASSET: 'other-current-asset',
   FIXED_ASSET: 'fixed-asset',
-  NON_CURRENT_ASSET: 'none-current-asset',
+  NON_CURRENT_ASSET: 'non-current-asset',
 
   ACCOUNTS_PAYABLE: 'accounts-payable',
   CREDIT_CARD: 'credit-card',

--- a/packages/webapp/src/constants/accountTypes.tsx
+++ b/packages/webapp/src/constants/accountTypes.tsx
@@ -26,7 +26,7 @@ export const ACCOUNT_TYPE = {
 export const ACCOUNT_PARENT_TYPE = {
   CURRENT_ASSET: 'current-asset',
   FIXED_ASSET: 'fixed-asset',
-  NON_CURRENT_ASSET: 'non-ACCOUNT_PARENT_TYPE.CURRENT_ASSET',
+  NON_CURRENT_ASSET: 'non-current-asset',
 
   CURRENT_LIABILITY: 'current-liability',
   LOGN_TERM_LIABILITY: 'long-term-liability',
@@ -41,7 +41,7 @@ export const ACCOUNT_ROOT_TYPE = {
   ASSET: 'asset',
   LIABILITY: 'liability',
   EQUITY: 'equity',
-  EXPENSE: 'expene',
+  EXPENSE: 'expense',
   INCOME: 'income',
 };
 


### PR DESCRIPTION
## Summary

- Fix `'none-current-asset'` → `'non-current-asset'` typo in `ACCOUNT_TYPE` constant (backend and frontend)
- Fix `'non-ACCOUNT_PARENT_TYPE.CURRENT_ASSET'` → `'non-current-asset'` copy-paste error in frontend `ACCOUNT_PARENT_TYPE`
- Fix `'expene'` → `'expense'` typo in `ACCOUNT_ROOT_TYPE`
- Add database migration to update existing records with the corrected account type value

## Changes

**Backend:**
- `packages/server/src/constants/accounts.ts` - Fixed `NON_CURRENT_ASSET` value
- `packages/server/src/modules/Accounts/Accounts.constants.ts` - Fixed `NON_CURRENT_ASSET` value
- `packages/server/src/database/tenant/migrations/20260316000000_fix_account_type_typos.ts` - New migration to fix existing data

**Frontend:**
- `packages/webapp/src/constants/accountTypes.tsx` - Fixed `NON_CURRENT_ASSET` and `EXPENSE` values

## Test plan

- [ ] Run database migration and verify existing records are updated
- [ ] Create a new "Non-Current Asset" account and verify it uses correct type
- [ ] Verify balance sheet reports still work correctly
- [ ] Query database to confirm no records remain with `account_type = 'none-current-asset'`

Fixes #1041

🤖 Generated with [Claude Code](https://claude.com/claude-code)