### PR TITLE
fix(auth): replace weak uniqid reset token with crypto.randomBytes and fix broken expiry check (GHSA-qx24-x69m-97wr)

### DIFF
--- a/packages/server/src/common/config/auth.ts
+++ b/packages/server/src/common/config/auth.ts
@@ -1,0 +1,8 @@
+import { registerAs } from '@nestjs/config';
+
+export default registerAs('auth', () => ({
+  resetPasswordSeconds: parseInt(
+    process.env.RESET_PASSWORD_SECONDS ?? '3600',
+    10,
+  ),
+}));

--- a/packages/server/src/common/config/index.ts
+++ b/packages/server/src/common/config/index.ts
@@ -1,4 +1,5 @@
 import app from './app';
+import auth from './auth';
 import systemDatabase from './system-database';
 import tenantDatabase from './tenant-database';
 import signup from './signup';
@@ -23,6 +24,7 @@ import bullBoard from './bull-board';
 
 export const config = [
   app,
+  auth,
   systemDatabase,
   cloud,
   tenantDatabase,

--- a/packages/server/src/modules/Auth/commands/AuthResetPassword.service.ts
+++ b/packages/server/src/modules/Auth/commands/AuthResetPassword.service.ts
@@ -1,3 +1,4 @@
+import moment from 'moment';
 import { ConfigService } from '@nestjs/config';
 import { Inject, Injectable } from '@nestjs/common';
 import { SystemUser } from '@/modules/System/models/SystemUser';
@@ -44,7 +45,7 @@ export class AuthResetPasswordService {
     if (!tokenModel) {
       throw new ServiceError(ERRORS.TOKEN_INVALID);
     }
-    const resetPasswordSeconds = this.configService.get('resetPasswordSeconds');
+    const resetPasswordSeconds = this.configService.get<number>('auth.resetPasswordSeconds');
 
     // Different between tokne creation datetime and current time.
     if (moment().diff(tokenModel.createdAt, 'seconds') > resetPasswordSeconds) {

--- a/packages/server/src/modules/Auth/commands/AuthSendResetPassword.service.ts
+++ b/packages/server/src/modules/Auth/commands/AuthSendResetPassword.service.ts
@@ -1,5 +1,5 @@
+import * as crypto from 'crypto';
 import { Inject, Injectable } from '@nestjs/common';
-import * as uniqid from 'uniqid';
 import {
   IAuthSendedResetPassword,
   IAuthSendingResetPassword,
@@ -35,7 +35,7 @@ export class AuthSendResetPasswordService {
 
     if (!user) return;
 
-    const token: string = uniqid();
+    const token: string = crypto.randomBytes(32).toString('hex');
 
     // Triggers sending reset password event.
     await this.eventPublisher.emitAsync(events.auth.sendingResetPassword, {
@@ -44,7 +44,7 @@ export class AuthSendResetPasswordService {
     } as IAuthSendingResetPassword);
 
     // Delete all stored tokens of reset password that associate to the give email.
-    this.deletePasswordResetToken(email);
+    await this.deletePasswordResetToken(email);
 
     // Creates a new password reset row with unique token.
     await this.resetPasswordModel.query().insert({ email, token });


### PR DESCRIPTION
## Description

<!-- pr_agent:summary -->

Fixes three compounding security vulnerabilities in the password reset flow reported in GHSA-qx24-x69m-97wr (CVSS 8.1 High).

**Bug 1 — Weak token generator**
`uniqid()` produces a time-based, ~42-bit hex token derived from `Date.now()` + `process.pid`. An attacker who knows the approximate reset time can enumerate the token space in seconds. Replaced with `crypto.randomBytes(32).toString('hex')` — the same approach already used for signup verification tokens (`AuthSignup.service.ts`).

**Bug 2 — Crash on every reset attempt (HTTP 500)**
`moment` was not imported in `AuthResetPassword.service.ts`, causing `ReferenceError: moment is not defined` on every call to `/api/auth/reset_password/:token`. Password reset was completely non-functional for all users.

**Bug 3 — Tokens never expire**
`resetPasswordSeconds` was referenced via `configService.get('resetPasswordSeconds')` but was never registered in any config module, so it always returned `undefined`. The expiry comparison `n > undefined` evaluates to `false` in JavaScript, making all tokens permanently valid. Added a dedicated `auth` config namespace with a `resetPasswordSeconds` key defaulting to 3600 s (1 hour), overridable via `RESET_PASSWORD_SECONDS` env var.

**Bug 4 — Race condition (unawaited delete)**
`deletePasswordResetToken()` was called without `await`, allowing two concurrent reset requests to produce two simultaneously valid tokens. Added the missing `await`.

## Changes

<!-- pr_agent:walkthrough -->

| File | Change |
|------|--------|
| `AuthSendResetPassword.service.ts` | Replace `uniqid()` with `crypto.randomBytes(32).toString('hex')`; add `await` on token deletion |
| `AuthResetPassword.service.ts` | Add `import moment from 'moment'`; fix config key to `auth.resetPasswordSeconds` |
| `common/config/auth.ts` | New config — registers `auth.resetPasswordSeconds` (default 3600 s) |
| `common/config/index.ts` | Register the new `auth` config |

## Security Advisory

- GHSA-qx24-x69m-97wr
- CWE-338 (Weak PRNG), CWE-476 (Null Dereference / missing import), CWE-613 (Insufficient Session Expiration)

## Test plan

- [ ] Request a password reset — token in DB is now 64 hex characters (256-bit)
- [ ] Use the token within 1 hour → password changes (HTTP 200)
- [ ] Use the token after 1 hour → HTTP 4xx `TOKEN_EXPIRED`
- [ ] Use an invalid/old token → HTTP 4xx `TOKEN_INVALID`
- [ ] No more HTTP 500 on `POST /api/auth/reset_password/:token`
- [ ] Concurrent reset requests leave only one valid token (race condition fixed)