### PR TITLE
fix(server): unify FinancialStatements number format DTOs

### DIFF
--- a/packages/server/src/modules/FinancialStatements/modules/JournalSheet/JournalSheet.types.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/JournalSheet/JournalSheet.types.ts
@@ -1,13 +1,10 @@
-import { IFinancialSheetCommonMeta } from '../../types/Report.types';
+import { IFinancialSheetCommonMeta, INumberFormatQuery } from '../../types/Report.types';
 import { IFinancialTable } from '../../types/Table.types';
 
 export interface IJournalReportQuery {
   fromDate: Date | string;
   toDate: Date | string;
-  numberFormat: {
-    noCents: boolean;
-    divideOn1000: boolean;
-  };
+  numberFormat: INumberFormatQuery;
   dateFormat?: string;
   transactionType: string;
   transactionId: string;

--- a/packages/server/src/modules/FinancialStatements/modules/JournalSheet/JournalSheetQuery.dto.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/JournalSheet/JournalSheetQuery.dto.ts
@@ -1,6 +1,5 @@
 import {
   IsArray,
-  IsBoolean,
   IsDateString,
   IsNumber,
   IsOptional,
@@ -10,24 +9,7 @@ import {
 import { Type } from 'class-transformer';
 import { FinancialSheetBranchesQueryDto } from '../../dtos/FinancialSheetBranchesQuery.dto';
 import { ApiPropertyOptional } from '@nestjs/swagger';
-
-class JournalSheetNumberFormatQueryDto {
-  @ApiPropertyOptional({
-    description: 'Whether to hide cents in the number format',
-    example: false,
-  })
-  @IsBoolean()
-  @IsOptional()
-  noCents: boolean;
-
-  @ApiPropertyOptional({
-    description: 'Whether to divide numbers by 1000',
-    example: false,
-  })
-  @IsBoolean()
-  @IsOptional()
-  divideOn1000: boolean;
-}
+import { NumberFormatQueryDto } from '@/modules/BankingTransactions/dtos/NumberFormatQuery.dto';
 
 export class JournalSheetQueryDto extends FinancialSheetBranchesQueryDto {
   @ApiPropertyOptional({
@@ -47,12 +29,13 @@ export class JournalSheetQueryDto extends FinancialSheetBranchesQueryDto {
   toDate: Date | string;
 
   @ApiPropertyOptional({
-    description: 'Number format options for the journal sheet',
-    example: { noCents: false, divideOn1000: false },
+    type: NumberFormatQueryDto,
+    description: 'Number formatting options',
   })
   @ValidateNested()
-  @Type(() => JournalSheetNumberFormatQueryDto)
-  numberFormat: JournalSheetNumberFormatQueryDto;
+  @Type(() => NumberFormatQueryDto)
+  @IsOptional()
+  numberFormat: NumberFormatQueryDto;
 
   @ApiPropertyOptional({
     description: 'Type of transaction to filter',

--- a/packages/server/src/modules/FinancialStatements/modules/JournalSheet/JournalSheetResponse.dto.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/JournalSheet/JournalSheetResponse.dto.ts
@@ -1,9 +1,9 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import {
-  FinancialReportTotalDto,
   FinancialReportMetaDto,
   FinancialTableDataDto,
 } from '../../dtos/FinancialReportResponse.dto';
+import { NumberFormatQueryDto } from '@/modules/BankingTransactions/dtos/NumberFormatQuery.dto';
 
 export class JournalEntryDto {
   @ApiProperty({ description: 'Entry index', type: Number })
@@ -99,11 +99,8 @@ export class JournalSheetQueryResponseDto {
   @ApiProperty({ description: 'Account IDs to include', type: [Number] })
   accountsIds: number[];
 
-  @ApiProperty({ description: 'Number format settings', type: Object })
-  numberFormat: {
-    noCents: boolean;
-    divideOn1000: boolean;
-  };
+  @ApiProperty({ description: 'Number format settings', type: NumberFormatQueryDto })
+  numberFormat: NumberFormatQueryDto;
 }
 
 export class JournalSheetResponseDto {

--- a/packages/server/src/modules/FinancialStatements/modules/JournalSheet/constant.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/JournalSheet/constant.ts
@@ -25,7 +25,10 @@ export const getJournalSheetDefaultQuery = () => ({
   toRange: null,
   accountsIds: [],
   numberFormat: {
-    noCents: false,
+    precision: 2,
     divideOn1000: false,
+    showZero: false,
+    formatMoney: 'total',
+    negativeFormat: 'mines',
   },
 });

--- a/packages/server/src/modules/FinancialStatements/modules/SalesTaxLiabilitySummary/dtos/SalesTaxLiabilityQuery.dto.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/SalesTaxLiabilitySummary/dtos/SalesTaxLiabilityQuery.dto.ts
@@ -1,5 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsDateString, IsEnum, IsNotEmpty, IsOptional } from 'class-validator';
+import { IsDateString, IsEnum, IsNotEmpty, IsOptional, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+import { NumberFormatQueryDto } from '@/modules/BankingTransactions/dtos/NumberFormatQuery.dto';
 
 export class SalesTaxLiabilitySummaryQueryDto {
   @ApiProperty({
@@ -26,4 +28,14 @@ export class SalesTaxLiabilitySummaryQueryDto {
   @IsEnum(['cash', 'accrual'])
   @IsNotEmpty()
   basis: 'cash' | 'accrual';
+
+  @ApiProperty({
+    type: NumberFormatQueryDto,
+    description: 'Number formatting options',
+    required: false,
+  })
+  @ValidateNested()
+  @Type(() => NumberFormatQueryDto)
+  @IsOptional()
+  numberFormat: NumberFormatQueryDto;
 }

--- a/packages/server/src/modules/FinancialStatements/modules/TransactionsByReference/TransactionsByReferenceQuery.dto.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/TransactionsByReference/TransactionsByReferenceQuery.dto.ts
@@ -1,5 +1,7 @@
-import { IsNotEmpty, IsString } from 'class-validator';
+import { IsNotEmpty, IsOptional, IsString, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
 import { ApiProperty } from '@nestjs/swagger';
+import { NumberFormatQueryDto } from '@/modules/BankingTransactions/dtos/NumberFormatQuery.dto';
 
 export class TransactionsByReferenceQueryDto {
   @IsString()
@@ -19,4 +21,14 @@ export class TransactionsByReferenceQueryDto {
     required: true,
   })
   referenceId: number;
+
+  @ApiProperty({
+    type: NumberFormatQueryDto,
+    description: 'Number formatting options',
+    required: false,
+  })
+  @ValidateNested()
+  @Type(() => NumberFormatQueryDto)
+  @IsOptional()
+  numberFormat: NumberFormatQueryDto;
 }

--- a/packages/server/src/modules/FinancialStatements/modules/TrialBalanceSheet/TrialBalanceSheetResponse.dto.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/TrialBalanceSheet/TrialBalanceSheetResponse.dto.ts
@@ -4,6 +4,7 @@ import {
   FinancialReportMetaDto,
   FinancialTableDataDto,
 } from '../../dtos/FinancialReportResponse.dto';
+import { NumberFormatQueryDto } from '@/modules/BankingTransactions/dtos/NumberFormatQuery.dto';
 
 export class TrialBalanceSheetAccountDto {
   @ApiProperty({ description: 'Account ID', type: Number })
@@ -120,6 +121,12 @@ export class TrialBalanceSheetQueryResponseDto {
     enum: ['day', 'month', 'year', 'quarter'],
   })
   displayColumnsBy: string;
+
+  @ApiProperty({
+    description: 'Number format settings',
+    type: NumberFormatQueryDto,
+  })
+  numberFormat: NumberFormatQueryDto;
 }
 
 export class TrialBalanceSheetResponseDto {

--- a/packages/webapp/src/components/App.tsx
+++ b/packages/webapp/src/components/App.tsx
@@ -10,10 +10,9 @@ import '@/style/App.scss';
 import AppIntlLoader from './AppIntlLoader';
 import { EnsureAuthenticated } from '@/components/Guards/EnsureAuthenticated';
 import { GlobalErrors } from '@/containers/GlobalErrors/GlobalErrors';
-
 import { SplashScreen, DashboardThemeProvider } from '../components';
-import { queryConfig } from '../hooks/query/base';
 import { EnsureUserEmailNotVerified } from './Guards/EnsureUserEmailNotVerified';
+import { queryConfig } from '../hooks/query/base';
 
 const DashboardPrivatePages = lazy(
   () => import('@/components/Dashboard/PrivatePages'),

--- a/packages/webapp/src/containers/FinancialStatements/FinancialStatementDateRange.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/FinancialStatementDateRange.tsx
@@ -20,8 +20,6 @@ export function FinancialStatementDateRange() {
               <FormGroup
                 label={intl.get('report_date_range')}
                 labelInfo={<Hint />}
-                minimal={true}
-                fill={true}
               >
                 <HTMLSelect
                   fill={true}
@@ -59,7 +57,6 @@ export function FinancialStatementDateRange() {
             name={'fromDate'}
             label={intl.get('from_date')}
             labelInfo={<Hint />}
-            fill
             fastField
           >
             <FDateInput
@@ -68,7 +65,6 @@ export function FinancialStatementDateRange() {
               popoverProps={{ minimal: true, position: Position.BOTTOM_LEFT }}
               maxDate={FINANCIAL_REPORT_MAX_DATE}
               canClearSelection={false}
-              minimal
               fill
             />
           </FFormGroup>
@@ -79,7 +75,6 @@ export function FinancialStatementDateRange() {
             name={'toDate'}
             label={intl.get('to_date')}
             labelInfo={<Hint />}
-            fill
             fastField
           >
             <FDateInput
@@ -88,7 +83,6 @@ export function FinancialStatementDateRange() {
               popoverProps={{ minimal: true, position: Position.BOTTOM }}
               canClearSelection={false}
               fill
-              minimal
               maxDate={FINANCIAL_REPORT_MAX_DATE}
             />
           </FFormGroup>

--- a/packages/webapp/src/containers/FinancialStatements/VendorsBalanceSummary/utils.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/VendorsBalanceSummary/utils.tsx
@@ -23,7 +23,6 @@ export const parseVendorsBalanceSummaryQuery = (
   locationQuery: Record<string, unknown>,
 ) => {
   const defaultQuery = getDefaultVendorsBalanceQuery();
-
   const transformed = {
     ...defaultQuery,
     ...transformToForm(locationQuery, defaultQuery),
@@ -36,7 +35,6 @@ export const parseVendorsBalanceSummaryQuery = (
 
 export const useVendorsBalanceSummaryQuery = () => {
   const [locationQuery, setLocationQuery] = useAppQueryString();
-
   const query = useMemo(
     () => parseVendorsBalanceSummaryQuery(locationQuery),
     [locationQuery],

--- a/shared/sdk-ts/openapi.json
+++ b/shared/sdk-ts/openapi.json
@@ -19556,6 +19556,65 @@
               "example": "1",
               "type": "number"
             }
+          },
+          {
+            "description": "Number of decimal places to display",
+            "required": false,
+            "name": "precision",
+            "in": "query",
+            "schema": {
+              "example": 2,
+              "type": "number"
+            }
+          },
+          {
+            "description": "Whether to divide the number by 1000",
+            "required": false,
+            "name": "divideOn1000",
+            "in": "query",
+            "schema": {
+              "example": false,
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Whether to show zero values",
+            "required": false,
+            "name": "showZero",
+            "in": "query",
+            "schema": {
+              "example": true,
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "How to format money values",
+            "required": false,
+            "name": "formatMoney",
+            "in": "query",
+            "schema": {
+              "example": "total",
+              "enum": [
+                "total",
+                "always",
+                "none"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "How to format negative numbers",
+            "required": false,
+            "name": "negativeFormat",
+            "in": "query",
+            "schema": {
+              "example": "parentheses",
+              "enum": [
+                "parentheses",
+                "mines"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -20769,6 +20828,65 @@
             }
           },
           {
+            "description": "Number of decimal places to display",
+            "required": false,
+            "name": "precision",
+            "in": "query",
+            "schema": {
+              "example": 2,
+              "type": "number"
+            }
+          },
+          {
+            "description": "Whether to divide the number by 1000",
+            "required": false,
+            "name": "divideOn1000",
+            "in": "query",
+            "schema": {
+              "example": false,
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Whether to show zero values",
+            "required": false,
+            "name": "showZero",
+            "in": "query",
+            "schema": {
+              "example": true,
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "How to format money values",
+            "required": false,
+            "name": "formatMoney",
+            "in": "query",
+            "schema": {
+              "example": "total",
+              "enum": [
+                "total",
+                "always",
+                "none"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "How to format negative numbers",
+            "required": false,
+            "name": "negativeFormat",
+            "in": "query",
+            "schema": {
+              "example": "parentheses",
+              "enum": [
+                "parentheses",
+                "mines"
+              ],
+              "type": "string"
+            }
+          },
+          {
             "name": "accept",
             "required": true,
             "in": "header",
@@ -20836,9 +20954,19 @@
             }
           },
           {
-            "description": "Whether to hide cents in the number format",
+            "description": "Number of decimal places to display",
             "required": false,
-            "name": "noCents",
+            "name": "precision",
+            "in": "query",
+            "schema": {
+              "example": 2,
+              "type": "number"
+            }
+          },
+          {
+            "description": "Whether to divide the number by 1000",
+            "required": false,
+            "name": "divideOn1000",
             "in": "query",
             "schema": {
               "example": false,
@@ -20846,13 +20974,42 @@
             }
           },
           {
-            "description": "Whether to divide numbers by 1000",
+            "description": "Whether to show zero values",
             "required": false,
-            "name": "divideOn1000",
+            "name": "showZero",
             "in": "query",
             "schema": {
-              "example": false,
+              "example": true,
               "type": "boolean"
+            }
+          },
+          {
+            "description": "How to format money values",
+            "required": false,
+            "name": "formatMoney",
+            "in": "query",
+            "schema": {
+              "example": "total",
+              "enum": [
+                "total",
+                "always",
+                "none"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "How to format negative numbers",
+            "required": false,
+            "name": "negativeFormat",
+            "in": "query",
+            "schema": {
+              "example": "parentheses",
+              "enum": [
+                "parentheses",
+                "mines"
+              ],
+              "type": "string"
             }
           },
           {
@@ -37812,6 +37969,14 @@
               "year",
               "quarter"
             ]
+          },
+          "numberFormat": {
+            "description": "Number format settings",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/NumberFormatQueryDto"
+              }
+            ]
           }
         },
         "required": [
@@ -37822,7 +37987,8 @@
           "noneTransactions",
           "basis",
           "displayColumnsType",
-          "displayColumnsBy"
+          "displayColumnsBy",
+          "numberFormat"
         ]
       },
       "TrialBalanceSheetAccountDto": {
@@ -39805,8 +39971,12 @@
             }
           },
           "numberFormat": {
-            "type": "object",
-            "description": "Number format settings"
+            "description": "Number format settings",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/NumberFormatQueryDto"
+              }
+            ]
           }
         },
         "required": [

--- a/shared/sdk-ts/src/schema.ts
+++ b/shared/sdk-ts/src/schema.ts
@@ -13301,6 +13301,8 @@ export interface components {
              * @enum {string}
              */
             displayColumnsBy: "day" | "month" | "year" | "quarter";
+            /** @description Number format settings */
+            numberFormat: components["schemas"]["NumberFormatQueryDto"];
         };
         TrialBalanceSheetAccountDto: {
             /** @description Account ID */
@@ -13919,7 +13921,7 @@ export interface components {
             /** @description Account IDs to include */
             accountsIds: number[];
             /** @description Number format settings */
-            numberFormat: Record<string, never>;
+            numberFormat: components["schemas"]["NumberFormatQueryDto"];
         };
         JournalEntryDto: {
             /** @description Entry index */
@@ -27197,6 +27199,16 @@ export interface operations {
                 referenceType: string;
                 /** @description The ID of the reference */
                 referenceId: number;
+                /** @description Number of decimal places to display */
+                precision?: number;
+                /** @description Whether to divide the number by 1000 */
+                divideOn1000?: boolean;
+                /** @description Whether to show zero values */
+                showZero?: boolean;
+                /** @description How to format money values */
+                formatMoney?: "total" | "always" | "none";
+                /** @description How to format negative numbers */
+                negativeFormat?: "parentheses" | "mines";
             };
             header?: never;
             path?: never;
@@ -27862,6 +27874,16 @@ export interface operations {
                 toDate: string;
                 /** @description Accounting basis for the summary */
                 basis: "cash" | "accrual";
+                /** @description Number of decimal places to display */
+                precision?: number;
+                /** @description Whether to divide the number by 1000 */
+                divideOn1000?: boolean;
+                /** @description Whether to show zero values */
+                showZero?: boolean;
+                /** @description How to format money values */
+                formatMoney?: "total" | "always" | "none";
+                /** @description How to format negative numbers */
+                negativeFormat?: "parentheses" | "mines";
             };
             header: {
                 /** @description Value must be 'Bearer <token>' where <token> is an API key prefixed with 'bc_' or a JWT token. */
@@ -27892,10 +27914,16 @@ export interface operations {
             query?: {
                 /** @description Filter out branches (if multiple branches feature is enabled) */
                 branchesIds?: number[];
-                /** @description Whether to hide cents in the number format */
-                noCents?: boolean;
-                /** @description Whether to divide numbers by 1000 */
+                /** @description Number of decimal places to display */
+                precision?: number;
+                /** @description Whether to divide the number by 1000 */
                 divideOn1000?: boolean;
+                /** @description Whether to show zero values */
+                showZero?: boolean;
+                /** @description How to format money values */
+                formatMoney?: "total" | "always" | "none";
+                /** @description How to format negative numbers */
+                negativeFormat?: "parentheses" | "mines";
                 /** @description Type of transaction to filter */
                 transactionType?: string;
                 /** @description ID of the transaction to filter */


### PR DESCRIPTION
## Summary
- Replace inline `numberFormat` DTO definitions in JournalSheet, SalesTaxLiabilitySummary, TransactionsByReference, and TrialBalanceSheet with the shared `NumberFormatQueryDto` from `BankingTransactions`, exposing the full set of formatting options (`precision`, `divideOn1000`, `showZero`, `formatMoney`, `negativeFormat`).
- Update `JournalSheet` default query to use the new number-format shape.
- Regenerate `shared/sdk-ts` OpenAPI JSON and schema types to reflect the unified DTO across the affected endpoints.
- Minor cosmetic cleanups in webapp (import ordering in `App.tsx`, removed redundant `minimal`/`fill` props in `FinancialStatementDateRange`, trailing blank lines in `VendorsBalanceSummary/utils`).

## Test plan
- [ ] `pnpm run server:build` passes
- [ ] `pnpm run webapp:build` passes
- [ ] Journal Sheet report renders and respects number-format query params
- [ ] Sales Tax Liability Summary accepts the new `numberFormat` fields
- [ ] Transactions by Reference accepts the new `numberFormat` fields
- [ ] Trial Balance Sheet response reflects the typed `numberFormat`
- [ ] SDK consumers type-check against the updated schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)