### PR TITLE
fix: bulk uncategorize transactions API endpoint

### DIFF
--- a/packages/webapp/src/containers/CashFlow/AccountTransactions/alerts/UncategorizeBankTransactionsBulkAlert.tsx
+++ b/packages/webapp/src/containers/CashFlow/AccountTransactions/alerts/UncategorizeBankTransactionsBulkAlert.tsx
@@ -35,11 +35,16 @@ function UncategorizeBankTransactionsBulkAlert({
     uncategorizeTransactions({ ids: uncategorizeTransactionsIds })
       .then(() => {
         AppToaster.show({
-          message: 'The bank feeds of the bank account has been resumed.',
+          message: 'The selected transactions have been uncategorized.',
           intent: Intent.SUCCESS,
         });
       })
-      .catch((error) => {})
+      .catch((error) => {
+        AppToaster.show({
+          message: 'Something went wrong while uncategorizing transactions.',
+          intent: Intent.DANGER,
+        });
+      })
       .finally(() => {
         closeAlert(name);
       });

--- a/packages/webapp/src/hooks/query/bank-transactions.ts
+++ b/packages/webapp/src/hooks/query/bank-transactions.ts
@@ -36,16 +36,10 @@ export function useUncategorizeTransactionsBulkAction(
     Error,
     UncategorizeTransactionsBulkValues
   >(
-    (value) => {
-      // Build query string with multiple uncategorizedTransactionIds parameters
-      const params = new URLSearchParams();
-      value.ids.forEach((id) =>
-        params.append('uncategorizedTransactionIds', String(id)),
-      );
-      return apiRequest.delete(
-        `/banking/categorize/bulk?${params.toString()}`,
-      );
-    },
+    (value) =>
+      apiRequest.delete(`/banking/categorize/bulk`, {
+        params: { uncategorizedTransactionIds: value.ids },
+      }),
     {
       onSuccess: (res, values) => {
         // Invalidate the account uncategorized transactions.

--- a/packages/webapp/src/hooks/query/bank-transactions.ts
+++ b/packages/webapp/src/hooks/query/bank-transactions.ts
@@ -36,10 +36,16 @@ export function useUncategorizeTransactionsBulkAction(
     Error,
     UncategorizeTransactionsBulkValues
   >(
-    (value) =>
-      apiRequest.post(`/cashflow/transactions/uncategorize/bulk`, {
-        ids: value.ids,
-      }),
+    (value) => {
+      // Build query string with multiple uncategorizedTransactionIds parameters
+      const params = new URLSearchParams();
+      value.ids.forEach((id) =>
+        params.append('uncategorizedTransactionIds', String(id)),
+      );
+      return apiRequest.delete(
+        `/banking/categorize/bulk?${params.toString()}`,
+      );
+    },
     {
       onSuccess: (res, values) => {
         // Invalidate the account uncategorized transactions.


### PR DESCRIPTION
Fixed the bulk "Uncategorize" action in Account Transactions which was not working due to calling a non-existent API endpoint. 