### PR TITLE
Fix pagination params silently ignored on collection GET endpoints

### DIFF
--- a/packages/server/src/modules/DynamicListing/dtos/DynamicFilterQuery.dto.ts
+++ b/packages/server/src/modules/DynamicListing/dtos/DynamicFilterQuery.dto.ts
@@ -1,9 +1,21 @@
 import { ToNumber } from '@/common/decorators/Validators';
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { IsArray, IsOptional, IsString } from 'class-validator';
+import { IsArray, IsInt, IsOptional, IsString } from 'class-validator';
 import { IFilterRole, ISortOrder } from '../DynamicFilter/DynamicFilter.types';
 
 export class DynamicFilterQueryDto {
+  @ApiPropertyOptional({ description: 'Page number (1-based)', type: Number })
+  @IsOptional()
+  @IsInt()
+  @ToNumber()
+  page?: number;
+
+  @ApiPropertyOptional({ description: 'Page size', type: Number })
+  @IsOptional()
+  @IsInt()
+  @ToNumber()
+  pageSize?: number;
+
   @ApiPropertyOptional({ description: 'Custom view ID', type: Number })
   @IsOptional()
   @ToNumber()

--- a/packages/server/test/expenses.e2e-spec.ts
+++ b/packages/server/test/expenses.e2e-spec.ts
@@ -77,4 +77,16 @@ describe('Expenses (e2e)', () => {
       .set('Authorization', AuthorizationHeader)
       .expect(200);
   });
+
+  it('/expenses (GET) honors page and pageSize query params', async () => {
+    const response = await request(app.getHttpServer())
+      .get('/expenses?page=2&pageSize=5')
+      .set('organization-id', orgainzationId)
+      .set('Authorization', AuthorizationHeader)
+      .expect(200);
+
+    expect(response.body.pagination).toBeDefined();
+    expect(response.body.pagination.page).toBe(2);
+    expect(response.body.pagination.page_size).toBe(5);
+  });
 });


### PR DESCRIPTION
Closes #1088

## Summary

Hoist `page` and `pageSize` declarations from the per-module query DTOs into the shared `DynamicFilterQueryDto` base class. Without them, the global `ValidationPipe` (`whitelist: true`) strips the params from the request before the service layer sees them, and list services fall back to their default `page=1, pageSize=12` regardless of what the client sent.

## Affected endpoints

9 collection GET endpoints whose query DTOs are empty subclasses of `DynamicFilterQueryDto`: `expenses`, `bills`, `credit-notes`, `manual-journals`, `payments-received`, `sale-invoices`, `sale-estimates`, `sale-receipts`, `vendor-credits`.

## Root cause

`packages/server/src/common/pipes/ClassValidation.pipe.ts:19` runs `validate(object, { whitelist: true })`. The 3 already-working DTOs (`GetCustomersQueryDto`, `GetVendorsQueryDto`, `GetItemsQueryDto`) declare `page` + `pageSize` locally with `@IsOptional() @IsInt() @ToNumber()`. The 10 broken ones are empty:

```ts
export class GetExpensesQueryDto extends DynamicFilterQueryDto {}
```

Since the base class doesn't declare those properties either, `whitelist: true` strips them from the validated object. The service-layer merge then has nothing to override the defaults:

```ts
// packages/server/src/modules/Expenses/queries/GetExpenses.service.ts:32
const _filterDto = {
  sortOrder: 'desc',
  columnSortBy: 'created_at',
  page: 1,
  pageSize: 12,
  ...filterDTO,  // empty after stripping → defaults stand
};
```

## Reproduction (before fix)

```bash
$ curl -H "Authorization: Bearer $KEY" -H "organization-id: $ORG" \
    'http://server:3000/api/expenses?page=2&pageSize=50' | jq .pagination
{ "total": 66, "page": 1, "page_size": 12 }
```

## Fix

Add `page` + `pageSize` to `DynamicFilterQueryDto` with the same decorator stack the working DTOs use. The 3 already-working DTOs (Customers/Vendors/Items) keep their local declarations as redundant overrides — no behavior change for them.

## Tests

Added an e2e assertion to `packages/server/test/expenses.e2e-spec.ts` that `GET /expenses?page=2&pageSize=5` returns `pagination.page === 2` and `pagination.page_size === 5`.
