### PR TITLE
fix(server): use CSPRNG for attachment S3 keys (GHSA-gj48-p5ff-g67f)

### DIFF
--- a/packages/server/src/database/tenant/migrations/20260516120000_add_unique_constraint_to_documents_key.ts
+++ b/packages/server/src/database/tenant/migrations/20260516120000_add_unique_constraint_to_documents_key.ts
@@ -1,0 +1,11 @@
+exports.up = function (knex) {
+  return knex.schema.alterTable('documents', (table) => {
+    table.unique('key');
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.alterTable('documents', (table) => {
+    table.dropUnique('key');
+  });
+};

--- a/packages/server/src/modules/Attachments/Attachment.module.ts
+++ b/packages/server/src/modules/Attachments/Attachment.module.ts
@@ -1,5 +1,7 @@
 import { Module } from "@nestjs/common";
+import { randomUUID } from 'node:crypto';
 import * as multerS3 from 'multer-s3';
+import { ClsService } from 'nestjs-cls';
 import { S3_CLIENT, S3Module } from "../S3/S3.module";
 import { DeleteAttachment } from "./DeleteAttachment";
 import { GetAttachment } from "./GetAttachment";
@@ -59,8 +61,12 @@ const models = [
     AttachmentUploadPipeline,
     {
       provide: MULTER_MODULE_OPTIONS,
-      inject: [ConfigService, S3_CLIENT],
-      useFactory: (configService: ConfigService, s3: S3Client) => ({
+      inject: [ConfigService, S3_CLIENT, ClsService],
+      useFactory: (
+        configService: ConfigService,
+        s3: S3Client,
+        cls: ClsService,
+      ) => ({
         storage: multerS3({
           s3,
           bucket: configService.get('s3.bucket'),
@@ -69,7 +75,11 @@ const models = [
             cb(null, { fieldName: file.fieldname });
           },
           key: function (req, file, cb) {
-            cb(null, Date.now().toString());
+            const organizationId = cls.get<string>('organizationId');
+            if (!organizationId) {
+              return cb(new Error('Tenant context required for upload.'), undefined as any);
+            }
+            cb(null, `${organizationId}/${randomUUID()}`);
           },
           acl: function(req, file, cb) {
             // Conditionally set file to public or private based on isPublic flag


### PR DESCRIPTION
## Summary

Fixes [GHSA-gj48-p5ff-g67f](https://github.com/bigcapitalhq/bigcapital/security/advisories/GHSA-gj48-p5ff-g67f) (CVSS 5.3, CWE-340).

The multer-s3 storage factory at `packages/server/src/modules/Attachments/Attachment.module.ts` used `Date.now().toString()` for every uploaded attachment's S3 key — a 13-digit ms-epoch value with no randomness. An attacker holding any registered account could enumerate keys for a known upload window (e.g. ~10 minutes for a 10-second window with a 10-proxy rotation), then download the files via `GET /attachments/:id/presigned-url`. Two uploads in the same millisecond also collided and silently overwrote each other.

### Changes

- **`packages/server/src/modules/Attachments/Attachment.module.ts`** — replaced the key callback. New keys are `` `${organizationId}/${randomUUID()}` ``:
  - `randomUUID()` from `node:crypto` (Node 14.17+) is a v4 UUID with 122 bits of entropy, making brute-force enumeration infeasible.
  - The `<organizationId>/` prefix is read from the `nestjs-cls` store populated by the global `ClsModule` middleware in `App.module.ts:168-178`. The multer key callback runs inside the request's `AsyncLocalStorage` context because `FileInterceptor` instantiates multer after middleware. Missing tenant context fails the upload via `cb(new Error(...))` rather than silently falling back.
  - Prevents future bucket-listing leaks from implying cross-tenant exposure.
- **`packages/server/src/database/tenant/migrations/20260516120000_add_unique_constraint_to_documents_key.ts`** — new tenant migration adding `unique('key')` to `documents` as defence-in-depth. Any hypothetical collision now surfaces as a DB error instead of a silent S3 overwrite.

### Backward compatibility

Legacy 13-digit numeric keys remain valid — only new uploads use the new format. All call sites (`GetAttachmentPresignedUrl`, `GetAttachment`, `DeleteAttachment`, `Attachments.controller`) treat the key as an opaque string, so no changes were needed there.

### Out of scope (recommended follow-ups)

- `acl: 'public-read'` on uploads (`Attachment.module.ts:84-89`) — direct-S3 access remains possible if a key is exposed. Switching to `private` would close that vector but may break any UI that embeds raw S3 URLs.
- Cross-tenant access to the presigned-URL / get / delete endpoints is already addressed on develop by #1093 (`fix(server): prevent cross-tenant attachment access (IDOR)`), which this PR builds on.

## Test plan

- [x] `pnpm --filter @bigcapital/server typecheck` passes
- [ ] **Manual end-to-end (mirrors advisory PoC)**:
  - [ ] `docker compose -f docker-compose.prod.yml up -d`; sign up + sign in to obtain `$TOKEN` and `$ORG`
  - [ ] `curl -X POST .../api/attachments -F 'file=@/tmp/sample.txt'` — assert `data.key` matches `^[^/]+/[0-9a-f-]{36}$` (org-id slash UUID) and is **not** a 13-digit number
  - [ ] Fire two parallel uploads — confirm both succeed with distinct keys and both rows persist
  - [ ] Replay the advisory's enumeration loop against `GET /attachments/$k/presigned-url` for numeric keys — confirm no hits for new uploads
- [ ] **Migration**: run `pnpm --filter @bigcapital/server cli:tenants:migrate:latest` on a fresh tenant DB; confirm the `documents.key` unique index exists (`SHOW INDEX FROM documents` on MySQL, `\d documents` on Postgres)