### PR TITLE
fix(server): handle missing ContentType in attachment download

### DIFF
--- a/packages/server/src/modules/Attachments/Attachments.controller.ts
+++ b/packages/server/src/modules/Attachments/Attachments.controller.ts
@@ -93,11 +93,12 @@ export class AttachmentsController {
     const data = await this.attachmentsApplication.get(documentId);
 
     const byte = await data.Body.transformToByteArray();
-    const extension = mime.extension(data.ContentType);
+    const contentType = data.ContentType || 'application/octet-stream';
+    const extension = mime.extension(contentType) || 'bin';
     const buffer = Buffer.from(byte);
 
     res.set('Content-Disposition', `filename="${documentId}.${extension}"`);
-    res.set('Content-Type', data.ContentType);
+    res.set('Content-Type', contentType);
     res.send(buffer);
   }
 


### PR DESCRIPTION
## Summary
- Add fallback for missing `ContentType` in `GET /api/attachments/:id` endpoint

## Problem
When an S3 object has no `ContentType` metadata, `data.ContentType` is `undefined`. This causes:
1. `mime.extension(undefined)` returns `undefined`
2. The `Content-Disposition` header template produces `filename="key.undefined"`
3. The endpoint crashes with `TypeError: Cannot read properties of undefined (reading 'extension')`

This happens when files are uploaded without explicit content type metadata, e.g., via API integrations or programmatic uploads.

## Fix
- Fallback `ContentType` to `'application/octet-stream'` when missing
- Fallback `extension` to `'bin'` when `mime.extension()` returns undefined

## Test plan
- [ ] Upload a file without content type metadata via API
- [ ] `GET /api/attachments/:key` returns the file with `application/octet-stream` content type instead of crashing

Generated with [Claude Code](https://claude.com/claude-code)