### PR TITLE
chore(webapp): add Prettier format and format:check scripts

### DIFF
--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -138,6 +138,8 @@
     "build": "vite build",
     "preview": "cross-env PORT=4173 vite preview",
     "typecheck": "tsc --noEmit",
+    "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,md}\"",
+    "format:check": "prettier --check \"src/**/*.{ts,tsx,js,jsx,json,md}\"",
     "test": "node scripts/test.js",
     "storybook": "start-storybook -p 6006"
   },


### PR DESCRIPTION
## Summary
- Add `format` and `format:check` npm scripts to the webapp package using Prettier
- Covers `.ts`, `.tsx`, `.js`, `.jsx`, `.json`, and `.md` files (excludes CSS/SCSS)
- Consistent with the existing server package setup, and picked up by the root `pnpm format` / `pnpm format:check` scripts via lerna

## Test plan
- [ ] Run `pnpm --filter @bigcapital/webapp format:check` and verify it executes without errors
- [ ] Run `pnpm --filter @bigcapital/webapp format` and verify files are formatted correctly
- [ ] Run `pnpm format:check` from root and verify webapp is included

🤖 Generated with [Claude Code](https://claude.com/claude-code)