### PR TITLE
feat(sdk): add table accept header to report fetchers and refactor audit log hooks

### DIFF
--- a/packages/webapp/src/containers/FinancialStatements/AuditLog/AuditLogReport.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/AuditLog/AuditLogReport.tsx
@@ -49,14 +49,14 @@ function AuditLogReportContent() {
 
       <DashboardPageContent>
         <FinancialStatement>
-          {/* <AuditLogHeader
+          <AuditLogHeader
             pageFilter={query}
             onSubmitFilter={handleFilterSubmit}
             isFilterDrawerOpen={isFilterDrawerOpen}
             toggleFilterDrawer={toggleFilterDrawer}
           />
           <AuditLogLoadingBar />
-          <AuditLogBody /> */}
+          <AuditLogBody /> 
         </FinancialStatement>
       </DashboardPageContent>
     </AuditLogProvider>

--- a/packages/webapp/src/hooks/query/audit-logs/index.tsx
+++ b/packages/webapp/src/hooks/query/audit-logs/index.tsx
@@ -1,12 +1,9 @@
-import * as qs from 'qs';
-import { useQuery, useInfiniteQuery } from '@tanstack/react-query';
-import useApiRequest from '../../useRequest';
-import { normalizeApiPath } from '@/utils';
+import { useQuery, useInfiniteQuery, keepPreviousData } from '@tanstack/react-query';
+import { useApiFetcher } from '../../useRequest';
+import { fetchAuditLogs, fetchAuditLogFilterOptions } from '@bigcapital/sdk-ts';
 import { AUDIT_LOGS, AUDIT_LOG_FILTER_OPTIONS } from './query-keys';
 
 export { AuditLogsQueryKeys } from './query-keys';
-
-const qsArrayOptions = { skipNulls: true, arrayFormat: 'repeat' as const };
 
 function auditLogStringListParam(value: string | string[] | null | undefined) {
   if (value == null || value === '') return undefined;
@@ -14,45 +11,39 @@ function auditLogStringListParam(value: string | string[] | null | undefined) {
   return [value];
 }
 
-export function useAuditLogsQuery(filters: Record<string, any>, props?: Record<string, any>) {
-  const apiRequest = useApiRequest();
+function buildAuditLogsQuery(page: number, filters: Record<string, any>) {
+  return {
+    page,
+    pageSize: filters.pageSize ?? 20,
+    subject: auditLogStringListParam(filters.subject) as any,
+    action: auditLogStringListParam(filters.action) as any,
+    userId: filters.userId || undefined,
+    from: filters.from || undefined,
+    to: filters.to || undefined,
+  };
+}
 
-  const query = qs.stringify(
-    {
-      page: filters.page ?? 1,
-      pageSize: filters.pageSize ?? 20,
-      subject: auditLogStringListParam(filters.subject),
-      action: auditLogStringListParam(filters.action),
-      userId: filters.userId || undefined,
-      from: filters.from || undefined,
-      to: filters.to || undefined,
-    },
-    qsArrayOptions,
-  );
+export function useAuditLogsQuery(filters: Record<string, any>, props?: Record<string, any>) {
+  const fetcher = useApiFetcher();
 
   return useQuery({
     queryKey: [AUDIT_LOGS, filters],
-    queryFn: () =>
-      apiRequest
-        .http({ method: 'get', url: `/api/${normalizeApiPath(`audit-logs?${query}`)}` })
-        .then((res) => res.data),
-    keepPreviousData: true,
+    queryFn: () => fetchAuditLogs(fetcher, buildAuditLogsQuery(filters.page ?? 1, filters)),
+    placeholderData: keepPreviousData,
     ...props,
   });
 }
 
 export function useAuditLogFilterOptionsQuery(props?: Record<string, any>) {
-  const apiRequest = useApiRequest();
+  const fetcher = useApiFetcher();
 
   return useQuery({
     queryKey: [AUDIT_LOG_FILTER_OPTIONS],
     queryFn: () =>
-      apiRequest
-        .http({ method: 'get', url: `/api/${normalizeApiPath('audit-logs/filter-options')}` })
-        .then((res) => ({
-          subjects: res.data?.subjects ?? [],
-          actions: res.data?.actions ?? [],
-        })),
+      fetchAuditLogFilterOptions(fetcher).then((data) => ({
+        subjects: data?.subjects ?? [],
+        actions: data?.actions ?? [],
+      })),
     placeholderData: { subjects: [], actions: [] },
     staleTime: 5 * 60 * 1000,
     ...props,
@@ -63,38 +54,19 @@ export function useAuditLogsInfinityQuery(
   filters: Record<string, any>,
   infinityProps?: Record<string, any>,
 ) {
-  const apiRequest = useApiRequest();
+  const fetcher = useApiFetcher();
 
-  return useInfiniteQuery(
-    [AUDIT_LOGS, filters],
-    async ({ pageParam = 1 }) => {
-      const query = qs.stringify(
-        {
-          page: pageParam,
-          pageSize: filters.pageSize ?? 20,
-          subject: auditLogStringListParam(filters.subject),
-          action: auditLogStringListParam(filters.action),
-          userId: filters.userId || undefined,
-          from: filters.from || undefined,
-          to: filters.to || undefined,
-        },
-        qsArrayOptions,
-      );
-
-      const response = await apiRequest.http({
-        method: 'get',
-        url: `/api/${normalizeApiPath(`audit-logs?${query}`)}`,
-      });
-      return response.data;
+  return useInfiniteQuery({
+    queryKey: [AUDIT_LOGS, filters],
+    initialPageParam: 1,
+    queryFn: ({ pageParam = 1 }) =>
+      fetchAuditLogs(fetcher, buildAuditLogsQuery(pageParam, filters)),
+    getNextPageParam: (lastPage: any) => {
+      const { pagination } = lastPage;
+      return pagination.total > pagination.page_size * pagination.page
+        ? pagination.page + 1
+        : undefined;
     },
-    {
-      getNextPageParam: (lastPage: any) => {
-        const { pagination } = lastPage;
-        return pagination.total > pagination.page_size * pagination.page
-          ? pagination.page + 1
-          : undefined;
-      },
-      ...infinityProps,
-    },
-  );
+    ...infinityProps,
+  });
 }

--- a/shared/sdk-ts/src/reports/balance-sheet.ts
+++ b/shared/sdk-ts/src/reports/balance-sheet.ts
@@ -24,7 +24,10 @@ export async function fetchBalanceSheetTable(
 ): Promise<BalanceSheetTableResponse> {
   const get = fetcher.path(BALANCE_SHEET_ROUTE).method('get').create();
   const { payload, init } = withNestedQuery(query);
-  const { data } = await get(payload as Arg, init);
+  const { data } = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: 'application/json+table' },
+  });
   return data as unknown as BalanceSheetTableResponse;
 }
 

--- a/shared/sdk-ts/src/reports/cashflow.ts
+++ b/shared/sdk-ts/src/reports/cashflow.ts
@@ -24,7 +24,10 @@ export async function fetchCashflowStatementTable(
 ): Promise<CashflowStatementTableResponse> {
   const get = fetcher.path(CASHFLOW_ROUTE).method('get').create();
   const { payload, init } = withNestedQuery(query);
-  const { data } = await get(payload as Arg, init);
+  const { data } = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: 'application/json+table' },
+  });
   return data as unknown as CashflowStatementTableResponse;
 }
 

--- a/shared/sdk-ts/src/reports/customer-balance.ts
+++ b/shared/sdk-ts/src/reports/customer-balance.ts
@@ -24,7 +24,10 @@ export async function fetchCustomerBalanceTable(
 ): Promise<CustomerBalanceTableResponse> {
   const get = fetcher.path(CUSTOMER_BALANCE_ROUTE).method('get').create();
   const { payload, init } = withNestedQuery(query);
-  const { data } = await get(payload as Arg, init);
+  const { data } = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: 'application/json+table' },
+  });
   return data as unknown as CustomerBalanceTableResponse;
 }
 

