### PR TITLE
refactor(webapp): simplify financial statements export progress toast

### DIFF
--- a/packages/webapp/src/containers/FinancialStatements/APAgingSummary/components.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/APAgingSummary/components.tsx
@@ -1,4 +1,3 @@
-import { useRef } from 'react';
 import classNames from 'classnames';
 import { AppToaster, If, Stack } from '@/components';
 import { FinancialLoadingBar } from '../FinancialLoadingBar';
@@ -16,6 +15,10 @@ import {
   useAPAgingSheetCsvExport,
   useAPAgingSheetXlsxExport,
 } from '@/hooks/query';
+import type {
+  PayableAgingXlsxQuery,
+  PayableAgingCsvQuery,
+} from '@bigcapital/sdk-ts';
 
 export const useAPAgingSummaryColumns = () => {
   const { APAgingSummary } = useAPAgingSummaryContext();
@@ -37,70 +40,54 @@ export function APAgingSummarySheetLoadingBar() {
 }
 
 export function APAgingSummaryExportMenu() {
-  const toastKey = useRef<string | undefined>(undefined);
   const commonToastConfig = { isCloseButtonShown: true, timeout: 2000 };
   const { httpQuery } = useAPAgingSummaryContext();
 
-  const openProgressToast = (amount: number) => {
+  const renderToast = (done: boolean) => {
     return (
       <Stack spacing={8}>
-        <Text>The report has been exported successfully.</Text>
+        <Text>
+          {done
+            ? 'The report has been exported successfully.'
+            : 'Exporting the report…'}
+        </Text>
         <ProgressBar
           className={classNames('toast-progress', {
-            [Classes.PROGRESS_NO_STRIPES]: amount >= 100,
+            [Classes.PROGRESS_NO_STRIPES]: done,
           })}
-          intent={amount < 100 ? Intent.PRIMARY : Intent.SUCCESS}
-          value={amount / 100}
+          intent={done ? Intent.SUCCESS : Intent.PRIMARY}
+          value={done ? 1 : undefined}
         />
       </Stack>
     );
   };
 
-  const { mutateAsync: xlsxExport } = useAPAgingSheetXlsxExport(httpQuery, {
-    onDownloadProgress: (xlsxExportProgress: number) => {
-      if (!toastKey.current) {
-        toastKey.current = AppToaster.show({
-          message: openProgressToast(xlsxExportProgress),
-          ...commonToastConfig,
-        });
-      } else {
-        AppToaster.show(
-          {
-            message: openProgressToast(xlsxExportProgress),
-            ...commonToastConfig,
-          },
-          toastKey.current,
-        );
-      }
-    },
-  });
+  const { mutateAsync: xlsxExport } = useAPAgingSheetXlsxExport(
+    httpQuery as PayableAgingXlsxQuery,
+  );
+  const { mutateAsync: csvExport } = useAPAgingSheetCsvExport(
+    httpQuery as PayableAgingCsvQuery,
+  );
 
-  const { mutateAsync: csvExport } = useAPAgingSheetCsvExport(httpQuery, {
-    onDownloadProgress: (xlsxExportProgress: number) => {
-      if (!toastKey.current) {
-        toastKey.current = AppToaster.show({
-          message: openProgressToast(xlsxExportProgress),
-          ...commonToastConfig,
-        });
-      } else {
-        AppToaster.show(
-          {
-            message: openProgressToast(xlsxExportProgress),
-            ...commonToastConfig,
-          },
-          toastKey.current,
-        );
-      }
-    },
-  });
-
-  const handleCsvExportBtnClick = () => {
-    csvExport();
+  const runExport = async (mutate: () => Promise<unknown>) => {
+    const key = AppToaster.show({
+      message: renderToast(false),
+      ...commonToastConfig,
+      timeout: 0,
+    });
+    try {
+      await mutate();
+      AppToaster.show(
+        { message: renderToast(true), ...commonToastConfig },
+        key,
+      );
+    } catch {
+      AppToaster.dismiss(key);
+    }
   };
 
-  const handleXlsxExportBtnClick = () => {
-    xlsxExport();
-  };
+  const handleCsvExportBtnClick = () => runExport(csvExport);
+  const handleXlsxExportBtnClick = () => runExport(xlsxExport);
 
   return (
     <Menu>

--- a/packages/webapp/src/containers/FinancialStatements/ARAgingSummary/components.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/ARAgingSummary/components.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React from 'react';
 import classNames from 'classnames';
 import {
   Classes,
@@ -17,6 +17,10 @@ import {
   useARAgingSheetCsvExport,
   useARAgingSheetXlsxExport,
 } from '@/hooks/query';
+import type {
+  ReceivableAgingXlsxQuery,
+  ReceivableAgingCsvQuery,
+} from '@bigcapital/sdk-ts';
 
 export const useARAgingSummaryColumns = () => {
   const { ARAgingSummary } = useARAgingSummaryContext();
@@ -38,72 +42,57 @@ export function ARAgingSummarySheetLoadingBar() {
 }
 
 export function ARAgingSummaryExportMenu() {
-  const toastKey = useRef<string | undefined>(undefined);
   const commonToastConfig = {
     isCloseButtonShown: true,
     timeout: 2000,
   };
   const { httpQuery } = useARAgingSummaryContext();
 
-  const openProgressToast = (amount: number) => {
+  const renderToast = (done: boolean) => {
     return (
       <Stack spacing={8}>
-        <Text>The report has been exported successfully.</Text>
+        <Text>
+          {done
+            ? 'The report has been exported successfully.'
+            : 'Exporting the report…'}
+        </Text>
         <ProgressBar
           className={classNames('toast-progress', {
-            [Classes.PROGRESS_NO_STRIPES]: amount >= 100,
+            [Classes.PROGRESS_NO_STRIPES]: done,
           })}
-          intent={amount < 100 ? Intent.PRIMARY : Intent.SUCCESS}
-          value={amount / 100}
+          intent={done ? Intent.SUCCESS : Intent.PRIMARY}
+          value={done ? 1 : undefined}
         />
       </Stack>
     );
   };
 
-  const { mutateAsync: xlsxExport } = useARAgingSheetXlsxExport(httpQuery, {
-    onDownloadProgress: (xlsxExportProgress: number) => {
-      if (!toastKey.current) {
-        toastKey.current = AppToaster.show({
-          message: openProgressToast(xlsxExportProgress),
-          ...commonToastConfig,
-        });
-      } else {
-        AppToaster.show(
-          {
-            message: openProgressToast(xlsxExportProgress),
-            ...commonToastConfig,
-          },
-          toastKey.current,
-        );
-      }
-    },
-  });
+  const { mutateAsync: xlsxExport } = useARAgingSheetXlsxExport(
+    httpQuery as ReceivableAgingXlsxQuery,
+  );
+  const { mutateAsync: csvExport } = useARAgingSheetCsvExport(
+    httpQuery as ReceivableAgingCsvQuery,
+  );
 
-  const { mutateAsync: csvExport } = useARAgingSheetCsvExport(httpQuery, {
-    onDownloadProgress: (xlsxExportProgress: number) => {
-      if (!toastKey.current) {
-        toastKey.current = AppToaster.show({
-          message: openProgressToast(xlsxExportProgress),
-          ...commonToastConfig,
-        });
-      } else {
-        AppToaster.show(
-          {
-            message: openProgressToast(xlsxExportProgress),
-            ...commonToastConfig,
-          },
-          toastKey.current,
-        );
-      }
-    },
-  });
+  const runExport = async (mutate: () => Promise<unknown>) => {
+    const key = AppToaster.show({
+      message: renderToast(false),
+      ...commonToastConfig,
+      timeout: 0,
+    });
+    try {
+      await mutate();
+      AppToaster.show(
+        { message: renderToast(true), ...commonToastConfig },
+        key,
+      );
+    } catch {
+      AppToaster.dismiss(key);
+    }
+  };
 
-  const handleCsvExportBtnClick = () => {
-    csvExport();
-  };
-  const handleXlsxExportBtnClick = () => {
-    xlsxExport();
-  };
+  const handleCsvExportBtnClick = () => runExport(csvExport);
+  const handleXlsxExportBtnClick = () => runExport(xlsxExport);
 
   return (
     <Menu>

--- a/packages/webapp/src/containers/FinancialStatements/BalanceSheet/components.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/BalanceSheet/components.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React from 'react';
 import {
   Button,
   Classes,
@@ -26,6 +26,10 @@ import {
   useBalanceSheetCsvExport,
   useBalanceSheetXlsxExport,
 } from '@/hooks/query';
+import type {
+  BalanceSheetXlsxQuery,
+  BalanceSheetCsvQuery,
+} from '@bigcapital/sdk-ts';
 
 /**
  * Balance sheet alerts.
@@ -91,75 +95,57 @@ export const useBalanceSheetColumns = () => {
  * @returns {JSX.Element}
  */
 export const BalanceSheetExportMenu = () => {
-  const toastKey = useRef(null);
   const commonToastConfig = {
     isCloseButtonShown: true,
     timeout: 2000,
   };
   const { httpQuery } = useBalanceSheetContext();
 
-  const openProgressToast = (amount: number) => {
+  const renderToast = (done: boolean) => {
     return (
       <Stack spacing={8}>
-        <Text>The report has been exported successfully.</Text>
+        <Text>
+          {done
+            ? 'The report has been exported successfully.'
+            : 'Exporting the report…'}
+        </Text>
         <ProgressBar
           className={classNames('toast-progress', {
-            [Classes.PROGRESS_NO_STRIPES]: amount >= 100,
+            [Classes.PROGRESS_NO_STRIPES]: done,
           })}
-          intent={amount < 100 ? Intent.PRIMARY : Intent.SUCCESS}
-          value={amount / 100}
+          intent={done ? Intent.SUCCESS : Intent.PRIMARY}
+          value={done ? 1 : undefined}
         />
       </Stack>
     );
   };
 
-  // Export the report to xlsx.
-  const { mutateAsync: xlsxExport } = useBalanceSheetXlsxExport(httpQuery, {
-    onDownloadProgress: (xlsxExportProgress: number) => {
-      if (!toastKey.current) {
-        toastKey.current = AppToaster.show({
-          message: openProgressToast(xlsxExportProgress),
-          ...commonToastConfig,
-        });
-      } else {
-        AppToaster.show(
-          {
-            message: openProgressToast(xlsxExportProgress),
-            ...commonToastConfig,
-          },
-          toastKey.current,
-        );
-      }
-    },
-  });
+  const { mutateAsync: xlsxExport } = useBalanceSheetXlsxExport(
+    httpQuery as BalanceSheetXlsxQuery,
+  );
+  const { mutateAsync: csvExport } = useBalanceSheetCsvExport(
+    httpQuery as BalanceSheetCsvQuery,
+  );
 
-  // Export the report to csv.
-  const { mutateAsync: csvExport } = useBalanceSheetCsvExport(httpQuery, {
-    onDownloadProgress: (xlsxExportProgress: number) => {
-      if (!toastKey.current) {
-        toastKey.current = AppToaster.show({
-          message: openProgressToast(xlsxExportProgress),
-          ...commonToastConfig,
-        });
-      } else {
-        AppToaster.show(
-          {
-            message: openProgressToast(xlsxExportProgress),
-            ...commonToastConfig,
-          },
-          toastKey.current,
-        );
-      }
-    },
-  });
-  // Handle csv export button click.
-  const handleCsvExportBtnClick = () => {
-    csvExport().then(() => {});
+  const runExport = async (mutate: () => Promise<unknown>) => {
+    const key = AppToaster.show({
+      message: renderToast(false),
+      ...commonToastConfig,
+      timeout: 0,
+    });
+    try {
+      await mutate();
+      AppToaster.show(
+        { message: renderToast(true), ...commonToastConfig },
+        key,
+      );
+    } catch {
+      AppToaster.dismiss(key);
+    }
   };
-  // Handle xlsx export button click.
-  const handleXlsxExportBtnClick = () => {
-    xlsxExport().then(() => {});
-  };
+
+  const handleCsvExportBtnClick = () => runExport(csvExport);
+  const handleXlsxExportBtnClick = () => runExport(xlsxExport);
 
   return (
     <Menu>

--- a/packages/webapp/src/containers/FinancialStatements/CashFlowStatement/components.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/CashFlowStatement/components.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React from 'react';
 import {
   Button,
   Classes,
@@ -21,6 +21,10 @@ import {
   useCashFlowStatementCsvExport,
   useCashFlowStatementXlsxExport,
 } from '@/hooks/query';
+import type {
+  CashflowStatementXlsxQuery,
+  CashflowStatementCsvQuery,
+} from '@bigcapital/sdk-ts';
 import { FinancialLoadingBar } from '../FinancialLoadingBar';
 
 import { dynamicColumns } from './dynamicColumns';
@@ -91,78 +95,57 @@ export function CashFlowStatementAlerts() {
  * @returns {JSX.Element}
  */
 export function CashflowSheetExportMenu() {
-  const toastKey = useRef(null);
   const commonToastConfig = {
     isCloseButtonShown: true,
     timeout: 2000,
   };
   const { httpQuery } = useCashFlowStatementContext();
 
-  const openProgressToast = (amount: number) => {
+  const renderToast = (done: boolean) => {
     return (
       <Stack spacing={8}>
-        <Text>The report has been exported successfully.</Text>
+        <Text>
+          {done
+            ? 'The report has been exported successfully.'
+            : 'Exporting the report…'}
+        </Text>
         <ProgressBar
           className={classNames('toast-progress', {
-            [Classes.PROGRESS_NO_STRIPES]: amount >= 100,
+            [Classes.PROGRESS_NO_STRIPES]: done,
           })}
-          intent={amount < 100 ? Intent.PRIMARY : Intent.SUCCESS}
-          value={amount / 100}
+          intent={done ? Intent.SUCCESS : Intent.PRIMARY}
+          value={done ? 1 : undefined}
         />
       </Stack>
     );
   };
 
-  // Export the report to xlsx.
   const { mutateAsync: xlsxExport } = useCashFlowStatementXlsxExport(
-    httpQuery,
-    {
-      onDownloadProgress: (xlsxExportProgress: number) => {
-        if (!toastKey.current) {
-          toastKey.current = AppToaster.show({
-            message: openProgressToast(xlsxExportProgress),
-            ...commonToastConfig,
-          });
-        } else {
-          AppToaster.show(
-            {
-              message: openProgressToast(xlsxExportProgress),
-              ...commonToastConfig,
-            },
-            toastKey.current,
-          );
-        }
-      },
-    },
+    httpQuery as CashflowStatementXlsxQuery,
+  );
+  const { mutateAsync: csvExport } = useCashFlowStatementCsvExport(
+    httpQuery as CashflowStatementCsvQuery,
   );
 
-  // Export the report to csv.
-  const { mutateAsync: csvExport } = useCashFlowStatementCsvExport(httpQuery, {
-    onDownloadProgress: (xlsxExportProgress: number) => {
-      if (!toastKey.current) {
-        toastKey.current = AppToaster.show({
-          message: openProgressToast(xlsxExportProgress),
-          ...commonToastConfig,
-        });
-      } else {
-        AppToaster.show(
-          {
-            message: openProgressToast(xlsxExportProgress),
-            ...commonToastConfig,
-          },
-          toastKey.current,
-        );
-      }
-    },
-  });
-  // Handle csv export button click.
-  const handleCsvExportBtnClick = () => {
-    csvExport();
+  const runExport = async (mutate: () => Promise<unknown>) => {
+    const key = AppToaster.show({
+      message: renderToast(false),
+      ...commonToastConfig,
+      timeout: 0,
+    });
+    try {
+      await mutate();
+      AppToaster.show(
+        { message: renderToast(true), ...commonToastConfig },
+        key,
+      );
+    } catch {
+      AppToaster.dismiss(key);
+    }
   };
-  // Handle xlsx export button click.
-  const handleXlsxExportBtnClick = () => {
-    xlsxExport();
-  };
+
+  const handleCsvExportBtnClick = () => runExport(csvExport);
+  const handleXlsxExportBtnClick = () => runExport(xlsxExport);
 
   return (
     <Menu>

--- a/packages/webapp/src/containers/FinancialStatements/CustomersBalanceSummary/components.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/CustomersBalanceSummary/components.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React from 'react';
 import intl from 'react-intl-universal';
 import * as R from 'ramda';
 import classNames from 'classnames';
@@ -19,6 +19,10 @@ import {
   useCustomerBalanceSummaryCsvExport,
   useCustomerBalanceSummaryXlsxExport,
 } from '@/hooks/query';
+import type {
+  CustomerBalanceXlsxQuery,
+  CustomerBalanceCsvQuery,
+} from '@bigcapital/sdk-ts';
 
 /**
  * Retrieve customers balance summary columns.
@@ -95,76 +99,57 @@ export function CustomersBalanceLoadingBar() {
  * Customer balance summary export menu.
  */
 export function CustomerBalanceSummaryExportMenu() {
-  const toastKey = useRef(null);
   const commonToastConfig = {
     isCloseButtonShown: true,
     timeout: 2000,
   };
   const { query } = useCustomersBalanceSummaryContext();
 
-  const openProgressToast = (amount: number) => {
+  const renderToast = (done: boolean) => {
     return (
       <Stack spacing={8}>
-        <Text>The report has been exported successfully.</Text>
+        <Text>
+          {done
+            ? 'The report has been exported successfully.'
+            : 'Exporting the report…'}
+        </Text>
         <ProgressBar
           className={classNames('toast-progress', {
-            [Classes.PROGRESS_NO_STRIPES]: amount >= 100,
+            [Classes.PROGRESS_NO_STRIPES]: done,
           })}
-          intent={amount < 100 ? Intent.PRIMARY : Intent.SUCCESS}
-          value={amount / 100}
+          intent={done ? Intent.SUCCESS : Intent.PRIMARY}
+          value={done ? 1 : undefined}
         />
       </Stack>
     );
   };
-  // Export the report to xlsx.
+
   const { mutateAsync: xlsxExport } = useCustomerBalanceSummaryXlsxExport(
-    query,
-    {
-      onDownloadProgress: (xlsxExportProgress: number) => {
-        if (!toastKey.current) {
-          toastKey.current = AppToaster.show({
-            message: openProgressToast(xlsxExportProgress),
-            ...commonToastConfig,
-          });
-        } else {
-          AppToaster.show(
-            {
-              message: openProgressToast(xlsxExportProgress),
-              ...commonToastConfig,
-            },
-            toastKey.current,
-          );
-        }
-      },
-    },
+    query as CustomerBalanceXlsxQuery,
   );
-  // Export the report to csv.
-  const { mutateAsync: csvExport } = useCustomerBalanceSummaryCsvExport(query, {
-    onDownloadProgress: (xlsxExportProgress: number) => {
-      if (!toastKey.current) {
-        toastKey.current = AppToaster.show({
-          message: openProgressToast(xlsxExportProgress),
-          ...commonToastConfig,
-        });
-      } else {
-        AppToaster.show(
-          {
-            message: openProgressToast(xlsxExportProgress),
-            ...commonToastConfig,
-          },
-          toastKey.current,
-        );
-      }
-    },
-  });
-  // Handle csv export button click.
-  const handleCsvExportBtnClick = () => {
-    csvExport();
+  const { mutateAsync: csvExport } = useCustomerBalanceSummaryCsvExport(
+    query as CustomerBalanceCsvQuery,
+  );
+
+  const runExport = async (mutate: () => Promise<unknown>) => {
+    const key = AppToaster.show({
+      message: renderToast(false),
+      ...commonToastConfig,
+      timeout: 0,
+    });
+    try {
+      await mutate();
+      AppToaster.show(
+        { message: renderToast(true), ...commonToastConfig },
+        key,
+      );
+    } catch {
+      AppToaster.dismiss(key);
+    }
   };
-  // Handle xlsx export button click.
-  const handleXlsxExportBtnClick = () => {
-    xlsxExport();
-  };
+
+  const handleCsvExportBtnClick = () => runExport(csvExport);
+  const handleXlsxExportBtnClick = () => runExport(xlsxExport);
 
   return (
     <Menu>

--- a/packages/webapp/src/containers/FinancialStatements/CustomersTransactions/components.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/CustomersTransactions/components.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React from 'react';
 import intl from 'react-intl-universal';
 import { AppToaster, If, Stack } from '@/components';
 import { Align } from '@/constants';
@@ -17,6 +17,10 @@ import {
   useCustomersTransactionsCsvExport,
   useCustomersTransactionsXlsxExport,
 } from '@/hooks/query';
+import type {
+  TransactionsByCustomersXlsxQuery,
+  TransactionsByCustomersCsvQuery,
+} from '@bigcapital/sdk-ts';
 import classNames from 'classnames';
 
 /**
@@ -110,77 +114,57 @@ export function CustomersTransactionsLoadingBar() {
  * Customers transactions export menu.
  */
 export function CustomersTransactionsExportMenu() {
-  const toastKey = useRef<string | null>(null);
   const commonToastConfig = {
     isCloseButtonShown: true,
     timeout: 2000,
   };
   const { query } = useCustomersTransactionsContext();
 
-  const openProgressToast = (amount: number) => {
+  const renderToast = (done: boolean) => {
     return (
       <Stack spacing={8}>
-        <Text>The report has been exported successfully.</Text>
+        <Text>
+          {done
+            ? 'The report has been exported successfully.'
+            : 'Exporting the report…'}
+        </Text>
         <ProgressBar
           className={classNames('toast-progress', {
-            [Classes.PROGRESS_NO_STRIPES]: amount >= 100,
+            [Classes.PROGRESS_NO_STRIPES]: done,
           })}
-          intent={amount < 100 ? Intent.PRIMARY : Intent.SUCCESS}
-          value={amount / 100}
+          intent={done ? Intent.SUCCESS : Intent.PRIMARY}
+          value={done ? 1 : undefined}
         />
       </Stack>
     );
   };
 
-  // Export the report to xlsx.
   const { mutateAsync: xlsxExport } = useCustomersTransactionsXlsxExport(
-    query,
-    {
-      onDownloadProgress: (xlsxExportProgress: number) => {
-        if (!toastKey.current) {
-          toastKey.current = AppToaster.show({
-            message: openProgressToast(xlsxExportProgress),
-            ...commonToastConfig,
-          });
-        } else {
-          AppToaster.show(
-            {
-              message: openProgressToast(xlsxExportProgress),
-              ...commonToastConfig,
-            },
-            toastKey.current,
-          );
-        }
-      },
-    },
+    query as TransactionsByCustomersXlsxQuery,
   );
-  // Export the report to csv.
-  const { mutateAsync: csvExport } = useCustomersTransactionsCsvExport(query, {
-    onDownloadProgress: (xlsxExportProgress: number) => {
-      if (!toastKey.current) {
-        toastKey.current = AppToaster.show({
-          message: openProgressToast(xlsxExportProgress),
-          ...commonToastConfig,
-        });
-      } else {
-        AppToaster.show(
-          {
-            message: openProgressToast(xlsxExportProgress),
-            ...commonToastConfig,
-          },
-          toastKey.current,
-        );
-      }
-    },
-  });
-  // Handle csv export button click.
-  const handleCsvExportBtnClick = () => {
-    csvExport();
+  const { mutateAsync: csvExport } = useCustomersTransactionsCsvExport(
+    query as TransactionsByCustomersCsvQuery,
+  );
+
+  const runExport = async (mutate: () => Promise<unknown>) => {
+    const key = AppToaster.show({
+      message: renderToast(false),
+      ...commonToastConfig,
+      timeout: 0,
+    });
+    try {
+      await mutate();
+      AppToaster.show(
+        { message: renderToast(true), ...commonToastConfig },
+        key,
+      );
+    } catch {
+      AppToaster.dismiss(key);
+    }
   };
-  // Handle xlsx export button click.
-  const handleXlsxExportBtnClick = () => {
-    xlsxExport();
-  };
+
+  const handleCsvExportBtnClick = () => runExport(csvExport);
+  const handleXlsxExportBtnClick = () => runExport(xlsxExport);
 
   return (
     <Menu>

--- a/packages/webapp/src/containers/FinancialStatements/GeneralLedger/components.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/GeneralLedger/components.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React from 'react';
 import classNames from 'classnames';
 import {
   Button,
@@ -25,6 +25,10 @@ import {
   useGeneralLedgerSheetCsvExport,
   useGeneralLedgerSheetXlsxExport,
 } from '@/hooks/query';
+import type {
+  GeneralLedgerXlsxQuery,
+  GeneralLedgerCsvQuery,
+} from '@bigcapital/sdk-ts';
 
 /**
  * General ledger sheet alerts.
@@ -74,76 +78,57 @@ export function GeneralLedgerSheetLoadingBar() {
  * @returns {JSX.Element}
  */
 export const GeneralLedgerSheetExportMenu = () => {
-  const toastKey = useRef<string | number | undefined>(null);
   const commonToastConfig = {
     isCloseButtonShown: true,
     timeout: 2000,
   };
   const { httpQuery } = useGeneralLedgerContext();
 
-  const openProgressToast = (amount: number) => {
+  const renderToast = (done: boolean) => {
     return (
       <Stack spacing={8}>
-        <Text>The report has been exported successfully.</Text>
+        <Text>
+          {done
+            ? 'The report has been exported successfully.'
+            : 'Exporting the report…'}
+        </Text>
         <ProgressBar
           className={classNames('toast-progress', {
-            [Classes.PROGRESS_NO_STRIPES]: amount >= 100,
+            [Classes.PROGRESS_NO_STRIPES]: done,
           })}
-          intent={amount < 100 ? Intent.PRIMARY : Intent.SUCCESS}
-          value={amount / 100}
+          intent={done ? Intent.SUCCESS : Intent.PRIMARY}
+          value={done ? 1 : undefined}
         />
       </Stack>
     );
   };
-  // Export the report to xlsx.
+
   const { mutateAsync: xlsxExport } = useGeneralLedgerSheetXlsxExport(
-    httpQuery,
-    {
-      onDownloadProgress: (xlsxExportProgress: number) => {
-        if (!toastKey.current) {
-          toastKey.current = AppToaster.show({
-            message: openProgressToast(xlsxExportProgress),
-            ...commonToastConfig,
-          });
-        } else {
-          AppToaster.show(
-            {
-              message: openProgressToast(xlsxExportProgress),
-              ...commonToastConfig,
-            },
-            toastKey.current,
-          );
-        }
-      },
-    },
+    httpQuery as GeneralLedgerXlsxQuery,
   );
-  // Export the report to csv.
-  const { mutateAsync: csvExport } = useGeneralLedgerSheetCsvExport(httpQuery, {
-    onDownloadProgress: (xlsxExportProgress: number) => {
-      if (!toastKey.current) {
-        toastKey.current = AppToaster.show({
-          message: openProgressToast(xlsxExportProgress),
-          ...commonToastConfig,
-        });
-      } else {
-        AppToaster.show(
-          {
-            message: openProgressToast(xlsxExportProgress),
-            ...commonToastConfig,
-          },
-          toastKey.current,
-        );
-      }
-    },
-  });
-  // Handle csv export button click.
-  const handleCsvExportBtnClick = () => {
-    csvExport();
+  const { mutateAsync: csvExport } = useGeneralLedgerSheetCsvExport(
+    httpQuery as GeneralLedgerCsvQuery,
+  );
+
+  const runExport = async (mutate: () => Promise<unknown>) => {
+    const key = AppToaster.show({
+      message: renderToast(false),
+      ...commonToastConfig,
+      timeout: 0,
+    });
+    try {
+      await mutate();
+      AppToaster.show(
+        { message: renderToast(true), ...commonToastConfig },
+        key,
+      );
+    } catch {
+      AppToaster.dismiss(key);
+    }
   };
-  // Handle xlsx export button click.
-  const handleXlsxExportBtnClick = () => {
-    xlsxExport();
-  };
+
+  const handleCsvExportBtnClick = () => runExport(csvExport);
+  const handleXlsxExportBtnClick = () => runExport(xlsxExport);
 
   return (
     <Menu>

--- a/packages/webapp/src/containers/FinancialStatements/InventoryItemDetails/components.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/InventoryItemDetails/components.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React from 'react';
 import {
   Button,
   Classes,
@@ -23,6 +23,10 @@ import {
   useInventoryItemDetailsCsvExport,
   useInventoryItemDetailsXlsxExport,
 } from '@/hooks/query';
+import type {
+  InventoryItemDetailsXlsxQuery,
+  InventoryItemDetailsCsvQuery,
+} from '@bigcapital/sdk-ts';
 import { useInventoryItemDetailsContext } from './InventoryItemDetailsProvider';
 import { FinancialComputeAlert } from '../FinancialReportPage';
 import { useInventoryValuationHttpQuery } from './utils2';
@@ -95,80 +99,57 @@ export function InventoryItemDetailsAlerts() {
  * @returns {JSX.Element}
  */
 export function InventoryItemDetailsExportMenu() {
-  const toastKey = useRef<string | number | undefined>(undefined);
   const commonToastConfig = {
     isCloseButtonShown: true,
     timeout: 2000,
   };
   const httpQuery = useInventoryValuationHttpQuery();
 
-  const openProgressToast = (amount: number) => {
+  const renderToast = (done: boolean) => {
     return (
       <Stack spacing={8}>
-        <Text>The report has been exported successfully.</Text>
+        <Text>
+          {done
+            ? 'The report has been exported successfully.'
+            : 'Exporting the report…'}
+        </Text>
         <ProgressBar
           className={classNames('toast-progress', {
-            [Classes.PROGRESS_NO_STRIPES]: amount >= 100,
+            [Classes.PROGRESS_NO_STRIPES]: done,
           })}
-          intent={amount < 100 ? Intent.PRIMARY : Intent.SUCCESS}
-          value={amount / 100}
+          intent={done ? Intent.SUCCESS : Intent.PRIMARY}
+          value={done ? 1 : undefined}
         />
       </Stack>
     );
   };
 
-  // Export the report to xlsx.
   const { mutateAsync: xlsxExport } = useInventoryItemDetailsXlsxExport(
-    httpQuery,
-    {
-      onDownloadProgress: (xlsxExportProgress: number) => {
-        if (!toastKey.current) {
-          toastKey.current = AppToaster.show({
-            message: openProgressToast(xlsxExportProgress),
-            ...commonToastConfig,
-          });
-        } else {
-          AppToaster.show(
-            {
-              message: openProgressToast(xlsxExportProgress),
-              ...commonToastConfig,
-            },
-            toastKey.current,
-          );
-        }
-      },
-    },
+    httpQuery as InventoryItemDetailsXlsxQuery,
   );
-  // Export the report to csv.
   const { mutateAsync: csvExport } = useInventoryItemDetailsCsvExport(
-    httpQuery,
-    {
-      onDownloadProgress: (xlsxExportProgress: number) => {
-        if (!toastKey.current) {
-          toastKey.current = AppToaster.show({
-            message: openProgressToast(xlsxExportProgress),
-            ...commonToastConfig,
-          });
-        } else {
-          AppToaster.show(
-            {
-              message: openProgressToast(xlsxExportProgress),
-              ...commonToastConfig,
-            },
-            toastKey.current,
-          );
-        }
-      },
-    },
+    httpQuery as InventoryItemDetailsCsvQuery,
   );
-  // Handle csv export button click.
-  const handleCsvExportBtnClick = () => {
-    csvExport();
+
+  const runExport = async (mutate: () => Promise<unknown>) => {
+    const key = AppToaster.show({
+      message: renderToast(false),
+      ...commonToastConfig,
+      timeout: 0,
+    });
+    try {
+      await mutate();
+      AppToaster.show(
+        { message: renderToast(true), ...commonToastConfig },
+        key,
+      );
+    } catch {
+      AppToaster.dismiss(key);
+    }
   };
-  // Handle xlsx export button click.
-  const handleXlsxExportBtnClick = () => {
-    xlsxExport();
-  };
+
+  const handleCsvExportBtnClick = () => runExport(csvExport);
+  const handleXlsxExportBtnClick = () => runExport(xlsxExport);
 
   return (
     <Menu>

--- a/packages/webapp/src/containers/FinancialStatements/InventoryValuation/components.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/InventoryValuation/components.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef } from 'react';
+import React, { useMemo } from 'react';
 import intl from 'react-intl-universal';
 import classNames from 'classnames';
 import { AppToaster, If, Stack } from '@/components';
@@ -19,6 +19,10 @@ import {
   useInventoryValuationCsvExport,
   useInventoryValuationXlsxExport,
 } from '@/hooks/query';
+import type {
+  InventoryValuationXlsxQuery,
+  InventoryValuationCsvQuery,
+} from '@bigcapital/sdk-ts';
 
 /**
  * Retrieve inventory valuation table columns.
@@ -94,73 +98,57 @@ export function InventoryValuationLoadingBar() {
  * @returns {JSX.Element}
  */
 export const InventoryValuationExportMenu = () => {
-  const toastKey = useRef<string | number | undefined>(undefined);
   const commonToastConfig = {
     isCloseButtonShown: true,
     timeout: 2000,
   };
   const { query } = useInventoryValuationContext();
 
-  const openProgressToast = (amount: number) => {
+  const renderToast = (done: boolean) => {
     return (
       <Stack spacing={8}>
-        <Text>The report has been exported successfully.</Text>
+        <Text>
+          {done
+            ? 'The report has been exported successfully.'
+            : 'Exporting the report…'}
+        </Text>
         <ProgressBar
           className={classNames('toast-progress', {
-            [Classes.PROGRESS_NO_STRIPES]: amount >= 100,
+            [Classes.PROGRESS_NO_STRIPES]: done,
           })}
-          intent={amount < 100 ? Intent.PRIMARY : Intent.SUCCESS}
-          value={amount / 100}
+          intent={done ? Intent.SUCCESS : Intent.PRIMARY}
+          value={done ? 1 : undefined}
         />
       </Stack>
     );
   };
-  // Export the report to xlsx.
-  const { mutateAsync: xlsxExport } = useInventoryValuationXlsxExport(query, {
-    onDownloadProgress: (xlsxExportProgress: number) => {
-      if (!toastKey.current) {
-        toastKey.current = AppToaster.show({
-          message: openProgressToast(xlsxExportProgress),
-          ...commonToastConfig,
-        });
-      } else {
-        AppToaster.show(
-          {
-            message: openProgressToast(xlsxExportProgress),
-            ...commonToastConfig,
-          },
-          toastKey.current,
-        );
-      }
-    },
-  });
-  // Export the report to csv.
-  const { mutateAsync: csvExport } = useInventoryValuationCsvExport(query, {
-    onDownloadProgress: (xlsxExportProgress: number) => {
-      if (!toastKey.current) {
-        toastKey.current = AppToaster.show({
-          message: openProgressToast(xlsxExportProgress),
-          ...commonToastConfig,
-        });
-      } else {
-        AppToaster.show(
-          {
-            message: openProgressToast(xlsxExportProgress),
-            ...commonToastConfig,
-          },
-          toastKey.current,
-        );
-      }
-    },
-  });
-  // Handle csv export button click.
-  const handleCsvExportBtnClick = () => {
-    csvExport();
+
+  const { mutateAsync: xlsxExport } = useInventoryValuationXlsxExport(
+    query as InventoryValuationXlsxQuery,
+  );
+  const { mutateAsync: csvExport } = useInventoryValuationCsvExport(
+    query as InventoryValuationCsvQuery,
+  );
+
+  const runExport = async (mutate: () => Promise<unknown>) => {
+    const key = AppToaster.show({
+      message: renderToast(false),
+      ...commonToastConfig,
+      timeout: 0,
+    });
+    try {
+      await mutate();
+      AppToaster.show(
+        { message: renderToast(true), ...commonToastConfig },
+        key,
+      );
+    } catch {
+      AppToaster.dismiss(key);
+    }
   };
-  // Handle xlsx export button click.
-  const handleXlsxExportBtnClick = () => {
-    xlsxExport();
-  };
+
+  const handleCsvExportBtnClick = () => runExport(csvExport);
+  const handleXlsxExportBtnClick = () => runExport(xlsxExport);
 
   return (
     <Menu>

--- a/packages/webapp/src/containers/FinancialStatements/Journal/components.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/Journal/components.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React from 'react';
 import classNames from 'classnames';
 import {
   Button,
@@ -23,6 +23,10 @@ import {
   useJournalSheetCsvExport,
   useJournalSheetXlsxExport,
 } from '@/hooks/query';
+import type {
+  JournalXlsxQuery,
+  JournalCsvQuery,
+} from '@bigcapital/sdk-ts';
 
 /**
  * Journal sheet loading bar.
@@ -72,79 +76,57 @@ export function JournalSheetAlerts() {
  * @returns {JSX.Element}
  */
 export const JournalSheetExportMenu = () => {
-  const toastKey = useRef<string | number | undefined>(null);
   const commonToastConfig = {
     isCloseButtonShown: true,
     timeout: 2000,
   };
   const { httpQuery } = useJournalSheetContext();
 
-  const openProgressToast = (amount: number) => {
+  const renderToast = (done: boolean) => {
     return (
       <Stack spacing={8}>
-        <Text>The report has been exported successfully.</Text>
+        <Text>
+          {done
+            ? 'The report has been exported successfully.'
+            : 'Exporting the report…'}
+        </Text>
         <ProgressBar
           className={classNames('toast-progress', {
-            [Classes.PROGRESS_NO_STRIPES]: amount >= 100,
+            [Classes.PROGRESS_NO_STRIPES]: done,
           })}
-          intent={amount < 100 ? Intent.PRIMARY : Intent.SUCCESS}
-          value={amount / 100}
+          intent={done ? Intent.SUCCESS : Intent.PRIMARY}
+          value={done ? 1 : undefined}
         />
       </Stack>
     );
   };
-  // Exports the report to xlsx.
+
   const { mutateAsync: xlsxExport } = useJournalSheetXlsxExport(
-    httpQuery as any,
-    {
-      onDownloadProgress: (xlsxExportProgress: number) => {
-        if (!toastKey.current) {
-          toastKey.current = AppToaster.show({
-            message: openProgressToast(xlsxExportProgress),
-            ...commonToastConfig,
-          });
-        } else {
-          AppToaster.show(
-            {
-              message: openProgressToast(xlsxExportProgress),
-              ...commonToastConfig,
-            },
-            toastKey.current,
-          );
-        }
-      },
-    },
+    httpQuery as JournalXlsxQuery,
   );
-  // Exports the report to csv.
   const { mutateAsync: csvExport } = useJournalSheetCsvExport(
-    httpQuery as any,
-    {
-      onDownloadProgress: (xlsxExportProgress: number) => {
-        if (!toastKey.current) {
-          toastKey.current = AppToaster.show({
-            message: openProgressToast(xlsxExportProgress),
-            ...commonToastConfig,
-          });
-        } else {
-          AppToaster.show(
-            {
-              message: openProgressToast(xlsxExportProgress),
-              ...commonToastConfig,
-            },
-            toastKey.current,
-          );
-        }
-      },
-    },
+    httpQuery as JournalCsvQuery,
   );
-  // Handle csv export button click.
-  const handleCsvExportBtnClick = () => {
-    csvExport();
+
+  const runExport = async (mutate: () => Promise<unknown>) => {
+    const key = AppToaster.show({
+      message: renderToast(false),
+      ...commonToastConfig,
+      timeout: 0,
+    });
+    try {
+      await mutate();
+      AppToaster.show(
+        { message: renderToast(true), ...commonToastConfig },
+        key,
+      );
+    } catch {
+      AppToaster.dismiss(key);
+    }
   };
-  // Handle xlsx export button click.
-  const handleXlsxExportBtnClick = () => {
-    xlsxExport();
-  };
+
+  const handleCsvExportBtnClick = () => runExport(csvExport);
+  const handleXlsxExportBtnClick = () => runExport(xlsxExport);
 
   return (
     <Menu>

--- a/packages/webapp/src/containers/FinancialStatements/ProfitLossSheet/components.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/ProfitLossSheet/components.tsx
@@ -1,4 +1,3 @@
-import { useRef } from 'react';
 import {
   Button,
   Classes,
@@ -22,6 +21,10 @@ import {
   useProfitLossSheetCsvExport,
   useProfitLossSheetXlsxExport,
 } from '@/hooks/query';
+import type {
+  ProfitLossXlsxQuery,
+  ProfitLossCsvQuery,
+} from '@bigcapital/sdk-ts';
 import classNames from 'classnames';
 
 /**
@@ -72,74 +75,57 @@ export function ProfitLossSheetAlerts() {
  * Profit/loss sheet export menu.
  */
 export const ProfitLossSheetExportMenu = () => {
-  const toastKey = useRef(null);
   const commonToastConfig = {
     isCloseButtonShown: true,
     timeout: 2000,
   };
   const { httpQuery } = useProfitLossSheetContext();
 
-  const openProgressToast = (amount: number) => {
+  const renderToast = (done: boolean) => {
     return (
       <Stack spacing={8}>
-        <Text>The report has been exported successfully.</Text>
+        <Text>
+          {done
+            ? 'The report has been exported successfully.'
+            : 'Exporting the report…'}
+        </Text>
         <ProgressBar
           className={classNames('toast-progress', {
-            [Classes.PROGRESS_NO_STRIPES]: amount >= 100,
+            [Classes.PROGRESS_NO_STRIPES]: done,
           })}
-          intent={amount < 100 ? Intent.PRIMARY : Intent.SUCCESS}
-          value={amount / 100}
+          intent={done ? Intent.SUCCESS : Intent.PRIMARY}
+          value={done ? 1 : undefined}
         />
       </Stack>
     );
   };
 
-  // Export the report to xlsx.
-  const { mutateAsync: xlsxExport } = useProfitLossSheetXlsxExport(httpQuery, {
-    onDownloadProgress: (xlsxExportProgress: number) => {
-      if (!toastKey.current) {
-        toastKey.current = AppToaster.show({
-          message: openProgressToast(xlsxExportProgress),
-          ...commonToastConfig,
-        });
-      } else {
-        AppToaster.show(
-          {
-            message: openProgressToast(xlsxExportProgress),
-            ...commonToastConfig,
-          },
-          toastKey.current,
-        );
-      }
-    },
-  });
-  // Export the report to csv.
-  const { mutateAsync: csvExport } = useProfitLossSheetCsvExport(httpQuery, {
-    onDownloadProgress: (xlsxExportProgress: number) => {
-      if (!toastKey.current) {
-        toastKey.current = AppToaster.show({
-          message: openProgressToast(xlsxExportProgress),
-          ...commonToastConfig,
-        });
-      } else {
-        AppToaster.show(
-          {
-            message: openProgressToast(xlsxExportProgress),
-            ...commonToastConfig,
-          },
-          toastKey.current,
-        );
-      }
-    },
-  });
-  // Handle csv export button click.
-  const handleCsvExportBtnClick = () => {
-    csvExport();
+  const { mutateAsync: xlsxExport } = useProfitLossSheetXlsxExport(
+    httpQuery as ProfitLossXlsxQuery,
+  );
+  const { mutateAsync: csvExport } = useProfitLossSheetCsvExport(
+    httpQuery as ProfitLossCsvQuery,
+  );
+
+  const runExport = async (mutate: () => Promise<unknown>) => {
+    const key = AppToaster.show({
+      message: renderToast(false),
+      ...commonToastConfig,
+      timeout: 0,
+    });
+    try {
+      await mutate();
+      AppToaster.show(
+        { message: renderToast(true), ...commonToastConfig },
+        key,
+      );
+    } catch {
+      AppToaster.dismiss(key);
+    }
   };
-  // Handle xlsx export button click.
-  const handleXlsxExportBtnClick = () => {
-    xlsxExport();
-  };
+
+  const handleCsvExportBtnClick = () => runExport(csvExport);
+  const handleXlsxExportBtnClick = () => runExport(xlsxExport);
 
   return (
     <Menu>

--- a/packages/webapp/src/containers/FinancialStatements/PurchasesByItems/components.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/PurchasesByItems/components.tsx
@@ -1,4 +1,3 @@
-import { useRef } from 'react';
 import classNames from 'classnames';
 import {
   Classes,
@@ -16,6 +15,10 @@ import {
   usePurchasesByItemsCsvExport,
   usePurchasesByItemsXlsxExport,
 } from '@/hooks/query';
+import type {
+  PurchasesByItemsXlsxQuery,
+  PurchasesByItemsCsvQuery,
+} from '@bigcapital/sdk-ts';
 
 /**
  * Purchases by items progress loading bar.
@@ -34,70 +37,54 @@ export function PurchasesByItemsLoadingBar() {
  * Retrieves the purchases by items export menu.
  */
 export const PurchasesByItemsExportMenu = () => {
-  const toastKey = useRef<string | number | undefined>(undefined);
   const commonToastConfig = { isCloseButtonShown: true, timeout: 2000 };
   const { httpQuery } = usePurchaseByItemsContext();
 
-  const openProgressToast = (amount: number) => {
+  const renderToast = (done: boolean) => {
     return (
       <Stack spacing={8}>
-        <Text>The report has been exported successfully.</Text>
+        <Text>
+          {done
+            ? 'The report has been exported successfully.'
+            : 'Exporting the report…'}
+        </Text>
         <ProgressBar
           className={classNames('toast-progress', {
-            [Classes.PROGRESS_NO_STRIPES]: amount >= 100,
+            [Classes.PROGRESS_NO_STRIPES]: done,
           })}
-          intent={amount < 100 ? Intent.PRIMARY : Intent.SUCCESS}
-          value={amount / 100}
+          intent={done ? Intent.SUCCESS : Intent.PRIMARY}
+          value={done ? 1 : undefined}
         />
       </Stack>
     );
   };
-  // Export the report to xlsx.
-  const { mutateAsync: xlsxExport } = usePurchasesByItemsXlsxExport(httpQuery, {
-    onDownloadProgress: (xlsxExportProgress: number) => {
-      if (!toastKey.current) {
-        toastKey.current = AppToaster.show({
-          message: openProgressToast(xlsxExportProgress),
-          ...commonToastConfig,
-        });
-      } else {
-        AppToaster.show(
-          {
-            message: openProgressToast(xlsxExportProgress),
-            ...commonToastConfig,
-          },
-          toastKey.current,
-        );
-      }
-    },
-  });
-  // Export the report to csv.
-  const { mutateAsync: csvExport } = usePurchasesByItemsCsvExport(httpQuery, {
-    onDownloadProgress: (xlsxExportProgress: number) => {
-      if (!toastKey.current) {
-        toastKey.current = AppToaster.show({
-          message: openProgressToast(xlsxExportProgress),
-          ...commonToastConfig,
-        });
-      } else {
-        AppToaster.show(
-          {
-            message: openProgressToast(xlsxExportProgress),
-            ...commonToastConfig,
-          },
-          toastKey.current,
-        );
-      }
-    },
-  });
-  // Handle csv export button click.
-  const handleCsvExportBtnClick = () => {
-    csvExport();
+
+  const { mutateAsync: xlsxExport } = usePurchasesByItemsXlsxExport(
+    httpQuery as PurchasesByItemsXlsxQuery,
+  );
+  const { mutateAsync: csvExport } = usePurchasesByItemsCsvExport(
+    httpQuery as PurchasesByItemsCsvQuery,
+  );
+
+  const runExport = async (mutate: () => Promise<unknown>) => {
+    const key = AppToaster.show({
+      message: renderToast(false),
+      ...commonToastConfig,
+      timeout: 0,
+    });
+    try {
+      await mutate();
+      AppToaster.show(
+        { message: renderToast(true), ...commonToastConfig },
+        key,
+      );
+    } catch {
+      AppToaster.dismiss(key);
+    }
   };
-  // Handle xlsx export button click.
-  const handleXlsxExportBtnClick = () => {
-    xlsxExport();
-  };
+
+  const handleCsvExportBtnClick = () => runExport(csvExport);
+  const handleXlsxExportBtnClick = () => runExport(xlsxExport);
 
   return (
     <Menu>

--- a/packages/webapp/src/containers/FinancialStatements/SalesByItems/components.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/SalesByItems/components.tsx
@@ -1,4 +1,3 @@
-import { useRef } from 'react';
 import classNames from 'classnames';
 import {
   Classes,
@@ -16,6 +15,10 @@ import {
   useSalesByItemsCsvExport,
   useSalesByItemsXlsxExport,
 } from '@/hooks/query';
+import type {
+  SalesByItemsXlsxQuery,
+  SalesByItemsCsvQuery,
+} from '@bigcapital/sdk-ts';
 
 /**
  * sales by items progress loading bar.
@@ -33,70 +36,54 @@ export function SalesByItemsLoadingBar() {
  * Retrieves the sales by items export menu.
  */
 export const SalesByItemsSheetExportMenu = () => {
-  const toastKey = useRef<string | number | undefined>(undefined);
   const commonToastConfig = { isCloseButtonShown: true, timeout: 2000 };
   const { httpQuery } = useSalesByItemsContext();
 
-  const openProgressToast = (amount: number) => {
+  const renderToast = (done: boolean) => {
     return (
       <Stack spacing={8}>
-        <Text>The report has been exported successfully.</Text>
+        <Text>
+          {done
+            ? 'The report has been exported successfully.'
+            : 'Exporting the report…'}
+        </Text>
         <ProgressBar
           className={classNames('toast-progress', {
-            [Classes.PROGRESS_NO_STRIPES]: amount >= 100,
+            [Classes.PROGRESS_NO_STRIPES]: done,
           })}
-          intent={amount < 100 ? Intent.PRIMARY : Intent.SUCCESS}
-          value={amount / 100}
+          intent={done ? Intent.SUCCESS : Intent.PRIMARY}
+          value={done ? 1 : undefined}
         />
       </Stack>
     );
   };
-  // Export the report to xlsx.
-  const { mutateAsync: xlsxExport } = useSalesByItemsXlsxExport(httpQuery, {
-    onDownloadProgress: (xlsxExportProgress: number) => {
-      if (!toastKey.current) {
-        toastKey.current = AppToaster.show({
-          message: openProgressToast(xlsxExportProgress),
-          ...commonToastConfig,
-        });
-      } else {
-        AppToaster.show(
-          {
-            message: openProgressToast(xlsxExportProgress),
-            ...commonToastConfig,
-          },
-          toastKey.current,
-        );
-      }
-    },
-  });
-  // Export the report to csv.
-  const { mutateAsync: csvExport } = useSalesByItemsCsvExport(httpQuery, {
-    onDownloadProgress: (xlsxExportProgress: number) => {
-      if (!toastKey.current) {
-        toastKey.current = AppToaster.show({
-          message: openProgressToast(xlsxExportProgress),
-          ...commonToastConfig,
-        });
-      } else {
-        AppToaster.show(
-          {
-            message: openProgressToast(xlsxExportProgress),
-            ...commonToastConfig,
-          },
-          toastKey.current,
-        );
-      }
-    },
-  });
-  // Handle csv export button click.
-  const handleCsvExportBtnClick = () => {
-    csvExport();
+
+  const { mutateAsync: xlsxExport } = useSalesByItemsXlsxExport(
+    httpQuery as SalesByItemsXlsxQuery,
+  );
+  const { mutateAsync: csvExport } = useSalesByItemsCsvExport(
+    httpQuery as SalesByItemsCsvQuery,
+  );
+
+  const runExport = async (mutate: () => Promise<unknown>) => {
+    const key = AppToaster.show({
+      message: renderToast(false),
+      ...commonToastConfig,
+      timeout: 0,
+    });
+    try {
+      await mutate();
+      AppToaster.show(
+        { message: renderToast(true), ...commonToastConfig },
+        key,
+      );
+    } catch {
+      AppToaster.dismiss(key);
+    }
   };
-  // Handle xlsx export button click.
-  const handleXlsxExportBtnClick = () => {
-    xlsxExport();
-  };
+
+  const handleCsvExportBtnClick = () => runExport(csvExport);
+  const handleXlsxExportBtnClick = () => runExport(xlsxExport);
 
   return (
     <Menu>

--- a/packages/webapp/src/containers/FinancialStatements/SalesTaxLiabilitySummary/components.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/SalesTaxLiabilitySummary/components.tsx
@@ -1,4 +1,3 @@
-import { useRef } from 'react';
 import classNames from 'classnames';
 import {
   Classes,
@@ -15,6 +14,10 @@ import {
   useSalesTaxLiabilitySummaryCsvExport,
   useSalesTaxLiabilitySummaryXlsxExport,
 } from '@/hooks/query';
+import type {
+  SalesTaxLiabilityXlsxQuery,
+  SalesTaxLiabilityCsvQuery,
+} from '@bigcapital/sdk-ts';
 
 /**
  * Sales tax liability summary loading bar.
@@ -32,80 +35,57 @@ export function SalesTaxLiabilitySummaryLoadingBar() {
  * Sales tax liability export menu.
  */
 export function SalesTaxLiabilityExportMenu() {
-  const toastKey = useRef<string | null>(null);
   const commonToastConfig = {
     isCloseButtonShown: true,
     timeout: 2000,
   };
   const { query } = useSalesTaxLiabilitySummaryContext();
 
-  const openProgressToast = (amount: number) => {
+  const renderToast = (done: boolean) => {
     return (
       <Stack spacing={8}>
-        <Text>The report has been exported successfully.</Text>
+        <Text>
+          {done
+            ? 'The report has been exported successfully.'
+            : 'Exporting the report…'}
+        </Text>
         <ProgressBar
           className={classNames('toast-progress', {
-            [Classes.PROGRESS_NO_STRIPES]: amount >= 100,
+            [Classes.PROGRESS_NO_STRIPES]: done,
           })}
-          intent={amount < 100 ? Intent.PRIMARY : Intent.SUCCESS}
-          value={amount / 100}
+          intent={done ? Intent.SUCCESS : Intent.PRIMARY}
+          value={done ? 1 : undefined}
         />
       </Stack>
     );
   };
 
-  // Export the report to xlsx.
   const { mutateAsync: xlsxExport } = useSalesTaxLiabilitySummaryXlsxExport(
-    query,
-    {
-      onDownloadProgress: (xlsxExportProgress: number) => {
-        if (!toastKey.current) {
-          toastKey.current = AppToaster.show({
-            message: openProgressToast(xlsxExportProgress),
-            ...commonToastConfig,
-          });
-        } else {
-          AppToaster.show(
-            {
-              message: openProgressToast(xlsxExportProgress),
-              ...commonToastConfig,
-            },
-            toastKey.current,
-          );
-        }
-      },
-    },
+    query as SalesTaxLiabilityXlsxQuery,
   );
-  // Export the report to csv.
   const { mutateAsync: csvExport } = useSalesTaxLiabilitySummaryCsvExport(
-    query,
-    {
-      onDownloadProgress: (xlsxExportProgress: number) => {
-        if (!toastKey.current) {
-          toastKey.current = AppToaster.show({
-            message: openProgressToast(xlsxExportProgress),
-            ...commonToastConfig,
-          });
-        } else {
-          AppToaster.show(
-            {
-              message: openProgressToast(xlsxExportProgress),
-              ...commonToastConfig,
-            },
-            toastKey.current,
-          );
-        }
-      },
-    },
+    query as SalesTaxLiabilityCsvQuery,
   );
-  // Handle csv export button click.
-  const handleCsvExportBtnClick = () => {
-    csvExport();
+
+  const runExport = async (mutate: () => Promise<unknown>) => {
+    const key = AppToaster.show({
+      message: renderToast(false),
+      ...commonToastConfig,
+      timeout: 0,
+    });
+    try {
+      await mutate();
+      AppToaster.show(
+        { message: renderToast(true), ...commonToastConfig },
+        key,
+      );
+    } catch {
+      AppToaster.dismiss(key);
+    }
   };
-  // Handle xlsx export button click.
-  const handleXlsxExportBtnClick = () => {
-    xlsxExport();
-  };
+
+  const handleCsvExportBtnClick = () => runExport(csvExport);
+  const handleXlsxExportBtnClick = () => runExport(xlsxExport);
 
   return (
     <Menu>

--- a/packages/webapp/src/containers/FinancialStatements/TrialBalanceSheet/components.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/TrialBalanceSheet/components.tsx
@@ -1,4 +1,3 @@
-import { useRef } from 'react';
 import {
   Button,
   Classes,
@@ -23,6 +22,10 @@ import {
   useTrialBalanceSheetCsvExport,
   useTrialBalanceSheetXlsxExport,
 } from '@/hooks/query';
+import type {
+  TrialBalanceXlsxQuery,
+  TrialBalanceCsvQuery,
+} from '@bigcapital/sdk-ts';
 import { useTrialBalanceSheetHttpQuery } from './utils';
 
 /**
@@ -74,76 +77,57 @@ export function TrialBalanceSheetAlerts() {
  * Trial balance sheet export menu.
  */
 export const TrialBalanceSheetExportMenu = () => {
-  const toastKey = useRef<string | number | undefined>(undefined);
   const commonToastConfig = {
     isCloseButtonShown: true,
     timeout: 2000,
   };
   const httpQuery = useTrialBalanceSheetHttpQuery();
 
-  const openProgressToast = (amount: number) => {
+  const renderToast = (done: boolean) => {
     return (
       <Stack spacing={8}>
-        <Text>The report has been exported successfully.</Text>
+        <Text>
+          {done
+            ? 'The report has been exported successfully.'
+            : 'Exporting the report…'}
+        </Text>
         <ProgressBar
           className={classNames('toast-progress', {
-            [Classes.PROGRESS_NO_STRIPES]: amount >= 100,
+            [Classes.PROGRESS_NO_STRIPES]: done,
           })}
-          intent={amount < 100 ? Intent.PRIMARY : Intent.SUCCESS}
-          value={amount / 100}
+          intent={done ? Intent.SUCCESS : Intent.PRIMARY}
+          value={done ? 1 : undefined}
         />
       </Stack>
     );
   };
-  // Export the report to xlsx.
+
   const { mutateAsync: xlsxExport } = useTrialBalanceSheetXlsxExport(
-    httpQuery,
-    {
-      onDownloadProgress: (xlsxExportProgress: number) => {
-        if (!toastKey.current) {
-          toastKey.current = AppToaster.show({
-            message: openProgressToast(xlsxExportProgress),
-            ...commonToastConfig,
-          });
-        } else {
-          AppToaster.show(
-            {
-              message: openProgressToast(xlsxExportProgress),
-              ...commonToastConfig,
-            },
-            toastKey.current,
-          );
-        }
-      },
-    },
+    httpQuery as TrialBalanceXlsxQuery,
   );
-  // Export the report to csv.
-  const { mutateAsync: csvExport } = useTrialBalanceSheetCsvExport(httpQuery, {
-    onDownloadProgress: (xlsxExportProgress: number) => {
-      if (!toastKey.current) {
-        toastKey.current = AppToaster.show({
-          message: openProgressToast(xlsxExportProgress),
-          ...commonToastConfig,
-        });
-      } else {
-        AppToaster.show(
-          {
-            message: openProgressToast(xlsxExportProgress),
-            ...commonToastConfig,
-          },
-          toastKey.current,
-        );
-      }
-    },
-  });
-  // Handle csv export button click.
-  const handleCsvExportBtnClick = () => {
-    csvExport();
+  const { mutateAsync: csvExport } = useTrialBalanceSheetCsvExport(
+    httpQuery as TrialBalanceCsvQuery,
+  );
+
+  const runExport = async (mutate: () => Promise<unknown>) => {
+    const key = AppToaster.show({
+      message: renderToast(false),
+      ...commonToastConfig,
+      timeout: 0,
+    });
+    try {
+      await mutate();
+      AppToaster.show(
+        { message: renderToast(true), ...commonToastConfig },
+        key,
+      );
+    } catch {
+      AppToaster.dismiss(key);
+    }
   };
-  // Handle xlsx export button click.
-  const handleXlsxExportBtnClick = () => {
-    xlsxExport();
-  };
+
+  const handleCsvExportBtnClick = () => runExport(csvExport);
+  const handleXlsxExportBtnClick = () => runExport(xlsxExport);
 
   return (
     <Menu>

--- a/packages/webapp/src/containers/FinancialStatements/VendorsBalanceSummary/components.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/VendorsBalanceSummary/components.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React from 'react';
 import intl from 'react-intl-universal';
 import * as R from 'ramda';
 import classNames from 'classnames';
@@ -101,72 +101,51 @@ export function VendorsSummarySheetLoadingBar() {
  * @returns {JSX.Element}
  */
 export function VendorSummarySheetExportMenu() {
-  const toastKey = useRef<string | undefined>(null);
   const commonToastConfig = {
     isCloseButtonShown: true,
     timeout: 2000,
   };
-  const openProgressToast = (amount: number) => {
+  const renderToast = (done: boolean) => {
     return (
       <Stack spacing={8}>
-        <Text>The report has been exported successfully.</Text>
+        <Text>
+          {done
+            ? 'The report has been exported successfully.'
+            : 'Exporting the report…'}
+        </Text>
         <ProgressBar
           className={classNames('toast-progress', {
-            [CLASSES.PROGRESS_NO_STRIPES]: amount >= 100,
+            [CLASSES.PROGRESS_NO_STRIPES]: done,
           })}
-          intent={amount < 100 ? Intent.PRIMARY : Intent.SUCCESS}
-          value={amount / 100}
+          intent={done ? Intent.SUCCESS : Intent.PRIMARY}
+          value={done ? 1 : undefined}
         />
       </Stack>
     );
   };
 
-  // Export the report to xlsx.
-  const { mutateAsync: xlsxExport } = useVendorBalanceSummaryXlsxExport({
-    onDownloadProgress: (xlsxExportProgress: number) => {
-      if (!toastKey.current) {
-        toastKey.current = AppToaster.show({
-          message: openProgressToast(xlsxExportProgress),
-          ...commonToastConfig,
-        });
-      } else {
-        AppToaster.show(
-          {
-            message: openProgressToast(xlsxExportProgress),
-            ...commonToastConfig,
-          },
-          toastKey.current,
-        );
-      }
-    },
-  });
-  // Export the report to csv.
-  const { mutateAsync: csvExport } = useVendorBalanceSummaryCsvExport({
-    onDownloadProgress: (xlsxExportProgress: number) => {
-      if (!toastKey.current) {
-        toastKey.current = AppToaster.show({
-          message: openProgressToast(xlsxExportProgress),
-          ...commonToastConfig,
-        });
-      } else {
-        AppToaster.show(
-          {
-            message: openProgressToast(xlsxExportProgress),
-            ...commonToastConfig,
-          },
-          toastKey.current,
-        );
-      }
-    },
-  });
-  // Handle csv export button click.
-  const handleCsvExportBtnClick = () => {
-    csvExport().then(() => {});
+  const { mutateAsync: xlsxExport } = useVendorBalanceSummaryXlsxExport();
+  const { mutateAsync: csvExport } = useVendorBalanceSummaryCsvExport();
+
+  const runExport = async (mutate: () => Promise<unknown>) => {
+    const key = AppToaster.show({
+      message: renderToast(false),
+      ...commonToastConfig,
+      timeout: 0,
+    });
+    try {
+      await mutate();
+      AppToaster.show(
+        { message: renderToast(true), ...commonToastConfig },
+        key,
+      );
+    } catch {
+      AppToaster.dismiss(key);
+    }
   };
-  // Handle xlsx export button click.
-  const handleXlsxExportBtnClick = () => {
-    xlsxExport().then(() => {});
-  };
+
+  const handleCsvExportBtnClick = () => runExport(csvExport);
+  const handleXlsxExportBtnClick = () => runExport(xlsxExport);
 
   return (
     <Menu>

--- a/packages/webapp/src/containers/FinancialStatements/VendorsTransactions/components.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/VendorsTransactions/components.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React from 'react';
 import intl from 'react-intl-universal';
 import {
   Classes,
@@ -18,6 +18,10 @@ import {
   useVendorsTransactionsCsvExport,
   useVendorsTransactionsXlsxExport,
 } from '@/hooks/query';
+import type {
+  TransactionsByVendorsXlsxQuery,
+  TransactionsByVendorsCsvQuery,
+} from '@bigcapital/sdk-ts';
 import { Align } from '@/constants';
 
 /**
@@ -111,73 +115,57 @@ export function VendorsTransactionsLoadingBar() {
  * Vendor transactions export menu.
  */
 export function VendorTransactionsExportMenu() {
-  const toastKey = useRef<string | undefined>(null);
   const commonToastConfig = {
     isCloseButtonShown: true,
     timeout: 2000,
   };
   const { filter: query } = useVendorsTransactionsContext();
 
-  const openProgressToast = (amount: number) => {
+  const renderToast = (done: boolean) => {
     return (
       <Stack spacing={8}>
-        <Text>The report has been exported successfully.</Text>
+        <Text>
+          {done
+            ? 'The report has been exported successfully.'
+            : 'Exporting the report…'}
+        </Text>
         <ProgressBar
           className={classNames('toast-progress', {
-            [Classes.PROGRESS_NO_STRIPES]: amount >= 100,
+            [Classes.PROGRESS_NO_STRIPES]: done,
           })}
-          intent={amount < 100 ? Intent.PRIMARY : Intent.SUCCESS}
-          value={amount / 100}
+          intent={done ? Intent.SUCCESS : Intent.PRIMARY}
+          value={done ? 1 : undefined}
         />
       </Stack>
     );
   };
-  // Export the report to xlsx.
-  const { mutateAsync: xlsxExport } = useVendorsTransactionsXlsxExport(query, {
-    onDownloadProgress: (xlsxExportProgress: number) => {
-      if (!toastKey.current) {
-        toastKey.current = AppToaster.show({
-          message: openProgressToast(xlsxExportProgress),
-          ...commonToastConfig,
-        });
-      } else {
-        AppToaster.show(
-          {
-            message: openProgressToast(xlsxExportProgress),
-            ...commonToastConfig,
-          },
-          toastKey.current,
-        );
-      }
-    },
-  });
-  // Export the report to csv.
-  const { mutateAsync: csvExport } = useVendorsTransactionsCsvExport({
-    onDownloadProgress: (xlsxExportProgress: number) => {
-      if (!toastKey.current) {
-        toastKey.current = AppToaster.show({
-          message: openProgressToast(xlsxExportProgress),
-          ...commonToastConfig,
-        });
-      } else {
-        AppToaster.show(
-          {
-            message: openProgressToast(xlsxExportProgress),
-            ...commonToastConfig,
-          },
-          toastKey.current,
-        );
-      }
-    },
-  });
-  // Handle csv export button click.
-  const handleCsvExportBtnClick = () => {
-    csvExport();
+
+  const { mutateAsync: xlsxExport } = useVendorsTransactionsXlsxExport(
+    query as TransactionsByVendorsXlsxQuery,
+  );
+  const { mutateAsync: csvExport } = useVendorsTransactionsCsvExport(
+    query as TransactionsByVendorsCsvQuery,
+  );
+
+  const runExport = async (mutate: () => Promise<unknown>) => {
+    const key = AppToaster.show({
+      message: renderToast(false),
+      ...commonToastConfig,
+      timeout: 0,
+    });
+    try {
+      await mutate();
+      AppToaster.show(
+        { message: renderToast(true), ...commonToastConfig },
+        key,
+      );
+    } catch {
+      AppToaster.dismiss(key);
+    }
   };
-  // Handle xlsx export button click.
-  const handleXlsxExportBtnClick = () => {
-    xlsxExport();
-  };
+
+  const handleCsvExportBtnClick = () => runExport(csvExport);
+  const handleXlsxExportBtnClick = () => runExport(xlsxExport);
 
   return (
     <Menu>


### PR DESCRIPTION
## Description

<!-- pr_agent:summary -->

Refactors the export progress toast across all 17 financial statement components to use a simpler indeterminate→success/error flow instead of the percentage-based progress bar.

The export hooks no longer expose an `onDownloadProgress` callback, so the previous percentage-driven toast (`openProgressToast(amount)`) no longer had a reliable signal to drive the progress bar value. Each component now renders a binary-state toast (`renderToast(done)`):

- On export start: an indeterminate progress bar (`value={undefined}`) with the message "Exporting the report…" and `timeout: 0` so it persists.
- On success: the same toast is updated (via its key) to a full success bar with "The report has been exported successfully." and the standard timeout.
- On error: the toast is dismissed.

This also drops the `useRef`-based toast-key tracking in favor of a single `runExport` wrapper that captures the key locally, and adds explicit `@bigcapital/sdk-ts` query-type casts on `httpQuery` for each export hook.

## Changes

<!-- pr_agent:walkthrough -->

| File | Change |
|------|--------|
| `packages/webapp/src/containers/FinancialStatements/*/components.tsx` (17 files) | Replace percentage-based `openProgressToast` with binary `renderToast(done)`; remove `useRef` toast-key tracking and `onDownloadProgress` callbacks; introduce `runExport` wrapper that shows an indeterminate toast during export and updates to success/error on completion; cast `httpQuery` to the report-specific export query types from `@bigcapital/sdk-ts`. |

Affected reports: APAgingSummary, ARAgingSummary, BalanceSheet, CashFlowStatement, CustomersBalanceSummary, CustomersTransactions, GeneralLedger, InventoryItemDetails, InventoryValuation, Journal, ProfitLossSheet, PurchasesByItems, SalesByItems, SalesTaxLiabilitySummary, TrialBalanceSheet, VendorsBalanceSummary, VendorsTransactions.

## Test plan

- [ ] Open any financial statement report and trigger an XLSX export — an indeterminate "Exporting the report…" toast appears, then flips to the success message on completion.
- [ ] Trigger a CSV export on the same report — same indeterminate→success behavior.
- [ ] Trigger an export that fails (e.g. network offline) — the indeterminate toast is dismissed instead of hanging forever.
- [ ] Verify the toast persists during long exports (no early timeout) and auto-dismisses ~2s after success.
- [ ] Spot-check at least 3–4 different reports (e.g. BalanceSheet, ProfitLossSheet, GeneralLedger, Journal) to confirm consistent behavior.
