### PR TITLE
refactor(server): replace direct TenancyContext/TransformerInjectable providers with TenancyModule import

### DIFF
--- a/packages/server/src/modules/Accounts/Accounts.module.ts
+++ b/packages/server/src/modules/Accounts/Accounts.module.ts
@@ -3,13 +3,12 @@ import { TenancyDatabaseModule } from '../Tenancy/TenancyDB/TenancyDB.module';
 import { AccountsController } from './Accounts.controller';
 import { AccountsApplication } from './AccountsApplication.service';
 import { CreateAccountService } from './CreateAccount.service';
-import { TenancyContext } from '../Tenancy/TenancyContext.service';
+import { TenancyModule } from '../Tenancy/Tenancy.module';
 import { CommandAccountValidators } from './CommandAccountValidators.service';
 import { AccountRepository } from './repositories/Account.repository';
 import { EditAccount } from './EditAccount.service';
 import { DeleteAccount } from './DeleteAccount.service';
 import { GetAccount } from './GetAccount.service';
-import { TransformerInjectable } from '../Transformer/TransformerInjectable.service';
 import { ActivateAccount } from './ActivateAccount.service';
 import { GetAccountTypesService } from './GetAccountTypes.service';
 import { GetAccountTransactionsService } from './GetAccountTransactions.service';
