### PR TITLE
fix(webapp): change manifest.json link from modulepreload to manifest

### DIFF
--- a/packages/webapp/index.html
+++ b/packages/webapp/index.html
@@ -9,7 +9,7 @@
       name="description"
       content="Bigcapital Financial Managment Software"
     />
-    <link rel="modulepreload" href="/manifest.json" />
+    <link rel="manifest" href="/manifest.json" />
     <script type="module" src="/public/preload-theme.js"></script>
     <title>Bigcapital</title>
   </head>


### PR DESCRIPTION
## Summary
- Change `<link rel="modulepreload" href="/manifest.json" />` to `<link rel="manifest" href="/manifest.json" />` in `packages/webapp/index.html`

## Problem
`modulepreload` tells the browser to fetch and parse the file as a JavaScript module. Since `manifest.json` is JSON (not JavaScript), this causes a MIME type checking error on every page load:

> Failed to load module script: Expected a JavaScript-or-Wasm module script but the server responded with a MIME type of "application/json"

## Fix
`rel="manifest"` is the correct HTML attribute for PWA web app manifests per the [W3C spec](https://www.w3.org/TR/appmanifest/#using-a-link-element-to-link-to-a-manifest).

## Test plan
- [ ] Open any page in browser, check console — no MIME type error for manifest.json

Generated with [Claude Code](https://claude.com/claude-code)