--- a/shared/sdk-ts/src/reports/general-ledger.ts
+++ b/shared/sdk-ts/src/reports/general-ledger.ts
@@ -24,7 +24,10 @@ export async function fetchGeneralLedgerTable(
 ): Promise<GeneralLedgerTableResponse> {
   const get = fetcher.path(GENERAL_LEDGER_ROUTE).method('get').create();
   const { payload, init } = withNestedQuery(query);
-  const { data } = await get(payload as Arg, init);
+  const { data } = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: 'application/json+table' },
+  });
   return data as unknown as GeneralLedgerTableResponse;
 }
 

--- a/shared/sdk-ts/src/reports/inventory-details.ts
+++ b/shared/sdk-ts/src/reports/inventory-details.ts
@@ -24,7 +24,10 @@ export async function fetchInventoryItemDetailsTable(
 ): Promise<InventoryItemDetailsTableResponse> {
   const get = fetcher.path(INVENTORY_DETAILS_ROUTE).method('get').create();
   const { payload, init } = withNestedQuery(query);
-  const { data } = await get(payload as Arg, init);
+  const { data } = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: 'application/json+table' },
+  });
   return data as unknown as InventoryItemDetailsTableResponse;
 }
 

--- a/shared/sdk-ts/src/reports/inventory-valuation.ts
+++ b/shared/sdk-ts/src/reports/inventory-valuation.ts
@@ -24,7 +24,10 @@ export async function fetchInventoryValuationTable(
 ): Promise<InventoryValuationTableResponse> {
   const get = fetcher.path(INVENTORY_VALUATION_ROUTE).method('get').create();
   const { payload, init } = withNestedQuery(query);
-  const { data } = await get(payload as Arg, init);
+  const { data } = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: 'application/json+table' },
+  });
   return data as unknown as InventoryValuationTableResponse;
 }
 

