### PR TITLE
fix(webapp): dynamically load moment.js locales

### DIFF
--- a/packages/webapp/src/components/App.tsx
+++ b/packages/webapp/src/components/App.tsx
@@ -6,8 +6,6 @@ import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
 import '@/style/App.scss';
-import 'moment/locale/ar-ly';
-import 'moment/locale/es-us';
 
 import AppIntlLoader from './AppIntlLoader';
 import { EnsureAuthenticated } from '@/components/Guards/EnsureAuthenticated';

--- a/packages/webapp/src/components/AppIntlLoader.tsx
+++ b/packages/webapp/src/components/AppIntlLoader.tsx
@@ -52,6 +52,15 @@ async function loadYupLocales(currentLocale) {
 }
 
 /**
+ * Dynamically loads the moment.js locale bundle for the given locale.
+ */
+async function loadMomentLocale(currentLocale) {
+  const momentLocale = transformMomentLocale(currentLocale);
+  if (momentLocale === 'en') return;
+  await import(`moment/locale/${momentLocale}`);
+}
+
+/**
  * Modifies the html document direction to RTl if it was rtl-language.
  */
 function useDocumentDirectionModifier(locale, isRTL) {
@@ -88,6 +97,7 @@ function useAppLoadLocales(currentLocale) {
           },
         });
       })
+      .then(() => loadMomentLocale(currentLocale))
       .then(() => {
         moment.locale(transformMomentLocale(currentLocale));
         setIsLoading(false);


### PR DESCRIPTION
## Summary

- Replace static moment locale imports in `App.tsx` with on-demand dynamic imports
- Add `loadMomentLocale` helper in `AppIntlLoader.tsx` that imports the required moment locale bundle based on the active locale
- Wire the locale load into the existing locale-loading promise chain so `moment.locale(...)` runs after the bundle is available

## Motivation

Static imports for `moment/locale/ar-ly` and `moment/locale/es-us` were always bundled regardless of the user's locale, adding unnecessary weight to the initial bundle. Loading the locale dynamically means only the active locale's bundle is fetched.

## Test plan

- [ ] App boots in English (`en`) — no moment locale bundle is fetched, dates format as before
- [ ] Switch locale to Arabic (`ar`) — `moment/locale/ar-ly` is fetched and Arabic date formatting works
- [ ] Verify `moment.locale(...)` is set correctly after locale switch
- [ ] Confirm no regressions in RTL document direction

🤖 Generated with [Claude Code](https://claude.com/claude-code)