@@ -26,19 +25,17 @@ import { AccountsSettingsService } from './AccountsSettings.service';
 const models = [RegisterTenancyModel(BankAccount)];
 
 @Module({
-  imports: [TenancyDatabaseModule, DynamicListModule, ...models],
+  imports: [TenancyModule, TenancyDatabaseModule, DynamicListModule, ...models],
   controllers: [AccountsController],
   providers: [
     AccountsApplication,
     AccountsSettingsService,
     CreateAccountService,
-    TenancyContext,
     CommandAccountValidators,
     AccountRepository,
     EditAccount,
     DeleteAccount,
     GetAccount,
-    TransformerInjectable,
     ActivateAccount,
     GetAccountTypesService,
     GetAccountTransactionsService,

--- a/packages/server/src/modules/BankingPlaid/BankingPlaid.module.ts
+++ b/packages/server/src/modules/BankingPlaid/BankingPlaid.module.ts
@@ -16,7 +16,7 @@ import { AccountsModule } from '../Accounts/Accounts.module';
 import { BankingCategorizeModule } from '../BankingCategorize/BankingCategorize.module';
 import { BankingTransactionsModule } from '../BankingTransactions/BankingTransactions.module';
 import { PlaidItemService } from './command/PlaidItem';
-import { TenancyContext } from '../Tenancy/TenancyContext.service';
+import { TenancyModule } from '../Tenancy/Tenancy.module';
 import { InjectSystemModel } from '../System/SystemModels/SystemModels.module';
 import { SystemPlaidItem } from './models/SystemPlaidItem';
 import { BankingPlaidController } from './BankingPlaid.controller';
@@ -30,6 +30,7 @@ const models = [RegisterTenancyModel(PlaidItem)];
 
 @Module({
   imports: [
+    TenancyModule,
     SocketModule,
     PlaidModule,
     AccountsModule,
@@ -52,7 +53,6 @@ const models = [RegisterTenancyModel(PlaidItem)];
     PlaidApplication,
     SetupPlaidItemTenantService,
     PlaidWebhookVerificationService,
-    TenancyContext,
     PlaidFetchTransactionsProcessor,
     PlaidUpdateTransactionsOnItemCreatedSubscriber,
   ],

--- a/packages/server/src/modules/BillPayments/BillPayments.module.ts
+++ b/packages/server/src/modules/BillPayments/BillPayments.module.ts
@@ -8,7 +8,7 @@ import { BillPaymentBillSync } from './commands/BillPaymentBillSync.service';
 import { GetPaymentBills } from './queries/GetPaymentBills.service';
 import { BillPaymentValidators } from './commands/BillPaymentValidators.service';
 import { CommandBillPaymentDTOTransformer } from './commands/CommandBillPaymentDTOTransformer.service';
-import { TenancyContext } from '../Tenancy/TenancyContext.service';
+import { TenancyModule } from '../Tenancy/Tenancy.module';
 import { BranchTransactionDTOTransformer } from '../Branches/integrations/BranchTransactionDTOTransform';
 import { BranchesSettingsService } from '../Branches/BranchesSettings';
 import { BillPaymentsController } from './BillPayments.controller';
@@ -24,7 +24,7 @@ import { DynamicListModule } from '../DynamicListing/DynamicList.module';
 import { BillPaymentsPages } from './commands/BillPaymentsPages.service';
 
 @Module({
-  imports: [LedgerModule, AccountsModule, DynamicListModule],
+  imports: [TenancyModule, LedgerModule, AccountsModule, DynamicListModule],
   providers: [
     BillPaymentsApplication,
     CreateBillPaymentService,
@@ -37,7 +37,6 @@ import { BillPaymentsPages } from './commands/BillPaymentsPages.service';
     CommandBillPaymentDTOTransformer,
     BranchTransactionDTOTransformer,
     BranchesSettingsService,
-    TenancyContext,
     BillPaymentGLEntries,
     BillPaymentGLEntriesSubscriber,
     BillPaymentBillSyncSubscriber,

--- a/packages/server/src/modules/Bills/Bills.module.ts
+++ b/packages/server/src/modules/Bills/Bills.module.ts
@@ -14,7 +14,7 @@ import { BranchesSettingsService } from '../Branches/BranchesSettings';
 import { WarehouseTransactionDTOTransform } from '../Warehouses/Integrations/WarehouseTransactionDTOTransform';
 import { WarehousesSettings } from '../Warehouses/WarehousesSettings';
 import { ItemEntriesTaxTransactions } from '../TaxRates/ItemEntriesTaxTransactions.service';
-import { TenancyContext } from '../Tenancy/TenancyContext.service';
+import { TenancyModule } from '../Tenancy/Tenancy.module';
 import { BillsController } from './Bills.controller';
 import { BillLandedCostsModule } from '../BillLandedCosts/BillLandedCosts.module';
 import { BillGLEntriesSubscriber } from './subscribers/BillGLEntriesSubscriber';
@@ -34,6 +34,7 @@ import { ValidateBulkDeleteBillsService } from './ValidateBulkDeleteBills.servic
 
 @Module({
   imports: [
+    TenancyModule,
     BillLandedCostsModule,
     LedgerModule,
     AccountsModule,
@@ -41,7 +42,6 @@ import { ValidateBulkDeleteBillsService } from './ValidateBulkDeleteBills.servic
     InventoryCostModule,
   ],
   providers: [
-    TenancyContext,
     BillsApplication,
     BranchTransactionDTOTransformer,
     WarehouseTransactionDTOTransform,

--- a/packages/server/src/modules/Branches/Branches.module.ts
+++ b/packages/server/src/modules/Branches/Branches.module.ts
@@ -1,7 +1,6 @@
 import { Module } from '@nestjs/common';
-import { TenancyContext } from '../Tenancy/TenancyContext.service';
+import { TenancyModule } from '../Tenancy/Tenancy.module';
 import { TenancyDatabaseModule } from '../Tenancy/TenancyDB/TenancyDB.module';
-import { TransformerInjectable } from '../Transformer/TransformerInjectable.service';
 import { BranchesController } from './Branches.controller';
 import { CreateBranchService } from './commands/CreateBranch.service';
 import { DeleteBranchService } from './commands/DeleteBranch.service';
@@ -40,7 +39,7 @@ import { PaymentMadeActivateBranchesSubscriber } from './subscribers/Activate/Pa
 import { FeaturesModule } from '../Features/Features.module';
 
 @Module({
-  imports: [TenancyDatabaseModule, FeaturesModule],
+  imports: [TenancyModule, TenancyDatabaseModule, FeaturesModule],
   controllers: [BranchesController],
   providers: [
     CreateBranchService,
@@ -52,8 +51,6 @@ import { FeaturesModule } from '../Features/Features.module';
     ActivateBranches,
     BranchesApplication,
     BranchesSettingsService,
-    TenancyContext,
-    TransformerInjectable,
     BranchCommandValidator,
     BranchTransactionDTOTransformer,
     ManualJournalBranchesDTOTransformer,

--- a/packages/server/src/modules/Customers/Customers.module.ts
+++ b/packages/server/src/modules/Customers/Customers.module.ts
@@ -1,7 +1,6 @@
 import { Module } from '@nestjs/common';
-import { TenancyContext } from '../Tenancy/TenancyContext.service';
+import { TenancyModule } from '../Tenancy/Tenancy.module';
 import { TenancyDatabaseModule } from '../Tenancy/TenancyDB/TenancyDB.module';
-import { TransformerInjectable } from '../Transformer/TransformerInjectable.service';
 import { ActivateCustomer } from './commands/ActivateCustomer.service';
 import { CreateCustomer } from './commands/CreateCustomer.service';
 import { CustomerValidators } from './commands/CustomerValidators.service';
@@ -26,6 +25,7 @@ import { CustomerWriteGLOpeningBalanceSubscriber } from './subscribers/CustomerG
 
 @Module({
   imports: [
+    TenancyModule,
     TenancyDatabaseModule,
     DynamicListModule,
     LedgerModule,
@@ -43,8 +43,6 @@ import { CustomerWriteGLOpeningBalanceSubscriber } from './subscribers/CustomerG
     GetCustomerService,
     CustomersApplication,
     DeleteCustomer,
-    TenancyContext,
-    TransformerInjectable,
     GetCustomerService,
     CustomersExportable,
     CustomersImportable,

--- a/packages/server/src/modules/Dashboard/Dashboard.module.ts
+++ b/packages/server/src/modules/Dashboard/Dashboard.module.ts
@@ -2,11 +2,11 @@ import { Module } from '@nestjs/common';
 import { DashboardService } from './Dashboard.service';
 import { FeaturesModule } from '../Features/Features.module';
 import { DashboardController } from './Dashboard.controller';
-import { TenancyContext } from '../Tenancy/TenancyContext.service';
+import { TenancyModule } from '../Tenancy/Tenancy.module';
 
 @Module({
-  imports: [FeaturesModule],
-  providers: [DashboardService, TenancyContext],
+  imports: [TenancyModule, FeaturesModule],
+  providers: [DashboardService],
   controllers: [DashboardController],
 })
 export class DashboardModule {}

--- a/packages/server/src/modules/EventsTracker/postHog.module.ts
+++ b/packages/server/src/modules/EventsTracker/postHog.module.ts
@@ -3,12 +3,12 @@ import { PostHog } from 'posthog-node';
 import { EventTrackerService } from './EventTracker.service';
 import { ConfigService } from '@nestjs/config';
 import { POSTHOG_PROVIDER } from './PostHog.constants';
-import { TenancyContext } from '../Tenancy/TenancyContext.service';
+import { TenancyModule } from '../Tenancy/Tenancy.module';
 
 @Module({
+  imports: [TenancyModule],
   providers: [
     EventTrackerService,
-    TenancyContext,
     {
       provide: POSTHOG_PROVIDER,
       useFactory: (configService: ConfigService) => {

--- a/packages/server/src/modules/Expenses/Expenses.module.ts
+++ b/packages/server/src/modules/Expenses/Expenses.module.ts
@@ -8,8 +8,7 @@ import { ExpensesApplication } from './ExpensesApplication.service';
 import { GetExpenseService } from './queries/GetExpense.service';
 import { ExpenseDTOTransformer } from './commands/CommandExpenseDTO.transformer';
 import { CommandExpenseValidator } from './commands/CommandExpenseValidator.service';
-import { TenancyContext } from '../Tenancy/TenancyContext.service';
-import { TransformerInjectable } from '../Transformer/TransformerInjectable.service';
+import { TenancyModule } from '../Tenancy/Tenancy.module';
 import { ExpensesWriteGLSubscriber } from './subscribers/ExpenseGLEntries.subscriber';
 import { ExpenseGLEntriesStorageService } from './subscribers/ExpenseGLEntriesStorage.sevice';
 import { ExpenseGLEntriesService } from './subscribers/ExpenseGLEntries.service';
@@ -23,7 +22,7 @@ import { BulkDeleteExpensesService } from './BulkDeleteExpenses.service';
 import { ValidateBulkDeleteExpensesService } from './ValidateBulkDeleteExpenses.service';
 
 @Module({
-  imports: [LedgerModule, BranchesModule, DynamicListModule],
+  imports: [TenancyModule, LedgerModule, BranchesModule, DynamicListModule],
   controllers: [ExpensesController],
   exports: [CreateExpense, ExpensesExportable, ExpensesImportable],
   providers: [
@@ -35,8 +34,6 @@ import { ValidateBulkDeleteExpensesService } from './ValidateBulkDeleteExpenses.
     PublishExpense,
     GetExpenseService,
     ExpensesApplication,
-    TenancyContext,
-    TransformerInjectable,
     ExpensesWriteGLSubscriber,
     ExpenseGLEntriesStorageService,
     ExpenseGLEntriesService,

--- a/packages/server/src/modules/FinancialStatements/common/FinancialSheetCommon.module.ts
+++ b/packages/server/src/modules/FinancialStatements/common/FinancialSheetCommon.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
 import { FinancialSheetMeta } from './FinancialSheetMeta';
-import { TenancyContext } from '@/modules/Tenancy/TenancyContext.service';
+import { TenancyModule } from '@/modules/Tenancy/Tenancy.module';
 import { TableSheetPdf } from './TableSheetPdf';
 import { TemplateInjectableModule } from '@/modules/TemplateInjectable/TemplateInjectable.module';
 import { ChromiumlyTenancyModule } from '@/modules/ChromiumlyTenancy/ChromiumlyTenancy.module';
@@ -8,11 +8,12 @@ import { InventoryCostModule } from '@/modules/InventoryCost/InventoryCost.modul
 
 @Module({
   imports: [
+    TenancyModule,
     TemplateInjectableModule,
     ChromiumlyTenancyModule,
     InventoryCostModule,
   ],
-  providers: [FinancialSheetMeta, TenancyContext, TableSheetPdf],
+  providers: [FinancialSheetMeta, TableSheetPdf],
   exports: [FinancialSheetMeta, TableSheetPdf],
 })
 export class FinancialSheetCommonModule {}

--- a/packages/server/src/modules/FinancialStatements/modules/APAgingSummary/APAgingSummary.module.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/APAgingSummary/APAgingSummary.module.ts
@@ -9,10 +9,10 @@ import { APAgingSummaryApplication } from './APAgingSummaryApplication';
 import { APAgingSummaryController } from './APAgingSummary.controller';
 import { APAgingSummaryMeta } from './APAgingSummaryMeta';
 import { FinancialSheetCommonModule } from '../../common/FinancialSheetCommon.module';
-import { TenancyContext } from '@/modules/Tenancy/TenancyContext.service';
+import { TenancyModule } from '@/modules/Tenancy/Tenancy.module';
 
 @Module({
-  imports: [AgingSummaryModule, FinancialSheetCommonModule],
+  imports: [TenancyModule, AgingSummaryModule, FinancialSheetCommonModule],
   providers: [
     APAgingSummaryService,
     APAgingSummaryMeta,
@@ -21,7 +21,6 @@ import { TenancyContext } from '@/modules/Tenancy/TenancyContext.service';
     APAgingSummaryPdfInjectable,
     APAgingSummaryRepository,
     APAgingSummaryApplication,
-    TenancyContext,
   ],
   controllers: [APAgingSummaryController],
 })

--- a/packages/server/src/modules/FinancialStatements/modules/ARAgingSummary/ARAgingSummary.module.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/ARAgingSummary/ARAgingSummary.module.ts
@@ -9,10 +9,10 @@ import { ARAgingSummaryApplication } from './ARAgingSummaryApplication';
 import { ARAgingSummaryController } from './ARAgingSummary.controller';
 import { ARAgingSummaryMeta } from './ARAgingSummaryMeta';
 import { FinancialSheetCommonModule } from '../../common/FinancialSheetCommon.module';
-import { TenancyContext } from '@/modules/Tenancy/TenancyContext.service';
+import { TenancyModule } from '@/modules/Tenancy/Tenancy.module';
 
 @Module({
-  imports: [AgingSummaryModule, FinancialSheetCommonModule],
+  imports: [TenancyModule, AgingSummaryModule, FinancialSheetCommonModule],
   controllers: [ARAgingSummaryController],
   providers: [
     ARAgingSummaryTableInjectable,
@@ -22,7 +22,6 @@ import { TenancyContext } from '@/modules/Tenancy/TenancyContext.service';
     ARAgingSummaryRepository,
     ARAgingSummaryApplication,
     ARAgingSummaryMeta,
-    TenancyContext,
   ],
 })
 export class ARAgingSummaryModule {}

--- a/packages/server/src/modules/FinancialStatements/modules/BalanceSheet/BalanceSheet.module.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/BalanceSheet/BalanceSheet.module.ts
@@ -5,14 +5,14 @@ import { BalanceSheetTableInjectable } from './BalanceSheetTableInjectable';
 import { BalanceSheetExportInjectable } from './BalanceSheetExportInjectable';
 import { BalanceSheetMetaInjectable } from './BalanceSheetMeta';
 import { BalanceSheetPdfInjectable } from './BalanceSheetPdfInjectable';
-import { TenancyContext } from '@/modules/Tenancy/TenancyContext.service';
+import { TenancyModule } from '@/modules/Tenancy/Tenancy.module';
 import { FinancialSheetCommonModule } from '../../common/FinancialSheetCommon.module';
 import { BalanceSheetStatementController } from './BalanceSheet.controller';
 import { BalanceSheetRepository } from './BalanceSheetRepository';
 import { AccountsModule } from '@/modules/Accounts/Accounts.module';
 
 @Module({
-  imports: [FinancialSheetCommonModule, AccountsModule],
+  imports: [TenancyModule, FinancialSheetCommonModule, AccountsModule],
   controllers: [BalanceSheetStatementController],
   providers: [
     BalanceSheetRepository,
@@ -22,7 +22,6 @@ import { AccountsModule } from '@/modules/Accounts/Accounts.module';
     BalanceSheetMetaInjectable,
     BalanceSheetApplication,
     BalanceSheetPdfInjectable,
-    TenancyContext,
   ],
   exports: [BalanceSheetInjectable],
 })

--- a/packages/server/src/modules/FinancialStatements/modules/CashFlowStatement/CashflowStatement.module.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/CashFlowStatement/CashflowStatement.module.ts
@@ -7,11 +7,11 @@ import { CashflowController } from './Cashflow.controller';
 import { FinancialSheetCommonModule } from '../../common/FinancialSheetCommon.module';
 import { CashflowTableInjectable } from './CashflowTableInjectable';
 import { CashFlowStatementService } from './CashFlowService';
-import { TenancyContext } from '@/modules/Tenancy/TenancyContext.service';
+import { TenancyModule } from '@/modules/Tenancy/Tenancy.module';
 import { CashflowSheetApplication } from './CashflowSheetApplication';
 
 @Module({
-  imports: [FinancialSheetCommonModule],
+  imports: [TenancyModule, FinancialSheetCommonModule],
   providers: [
     CashFlowRepository,
     CashflowSheetMeta,
@@ -20,7 +20,6 @@ import { CashflowSheetApplication } from './CashflowSheetApplication';
     CashflowExportInjectable,
     CashflowTableInjectable,
     CashflowSheetApplication,
-    TenancyContext,
   ],
   controllers: [CashflowController],
 })

--- a/packages/server/src/modules/FinancialStatements/modules/CustomerBalanceSummary/CustomerBalanceSummary.module.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/CustomerBalanceSummary/CustomerBalanceSummary.module.ts
@@ -8,10 +8,10 @@ import { CustomerBalanceSummaryTableInjectable } from './CustomerBalanceSummaryT
 import { CustomerBalanceSummaryController } from './CustomerBalanceSummary.controller';
 import { FinancialSheetCommonModule } from '../../common/FinancialSheetCommon.module';
 import { CustomerBalanceSummaryRepository } from './CustomerBalanceSummaryRepository';
-import { TenancyContext } from '@/modules/Tenancy/TenancyContext.service';
+import { TenancyModule } from '@/modules/Tenancy/Tenancy.module';
 
 @Module({
-  imports: [FinancialSheetCommonModule],
+  imports: [TenancyModule, FinancialSheetCommonModule],
   controllers: [CustomerBalanceSummaryController],
   providers: [
     CustomerBalanceSummaryApplication,
@@ -21,7 +21,6 @@ import { TenancyContext } from '@/modules/Tenancy/TenancyContext.service';
     CustomerBalanceSummaryService,
     CustomerBalanceSummaryTableInjectable,
     CustomerBalanceSummaryRepository,
-    TenancyContext,
   ],
 })
 export class CustomerBalanceSummaryModule {}

--- a/packages/server/src/modules/FinancialStatements/modules/GeneralLedger/GeneralLedger.module.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/GeneralLedger/GeneralLedger.module.ts
@@ -9,10 +9,10 @@ import { GeneralLedgerController } from './GeneralLedger.controller';
 import { FinancialSheetCommonModule } from '../../common/FinancialSheetCommon.module';
 import { GeneralLedgerMeta } from './GeneralLedgerMeta';
 import { AccountsModule } from '@/modules/Accounts/Accounts.module';
-import { TenancyContext } from '@/modules/Tenancy/TenancyContext.service';
+import { TenancyModule } from '@/modules/Tenancy/Tenancy.module';
 
 @Module({
-  imports: [FinancialSheetCommonModule, AccountsModule],
+  imports: [TenancyModule, FinancialSheetCommonModule, AccountsModule],
   providers: [
     GeneralLedgerRepository,
     GeneralLedgerApplication,
@@ -21,7 +21,6 @@ import { TenancyContext } from '@/modules/Tenancy/TenancyContext.service';
     GeneralLedgerTableInjectable,
     GeneralLedgerService,
     GeneralLedgerMeta,
-    TenancyContext,
   ],
   controllers: [GeneralLedgerController],
 })

--- a/packages/server/src/modules/FinancialStatements/modules/InventoryItemDetails/InventoryItemDetails.module.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/InventoryItemDetails/InventoryItemDetails.module.ts
@@ -9,10 +9,10 @@ import { InventoryItemDetailsRepository } from './InventoryItemDetailsRepository
 import { InventoryDetailsMetaInjectable } from './InventoryItemDetailsMeta';
 import { FinancialSheetCommonModule } from '../../common/FinancialSheetCommon.module';
 import { InventoryCostModule } from '@/modules/InventoryCost/InventoryCost.module';
-import { TenancyContext } from '@/modules/Tenancy/TenancyContext.service';
+import { TenancyModule } from '@/modules/Tenancy/Tenancy.module';
 
 @Module({
-  imports: [FinancialSheetCommonModule, InventoryCostModule],
+  imports: [TenancyModule, FinancialSheetCommonModule, InventoryCostModule],
   providers: [
     InventoryItemDetailsApplication,
     InventoryItemDetailsExportInjectable,
@@ -21,7 +21,6 @@ import { TenancyContext } from '@/modules/Tenancy/TenancyContext.service';
     InventoryDetailsTablePdf,
     InventoryItemDetailsRepository,
     InventoryDetailsMetaInjectable,
-    TenancyContext,
   ],
   controllers: [InventoryItemDetailsController],
 })

--- a/packages/server/src/modules/FinancialStatements/modules/InventoryValuationSheet/InventoryValuationSheet.module.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/InventoryValuationSheet/InventoryValuationSheet.module.ts
@@ -9,10 +9,10 @@ import { FinancialSheetCommonModule } from '../../common/FinancialSheetCommon.mo
 import { InventoryValuationSheetRepository } from './InventoryValuationSheetRepository';
 import { InventoryValuationSheetExportable } from './InventoryValuationSheetExportable';
 import { InventoryCostModule } from '@/modules/InventoryCost/InventoryCost.module';
-import { TenancyContext } from '@/modules/Tenancy/TenancyContext.service';
+import { TenancyModule } from '@/modules/Tenancy/Tenancy.module';
 
 @Module({
-  imports: [FinancialSheetCommonModule, InventoryCostModule],
+  imports: [TenancyModule, FinancialSheetCommonModule, InventoryCostModule],
   providers: [
     InventoryValuationSheetPdf,
     InventoryValuationSheetTableInjectable,
@@ -21,7 +21,6 @@ import { TenancyContext } from '@/modules/Tenancy/TenancyContext.service';
     InventoryValuationSheetApplication,
     InventoryValuationSheetRepository,
     InventoryValuationSheetExportable,
-    TenancyContext,
   ],
   controllers: [InventoryValuationController],
   exports: [InventoryValuationSheetApplication],

--- a/packages/server/src/modules/FinancialStatements/modules/JournalSheet/JournalSheet.module.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/JournalSheet/JournalSheet.module.ts
@@ -8,11 +8,11 @@ import { JournalSheetTableInjectable } from './JournalSheetTableInjectable';
 import { JournalSheetRepository } from './JournalSheetRepository';
 import { JournalSheetMeta } from './JournalSheetMeta';
 import { FinancialSheetCommonModule } from '../../common/FinancialSheetCommon.module';
-import { TenancyContext } from '@/modules/Tenancy/TenancyContext.service';
+import { TenancyModule } from '@/modules/Tenancy/Tenancy.module';
 import { AccountsModule } from '@/modules/Accounts/Accounts.module';
 
 @Module({
-  imports: [FinancialSheetCommonModule, AccountsModule],
+  imports: [TenancyModule, FinancialSheetCommonModule, AccountsModule],
   controllers: [JournalSheetController],
   providers: [
     JournalSheetApplication,
@@ -22,7 +22,6 @@ import { AccountsModule } from '@/modules/Accounts/Accounts.module';
     JournalSheetPdfInjectable,
     JournalSheetRepository,
     JournalSheetMeta,
-    TenancyContext,
   ],
 })
 export class JournalSheetModule {}

--- a/packages/server/src/modules/FinancialStatements/modules/ProfitLossSheet/ProfitLossSheet.module.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/ProfitLossSheet/ProfitLossSheet.module.ts
@@ -7,12 +7,12 @@ import { ProfitLossSheetMeta } from './ProfitLossSheetMeta';
 import { ProfitLossSheetRepository } from './ProfitLossSheetRepository';
 import { AccountsModule } from '@/modules/Accounts/Accounts.module';
 import { FinancialSheetCommonModule } from '../../common/FinancialSheetCommon.module';
-import { TenancyContext } from '@/modules/Tenancy/TenancyContext.service';
+import { TenancyModule } from '@/modules/Tenancy/Tenancy.module';
 import { ProfitLossSheetController } from './ProfitLossSheet.controller';
 import { ProfitLossSheetApplication } from './ProfitLossSheetApplication';
 
 @Module({
-  imports: [FinancialSheetCommonModule, AccountsModule],
+  imports: [TenancyModule, FinancialSheetCommonModule, AccountsModule],
   controllers: [ProfitLossSheetController],
   providers: [
     ProfitLossSheetApplication,
@@ -22,7 +22,6 @@ import { ProfitLossSheetApplication } from './ProfitLossSheetApplication';
     ProfitLossSheetTableInjectable,
     ProfitLossSheetMeta,
     ProfitLossSheetRepository,
-    TenancyContext,
   ],
 })
 export class ProfitLossSheetModule {}

--- a/packages/server/src/modules/FinancialStatements/modules/PurchasesByItems/PurchasesByItems.module.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/PurchasesByItems/PurchasesByItems.module.ts
@@ -6,12 +6,12 @@ import { PurchasesByItemsExport } from './PurchasesByItemsExport';
 import { PurchasesByItemsApplication } from './PurchasesByItemsApplication';
 import { PurchasesByItemReportController } from './PurchasesByItems.controller';
 import { PurchasesByItemsMeta } from './PurchasesByItemsMeta';
-import { TenancyContext } from '@/modules/Tenancy/TenancyContext.service';
+import { TenancyModule } from '@/modules/Tenancy/Tenancy.module';
 import { InventoryCostModule } from '@/modules/InventoryCost/InventoryCost.module';
 import { FinancialSheetCommonModule } from '../../common/FinancialSheetCommon.module';
 
 @Module({
-  imports: [InventoryCostModule, FinancialSheetCommonModule],
+  imports: [TenancyModule, InventoryCostModule, FinancialSheetCommonModule],
   providers: [
     PurchasesByItemsTableInjectable,
     PurchasesByItemsService,
@@ -19,7 +19,6 @@ import { FinancialSheetCommonModule } from '../../common/FinancialSheetCommon.mo
     PurchasesByItemsPdf,
     PurchasesByItemsMeta,
     PurchasesByItemsApplication,
-    TenancyContext,
   ],
   exports: [PurchasesByItemsApplication],
   controllers: [PurchasesByItemReportController],

--- a/packages/server/src/modules/FinancialStatements/modules/SalesByItems/SalesByItems.module.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/SalesByItems/SalesByItems.module.ts
@@ -6,7 +6,7 @@ import { SalesByItemsReportService } from './SalesByItemsService';
 import { SalesByItemsExport } from './SalesByItemsExport';
 import { FinancialSheetCommonModule } from '../../common/FinancialSheetCommon.module';
 import { SalesByItemsMeta } from './SalesByItemsMeta';
-import { TenancyContext } from '@/modules/Tenancy/TenancyContext.service';
+import { TenancyModule } from '@/modules/Tenancy/Tenancy.module';
 import { InventoryCostModule } from '@/modules/InventoryCost/InventoryCost.module';
 import { SalesByItemsController } from './SalesByItems.controller';
 
@@ -18,9 +18,8 @@ import { SalesByItemsController } from './SalesByItems.controller';
     SalesByItemsReportService,
     SalesByItemsExport,
     SalesByItemsMeta,
-    TenancyContext,
   ],
   controllers: [SalesByItemsController],
-  imports: [FinancialSheetCommonModule, InventoryCostModule],
+  imports: [TenancyModule, FinancialSheetCommonModule, InventoryCostModule],
 })
 export class SalesByItemsModule {}

--- a/packages/server/src/modules/FinancialStatements/modules/TransactionsByCustomer/TransactionsByCustomer.module.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/TransactionsByCustomer/TransactionsByCustomer.module.ts
@@ -5,14 +5,14 @@ import { TransactionsByCustomersRepository } from './TransactionsByCustomersRepo
 import { TransactionsByCustomersSheet } from './TransactionsByCustomersService';
 import { TransactionsByCustomersTableInjectable } from './TransactionsByCustomersTableInjectable';
 import { TransactionsByCustomersMeta } from './TransactionsByCustomersMeta';
-import { TenancyContext } from '@/modules/Tenancy/TenancyContext.service';
+import { TenancyModule } from '@/modules/Tenancy/Tenancy.module';
 import { FinancialSheetCommonModule } from '../../common/FinancialSheetCommon.module';
 import { AccountsModule } from '@/modules/Accounts/Accounts.module';
 import { TransactionsByCustomerController } from './TransactionsByCustomer.controller';
 import { TransactionsByCustomerApplication } from './TransactionsByCustomersApplication';
 
 @Module({
-  imports: [FinancialSheetCommonModule, AccountsModule],
+  imports: [TenancyModule, FinancialSheetCommonModule, AccountsModule],
   providers: [
     TransactionsByCustomerApplication,
     TransactionsByCustomersRepository,
@@ -21,7 +21,6 @@ import { TransactionsByCustomerApplication } from './TransactionsByCustomersAppl
     TransactionsByCustomersSheet,
     TransactionsByCustomersPdf,
     TransactionsByCustomersMeta,
-    TenancyContext,
   ],
   controllers: [TransactionsByCustomerController],
 })

--- a/packages/server/src/modules/FinancialStatements/modules/TransactionsByReference/TransactionByReference.module.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/TransactionsByReference/TransactionByReference.module.ts
@@ -3,17 +3,16 @@ import { TransactionsByReferenceApplication } from './TransactionsByReferenceApp
 import { TransactionsByReferenceRepository } from './TransactionsByReferenceRepository';
 import { TransactionsByReferenceService } from './TransactionsByReference.service';
 import { TransactionsByReferenceController } from './TransactionsByReference.controller';
-import { TenancyContext } from '@/modules/Tenancy/TenancyContext.service';
+import { TenancyModule } from '@/modules/Tenancy/Tenancy.module';
 import { FinancialSheetCommonModule } from '../../common/FinancialSheetCommon.module';
 import { AccountsModule } from '@/modules/Accounts/Accounts.module';
 
 @Module({
-  imports: [FinancialSheetCommonModule, AccountsModule],
+  imports: [TenancyModule, FinancialSheetCommonModule, AccountsModule],
   providers: [
     TransactionsByReferenceRepository,
     TransactionsByReferenceApplication,
     TransactionsByReferenceService,
-    TenancyContext,
   ],
   controllers: [TransactionsByReferenceController],
 })

--- a/packages/server/src/modules/FinancialStatements/modules/TransactionsByVendor/TransactionsByVendor.module.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/TransactionsByVendor/TransactionsByVendor.module.ts
@@ -8,11 +8,11 @@ import { TransactionsByVendorExportInjectable } from './TransactionsByVendorExpo
 import { TransactionsByVendorsPdf } from './TransactionsByVendorPdf';
 import { TransactionsByVendorApplication } from './TransactionsByVendorApplication';
 import { FinancialSheetCommonModule } from '../../common/FinancialSheetCommon.module';
-import { TenancyContext } from '@/modules/Tenancy/TenancyContext.service';
+import { TenancyModule } from '@/modules/Tenancy/Tenancy.module';
 import { AccountsModule } from '@/modules/Accounts/Accounts.module';
 
 @Module({
-  imports: [FinancialSheetCommonModule, AccountsModule],
+  imports: [TenancyModule, FinancialSheetCommonModule, AccountsModule],
   controllers: [TransactionsByVendorController],
   providers: [
     TransactionsByVendorsInjectable,
@@ -22,7 +22,6 @@ import { AccountsModule } from '@/modules/Accounts/Accounts.module';
     TransactionsByVendorExportInjectable,
     TransactionsByVendorsPdf,
     TransactionsByVendorApplication,
-    TenancyContext,
   ],
   exports: [TransactionsByVendorApplication],
 })

--- a/packages/server/src/modules/FinancialStatements/modules/TrialBalanceSheet/TrialBalanceSheet.module.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/TrialBalanceSheet/TrialBalanceSheet.module.ts
@@ -6,13 +6,13 @@ import { TrialBalanceSheetService } from './TrialBalanceSheetInjectable';
 import { TrialBalanceSheetTableInjectable } from './TrialBalanceSheetTableInjectable';
 import { TrialBalanceSheetMeta } from './TrialBalanceSheetMeta';
 import { TrialBalanceSheetRepository } from './TrialBalanceSheetRepository';
-import { TenancyContext } from '@/modules/Tenancy/TenancyContext.service';
+import { TenancyModule } from '@/modules/Tenancy/Tenancy.module';
 import { TrialBalanceSheetPdfInjectable } from './TrialBalanceSheetPdfInjectsable';
 import { FinancialSheetCommonModule } from '../../common/FinancialSheetCommon.module';
 import { AccountsModule } from '@/modules/Accounts/Accounts.module';
 
 @Module({
-  imports: [FinancialSheetCommonModule, AccountsModule],
+  imports: [TenancyModule, FinancialSheetCommonModule, AccountsModule],
   providers: [
     TrialBalanceSheetApplication,
     TrialBalanceSheetService,
@@ -20,7 +20,6 @@ import { AccountsModule } from '@/modules/Accounts/Accounts.module';
     TrialBalanceExportInjectable,
     TrialBalanceSheetMeta,
     TrialBalanceSheetRepository,
-    TenancyContext,
     TrialBalanceSheetPdfInjectable,
   ],
   controllers: [TrialBalanceSheetController],

--- a/packages/server/src/modules/InventoryAdjutments/InventoryAdjustments.module.ts
+++ b/packages/server/src/modules/InventoryAdjutments/InventoryAdjustments.module.ts
@@ -17,7 +17,7 @@ import { InventoryAdjustmentInventoryTransactionsSubscriber } from './inventory/
 import { InventoryAdjustmentInventoryTransactions } from './inventory/InventoryAdjustmentInventoryTransactions';
 import { DynamicListModule } from '../DynamicListing/DynamicList.module';
 import { LedgerModule } from '../Ledger/Ledger.module';
-import { TenancyContext } from '../Tenancy/TenancyContext.service';
+import { TenancyModule } from '../Tenancy/Tenancy.module';
 import { InventoryCostModule } from '../InventoryCost/InventoryCost.module';
 
 const models = [
@@ -26,6 +26,7 @@ const models = [
 ];
 @Module({
   imports: [
+    TenancyModule,
     BranchesModule,
     WarehousesModule,
     LedgerModule,
@@ -43,7 +44,6 @@ const models = [
     InventoryAdjustmentsApplicationService,
     InventoryAdjustmentsGLSubscriber,
     InventoryAdjustmentsGLEntries,
-    TenancyContext,
     InventoryAdjustmentInventoryTransactionsSubscriber,
     InventoryAdjustmentInventoryTransactions,
   ],

--- a/packages/server/src/modules/ItemCategories/ItemCategory.module.ts
+++ b/packages/server/src/modules/ItemCategories/ItemCategory.module.ts
@@ -7,15 +7,14 @@ import { GetItemCategoryService } from './queries/GetItemCategory.service';
 import { ItemCategoryApplication } from './ItemCategory.application';
 import { ItemCategoryController } from './ItemCategory.controller';
 import { CommandItemCategoryValidatorService } from './commands/CommandItemCategoryValidator.service';
-import { TransformerInjectable } from '../Transformer/TransformerInjectable.service';
-import { TenancyContext } from '../Tenancy/TenancyContext.service';
+import { TenancyModule } from '../Tenancy/Tenancy.module';
 import { GetItemCategoriesService } from './queries/GetItemCategories.service';
 import { DynamicListModule } from '../DynamicListing/DynamicList.module';
 import { ItemCategoriesExportable } from './ItemCategoriesExportable';
 import { ItemCategoriesImportable } from './ItemCategoriesImportable';
 
 @Module({
-  imports: [TenancyDatabaseModule, DynamicListModule],
+  imports: [TenancyModule, TenancyDatabaseModule, DynamicListModule],
   controllers: [ItemCategoryController],
   providers: [
     CreateItemCategoryService,
@@ -25,8 +24,6 @@ import { ItemCategoriesImportable } from './ItemCategoriesImportable';
     DeleteItemCategoryService,
     ItemCategoryApplication,
     CommandItemCategoryValidatorService,
-    TransformerInjectable,
-    TenancyContext,
     ItemCategoriesExportable,
     ItemCategoriesImportable,
   ],

--- a/packages/server/src/modules/Items/Items.module.ts
+++ b/packages/server/src/modules/Items/Items.module.ts
@@ -4,14 +4,13 @@ import { CreateItemService } from './CreateItem.service';
 import { TenancyDatabaseModule } from '../Tenancy/TenancyDB/TenancyDB.module';
 import { ItemsValidators } from './ItemValidator.service';
 import { DeleteItemService } from './DeleteItem.service';
-import { TenancyContext } from '../Tenancy/TenancyContext.service';
+import { TenancyModule } from '../Tenancy/Tenancy.module';
 import { EditItemService } from './EditItem.service';
 import { InactivateItem } from './InactivateItem.service';
 import { ActivateItemService } from './ActivateItem.service';
 import { ItemsApplicationService } from './ItemsApplication.service';
 import { ItemTransactionsService } from './ItemTransactions.service';
 import { GetItemService } from './GetItem.service';
-import { TransformerInjectable } from '../Transformer/TransformerInjectable.service';
 import { ItemsEntriesService } from './ItemsEntries.service';
 import { GetItemsService } from './GetItems.service';
 import { DynamicListModule } from '../DynamicListing/DynamicList.module';
@@ -23,6 +22,7 @@ import { ValidateBulkDeleteItemsService } from './ValidateBulkDeleteItems.servic
 
 @Module({
   imports: [
+    TenancyModule,
     TenancyDatabaseModule,
     DynamicListModule,
     InventoryAdjustmentsModule,
@@ -39,8 +39,6 @@ import { ValidateBulkDeleteItemsService } from './ValidateBulkDeleteItems.servic
     GetItemService,
     GetItemsService,
     ItemTransactionsService,
-    TenancyContext,
-    TransformerInjectable,
     ItemsEntriesService,
     ItemsExportable,
     ItemsImportable,

--- a/packages/server/src/modules/Ledger/Ledger.module.ts
+++ b/packages/server/src/modules/Ledger/Ledger.module.ts
@@ -3,19 +3,18 @@ import { LedgerStorageService } from './LedgerStorage.service';
 import { LedgerEntriesStorageService } from './LedgerEntriesStorage.service';
 import { LedgerRevertService } from './LedgerStorageRevert.service';
 import { LedgerContactsBalanceStorage } from './LedgerContactStorage.service';
-import { TenancyContext } from '../Tenancy/TenancyContext.service';
+import { TenancyModule } from '../Tenancy/Tenancy.module';
 import { LedegrAccountsStorage } from './LedgetAccountStorage.service';
 import { AccountsModule } from '../Accounts/Accounts.module';
 
 @Module({
-  imports: [AccountsModule],
+  imports: [TenancyModule, AccountsModule],
   providers: [
     LedgerStorageService,
     LedgerEntriesStorageService,
     LedgerRevertService,
     LedgerContactsBalanceStorage,
     LedegrAccountsStorage,
-    TenancyContext,
   ],
   exports: [
     LedgerStorageService,

--- a/packages/server/src/modules/MailNotification/MailNotification.module.ts
+++ b/packages/server/src/modules/MailNotification/MailNotification.module.ts
@@ -1,11 +1,11 @@
 import { Module } from '@nestjs/common';
 import { ContactMailNotification } from './ContactMailNotification';
 import { MailTenancyModule } from '../MailTenancy/MailTenancy.module';
-import { TenancyContext } from '../Tenancy/TenancyContext.service';
+import { TenancyModule } from '../Tenancy/Tenancy.module';
 
 @Module({
-  imports: [MailTenancyModule],
-  providers: [ContactMailNotification, TenancyContext],
+  imports: [TenancyModule, MailTenancyModule],
+  providers: [ContactMailNotification],
   exports: [ContactMailNotification],
 })
 export class MailNotificationModule {}

--- a/packages/server/src/modules/MailTenancy/MailTenancy.module.ts
+++ b/packages/server/src/modules/MailTenancy/MailTenancy.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { MailTenancy } from './MailTenancy.service';
-import { TenancyContext } from '../Tenancy/TenancyContext.service';
+import { TenancyModule } from '../Tenancy/Tenancy.module';
 
 @Module({
-  providers: [MailTenancy, TenancyContext],
+  imports: [TenancyModule],
+  providers: [MailTenancy],
   exports: [MailTenancy],
 })
 export class MailTenancyModule {}

--- a/packages/server/src/modules/ManualJournals/ManualJournals.module.ts
+++ b/packages/server/src/modules/ManualJournals/ManualJournals.module.ts
@@ -6,7 +6,7 @@ import { PublishManualJournal } from './commands/PublishManualJournal.service';
 import { CommandManualJournalValidators } from './commands/CommandManualJournalValidators.service';
 import { AutoIncrementManualJournal } from './commands/AutoIncrementManualJournal.service';
 import { ManualJournalBranchesDTOTransformer } from '../Branches/integrations/ManualJournals/ManualJournalDTOTransformer.service';
-import { TenancyContext } from '../Tenancy/TenancyContext.service';
+import { TenancyModule } from '../Tenancy/Tenancy.module';
 import { AutoIncrementOrdersService } from '../AutoIncrementOrders/AutoIncrementOrders.service';
 import { BranchesModule } from '../Branches/Branches.module';
 import { ManualJournalsController } from './ManualJournals.controller';
@@ -23,10 +23,9 @@ import { BulkDeleteManualJournalsService } from './BulkDeleteManualJournals.serv
 import { ValidateBulkDeleteManualJournalsService } from './ValidateBulkDeleteManualJournals.service';
 
 @Module({
-  imports: [BranchesModule, LedgerModule, DynamicListModule],
+  imports: [TenancyModule, BranchesModule, LedgerModule, DynamicListModule],
   controllers: [ManualJournalsController],
   providers: [
-    TenancyContext,
     CreateManualJournalService,
     EditManualJournal,
     DeleteManualJournalService,

--- a/packages/server/src/modules/Organization/Organization.module.ts
+++ b/packages/server/src/modules/Organization/Organization.module.ts
@@ -9,7 +9,7 @@ import { BullModule } from '@nestjs/bullmq';
 import { OrganizationBuildQueue } from './Organization.types';
 import { OrganizationBuildProcessor } from './processors/OrganizationBuild.processor';
 import { CommandOrganizationValidators } from './commands/CommandOrganizationValidators.service';
-import { TenancyContext } from '../Tenancy/TenancyContext.service';
+import { TenancyModule } from '../Tenancy/Tenancy.module';
 import { TenantDBManagerModule } from '../TenantDBManager/TenantDBManager.module';
 import { OrganizationBaseCurrencyLocking } from './Organization/OrganizationBaseCurrencyLocking.service';
 import { SyncSystemUserToTenantService } from './commands/SyncSystemUserToTenant.service';
@@ -22,7 +22,6 @@ import { OrganizationBuiltSubscriber } from './subscribers/OrganizationBuilt.sub
 
 @Module({
   providers: [
-    TenancyContext,
     GetCurrentOrganizationService,
     BuildOrganizationService,
     UpdateOrganizationService,
@@ -35,6 +34,7 @@ import { OrganizationBuiltSubscriber } from './subscribers/OrganizationBuilt.sub
     OrganizationBuiltSubscriber,
   ],
   imports: [
+    TenancyModule,
     BullModule.registerQueue({ name: OrganizationBuildQueue }),
     BullBoardModule.forFeature({
       name: OrganizationBuildQueue,

--- a/packages/server/src/modules/PaymentLinks/PaymentLinks.module.ts
+++ b/packages/server/src/modules/PaymentLinks/PaymentLinks.module.ts
@@ -8,18 +8,18 @@ import { PaymentLink } from './models/PaymentLink';
 import { StripePaymentModule } from '../StripePayment/StripePayment.module';
 import { SaleInvoicesModule } from '../SaleInvoices/SaleInvoices.module';
 import { GetInvoicePaymentLinkMetadata } from './GetInvoicePaymentLinkMetadata';
-import { TenancyContext } from '../Tenancy/TenancyContext.service';
+import { TenancyModule } from '../Tenancy/Tenancy.module';
 
 const models = [InjectSystemModel(PaymentLink)];
 
 @Module({
   imports: [
+    TenancyModule,
     forwardRef(() => StripePaymentModule),
     forwardRef(() => SaleInvoicesModule),
   ],
   providers: [
     ...models,
-    TenancyContext,
     CreateInvoiceCheckoutSession,
     GetPaymentLinkInvoicePdf,
     PaymentLinksApplication,

--- a/packages/server/src/modules/PaymentReceived/PaymentsReceived.module.ts
+++ b/packages/server/src/modules/PaymentReceived/PaymentsReceived.module.ts
@@ -13,7 +13,7 @@ import { GetPaymentReceivedInvoices } from './queries/GetPaymentReceivedInvoices
 import { GetPaymentReceivedPdfService } from './queries/GetPaymentReceivedPdf.service';
 import { PaymentReceivedValidators } from './commands/PaymentReceivedValidators.service';
 import { PaymentReceiveDTOTransformer } from './commands/PaymentReceivedDTOTransformer';
-import { TenancyContext } from '../Tenancy/TenancyContext.service';
+import { TenancyModule } from '../Tenancy/Tenancy.module';
 import { ChromiumlyTenancyModule } from '../ChromiumlyTenancy/ChromiumlyTenancy.module';
 import { TemplateInjectableModule } from '../TemplateInjectable/TemplateInjectable.module';
 import { PaymentReceivedBrandingTemplate } from './queries/PaymentReceivedBrandingTemplate.service';
@@ -60,7 +60,6 @@ import { ValidateBulkDeletePaymentReceivedService } from './ValidateBulkDeletePa
     PaymentReceivedBrandingTemplate,
     PaymentReceivedIncrement,
     PaymentReceivedGLEntries,
-    TenancyContext,
     PaymentReceivedInvoiceSync,
     PaymentReceivedAutoIncrementSubscriber,
     PaymentReceivedGLEntriesSubscriber,
@@ -85,6 +84,7 @@ import { ValidateBulkDeletePaymentReceivedService } from './ValidateBulkDeletePa
     PaymentReceivedValidators,
   ],
   imports: [
+    TenancyModule,
     ChromiumlyTenancyModule,
     TemplateInjectableModule,
     BranchesModule,

--- a/packages/server/src/modules/PdfTemplate/PdfTemplates.module.ts
+++ b/packages/server/src/modules/PdfTemplate/PdfTemplates.module.ts
@@ -1,7 +1,6 @@
 import { Module } from '@nestjs/common';
-import { TenancyContext } from '../Tenancy/TenancyContext.service';
+import { TenancyModule } from '../Tenancy/Tenancy.module';
 import { TenancyDatabaseModule } from '../Tenancy/TenancyDB/TenancyDB.module';
-import { TransformerInjectable } from '../Transformer/TransformerInjectable.service';
 import { AssignPdfTemplateDefaultService } from './commands/AssignPdfTemplateDefault.service';
 import { CreatePdfTemplateService } from './commands/CreatePdfTemplate.service';
 import { DeletePdfTemplateService } from './commands/DeletePdfTemplate.service';
@@ -21,7 +20,7 @@ import { AttachmentsModule } from '../Attachments/Attachment.module';
     BrandingTemplateDTOTransformer,
     GetOrganizationBrandingAttributesService,
   ],
-  imports: [TenancyDatabaseModule, AttachmentsModule],
+  imports: [TenancyModule, TenancyDatabaseModule, AttachmentsModule],
   controllers: [PdfTemplatesController],
   providers: [
     PdfTemplateApplication,
@@ -31,8 +30,6 @@ import { AttachmentsModule } from '../Attachments/Attachment.module';
     GetPdfTemplates,
     EditPdfTemplateService,
     AssignPdfTemplateDefaultService,
-    TenancyContext,
-    TransformerInjectable,
     BrandingTemplateDTOTransformer,
     GetOrganizationBrandingAttributesService,
     GetPdfTemplateBrandingState,

--- a/packages/server/src/modules/SaleEstimates/SaleEstimates.module.ts
+++ b/packages/server/src/modules/SaleEstimates/SaleEstimates.module.ts
@@ -2,9 +2,8 @@ import { Module } from '@nestjs/common';
 import { BullBoardModule } from '@bull-board/nestjs';
 import { BullMQAdapter } from '@bull-board/api/bullMQAdapter';
 import { BullModule } from '@nestjs/bullmq';
-import { TenancyContext } from '../Tenancy/TenancyContext.service';
+import { TenancyModule } from '../Tenancy/Tenancy.module';
 import { TenancyDatabaseModule } from '../Tenancy/TenancyDB/TenancyDB.module';
-import { TransformerInjectable } from '../Transformer/TransformerInjectable.service';
 import { ApproveSaleEstimateService } from './commands/ApproveSaleEstimate.service';
 import { ConvertSaleEstimate } from './commands/ConvetSaleEstimate.service';
 import { CreateSaleEstimate } from './commands/CreateSaleEstimate.service';
@@ -48,6 +47,7 @@ import { SendSaleEstimateMailProcess } from './processes/SendSaleEstimateMail.pr
 
 @Module({
   imports: [
+    TenancyModule,
     TenancyDatabaseModule,
     DynamicListModule,
     MailNotificationModule,
@@ -83,8 +83,6 @@ import { SendSaleEstimateMailProcess } from './processes/SendSaleEstimateMail.pr
     BranchTransactionDTOTransformer,
     WarehouseTransactionDTOTransform,
     SaleEstimateDTOTransformer,
-    TenancyContext,
-    TransformerInjectable,
     SaleEstimatesApplication,
     SendSaleEstimateMail,
     GetSaleEstimatePdf,

--- a/packages/server/src/modules/SaleInvoices/SaleInvoices.module.ts
+++ b/packages/server/src/modules/SaleInvoices/SaleInvoices.module.ts
@@ -1,7 +1,6 @@
 import { forwardRef, Module } from '@nestjs/common';
-import { TenancyContext } from '../Tenancy/TenancyContext.service';
+import { TenancyModule } from '../Tenancy/Tenancy.module';
 import { TenancyDatabaseModule } from '../Tenancy/TenancyDB/TenancyDB.module';
-import { TransformerInjectable } from '../Transformer/TransformerInjectable.service';
 import { CreateSaleInvoice } from './commands/CreateSaleInvoice.service';
 import { DeleteSaleInvoice } from './commands/DeleteSaleInvoice.service';
 import { DeliverSaleInvoice } from './commands/DeliverSaleInvoice.service';
@@ -67,6 +66,7 @@ import { ValidateBulkDeleteSaleInvoicesService } from './ValidateBulkDeleteSaleI
 
 @Module({
   imports: [
+    TenancyModule,
     TenancyDatabaseModule,
     PdfTemplatesModule,
     AutoIncrementOrdersModule,
@@ -103,8 +103,6 @@ import { ValidateBulkDeleteSaleInvoicesService } from './ValidateBulkDeleteSaleI
     GetInvoicePaymentMail,
     SaleInvoicePdf,
     SaleInvoiceApplication,
-    TenancyContext,
-    TransformerInjectable,
     ItemsEntriesService,
     CommandSaleInvoiceValidators,
     CommandSaleInvoiceDTOTransformer,

--- a/packages/server/src/modules/SaleReceipts/SaleReceipts.module.ts
+++ b/packages/server/src/modules/SaleReceipts/SaleReceipts.module.ts
@@ -15,7 +15,7 @@ import { SaleReceiptDTOTransformer } from './commands/SaleReceiptDTOTransformer.
 import { SaleReceiptValidators } from './commands/SaleReceiptValidators.service';
 import { ChromiumlyTenancyModule } from '../ChromiumlyTenancy/ChromiumlyTenancy.module';
 import { TemplateInjectableModule } from '../TemplateInjectable/TemplateInjectable.module';
-import { TenancyContext } from '../Tenancy/TenancyContext.service';
+import { TenancyModule } from '../Tenancy/Tenancy.module';
 import { SaleReceiptBrandingTemplate } from './queries/SaleReceiptBrandingTemplate.service';
 import { BranchesModule } from '../Branches/Branches.module';
 import { WarehousesModule } from '../Warehouses/Warehouses.module';
@@ -50,6 +50,7 @@ import { ValidateBulkDeleteSaleReceiptsService } from './ValidateBulkDeleteSaleR
 @Module({
   controllers: [SaleReceiptsController],
   imports: [
+    TenancyModule,
     ItemsModule,
     ChromiumlyTenancyModule,
     TemplateInjectableModule,
@@ -70,7 +71,6 @@ import { ValidateBulkDeleteSaleReceiptsService } from './ValidateBulkDeleteSaleR
     }),
   ],
   providers: [
-    TenancyContext,
     SaleReceiptValidators,
     SaleReceiptApplication,
     CreateSaleReceipt,

--- a/packages/server/src/modules/StripePayment/StripePayment.module.ts
+++ b/packages/server/src/modules/StripePayment/StripePayment.module.ts
@@ -13,10 +13,11 @@ import { AccountsModule } from '../Accounts/Accounts.module';
 import { CreatePaymentReceiveStripePayment } from './CreatePaymentReceivedStripePayment';
 import { SaleInvoicesModule } from '../SaleInvoices/SaleInvoices.module';
 import { PaymentsReceivedModule } from '../PaymentReceived/PaymentsReceived.module';
-import { TenancyContext } from '../Tenancy/TenancyContext.service';
+import { TenancyModule } from '../Tenancy/Tenancy.module';
 
 @Module({
   imports: [
+    TenancyModule,
     AccountsModule,
     PaymentsReceivedModule,
     forwardRef(() => SaleInvoicesModule),
@@ -31,7 +32,6 @@ import { TenancyContext } from '../Tenancy/TenancyContext.service';
     CreatePaymentReceiveStripePayment,
     SeedStripeAccountsOnOAuthGrantedSubscriber,
     StripeWebhooksSubscriber,
-    TenancyContext,
   ],
   exports: [StripePaymentService, GetStripeAuthorizationLinkService],
   controllers: [StripeIntegrationController, StripePaymentWebhooksController],

--- a/packages/server/src/modules/Subscription/Subscription.module.ts
+++ b/packages/server/src/modules/Subscription/Subscription.module.ts
@@ -17,7 +17,7 @@ import { MarkSubscriptionPlanChanged } from './commands/MarkSubscriptionChanged.
 import { MarkSubscriptionResumedService } from './commands/MarkSubscriptionResumed.sevice';
 import { Plan } from './models/Plan';
 import { SubscriptionApplication } from './SubscriptionApplication';
-import { TenancyContext } from '../Tenancy/TenancyContext.service';
+import { TenancyModule } from '../Tenancy/Tenancy.module';
 import { NewSubscriptionService } from './commands/NewSubscription.service';
 import { GetSubscriptionsService } from './queries/GetSubscriptions.service';
 import { GetLemonSqueezyCheckoutService } from './queries/GetLemonSqueezyCheckout.service';
@@ -26,10 +26,9 @@ import { PlanSubscriptionRepository } from './repositories/PlanSubscription.repo
 const models = [InjectSystemModel(Plan), InjectSystemModel(PlanSubscription)];
 
 @Module({
-  imports: [SocketModule],
+  imports: [TenancyModule, SocketModule],
   providers: [
     ...models,
-    TenancyContext,
     PlanSubscriptionRepository,
     NewSubscriptionService,
     GetSubscriptionsService,

--- a/packages/server/src/modules/TaxRates/TaxRate.module.ts
+++ b/packages/server/src/modules/TaxRates/TaxRate.module.ts
@@ -1,5 +1,4 @@
 import { Module } from '@nestjs/common';
-import { TransformerInjectable } from '../Transformer/TransformerInjectable.service';
 import { TaxRatesController } from './TaxRate.controller';
 import { CreateTaxRate } from './commands/CreateTaxRate.service';
 import { InactivateTaxRateService } from './commands/InactivateTaxRate';
@@ -8,7 +7,7 @@ import { GetTaxRateService } from './queries/GetTaxRate.service';
 import { DeleteTaxRateService } from './commands/DeleteTaxRate.service';
 import { EditTaxRateService } from './commands/EditTaxRate.service';
 import { CommandTaxRatesValidators } from './commands/CommandTaxRatesValidator.service';
-import { TenancyContext } from '../Tenancy/TenancyContext.service';
+import { TenancyModule } from '../Tenancy/Tenancy.module';
 import { TaxRatesApplication } from './TaxRate.application';
 import { ItemEntriesTaxTransactions } from './ItemEntriesTaxTransactions.service';
 import { GetTaxRatesService } from './queries/GetTaxRates.service';
@@ -27,7 +26,7 @@ import { TaxRatesImportable } from './TaxRatesImportable';
 const models = [RegisterTenancyModel(TaxRateTransaction)];
 
 @Module({
-  imports: [...models],
+  imports: [TenancyModule, ...models],
   controllers: [TaxRatesController],
   providers: [
     CreateTaxRate,
@@ -38,8 +37,6 @@ const models = [RegisterTenancyModel(TaxRateTransaction)];
     ActivateTaxRateService,
     InactivateTaxRateService,
     CommandTaxRatesValidators,
-    TransformerInjectable,
-    TenancyContext,
     TaxRatesApplication,
     ItemEntriesTaxTransactions,
     WriteBillTaxTransactionsSubscriber,

--- a/packages/server/src/modules/TemplateInjectable/TemplateInjectable.module.ts
+++ b/packages/server/src/modules/TemplateInjectable/TemplateInjectable.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { TemplateInjectable } from './TemplateInjectable.service';
-import { TenancyContext } from '../Tenancy/TenancyContext.service';
+import { TenancyModule } from '../Tenancy/Tenancy.module';
 
 @Module({
-  providers: [TemplateInjectable, TenancyContext],
+  imports: [TenancyModule],
+  providers: [TemplateInjectable],
   exports: [TemplateInjectable],
 })
 export class TemplateInjectableModule {}

--- a/packages/server/src/modules/TenantDBManager/TenantDBManager.module.ts
+++ b/packages/server/src/modules/TenantDBManager/TenantDBManager.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { TenantsManagerService } from './TenantsManager';
 import { TenantDBManager } from './TenantDBManager';
-import { TenancyContext } from '../Tenancy/TenancyContext.service';
+import { TenancyModule } from '../Tenancy/Tenancy.module';
 
 @Module({
-  providers: [TenancyContext, TenantsManagerService, TenantDBManager],
+  imports: [TenancyModule],
+  providers: [TenantsManagerService, TenantDBManager],
   exports: [TenantsManagerService, TenantDBManager],
 })
 export class TenantDBManagerModule {}

--- a/packages/server/src/modules/Transformer/Transformer.module.ts
+++ b/packages/server/src/modules/Transformer/Transformer.module.ts
@@ -1,11 +1,11 @@
 import { Global, Module } from '@nestjs/common';
 import { TransformerInjectable } from './TransformerInjectable.service';
-import { TenancyContext } from '../Tenancy/TenancyContext.service';
+import { TenancyModule } from '../Tenancy/Tenancy.module';
 
 @Global()
 @Module({
-  providers: [TransformerInjectable, TenancyContext],
+  providers: [TransformerInjectable],
   exports: [TransformerInjectable],
-  imports: [],
+  imports: [TenancyModule],
 })
 export class TransformerModule {}

--- a/packages/server/src/modules/Vendors/Vendors.module.ts
+++ b/packages/server/src/modules/Vendors/Vendors.module.ts
@@ -1,6 +1,5 @@
 import { Module } from '@nestjs/common';
 import { TenancyDatabaseModule } from '../Tenancy/TenancyDB/TenancyDB.module';
-import { TransformerInjectable } from '../Transformer/TransformerInjectable.service';
 import { ActivateVendorService } from './commands/ActivateVendor.service';
 import { CreateEditVendorDTOService } from './commands/CreateEditVendorDTO';
 import { CreateVendorService } from './commands/CreateVendor.service';
@@ -10,7 +9,7 @@ import { EditVendorService } from './commands/EditVendor.service';
 import { GetVendorService } from './queries/GetVendor';
 import { VendorValidators } from './commands/VendorValidators';
 import { VendorsApplication } from './VendorsApplication.service';
-import { TenancyContext } from '../Tenancy/TenancyContext.service';
+import { TenancyModule } from '../Tenancy/Tenancy.module';
 import { VendorsController } from './Vendors.controller';
 import { GetVendorsService } from './queries/GetVendors.service';
 import { DynamicListModule } from '../DynamicListing/DynamicList.module';
@@ -26,6 +25,7 @@ import { VendorsWriteGLOpeningSubscriber } from './subscribers/VendorGLEntriesSu
 
 @Module({
   imports: [
+    TenancyModule,
     TenancyDatabaseModule,
     DynamicListModule,
     LedgerModule,
@@ -45,8 +45,6 @@ import { VendorsWriteGLOpeningSubscriber } from './subscribers/VendorGLEntriesSu
     VendorsApplication,
     BulkDeleteVendorsService,
     ValidateBulkDeleteVendorsService,
-    TransformerInjectable,
-    TenancyContext,
     VendorsExportable,
     VendorsImportable,
     VendorGLEntries,

--- a/packages/server/src/modules/Warehouses/Warehouses.module.ts
+++ b/packages/server/src/modules/Warehouses/Warehouses.module.ts
@@ -1,8 +1,7 @@
 import { Module } from '@nestjs/common';
 import { I18nContext } from 'nestjs-i18n';
 import { TenancyDatabaseModule } from '../Tenancy/TenancyDB/TenancyDB.module';
-import { TenancyContext } from '../Tenancy/TenancyContext.service';
-import { TransformerInjectable } from '../Transformer/TransformerInjectable.service';
+import { TenancyModule } from '../Tenancy/Tenancy.module';
 import { CreateWarehouse } from './commands/CreateWarehouse.service';
 import { EditWarehouse } from './commands/EditWarehouse.service';
 import { DeleteWarehouseService } from './commands/DeleteWarehouse.service';
@@ -47,7 +46,7 @@ import { ValidateWarehouseExistance } from './Integrations/ValidateWarehouseExis
 const models = [RegisterTenancyModel(Warehouse)];
 
 @Module({
-  imports: [TenancyDatabaseModule, ...models],
+  imports: [TenancyModule, TenancyDatabaseModule, ...models],
   controllers: [WarehousesController, WarehouseItemsController],
   providers: [
     CreateWarehouse,
@@ -63,8 +62,6 @@ const models = [RegisterTenancyModel(Warehouse)];
     CreateInitialWarehouse,
     WarehousesSettings,
     I18nContext,
-    TenancyContext,
-    TransformerInjectable,
     WarehouseTransactionDTOTransform,
     BillsActivateWarehousesSubscriber,
     CreditsActivateWarehousesSubscriber,


### PR DESCRIPTION
## What changed
- Replaced direct `TenancyContext` and `TransformerInjectable` provider registrations with `TenancyModule` import across 47+ NestJS server modules
- Eliminates duplicated provider declarations and centralizes tenancy context wiring through the module system

## Why
Consolidating these repeated manual provider registrations reduces boilerplate and ensures consistent tenancy context availability through proper NestJS module composition rather than ad-hoc provider injection.

## Test plan
- [ ] Server starts without DI errors
- [ ] Smoke test key endpoints (accounts, invoices, bills, financial statements)

<!-- pr_agent:summary -->
<!-- pr_agent:walkthrough -->