### PR TITLE
feat(payment-services): add OpenAPI DTOs and derive SDK types from schema

### DIFF
--- a/packages/server/src/modules/PaymentServices/PaymentServices.controller.ts
+++ b/packages/server/src/modules/PaymentServices/PaymentServices.controller.ts
@@ -7,11 +7,29 @@ import {
   Body,
   HttpCode,
 } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+import {
+  ApiBody,
+  ApiExtraModels,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiTags,
+  getSchemaPath,
+} from '@nestjs/swagger';
+import { ApiCommonHeaders } from '@/common/decorators/ApiCommonHeaders';
 import { PaymentServicesApplication } from './PaymentServicesApplication';
-import { EditPaymentMethodDTO } from './types';
+import {
+  EditPaymentMethodDTO,
+  GetPaymentMethodsStateDto,
+  PaymentIntegrationDto,
+  PaymentMethodMutationResponseDto,
+} from './types';
 
 @ApiTags('Payment Services')
+@ApiExtraModels(GetPaymentMethodsStateDto)
+@ApiExtraModels(PaymentMethodMutationResponseDto)
+@ApiExtraModels(PaymentIntegrationDto)
+@ApiCommonHeaders()
 @Controller('payment-services')
 export class PaymentServicesController {
   constructor(
@@ -19,31 +37,65 @@ export class PaymentServicesController {
   ) {}
 
   @Get('/')
+  @ApiOperation({ summary: 'Retrieves the payment services for the invoice.' })
+  @ApiResponse({
+    status: 200,
+    description: 'Payment services have been successfully retrieved.',
+    schema: {
+      type: 'array',
+      items: { $ref: getSchemaPath(PaymentIntegrationDto) },
+    },
+  })
   async getPaymentServicesSpecificInvoice() {
-    const paymentServices =
-      await this.paymentServicesApp.getPaymentServicesForInvoice();
-
-    return { paymentServices };
+    return this.paymentServicesApp.getPaymentServicesForInvoice();
   }
 
   @Get('/state')
+  @ApiOperation({
+    summary: 'Retrieves the payment methods state (Stripe, etc.).',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Payment methods state has been successfully retrieved.',
+    schema: { $ref: getSchemaPath(GetPaymentMethodsStateDto) },
+  })
   async getPaymentMethodsState() {
-    const paymentMethodsState =
-      await this.paymentServicesApp.getPaymentMethodsState();
-
-    return { data: paymentMethodsState };
+    return this.paymentServicesApp.getPaymentMethodsState();
   }
 
   @Get('/:paymentServiceId')
+  @ApiOperation({ summary: 'Retrieves a specific payment service details.' })
+  @ApiParam({
+    name: 'paymentServiceId',
+    type: Number,
+    description: 'Payment service id.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Payment service details have been successfully retrieved.',
+    schema: { $ref: getSchemaPath(PaymentIntegrationDto) },
+  })
   async getPaymentService(@Param('paymentServiceId') paymentServiceId: number) {
-    const paymentService =
-      await this.paymentServicesApp.getPaymentService(paymentServiceId);
-
-    return { data: paymentService };
+    return this.paymentServicesApp.getPaymentService(paymentServiceId);
   }
 
   @Post('/:paymentMethodId')
   @HttpCode(200)
+  @ApiOperation({ summary: 'Updates the given payment method.' })
+  @ApiParam({
+    name: 'paymentMethodId',
+    type: Number,
+    description: 'Payment method id.',
+  })
+  @ApiBody({
+    type: EditPaymentMethodDTO,
+    description: 'Payment method update payload.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'The payment method has been successfully updated.',
+    schema: { $ref: getSchemaPath(PaymentMethodMutationResponseDto) },
+  })
   async updatePaymentMethod(
     @Param('paymentMethodId') paymentMethodId: number,
     @Body() updatePaymentMethodDTO: EditPaymentMethodDTO,
@@ -60,6 +112,17 @@ export class PaymentServicesController {
 
   @Delete('/:paymentMethodId')
   @HttpCode(200)
+  @ApiOperation({ summary: 'Deletes the given payment method.' })
+  @ApiParam({
+    name: 'paymentMethodId',
+    type: Number,
+    description: 'Payment method id.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'The payment method has been successfully deleted.',
+    schema: { $ref: getSchemaPath(PaymentMethodMutationResponseDto) },
+  })
   async deletePaymentMethod(@Param('paymentMethodId') paymentMethodId: number) {
     await this.paymentServicesApp.deletePaymentMethod(paymentMethodId);
 

--- a/packages/server/src/modules/PaymentServices/types.ts
+++ b/packages/server/src/modules/PaymentServices/types.ts
@@ -1,4 +1,4 @@
-import { ApiPropertyOptional } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import {
   IsBoolean,
@@ -8,35 +8,68 @@ import {
   ValidateNested,
 } from 'class-validator';
 
-class EditPaymentMethodOptionsDto {
+export class EditPaymentMethodOptionsDto {
+  @ApiPropertyOptional({
+    description: 'Linked bank account id',
+    example: 12,
+  })
   @IsOptional()
   @IsNumber()
   bankAccountId?: number;
 
+  // Typo retained to match the underlying column mapping.
+  @ApiPropertyOptional({
+    description: 'Linked clearing account id',
+    example: 34,
+  })
   @IsOptional()
   @IsNumber()
   clearningAccountId?: number;
 
+  @ApiPropertyOptional({
+    description: 'Whether Visa is displayed at checkout.',
+    example: true,
+  })
   @IsOptional()
   @IsBoolean()
   showVisa?: boolean;
 
+  @ApiPropertyOptional({
+    description: 'Whether MasterCard is displayed at checkout.',
+    example: true,
+  })
   @IsOptional()
   @IsBoolean()
   showMasterCard?: boolean;
 
+  @ApiPropertyOptional({
+    description: 'Whether Discover is displayed at checkout.',
+    example: false,
+  })
   @IsOptional()
   @IsBoolean()
   showDiscover?: boolean;
 
+  @ApiPropertyOptional({
+    description: 'Whether American Express is displayed at checkout.',
+    example: false,
+  })
   @IsOptional()
   @IsBoolean()
   showAmer?: boolean;
 
+  @ApiPropertyOptional({
+    description: 'Whether JCB is displayed at checkout.',
+    example: false,
+  })
   @IsOptional()
   @IsBoolean()
   showJcb?: boolean;
 
+  @ApiPropertyOptional({
+    description: 'Whether Diners is displayed at checkout.',
+    example: false,
+  })
   @IsOptional()
   @IsBoolean()
   showDiners?: boolean;
@@ -55,8 +88,8 @@ export class EditPaymentMethodDTO {
   @IsOptional()
   @IsString()
   @ApiPropertyOptional({
-    type: String,
     description: 'Payment method name',
+    example: 'Stripe',
   })
   name?: string;
 }
@@ -64,13 +97,10 @@ export class EditPaymentMethodDTO {
 export interface GetPaymentMethodsPOJO {
   stripe: {
     isStripeAccountCreated: boolean;
-
     isStripePaymentEnabled: boolean;
     isStripePayoutEnabled: boolean;
     isStripeEnabled: boolean;
-
     isStripeServerConfigured: boolean;
-
     stripeAccountId: string | null;
     stripePaymentMethodId: number | null;
     stripePublishableKey: string | null;
@@ -78,4 +108,155 @@ export interface GetPaymentMethodsPOJO {
     stripeCurrencies: Array<string>;
     stripeRedirectUrl: string | null;
   };
+}
+
+export class StripePaymentMethodsStateDto {
+  @ApiProperty({
+    description: 'Whether the Stripe account record exists.',
+    example: true,
+  })
+  isStripeAccountCreated: boolean;
+
+  @ApiProperty({
+    description: 'Whether Stripe payments are enabled.',
+    example: true,
+  })
+  isStripePaymentEnabled: boolean;
+
+  @ApiProperty({
+    description: 'Whether Stripe payouts are enabled.',
+    example: false,
+  })
+  isStripePayoutEnabled: boolean;
+
+  @ApiProperty({
+    description: 'Whether Stripe is enabled overall.',
+    example: true,
+  })
+  isStripeEnabled: boolean;
+
+  @ApiProperty({
+    description: 'Whether Stripe is configured on the server (keys present).',
+    example: true,
+  })
+  isStripeServerConfigured: boolean;
+
+  @ApiProperty({
+    description: 'Stripe account id, if connected.',
+    example: 'acct_1MwQ...',
+    nullable: true,
+  })
+  stripeAccountId: string | null;
+
+  @ApiProperty({
+    description: 'Internal payment method id of the Stripe integration.',
+    example: 5,
+    nullable: true,
+  })
+  stripePaymentMethodId: number | null;
+
+  @ApiProperty({
+    description: 'Stripe publishable key, if configured.',
+    example: 'pk_live_...',
+    nullable: true,
+  })
+  stripePublishableKey: string | null;
+
+  @ApiProperty({
+    description: 'Stripe OAuth authorization link.',
+    example: 'https://connect.stripe.com/...',
+  })
+  stripeAuthLink: string;
+
+  @ApiProperty({
+    type: [String],
+    description: 'Currencies supported by the Stripe integration.',
+    example: ['USD', 'EUR'],
+  })
+  stripeCurrencies: string[];
+
+  @ApiProperty({
+    description: 'Redirect URL after Stripe OAuth flow.',
+    example: 'https://app.example.com/settings/payment',
+    nullable: true,
+  })
+  stripeRedirectUrl: string | null;
+}
+
+export class GetPaymentMethodsStateDto {
+  @ApiProperty({
+    type: () => StripePaymentMethodsStateDto,
+    description: 'Stripe payment integration state.',
+  })
+  stripe: StripePaymentMethodsStateDto;
+}
+
+export class PaymentIntegrationDto {
+  @ApiProperty({ description: 'Payment integration id.', example: 5 })
+  id: number;
+
+  @ApiProperty({
+    description: 'Display name of the payment integration.',
+    example: 'Stripe',
+  })
+  name: string;
+
+  @ApiProperty({
+    description: 'Payment service key (e.g. "stripe").',
+    example: 'stripe',
+  })
+  service: string;
+
+  @ApiProperty({
+    description: 'Whether payment processing is enabled.',
+    example: true,
+  })
+  paymentEnabled: boolean;
+
+  @ApiProperty({
+    description: 'Whether payout is enabled.',
+    example: false,
+  })
+  payoutEnabled: boolean;
+
+  @ApiProperty({
+    description: 'Connected account id at the provider.',
+    example: 'acct_1MwQ...',
+  })
+  accountId: string;
+
+  @ApiProperty({
+    description: 'Provider-specific options (bank account id, clearing account id, card brand flags, ...).',
+    type: 'object',
+    additionalProperties: true,
+    example: { bankAccountId: 12, clearingAccountId: 34 },
+  })
+  options: Record<string, unknown>;
+
+  @ApiProperty({
+    description: 'Virtual attribute — true when both payment and payout are enabled.',
+    example: false,
+  })
+  fullEnabled: boolean;
+
+  @ApiPropertyOptional({
+    description:
+      'Human-readable service label. Present on the list endpoint (added by the transformer).',
+    example: 'Stripe',
+  })
+  serviceFormatted?: string;
+}
+
+export class PaymentMethodMutationResponseDto {
+  @ApiProperty({
+    description: 'Id of the affected payment method.',
+    example: 7,
+  })
+  id: number;
+
+  @ApiProperty({
+    description: 'Human-readable confirmation message.',
+    example: 'The given payment method has been updated.',
+  })
+  message: string;
 }

--- a/packages/webapp/src/hooks/query/payment-services/queries.ts
+++ b/packages/webapp/src/hooks/query/payment-services/queries.ts
@@ -33,10 +33,7 @@ export const useGetPaymentServices = (
 
   return useQuery<GetPaymentServicesResponse, Error>({
     queryKey: paymentServicesKeys.list(),
-    queryFn: () =>
-      fetchGetPaymentServices(fetcher).then(
-        (res) => res?.payment_services as GetPaymentServicesResponse,
-      ),
+    queryFn: () => fetchGetPaymentServices(fetcher),
     ...options,
   });
 };
@@ -125,10 +122,7 @@ export const useGetPaymentMethod = (
 
   return useQuery<GetPaymentServiceResponse, Error>({
     queryKey: paymentServicesKeys.detail(paymentMethodId),
-    queryFn: () =>
-      fetchGetPaymentService(fetcher, paymentMethodId).then(
-        (res) => res?.data as GetPaymentServiceResponse,
-      ),
+    queryFn: () => fetchGetPaymentService(fetcher, paymentMethodId),
     enabled: !!paymentMethodId,
     ...options,
   });

--- a/shared/sdk-ts/openapi.json
+++ b/shared/sdk-ts/openapi.json
@@ -23135,10 +23135,41 @@
     "/api/payment-services": {
       "get": {
         "operationId": "PaymentServicesController_getPaymentServicesSpecificInvoice",
-        "parameters": [],
+        "summary": "Retrieves the payment services for the invoice.",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "Value must be 'Bearer <token>' where <token> is an API key prefixed with 'bc_' or a JWT token.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "Bearer bc_1234567890abcdef"
+            }
+          },
+          {
+            "name": "organization-id",
+            "in": "header",
+            "description": "Required if Authorization is a JWT token. The organization ID to operate within.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "Payment services have been successfully retrieved.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PaymentIntegrationDto"
+                  }
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -23149,10 +23180,38 @@
     "/api/payment-services/state": {
       "get": {
         "operationId": "PaymentServicesController_getPaymentMethodsState",
-        "parameters": [],
+        "summary": "Retrieves the payment methods state (Stripe, etc.).",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "Value must be 'Bearer <token>' where <token> is an API key prefixed with 'bc_' or a JWT token.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "Bearer bc_1234567890abcdef"
+            }
+          },
+          {
+            "name": "organization-id",
+            "in": "header",
+            "description": "Required if Authorization is a JWT token. The organization ID to operate within.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "Payment methods state has been successfully retrieved.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetPaymentMethodsStateDto"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -23163,11 +23222,32 @@
     "/api/payment-services/{paymentServiceId}": {
       "get": {
         "operationId": "PaymentServicesController_getPaymentService",
+        "summary": "Retrieves a specific payment service details.",
         "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "Value must be 'Bearer <token>' where <token> is an API key prefixed with 'bc_' or a JWT token.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "Bearer bc_1234567890abcdef"
+            }
+          },
+          {
+            "name": "organization-id",
+            "in": "header",
+            "description": "Required if Authorization is a JWT token. The organization ID to operate within.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
           {
             "name": "paymentServiceId",
             "required": true,
             "in": "path",
+            "description": "Payment service id.",
             "schema": {
               "type": "number"
             }
@@ -23175,7 +23255,14 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "Payment service details have been successfully retrieved.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentIntegrationDto"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -23186,11 +23273,32 @@
     "/api/payment-services/{paymentMethodId}": {
       "post": {
         "operationId": "PaymentServicesController_updatePaymentMethod",
+        "summary": "Updates the given payment method.",
         "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "Value must be 'Bearer <token>' where <token> is an API key prefixed with 'bc_' or a JWT token.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "Bearer bc_1234567890abcdef"
+            }
+          },
+          {
+            "name": "organization-id",
+            "in": "header",
+            "description": "Required if Authorization is a JWT token. The organization ID to operate within.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
           {
             "name": "paymentMethodId",
             "required": true,
             "in": "path",
+            "description": "Payment method id.",
             "schema": {
               "type": "number"
             }
@@ -23198,6 +23306,7 @@
         ],
         "requestBody": {
           "required": true,
+          "description": "Payment method update payload.",
           "content": {
             "application/json": {
               "schema": {
@@ -23208,7 +23317,14 @@
         },
         "responses": {
           "200": {
-            "description": ""
+            "description": "The payment method has been successfully updated.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentMethodMutationResponseDto"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -23217,11 +23333,32 @@
       },
       "delete": {
         "operationId": "PaymentServicesController_deletePaymentMethod",
+        "summary": "Deletes the given payment method.",
         "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "Value must be 'Bearer <token>' where <token> is an API key prefixed with 'bc_' or a JWT token.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "Bearer bc_1234567890abcdef"
+            }
+          },
+          {
+            "name": "organization-id",
+            "in": "header",
+            "description": "Required if Authorization is a JWT token. The organization ID to operate within.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
           {
             "name": "paymentMethodId",
             "required": true,
             "in": "path",
+            "description": "Payment method id.",
             "schema": {
               "type": "number"
             }
@@ -23229,7 +23366,14 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "The payment method has been successfully deleted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentMethodMutationResponseDto"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -41035,9 +41179,232 @@
           "organizationId"
         ]
       },
+      "PaymentIntegrationDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number",
+            "description": "Payment integration id.",
+            "example": 5
+          },
+          "name": {
+            "type": "string",
+            "description": "Display name of the payment integration.",
+            "example": "Stripe"
+          },
+          "service": {
+            "type": "string",
+            "description": "Payment service key (e.g. \"stripe\").",
+            "example": "stripe"
+          },
+          "paymentEnabled": {
+            "type": "boolean",
+            "description": "Whether payment processing is enabled.",
+            "example": true
+          },
+          "payoutEnabled": {
+            "type": "boolean",
+            "description": "Whether payout is enabled.",
+            "example": false
+          },
+          "accountId": {
+            "type": "string",
+            "description": "Connected account id at the provider.",
+            "example": "acct_1MwQ..."
+          },
+          "options": {
+            "type": "object",
+            "description": "Provider-specific options (bank account id, clearing account id, card brand flags, ...).",
+            "additionalProperties": true,
+            "example": {
+              "bankAccountId": 12,
+              "clearingAccountId": 34
+            }
+          },
+          "fullEnabled": {
+            "type": "boolean",
+            "description": "Virtual attribute — true when both payment and payout are enabled.",
+            "example": false
+          },
+          "serviceFormatted": {
+            "type": "string",
+            "description": "Human-readable service label. Present on the list endpoint (added by the transformer).",
+            "example": "Stripe"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "service",
+          "paymentEnabled",
+          "payoutEnabled",
+          "accountId",
+          "options",
+          "fullEnabled"
+        ]
+      },
+      "PaymentMethodMutationResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number",
+            "description": "Id of the affected payment method.",
+            "example": 7
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable confirmation message.",
+            "example": "The given payment method has been updated."
+          }
+        },
+        "required": [
+          "id",
+          "message"
+        ]
+      },
+      "StripePaymentMethodsStateDto": {
+        "type": "object",
+        "properties": {
+          "isStripeAccountCreated": {
+            "type": "boolean",
+            "description": "Whether the Stripe account record exists.",
+            "example": true
+          },
+          "isStripePaymentEnabled": {
+            "type": "boolean",
+            "description": "Whether Stripe payments are enabled.",
+            "example": true
+          },
+          "isStripePayoutEnabled": {
+            "type": "boolean",
+            "description": "Whether Stripe payouts are enabled.",
+            "example": false
+          },
+          "isStripeEnabled": {
+            "type": "boolean",
+            "description": "Whether Stripe is enabled overall.",
+            "example": true
+          },
+          "isStripeServerConfigured": {
+            "type": "boolean",
+            "description": "Whether Stripe is configured on the server (keys present).",
+            "example": true
+          },
+          "stripeAccountId": {
+            "type": "string",
+            "description": "Stripe account id, if connected.",
+            "example": "acct_1MwQ...",
+            "nullable": true
+          },
+          "stripePaymentMethodId": {
+            "type": "number",
+            "description": "Internal payment method id of the Stripe integration.",
+            "example": 5,
+            "nullable": true
+          },
+          "stripePublishableKey": {
+            "type": "string",
+            "description": "Stripe publishable key, if configured.",
+            "example": "pk_live_...",
+            "nullable": true
+          },
+          "stripeAuthLink": {
+            "type": "string",
+            "description": "Stripe OAuth authorization link.",
+            "example": "https://connect.stripe.com/..."
+          },
+          "stripeCurrencies": {
+            "description": "Currencies supported by the Stripe integration.",
+            "example": [
+              "USD",
+              "EUR"
+            ],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "stripeRedirectUrl": {
+            "type": "string",
+            "description": "Redirect URL after Stripe OAuth flow.",
+            "example": "https://app.example.com/settings/payment",
+            "nullable": true
+          }
+        },
+        "required": [
+          "isStripeAccountCreated",
+          "isStripePaymentEnabled",
+          "isStripePayoutEnabled",
+          "isStripeEnabled",
+          "isStripeServerConfigured",
+          "stripeAccountId",
+          "stripePaymentMethodId",
+          "stripePublishableKey",
+          "stripeAuthLink",
+          "stripeCurrencies",
+          "stripeRedirectUrl"
+        ]
+      },
+      "GetPaymentMethodsStateDto": {
+        "type": "object",
+        "properties": {
+          "stripe": {
+            "description": "Stripe payment integration state.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/StripePaymentMethodsStateDto"
+              }
+            ]
+          }
+        },
+        "required": [
+          "stripe"
+        ]
+      },
       "EditPaymentMethodOptionsDto": {
         "type": "object",
-        "properties": {}
+        "properties": {
+          "bankAccountId": {
+            "type": "number",
+            "description": "Linked bank account id",
+            "example": 12
+          },
+          "clearningAccountId": {
+            "type": "number",
+            "description": "Linked clearing account id",
+            "example": 34
+          },
+          "showVisa": {
+            "type": "boolean",
+            "description": "Whether Visa is displayed at checkout.",
+            "example": true
+          },
+          "showMasterCard": {
+            "type": "boolean",
+            "description": "Whether MasterCard is displayed at checkout.",
+            "example": true
+          },
+          "showDiscover": {
+            "type": "boolean",
+            "description": "Whether Discover is displayed at checkout.",
+            "example": false
+          },
+          "showAmer": {
+            "type": "boolean",
+            "description": "Whether American Express is displayed at checkout.",
+            "example": false
+          },
+          "showJcb": {
+            "type": "boolean",
+            "description": "Whether JCB is displayed at checkout.",
+            "example": false
+          },
+          "showDiners": {
+            "type": "boolean",
+            "description": "Whether Diners is displayed at checkout.",
+            "example": false
+          }
+        }
       },
       "EditPaymentMethodDTO": {
         "type": "object",
@@ -41052,7 +41419,8 @@
           },
           "name": {
             "type": "string",
-            "description": "Payment method name"
+            "description": "Payment method name",
+            "example": "Stripe"
           }
         }
       },

--- a/shared/sdk-ts/src/payment-services.ts
+++ b/shared/sdk-ts/src/payment-services.ts
@@ -1,5 +1,6 @@
 import type { ApiFetcher } from './fetch-utils';
 import { paths } from './schema';
+import { OpForPath, OpRequestBody, OpResponseBody } from './utils';
 
 export const PAYMENT_SERVICES_ROUTES = {
   LIST: '/api/payment-services',
@@ -9,55 +10,24 @@ export const PAYMENT_SERVICES_ROUTES = {
   DELETE_METHOD: '/api/payment-services/{paymentMethodId}',
 } as const satisfies Record<string, keyof paths>;
 
-export interface GetPaymentServicesResponse {
-  payment_services?: unknown;
-}
-
-export interface GetPaymentServicesStateResponse {
-  stripe: {
-    is_stripe_account_created: boolean;
-    is_stripe_payment_enabled: boolean;
-    is_stripe_payout_enabled: boolean;
-    is_stripe_enabled: boolean;
-    is_stripe_server_configured: boolean;
-    stripe_account_id: string | null;
-    stripe_payment_method_id: number | null;
-    stripe_currencies: string[];
-    stripe_publishable_key: string;
-    stripe_auth_link: string;
-    stripe_redirect_url: string;
-  };
-}
-
-export interface GetPaymentServiceResponse {
-  data?: unknown;
-}
-
-export interface EditPaymentMethodOptionsBody {
-  bankAccountId?: number;
-  clearningAccountId?: number;
-  showVisa?: boolean;
-  showMasterCard?: boolean;
-  showDiscover?: boolean;
-  showAmer?: boolean;
-  showJcb?: boolean;
-  showDiners?: boolean;
-}
-
-export interface UpdatePaymentMethodBody {
-  name?: string;
-  options?: EditPaymentMethodOptionsBody;
-}
-
-export interface UpdatePaymentMethodResponse {
-  id: number;
-  message: string;
-}
-
-export interface DeletePaymentMethodResponse {
-  id: number;
-  message: string;
-}
+export type GetPaymentServicesResponse = OpResponseBody<
+  OpForPath<typeof PAYMENT_SERVICES_ROUTES.LIST, 'get'>
+>;
+export type GetPaymentServicesStateResponse = OpResponseBody<
+  OpForPath<typeof PAYMENT_SERVICES_ROUTES.STATE, 'get'>
+>;
+export type GetPaymentServiceResponse = OpResponseBody<
+  OpForPath<typeof PAYMENT_SERVICES_ROUTES.BY_ID, 'get'>
+>;
+export type UpdatePaymentMethodBody = OpRequestBody<
+  OpForPath<typeof PAYMENT_SERVICES_ROUTES.UPDATE_METHOD, 'post'>
+>;
+export type UpdatePaymentMethodResponse = OpResponseBody<
+  OpForPath<typeof PAYMENT_SERVICES_ROUTES.UPDATE_METHOD, 'post'>
+>;
+export type DeletePaymentMethodResponse = OpResponseBody<
+  OpForPath<typeof PAYMENT_SERVICES_ROUTES.DELETE_METHOD, 'delete'>
+>;
 
 export async function fetchGetPaymentServices(
   fetcher: ApiFetcher,
@@ -67,7 +37,7 @@ export async function fetchGetPaymentServices(
     .method('get')
     .create();
   const { data } = await get({});
-  return data as GetPaymentServicesResponse;
+  return data;
 }
 
 export async function fetchGetPaymentServicesState(
@@ -78,8 +48,7 @@ export async function fetchGetPaymentServicesState(
     .method('get')
     .create();
   const { data } = await get({});
-  const wrapped = data as { data?: GetPaymentServicesStateResponse };
-  return wrapped?.data ?? (data as GetPaymentServicesStateResponse);
+  return data;
 }
 
 export async function fetchGetPaymentService(
@@ -91,7 +60,7 @@ export async function fetchGetPaymentService(
     .method('get')
     .create();
   const { data } = await get({ paymentServiceId });
-  return data as GetPaymentServiceResponse;
+  return data;
 }
 
 export async function fetchUpdatePaymentMethod(
@@ -103,8 +72,8 @@ export async function fetchUpdatePaymentMethod(
     .path(PAYMENT_SERVICES_ROUTES.UPDATE_METHOD)
     .method('post')
     .create();
-  const { data } = await post({ paymentMethodId, ...body } as never);
-  return data as UpdatePaymentMethodResponse;
+  const { data } = await post({ paymentMethodId, ...body });
+  return data;
 }
 
 export async function fetchDeletePaymentMethod(
@@ -116,5 +85,5 @@ export async function fetchDeletePaymentMethod(
     .method('delete')
     .create();
   const { data } = await del({ paymentMethodId });
-  return data as DeletePaymentMethodResponse;
+  return data;
 }

--- a/shared/sdk-ts/src/schema.ts
+++ b/shared/sdk-ts/src/schema.ts
@@ -4365,6 +4365,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
+        /** Retrieves the payment services for the invoice. */
         get: operations["PaymentServicesController_getPaymentServicesSpecificInvoice"];
         put?: never;
         post?: never;
@@ -4381,6 +4382,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
+        /** Retrieves the payment methods state (Stripe, etc.). */
         get: operations["PaymentServicesController_getPaymentMethodsState"];
         put?: never;
         post?: never;
@@ -4397,6 +4399,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
+        /** Retrieves a specific payment service details. */
         get: operations["PaymentServicesController_getPaymentService"];
         put?: never;
         post?: never;
@@ -4415,7 +4418,9 @@ export interface paths {
         };
         get?: never;
         put?: never;
+        /** Updates the given payment method. */
         post: operations["PaymentServicesController_updatePaymentMethod"];
+        /** Deletes the given payment method. */
         delete: operations["PaymentServicesController_deletePaymentMethod"];
         options?: never;
         head?: never;
@@ -14640,11 +14645,183 @@ export interface components {
             /** @description The organization ID to set as default */
             organizationId: string;
         };
-        EditPaymentMethodOptionsDto: Record<string, never>;
+        PaymentIntegrationDto: {
+            /**
+             * @description Payment integration id.
+             * @example 5
+             */
+            id: number;
+            /**
+             * @description Display name of the payment integration.
+             * @example Stripe
+             */
+            name: string;
+            /**
+             * @description Payment service key (e.g. "stripe").
+             * @example stripe
+             */
+            service: string;
+            /**
+             * @description Whether payment processing is enabled.
+             * @example true
+             */
+            paymentEnabled: boolean;
+            /**
+             * @description Whether payout is enabled.
+             * @example false
+             */
+            payoutEnabled: boolean;
+            /**
+             * @description Connected account id at the provider.
+             * @example acct_1MwQ...
+             */
+            accountId: string;
+            /**
+             * @description Provider-specific options (bank account id, clearing account id, card brand flags, ...).
+             * @example {
+             *       "bankAccountId": 12,
+             *       "clearingAccountId": 34
+             *     }
+             */
+            options: {
+                [key: string]: unknown;
+            };
+            /**
+             * @description Virtual attribute — true when both payment and payout are enabled.
+             * @example false
+             */
+            fullEnabled: boolean;
+            /**
+             * @description Human-readable service label. Present on the list endpoint (added by the transformer).
+             * @example Stripe
+             */
+            serviceFormatted?: string;
+        };
+        PaymentMethodMutationResponseDto: {
+            /**
+             * @description Id of the affected payment method.
+             * @example 7
+             */
+            id: number;
+            /**
+             * @description Human-readable confirmation message.
+             * @example The given payment method has been updated.
+             */
+            message: string;
+        };
+        StripePaymentMethodsStateDto: {
+            /**
+             * @description Whether the Stripe account record exists.
+             * @example true
+             */
+            isStripeAccountCreated: boolean;
+            /**
+             * @description Whether Stripe payments are enabled.
+             * @example true
+             */
+            isStripePaymentEnabled: boolean;
+            /**
+             * @description Whether Stripe payouts are enabled.
+             * @example false
+             */
+            isStripePayoutEnabled: boolean;
+            /**
+             * @description Whether Stripe is enabled overall.
+             * @example true
+             */
+            isStripeEnabled: boolean;
+            /**
+             * @description Whether Stripe is configured on the server (keys present).
+             * @example true
+             */
+            isStripeServerConfigured: boolean;
+            /**
+             * @description Stripe account id, if connected.
+             * @example acct_1MwQ...
+             */
+            stripeAccountId: string | null;
+            /**
+             * @description Internal payment method id of the Stripe integration.
+             * @example 5
+             */
+            stripePaymentMethodId: number | null;
+            /**
+             * @description Stripe publishable key, if configured.
+             * @example pk_live_...
+             */
+            stripePublishableKey: string | null;
+            /**
+             * @description Stripe OAuth authorization link.
+             * @example https://connect.stripe.com/...
+             */
+            stripeAuthLink: string;
+            /**
+             * @description Currencies supported by the Stripe integration.
+             * @example [
+             *       "USD",
+             *       "EUR"
+             *     ]
+             */
+            stripeCurrencies: string[];
+            /**
+             * @description Redirect URL after Stripe OAuth flow.
+             * @example https://app.example.com/settings/payment
+             */
+            stripeRedirectUrl: string | null;
+        };
+        GetPaymentMethodsStateDto: {
+            /** @description Stripe payment integration state. */
+            stripe: components["schemas"]["StripePaymentMethodsStateDto"];
+        };
+        EditPaymentMethodOptionsDto: {
+            /**
+             * @description Linked bank account id
+             * @example 12
+             */
+            bankAccountId?: number;
+            /**
+             * @description Linked clearing account id
+             * @example 34
+             */
+            clearningAccountId?: number;
+            /**
+             * @description Whether Visa is displayed at checkout.
+             * @example true
+             */
+            showVisa?: boolean;
+            /**
+             * @description Whether MasterCard is displayed at checkout.
+             * @example true
+             */
+            showMasterCard?: boolean;
+            /**
+             * @description Whether Discover is displayed at checkout.
+             * @example false
+             */
+            showDiscover?: boolean;
+            /**
+             * @description Whether American Express is displayed at checkout.
+             * @example false
+             */
+            showAmer?: boolean;
+            /**
+             * @description Whether JCB is displayed at checkout.
+             * @example false
+             */
+            showJcb?: boolean;
+            /**
+             * @description Whether Diners is displayed at checkout.
+             * @example false
+             */
+            showDiners?: boolean;
+        };
         EditPaymentMethodDTO: {
             /** @description Edit payment method options */
             options?: components["schemas"]["EditPaymentMethodOptionsDto"];
-            /** @description Payment method name */
+            /**
+             * @description Payment method name
+             * @example Stripe
+             */
             name?: string;
         };
         ViewColumn: Record<string, never>;
@@ -29267,95 +29444,139 @@ export interface operations {
     PaymentServicesController_getPaymentServicesSpecificInvoice: {
         parameters: {
             query?: never;
-            header?: never;
+            header: {
+                /** @description Value must be 'Bearer <token>' where <token> is an API key prefixed with 'bc_' or a JWT token. */
+                Authorization: string;
+                /** @description Required if Authorization is a JWT token. The organization ID to operate within. */
+                "organization-id": string;
+            };
             path?: never;
             cookie?: never;
         };
         requestBody?: never;
         responses: {
+            /** @description Payment services have been successfully retrieved. */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["PaymentIntegrationDto"][];
+                };
             };
         };
     };
     PaymentServicesController_getPaymentMethodsState: {
         parameters: {
             query?: never;
-            header?: never;
+            header: {
+                /** @description Value must be 'Bearer <token>' where <token> is an API key prefixed with 'bc_' or a JWT token. */
+                Authorization: string;
+                /** @description Required if Authorization is a JWT token. The organization ID to operate within. */
+                "organization-id": string;
+            };
             path?: never;
             cookie?: never;
         };
         requestBody?: never;
         responses: {
+            /** @description Payment methods state has been successfully retrieved. */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["GetPaymentMethodsStateDto"];
+                };
             };
         };
     };
     PaymentServicesController_getPaymentService: {
         parameters: {
             query?: never;
-            header?: never;
+            header: {
+                /** @description Value must be 'Bearer <token>' where <token> is an API key prefixed with 'bc_' or a JWT token. */
+                Authorization: string;
+                /** @description Required if Authorization is a JWT token. The organization ID to operate within. */
+                "organization-id": string;
+            };
             path: {
+                /** @description Payment service id. */
                 paymentServiceId: number;
             };
             cookie?: never;
         };
         requestBody?: never;
         responses: {
+            /** @description Payment service details have been successfully retrieved. */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["PaymentIntegrationDto"];
+                };
             };
         };
     };
     PaymentServicesController_updatePaymentMethod: {
         parameters: {
             query?: never;
-            header?: never;
+            header: {
+                /** @description Value must be 'Bearer <token>' where <token> is an API key prefixed with 'bc_' or a JWT token. */
+                Authorization: string;
+                /** @description Required if Authorization is a JWT token. The organization ID to operate within. */
+                "organization-id": string;
+            };
             path: {
+                /** @description Payment method id. */
                 paymentMethodId: number;
             };
             cookie?: never;
         };
+        /** @description Payment method update payload. */
         requestBody: {
             content: {
                 "application/json": components["schemas"]["EditPaymentMethodDTO"];
             };
         };
         responses: {
+            /** @description The payment method has been successfully updated. */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["PaymentMethodMutationResponseDto"];
+                };
             };
         };
     };
     PaymentServicesController_deletePaymentMethod: {
         parameters: {
             query?: never;
-            header?: never;
+            header: {
+                /** @description Value must be 'Bearer <token>' where <token> is an API key prefixed with 'bc_' or a JWT token. */
+                Authorization: string;
+                /** @description Required if Authorization is a JWT token. The organization ID to operate within. */
+                "organization-id": string;
+            };
             path: {
+                /** @description Payment method id. */
                 paymentMethodId: number;
             };
             cookie?: never;
         };
         requestBody?: never;
         responses: {
+            /** @description The payment method has been successfully deleted. */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["PaymentMethodMutationResponseDto"];
+                };
             };
         };
     };


### PR DESCRIPTION
## Summary

- Declare proper OpenAPI DTOs on the `PaymentServices` controller (`@ApiOperation`, `@ApiResponse`, `@ApiParam`, `@ApiBody`) and add response/request DTOs (`PaymentIntegrationDto`, `GetPaymentMethodsStateDto` + `StripePaymentMethodsStateDto`, decorated `EditPaymentMethodOptionsDto`, `PaymentMethodMutationResponseDto`) so the generated SDK schema is accurate instead of `unknown`.
- Unwrap response envelopes so handlers return payloads directly: `GET /payment-services` → `PaymentIntegration[]`, `GET /payment-services/state` → `{ stripe: … }`, `GET /payment-services/:id` → `PaymentIntegration`. Removes the redundant `{ paymentServices }`, `{ data }` wrappers and drops the now-unused `PaymentServicesResponseDto` / `PaymentServiceResponseDto`.
- Regenerate `shared/sdk-ts` schema and refactor `payment-services.ts` to derive types via `OpForPath` / `OpRequestBody` / `OpResponseBody` (matching `customers.ts`); deletes the hand-rolled interfaces (which had wrong snake_case field names) and all `as never` casts.
- Update webapp `useGetPaymentServices` / `useGetPaymentService` fetchers to drop the `.then`/cast unwrapping; consumer access patterns (`paymentMethodsState?.stripe.*`, `isEmpty(paymentServices)`) are now type-correct against the unwrapped shapes.

## Motivation

The controller previously declared no OpenAPI metadata, forcing the SDK to ship `unknown`/`Record<string, never>` shapes and the webapp to consume loosely-typed data. The old SDK interfaces also declared fields in snake_case while the server actually returns camelCase, so the types were wrong even where they existed. Unwrapping the response envelopes additionally aligns the wire shape with how the webapp already uses the data (e.g. `paymentMethodsState?.stripe.stripeAuthLink` was accessing past the type system).

## Test plan

- [x] `pnpm -w run generate:sdk-types` succeeds; `schema.ts` references `PaymentIntegrationDto`, `GetPaymentMethodsStateDto` for the three GET routes.
- [x] `pnpm --filter @bigcapital/sdk-ts build` passes.
- [x] `pnpm --filter webapp typecheck` — no new errors (144 baseline preserved; the previously-latent `.stripe` / array accesses are now type-correct).
- [ ] Runtime: load the Invoice form footer (`GET /`), Preferences → Payment Methods page (`GET /state`), and the Stripe integration edit drawer (`GET /:id`) to confirm round-trip still works end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)