### PR TITLE
fix: Add email functionality to Save & Deliver button in Invoices and Estimates

### DIFF
--- a/packages/webapp/src/containers/Sales/Estimates/EstimateForm/EstimateForm.tsx
+++ b/packages/webapp/src/containers/Sales/Estimates/EstimateForm/EstimateForm.tsx
@@ -26,6 +26,8 @@ import { withSettings } from '@/containers/Settings/withSettings';
 import { withCurrentOrganization } from '@/containers/Organization/withCurrentOrganization';
 
 import { AppToaster } from '@/components';
+import { useDrawerActions } from '@/hooks/state';
+import { DRAWERS } from '@/constants/drawers';
 import { compose, transactionNumber, orderingLinesIndexes } from '@/utils';
 import { useEstimateFormContext } from './EstimateFormProvider';
 import {
@@ -52,6 +54,7 @@ function EstimateForm({
   organization: { base_currency },
 }) {
   const history = useHistory();
+  const { openDrawer } = useDrawerActions();
   const {
     estimate,
     isNewMode,
@@ -111,6 +114,11 @@ function EstimateForm({
     };
     // Handle the request success.
     const onSuccess = (response) => {
+      // Get the estimate ID from the response (try multiple possible paths)
+      const estimateId = isNewMode
+        ? response?.data?.estimate?.id ?? response?.data?.id ?? response?.data?.sale_estimate?.id
+        : estimate.id;
+
       AppToaster.show({
         message: intl.get(
           isNewMode
@@ -122,7 +130,15 @@ function EstimateForm({
       });
       setSubmitting(false);
 
-      if (submitPayload.redirect) {
+      // If deliver was requested, open the send mail drawer with the estimate
+      if (submitPayload.deliver && estimateId) {
+        openDrawer(DRAWERS.ESTIMATE_SEND_MAIL, { 
+          estimateId,
+          onMailSent: () => history.push('/estimates'),
+        });
+      }
+
+      if (submitPayload.redirect && !submitPayload.deliver) {
         history.push('/estimates');
       }
       if (submitPayload.resetForm) {

--- a/packages/webapp/src/containers/Sales/Estimates/EstimateSendMailDrawer/EstimateSendMailForm.tsx
+++ b/packages/webapp/src/containers/Sales/Estimates/EstimateSendMailDrawer/EstimateSendMailForm.tsx
@@ -28,8 +28,11 @@ export function EstimateSendMailForm({ children }: EstimateSendMailFormProps) {
   const { mutateAsync: sendEstimateMail } = useSendSaleEstimateMail();
   const { estimateId, estimateMailState } = useEstimateSendMailBoot();
 
-  const { name } = useDrawerContext();
+  const { name, payload } = useDrawerContext();
   const { closeDrawer } = useDrawerActions();
+
+  // Callback to call when mail is sent
+  const onMailSent = payload?.onMailSent;
 
   const _initialValues: EstimateSendMailFormValues = {
     ...initialValues,
@@ -48,6 +51,10 @@ export function EstimateSendMailForm({ children }: EstimateSendMailFormProps) {
         });
         setSubmitting(false);
         closeDrawer(name);
+        // Call the onMailSent callback if provided
+        if (onMailSent) {
+          onMailSent();
+        }
       })
       .catch((error) => {
         setSubmitting(false);

--- a/packages/webapp/src/containers/Sales/Estimates/EstimateSendMailDrawer/EstimateSnedMailFields.tsx
+++ b/packages/webapp/src/containers/Sales/Estimates/EstimateSendMailDrawer/EstimateSnedMailFields.tsx
@@ -40,12 +40,19 @@ export function EstimateSendMailFields() {
 
 function EstimateSendMailFooter() {
   const { isSubmitting } = useFormikContext();
-  const { name } = useDrawerContext();
+  const { name, payload } = useDrawerContext();
   const { closeDrawer } = useDrawerActions();
   const isDarkmode = useIsDarkMode();
 
+  // Callback to call when drawer is closed without sending
+  const onMailSent = payload?.onMailSent;
+
   const handleClose = () => {
     closeDrawer(name);
+    // Call the onMailSent callback if provided (for close without sending)
+    if (onMailSent) {
+      onMailSent();
+    }
   };
 
   return (

--- a/packages/webapp/src/containers/Sales/Invoices/InvoiceForm/InvoiceForm.tsx
+++ b/packages/webapp/src/containers/Sales/Invoices/InvoiceForm/InvoiceForm.tsx
@@ -23,6 +23,8 @@ import { withSettings } from '@/containers/Settings/withSettings';
 import { withCurrentOrganization } from '@/containers/Organization/withCurrentOrganization';
 
 import { AppToaster, Box } from '@/components';
+import { useDrawerActions } from '@/hooks/state';
+import { DRAWERS } from '@/constants/drawers';
 import { compose, orderingLinesIndexes, transactionNumber } from '@/utils';
 import { useInvoiceFormContext } from './InvoiceFormProvider';
 import { InvoiceFormActions } from './InvoiceFormActions';
@@ -54,6 +56,7 @@ function InvoiceFormRoot({
   organization: { base_currency },
 }) {
   const history = useHistory();
+  const { openDrawer } = useDrawerActions();
 
   // Invoice form context.
   const {
@@ -116,7 +119,12 @@ function InvoiceFormRoot({
       from_estimate_id: estimateId,
     };
     // Handle the request success.
-    const onSuccess = () => {
+    const onSuccess = (response) => {
+      // Get the invoice ID from the response (try multiple possible paths)
+      const invoiceId = isNewMode
+        ? response?.data?.invoice?.id ?? response?.data?.id ?? response?.data?.sale_invoice?.id
+        : invoice.id;
+
       AppToaster.show({
         message: intl.get(
           isNewMode
@@ -128,7 +136,15 @@ function InvoiceFormRoot({
       });
       setSubmitting(false);
 
-      if (submitPayload.redirect) {
+      // If deliver was requested, open the send mail drawer with the invoice
+      if (submitPayload.deliver && invoiceId) {
+        openDrawer(DRAWERS.INVOICE_SEND_MAIL, { 
+          invoiceId,
+          onMailSent: () => history.push('/invoices'),
+        });
+      }
+
+      if (submitPayload.redirect && !submitPayload.deliver) {
         history.push('/invoices');
       }
       if (submitPayload.resetForm) {

--- a/packages/webapp/src/containers/Sales/Invoices/InvoiceSendMailDrawer/InvoiceSendMailFields.tsx
+++ b/packages/webapp/src/containers/Sales/Invoices/InvoiceSendMailDrawer/InvoiceSendMailFields.tsx
@@ -38,12 +38,19 @@ export function InvoiceSendMailFields() {
 
 function InvoiceSendMailFooter() {
   const { isSubmitting } = useFormikContext();
-  const { name } = useDrawerContext();
+  const { name, payload } = useDrawerContext();
   const { closeDrawer } = useDrawerActions();
   const isDarkMode = useIsDarkMode();
 
+  // Callback to call when drawer is closed without sending
+  const onMailSent = payload?.onMailSent;
+
   const handleClose = () => {
     closeDrawer(name);
+    // Call the onMailSent callback if provided (for close without sending)
+    if (onMailSent) {
+      onMailSent();
+    }
   };
 
   return (

--- a/packages/webapp/src/containers/Sales/Invoices/InvoiceSendMailDrawer/InvoiceSendMailForm.tsx
+++ b/packages/webapp/src/containers/Sales/Invoices/InvoiceSendMailDrawer/InvoiceSendMailForm.tsx
@@ -27,8 +27,11 @@ export function InvoiceSendMailForm({ children }: InvoiceSendMailFormProps) {
   const { mutateAsync: sendInvoiceMail } = useSendSaleInvoiceMail();
   const { invoiceId, invoiceMailState } = useInvoiceSendMailBoot();
 
-  const { name } = useDrawerContext();
+  const { name, payload } = useDrawerContext();
   const { closeDrawer } = useDrawerActions();
+
+  // Callback to call when mail is sent or drawer is closed
+  const onMailSent = payload?.onMailSent;
 
   const _initialValues: InvoiceSendMailFormValues = {
     ...initialValues,
@@ -47,6 +50,10 @@ export function InvoiceSendMailForm({ children }: InvoiceSendMailFormProps) {
         });
         setSubmitting(false);
         closeDrawer(name);
+        // Call the onMailSent callback if provided
+        if (onMailSent) {
+          onMailSent();
+        }
       })
       .catch((error) => {
         setSubmitting(false);


### PR DESCRIPTION
Fixed the "Save & Deliver" button to actually send emails by opening the Send Mail drawer after saving the invoice/estimate. After sending the email (or closing the drawer without sending), the user is redirected to the list page.