### PR TITLE
fix(server): localize i18n column headers in CSV/XLSX/PDF exports

### DIFF
--- a/packages/server/src/modules/Export/ExportService.ts
+++ b/packages/server/src/modules/Export/ExportService.ts
@@ -12,6 +12,7 @@ import { ServiceError } from '../Items/ServiceError';
 import { ResourceService } from '../Resource/ResourceService';
 import { getExportableService } from './decorators/ExportableModel.decorator';
 import { ContextIdFactory, ModuleRef } from '@nestjs/core';
+import { I18nService } from 'nestjs-i18n';
 
 @Injectable()
 export class ExportResourceService {
@@ -20,6 +21,7 @@ export class ExportResourceService {
     private readonly exportPdf: ExportPdf,
     private readonly resourceService: ResourceService,
     private readonly moduleRef: ModuleRef,
+    private readonly i18nService: I18nService,
   ) {}
 
   /**
@@ -147,7 +149,7 @@ export class ExportResourceService {
             const group = parent;
             return [
               {
-                name: value.name,
+                name: this.i18nService.t(value.name, { defaultValue: value.name }),
                 type: value.type || 'text',
                 accessor: value.accessor || key,
                 group,
@@ -174,7 +176,7 @@ export class ExportResourceService {
             const group = parent;
             return [
               {
-                name: value.name,
+                name: this.i18nService.t(value.name, { defaultValue: value.name }),
                 type: value.type || 'text',
                 accessor: value.accessor || key,
                 group,


### PR DESCRIPTION
## Summary
- Fix export column headers showing raw i18n keys (e.g. `expense.field.payment_account`) instead of translated names (e.g. "Payment Account")
- Inject `I18nService` into `ExportResourceService` and translate column names in both `getExportableColumns()` (CSV/XLSX path) and `getPrintableColumns()` (PDF path)
- Fix applies to all resources using i18n keys in column definitions (Expenses, SaleInvoices, etc.)

## Test plan
- [ ] Export expenses to CSV/XLSX and verify column headers show translated names
- [ ] Export expenses to PDF and verify column headers show translated names
- [ ] Export sale invoices and verify headers are also properly translated

Closes #1073

🤖 Generated with [Claude Code](https://claude.com/claude-code)