### PR TITLE
fix(proxy): increase Envoy buffer limits and timeouts for large JS bundles

### DIFF
--- a/docker/envoy/envoy.yaml
+++ b/docker/envoy/envoy.yaml
@@ -5,6 +5,7 @@ static_resources:
         socket_address:
           address: 0.0.0.0
           port_value: 80
+      per_connection_buffer_limit_bytes: 10485760
       filter_chains:
         - filters:
             - name: envoy.filters.network.http_connection_manager
@@ -21,10 +22,12 @@ static_resources:
                             prefix: '/api'
                           route:
                             cluster: dynamic_server
+                            timeout: 60s
                         - match:
                             prefix: '/'
                           route:
                             cluster: webapp
+                            timeout: 30s
                 http_filters:
                   - name: envoy.filters.http.router
                     typed_config:
@@ -32,7 +35,7 @@ static_resources:
 
   clusters:
     - name: dynamic_server
-      connect_timeout: 0.25s
+      connect_timeout: 5s
       type: STRICT_DNS
       dns_lookup_family: V4_ONLY
       lb_policy: ROUND_ROBIN
@@ -47,7 +50,7 @@ static_resources:
                       port_value: 3000
 
     - name: webapp
-      connect_timeout: 0.25s
+      connect_timeout: 5s
       type: STRICT_DNS
       dns_lookup_family: V4_ONLY
       lb_policy: ROUND_ROBIN


### PR DESCRIPTION
## Summary
- Increase `per_connection_buffer_limit_bytes` to 10MB (from 1MB default)
- Increase `connect_timeout` from 0.25s to 5s
- Add route-level timeouts (30s for webapp, 60s for API)

## Problem
The main webapp JS bundle is ~2.5MB. Envoy's default per-connection buffer limit is 1MB. When the buffer fills during transfer, the connection is truncated, causing intermittent `ERR_CONTENT_LENGTH_MISMATCH` errors in the browser. The 0.25s connect timeout also causes failures on slower networks.

## Test plan
- [ ] Hard refresh the webapp multiple times — no `ERR_CONTENT_LENGTH_MISMATCH` errors
- [ ] Test on a slow network connection — page loads reliably

Generated with [Claude Code](https://claude.com/claude-code)