--- a/shared/sdk-ts/src/reports/journal.ts
+++ b/shared/sdk-ts/src/reports/journal.ts
@@ -24,7 +24,10 @@ export async function fetchJournalTable(
 ): Promise<JournalTableResponse> {
   const get = fetcher.path(JOURNAL_ROUTE).method('get').create();
   const { payload, init } = withNestedQuery(query);
-  const { data } = await get(payload as Arg, init);
+  const { data } = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: 'application/json+table' },
+  });
   return data as unknown as JournalTableResponse;
 }
 

--- a/shared/sdk-ts/src/reports/payable-aging.ts
+++ b/shared/sdk-ts/src/reports/payable-aging.ts
@@ -24,7 +24,10 @@ export async function fetchPayableAgingTable(
 ): Promise<PayableAgingTableResponse> {
   const get = fetcher.path(PAYABLE_AGING_ROUTE).method('get').create();
   const { payload, init } = withNestedQuery(query);
-  const { data } = await get(payload as Arg, init);
+  const { data } = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: 'application/json+table' },
+  });
   return data as unknown as PayableAgingTableResponse;
 }
 

--- a/shared/sdk-ts/src/reports/profit-loss.ts
+++ b/shared/sdk-ts/src/reports/profit-loss.ts
@@ -24,7 +24,10 @@ export async function fetchProfitLossTable(
 ): Promise<ProfitLossTableResponse> {
   const get = fetcher.path(PROFIT_LOSS_ROUTE).method('get').create();
   const { payload, init } = withNestedQuery(query);
-  const { data } = await get(payload as Arg, init);
+  const { data } = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: 'application/json+table' },
+  });
   return data as unknown as ProfitLossTableResponse;
 }
 

--- a/shared/sdk-ts/src/reports/purchases-by-items.ts
+++ b/shared/sdk-ts/src/reports/purchases-by-items.ts
@@ -24,7 +24,10 @@ export async function fetchPurchasesByItemsTable(
 ): Promise<PurchasesByItemsTableResponse> {
   const get = fetcher.path(PURCHASES_BY_ITEMS_ROUTE).method('get').create();
   const { payload, init } = withNestedQuery(query);
-  const { data } = await get(payload as Arg, init);
+  const { data } = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: 'application/json+table' },
+  });
   return data as unknown as PurchasesByItemsTableResponse;
 }
 

--- a/shared/sdk-ts/src/reports/receivable-aging.ts
+++ b/shared/sdk-ts/src/reports/receivable-aging.ts
@@ -24,7 +24,10 @@ export async function fetchReceivableAgingTable(
 ): Promise<ReceivableAgingTableResponse> {
   const get = fetcher.path(RECEIVABLE_AGING_ROUTE).method('get').create();
   const { payload, init } = withNestedQuery(query);
-  const { data } = await get(payload as Arg, init);
+  const { data } = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: 'application/json+table' },
+  });
   return data as unknown as ReceivableAgingTableResponse;
 }
 

--- a/shared/sdk-ts/src/reports/sales-by-items.ts
+++ b/shared/sdk-ts/src/reports/sales-by-items.ts
@@ -24,7 +24,10 @@ export async function fetchSalesByItemsTable(
 ): Promise<SalesByItemsTableResponse> {
   const get = fetcher.path(SALES_BY_ITEMS_ROUTE).method('get').create();
   const { payload, init } = withNestedQuery(query);
-  const { data } = await get(payload as Arg, init);
+  const { data } = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: 'application/json+table' },
+  });
   return data as unknown as SalesByItemsTableResponse;
 }
 

