### PR TITLE
fix(server): correct "Liabilties" typo to "Liabilities" in balance sheet

### DIFF
--- a/packages/server/src/i18n/en/balance_sheet.json
+++ b/packages/server/src/i18n/en/balance_sheet.json
@@ -9,7 +9,7 @@
   "non_current_assets": "Non-Current Assets",
   "liabilities_and_equity": "Liabilities and Equity",
   "liabilities": "Liabilities",
-  "current_liabilties": "Current Liabilties",
+  "current_liabilities": "Current Liabilities",
   "long_term_liabilities": "Long-Term Liabilities",
   "non_current_liabilities": "Non-Current Liabilities",
   "equity": "Equity",

--- a/packages/server/src/modules/FinancialStatements/modules/BalanceSheet/BalanceSheet.swagger.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/BalanceSheet/BalanceSheet.swagger.ts
@@ -281,7 +281,7 @@ export const BalanceSheetResponseExample = {
           },
           children: [
             {
-              name: 'Current Liabilties',
+              name: 'Current Liabilities',
               id: 'CURRENT_LIABILITY',
               node_type: 'AGGREGATE',
               type: 'AGGREGATE',
@@ -912,7 +912,7 @@ export const BalanceSheetTableResponseExample = {
                 cells: [
                   {
                     key: 'name',
-                    value: 'Current Liabilties',
+                    value: 'Current Liabilities',
                   },
                   {
                     key: 'total',
@@ -1024,7 +1024,7 @@ export const BalanceSheetTableResponseExample = {
                     cells: [
                       {
                         key: 'name',
-                        value: 'Total Current Liabilties',
+                        value: 'Total Current Liabilities',
                       },
                       {
                         key: 'total',

--- a/packages/server/src/modules/FinancialStatements/modules/BalanceSheet/BalanceSheetSchema.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/BalanceSheet/BalanceSheetSchema.ts
@@ -88,7 +88,7 @@ export const getBalanceSheetSchema = () => [
         type: BALANCE_SHEET_SCHEMA_NODE_TYPE.AGGREGATE,
         children: [
           {
-            name: 'balance_sheet.current_liabilties',
+            name: 'balance_sheet.current_liabilities',
             id: BALANCE_SHEET_SCHEMA_NODE_ID.CURRENT_LIABILITY,
             type: BALANCE_SHEET_SCHEMA_NODE_TYPE.ACCOUNTS,
             accountsTypes: [

--- a/shared/sdk-ts/openapi.json
+++ b/shared/sdk-ts/openapi.json
@@ -15262,7 +15262,7 @@
                           },
                           "children": [
                             {
-                              "name": "Current Liabilties",
+                              "name": "Current Liabilities",
                               "id": "CURRENT_LIABILITY",
                               "node_type": "AGGREGATE",
                               "type": "AGGREGATE",
@@ -15951,7 +15951,7 @@
                                 "cells": [
                                   {
                                     "key": "name",
-                                    "value": "Current Liabilties"
+                                    "value": "Current Liabilities"
                                   },
                                   {
                                     "key": "total",
@@ -16079,7 +16079,7 @@
                                     "cells": [
                                       {
                                         "key": "name",
-                                        "value": "Total Current Liabilties"
+                                        "value": "Total Current Liabilities"
                                       },
                                       {
                                         "key": "total",

--- a/shared/sdk-ts/src/schema.ts
+++ b/shared/sdk-ts/src/schema.ts
@@ -22923,7 +22923,7 @@ export interface operations {
                      *               },
                      *               "children": [
                      *                 {
-                     *                   "name": "Current Liabilties",
+                     *                   "name": "Current Liabilities",
                      *                   "id": "CURRENT_LIABILITY",
                      *                   "node_type": "AGGREGATE",
                      *                   "type": "AGGREGATE",
@@ -23610,7 +23610,7 @@ export interface operations {
                      *                     "cells": [
                      *                       {
                      *                         "key": "name",
-                     *                         "value": "Current Liabilties"
+                     *                         "value": "Current Liabilities"
                      *                       },
                      *                       {
                      *                         "key": "total",
@@ -23738,7 +23738,7 @@ export interface operations {
                      *                         "cells": [
                      *                           {
                      *                             "key": "name",
-                     *                             "value": "Total Current Liabilties"
+                     *                             "value": "Total Current Liabilities"
                      *                           },
                      *                           {
                      *                             "key": "total",


### PR DESCRIPTION
## Summary
- The balance sheet renders "Current Liabilties" instead of "Current Liabilities" — visible in HTML view, PDF export, and JSON API response
- Root cause: the i18n key `current_liabilties` is misspelled, and the swagger example responses + generated SDK fixtures repeat the typo
- Fixed all five files so every render path produces "Current Liabilities"

## Files changed
- `packages/server/src/i18n/en/balance_sheet.json` — rename key + value
- `packages/server/src/modules/FinancialStatements/modules/BalanceSheet/BalanceSheetSchema.ts` — i18n key reference
- `packages/server/src/modules/FinancialStatements/modules/BalanceSheet/BalanceSheet.swagger.ts` — three example response strings
- `shared/sdk-ts/openapi.json` + `shared/sdk-ts/src/schema.ts` — keep generated SDK in sync

## Test plan
- [ ] `pnpm` build of server package succeeds
- [ ] Balance sheet HTML/PDF render shows "Current Liabilities"
- [ ] No remaining occurrences: `rg -n 'Liabilties|liabilties'` returns nothing