### PR TITLE
fix(server): use correct base currency in financial reports

### DIFF
--- a/packages/server/src/modules/FinancialStatements/modules/APAgingSummary/APAgingSummarySheet.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/APAgingSummary/APAgingSummarySheet.ts
@@ -38,6 +38,7 @@ export class APAgingSummarySheet extends AgingSummaryReport {
 
     this.query = query;
     this.repository = repository;
+    this.baseCurrency = meta.baseCurrency;
     this.numberFormat = this.query.numberFormat;
     this.dateFormat = meta.dateFormat || DEFAULT_REPORT_META.dateFormat;
 

--- a/packages/server/src/modules/FinancialStatements/modules/ARAgingSummary/ARAgingSummarySheet.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/ARAgingSummary/ARAgingSummarySheet.ts
@@ -44,6 +44,7 @@ export class ARAgingSummarySheet extends AgingSummaryReport {
 
     this.query = query;
     this.repository = repository;
+    this.baseCurrency = meta.baseCurrency;
     this.numberFormat = this.query.numberFormat;
     this.dateFormat = meta.dateFormat || DEFAULT_REPORT_META.dateFormat;
 

--- a/packages/server/src/modules/FinancialStatements/modules/AgingSummary/AgingSummary.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/AgingSummary/AgingSummary.ts
@@ -18,7 +18,7 @@ import { IARAgingSummaryCustomer } from '../ARAgingSummary/ARAgingSummary.types'
 export abstract class AgingSummaryReport extends AgingReport {
   readonly contacts: ModelObject<Customer | Vendor>[];
   readonly agingPeriods: IAgingPeriod[] = [];
-  readonly baseCurrency: string;
+  public baseCurrency: string;
   readonly query: IAgingSummaryQuery;
   readonly overdueInvoicesByContactId: Record<
     number,

--- a/packages/server/src/modules/FinancialStatements/modules/InventoryValuationSheet/InventoryValuationSheet.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/InventoryValuationSheet/InventoryValuationSheet.ts
@@ -33,6 +33,7 @@ export class InventoryValuationSheet extends FinancialSheet {
 
     this.query = query;
     this.repository = repository;
+    this.baseCurrency = meta.baseCurrency;
     this.numberFormat = this.query.numberFormat;
     this.dateFormat = meta.dateFormat || DEFAULT_REPORT_META.dateFormat;
   }

--- a/packages/server/src/modules/FinancialStatements/modules/SalesTaxLiabilitySummary/SalesTaxLiabilitySummary.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/SalesTaxLiabilitySummary/SalesTaxLiabilitySummary.ts
@@ -31,6 +31,7 @@ export class SalesTaxLiabilitySummary extends FinancialSheet {
 
     this.query = query;
     this.repository = repository;
+    this.baseCurrency = meta.baseCurrency;
     this.dateFormat = meta.dateFormat || DEFAULT_REPORT_META.dateFormat;
   }
 

--- a/packages/server/src/modules/FinancialStatements/modules/VendorBalanceSummary/VendorBalanceSummaryService.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/VendorBalanceSummary/VendorBalanceSummaryService.ts
@@ -38,7 +38,7 @@ export class VendorBalanceSummaryService {
     const reportInstance = new VendorBalanceSummaryReport(
       this.vendorBalanceSummaryRepository,
       filter,
-      { baseCurrency: this.vendorBalanceSummaryRepository.baseCurrency, dateFormat: meta.dateFormat },
+      { baseCurrency: meta.baseCurrency, dateFormat: meta.dateFormat },
     );
 
     // Triggers `onVendorBalanceSummaryViewed` event.


### PR DESCRIPTION
## Summary
- Fix 5 financial reports not using the organization's base currency (showed USD instead of EUR, etc.)
- Root cause: report sheet constructors received `meta.baseCurrency` but never assigned it to `this.baseCurrency`, leaving `FinancialSheet.baseCurrency` as `undefined`
- Affected reports: Receivable Aging Summary, Payable Aging Summary, Inventory Valuation, Sales Tax Liability Summary, Vendor Balance Summary

## Changes
- Added `this.baseCurrency = meta.baseCurrency` in constructors of `ARAgingSummarySheet`, `APAgingSummarySheet`, `InventoryValuationSheet`, `SalesTaxLiabilitySummary`
- Fixed `VendorBalanceSummaryService` to use `meta.baseCurrency` instead of the unset `repository.baseCurrency`
- Changed `readonly` to `public` on `baseCurrency` in `AgingSummaryReport` to allow subclass assignment

Closes #1069

<!-- pr_agent:summary -->
${{ pr_agent:summary }}
<!-- /pr_agent:summary -->

<!-- pr_agent:walkthrough -->
${{ pr_agent:walkthrough }}
<!-- /pr_agent:walkthrough -->