--- a/shared/sdk-ts/src/reports/sales-tax-liability.ts
+++ b/shared/sdk-ts/src/reports/sales-tax-liability.ts
@@ -24,7 +24,10 @@ export async function fetchSalesTaxLiabilityTable(
 ): Promise<SalesTaxLiabilityTableResponse> {
   const get = fetcher.path(SALES_TAX_LIABILITY_ROUTE).method('get').create();
   const { payload, init } = withNestedQuery(query);
-  const { data } = await get(payload as Arg, init);
+  const { data } = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: 'application/json+table' },
+  });
   return data as unknown as SalesTaxLiabilityTableResponse;
 }
 

--- a/shared/sdk-ts/src/reports/transactions-customers.ts
+++ b/shared/sdk-ts/src/reports/transactions-customers.ts
@@ -24,7 +24,10 @@ export async function fetchTransactionsByCustomersTable(
 ): Promise<TransactionsByCustomersTableResponse> {
   const get = fetcher.path(TRANSACTIONS_CUSTOMERS_ROUTE).method('get').create();
   const { payload, init } = withNestedQuery(query);
-  const { data } = await get(payload as Arg, init);
+  const { data } = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: 'application/json+table' },
+  });
   return data as unknown as TransactionsByCustomersTableResponse;
 }
 

--- a/shared/sdk-ts/src/reports/transactions-reference.ts
+++ b/shared/sdk-ts/src/reports/transactions-reference.ts
@@ -24,7 +24,10 @@ export async function fetchTransactionsByReferenceTable(
 ): Promise<TransactionsByReferenceTableResponse> {
   const get = fetcher.path(TRANSACTIONS_REFERENCE_ROUTE).method('get').create();
   const { payload, init } = withNestedQuery(query);
-  const { data } = await get(payload as Arg, init);
+  const { data } = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: 'application/json+table' },
+  });
   return data as unknown as TransactionsByReferenceTableResponse;
 }
 

--- a/shared/sdk-ts/src/reports/transactions-vendors.ts
+++ b/shared/sdk-ts/src/reports/transactions-vendors.ts
@@ -24,7 +24,10 @@ export async function fetchTransactionsByVendorsTable(
 ): Promise<TransactionsByVendorsTableResponse> {
   const get = fetcher.path(TRANSACTIONS_VENDORS_ROUTE).method('get').create();
   const { payload, init } = withNestedQuery(query);
-  const { data } = await get(payload as Arg, init);
+  const { data } = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: 'application/json+table' },
+  });
   return data as unknown as TransactionsByVendorsTableResponse;
 }
 

--- a/shared/sdk-ts/src/reports/trial-balance.ts
+++ b/shared/sdk-ts/src/reports/trial-balance.ts
@@ -24,7 +24,10 @@ export async function fetchTrialBalanceTable(
 ): Promise<TrialBalanceTableResponse> {
   const get = fetcher.path(TRIAL_BALANCE_ROUTE).method('get').create();
   const { payload, init } = withNestedQuery(query);
-  const { data } = await get(payload as Arg, init);
+  const { data } = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: 'application/json+table' },
+  });
   return data as unknown as TrialBalanceTableResponse;
 }
 

--- a/shared/sdk-ts/src/reports/vendor-balance.ts
+++ b/shared/sdk-ts/src/reports/vendor-balance.ts
@@ -24,7 +24,10 @@ export async function fetchVendorBalanceTable(
 ): Promise<VendorBalanceTableResponse> {
   const get = fetcher.path(VENDOR_BALANCE_ROUTE).method('get').create();
   const { payload, init } = withNestedQuery(query);
-  const { data } = await get(payload as Arg, init);
+  const { data } = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: 'application/json+table' },
+  });
   return data as unknown as VendorBalanceTableResponse;
 }
 


### PR DESCRIPTION
## Summary
- Add `accept: application/json+table` header to all 16 SDK report table fetcher functions for proper table response negotiation
- Refactor audit log query hooks to use SDK fetch functions (`fetchAuditLogs`, `fetchAuditLogFilterOptions`) instead of manual API calls with `qs.stringify`
- Modernize `useInfiniteQuery` to object syntax with `initialPageParam`, replace deprecated `keepPreviousData` with `placeholderData`
- Uncomment `AuditLogHeader`, `AuditLogLoadingBar`, and `AuditLogBody` components to restore audit log UI

## Test plan
- [ ] Verify all financial report pages load correctly with table data
- [ ] Verify audit log page renders with filters and pagination working
- [ ] Verify infinite scroll on audit log works as expected
- [ ] Confirm no regressions in other report pages

<!-- pr_agent:summary -->
<!-- pr_agent:walkthrough -->