### PR TITLE
fix(server): prevent cross-tenant access via organization-id header

### DIFF
--- a/packages/server/src/modules/App/App.module.ts
+++ b/packages/server/src/modules/App/App.module.ts
@@ -18,7 +18,7 @@ import { createBullBoardAuthMiddleware } from '@/middleware/bull-board-auth.midd
 import { BullModule } from '@nestjs/bullmq';
 import { ScheduleModule } from '@nestjs/schedule';
 import { PassportModule } from '@nestjs/passport';
-import { ClsModule, ClsService } from 'nestjs-cls';
+import { ClsModule } from 'nestjs-cls';
 import { AppController } from './App.controller';
 import { AppService } from './App.service';
 import { ItemsModule } from '../Items/Items.module';
@@ -169,9 +169,6 @@ import { AppThrottleModule } from './AppThrottle.module';
       global: true,
       middleware: {
         mount: true,
-        setup: (cls: ClsService, req: Request, res: Response) => {
-          cls.set('organizationId', req.headers['organization-id']);
-        },
         generateId: true,
         saveReq: true,
       },

--- a/packages/server/src/modules/Auth/commands/AuthSignin.service.ts
+++ b/packages/server/src/modules/Auth/commands/AuthSignin.service.ts
@@ -2,6 +2,7 @@ import { ClsService } from 'nestjs-cls';
 import { Inject, Injectable } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { SystemUser } from '@/modules/System/models/SystemUser';
+import { TenantModel } from '@/modules/System/models/TenantModel';
 import { ModelObject } from 'objection';
 import { JwtPayload } from '../Auth.interfaces';
 import { InvalidEmailPasswordException } from '../exceptions/InvalidEmailPassword.exception';
@@ -12,6 +13,10 @@ export class AuthSigninService {
   constructor(
     @Inject(SystemUser.name)
     private readonly systemUserModel: typeof SystemUser,
+
+    @Inject(TenantModel.name)
+    private readonly tenantModel: typeof TenantModel,
+
     private readonly jwtService: JwtService,
     private readonly clsService: ClsService,
   ) { }
@@ -49,6 +54,7 @@ export class AuthSigninService {
    */
   async verifyPayload(payload: JwtPayload): Promise<any> {
     let user: SystemUser;
+    let tenant: TenantModel | undefined;
 
     try {
       user = await this.systemUserModel
@@ -56,8 +62,14 @@ export class AuthSigninService {
         .findOne({ email: payload.sub })
         .throwIfNotFound();
 
+      tenant = await this.tenantModel
+        .query()
+        .findById(user.tenantId)
+        .throwIfNotFound();
+
       this.clsService.set('tenantId', user.tenantId);
       this.clsService.set('userId', user.id);
+      this.clsService.set('organizationId', tenant.organizationId);
     } catch (error) {
       throw new UserNotFoundException(String(payload.sub));
     }

--- a/packages/server/src/modules/Tenancy/TenancyGlobal.guard.ts
+++ b/packages/server/src/modules/Tenancy/TenancyGlobal.guard.ts
@@ -7,6 +7,7 @@ import {
   SetMetadata,
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
+import { ClsService } from 'nestjs-cls';
 import { IS_PUBLIC_ROUTE } from '../Auth/Auth.constants';
 import { getAuthApiKey } from '../Auth/Auth.utils';
 
@@ -16,7 +17,10 @@ export const TenantAgnosticRoute = () => SetMetadata(IS_TENANT_AGNOSTIC, true);
 
 @Injectable()
 export class TenancyGlobalGuard implements CanActivate {
-  constructor(private reflector: Reflector) {}
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly clsService: ClsService,
+  ) {}
 
   /**
    * Validates the organization ID in the request headers.
@@ -42,6 +46,14 @@ export class TenancyGlobalGuard implements CanActivate {
     }
     if (!organizationId) {
       throw new UnauthorizedException('Organization ID is required.');
+    }
+    const authenticatedOrganizationId =
+      this.clsService.get('organizationId');
+    if (
+      authenticatedOrganizationId &&
+      authenticatedOrganizationId !== organizationId
+    ) {
+      throw new UnauthorizedException('Organization mismatch.');
     }
     return true;
   }


### PR DESCRIPTION
## Summary

Fixes [GHSA-2g96-86rw-qmvg](https://github.com/bigcapitalhq/bigcapital/security/advisories/GHSA-2g96-86rw-qmvg) — tenant bypass via the `organization-id` request header (CVSS 7.4 High, CWE-639).

The CLS middleware in `App.module.ts` copied the request `organization-id` header straight into `cls.organizationId`, which `TenancyDB` used to pick the per-tenant database connection. The JWT path never set `organizationId` from the authenticated user, and `TenancyGlobalGuard` only checked the header was present. As a result, any authenticated user could read and write another tenant's database by sending their own JWT plus the victim's `organization-id`.

## Changes

- **`Auth/commands/AuthSignin.service.ts`** — `verifyPayload` now loads the user's tenant via `TenantModel` and sets `cls.organizationId` from `tenant.organizationId`, mirroring the already-safe API-key path in `AuthApiKeyAuthorizeService`.
- **`Tenancy/TenancyGlobal.guard.ts`** — Injects `ClsService` and rejects with `Organization mismatch.` when the request header disagrees with the CLS value established by the auth guard.
- **`App/App.module.ts`** — Removes the line that seeded `cls.organizationId` from the attacker-controlled request header. JWT and API-key guards now establish `organizationId` authoritatively before any handler runs.

The header is still required (no API-contract change for existing clients); it's now validated against the JWT, not used as the source of truth.

## Test plan

- [ ] `pnpm --filter server typecheck` passes on the changed files (no new diagnostics)
- [ ] Reproduce the advisory's PoC against a local stack:
  - [ ] Sign up two tenants (Alice, Mallory); build Alice's org
  - [ ] As Mallory with `organization-id: $ALICE_ORG` → `/api/organization/current` returns **401 Organization mismatch.** (previously leaked Alice's metadata)
  - [ ] As Mallory with `organization-id: $ALICE_ORG` → `/api/users` returns **401** (previously leaked Alice's member roster)
  - [ ] As Mallory with `organization-id: $MALLORY_ORG` → normal 2xx (no regression on the happy path)
  - [ ] As Mallory with no `organization-id` header → still **401 Organization ID is required.**
- [ ] `pnpm --filter server test:e2e` (`auth.e2e-spec.ts`, `api-keys.e2e-spec.ts`, `organization.e2e-spec.ts`, `users.e2e-spec.ts`, `users-invite.e2e-spec.ts`) passes
- [ ] API-key flows continue to work (guard short-circuits when `Authorization` carries an API key; `AuthApiKeyAuthorizeService` already sets `organizationId` from the looked-up tenant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)