### PR TITLE
refactor: FS query type-safety and response DTO ids

### DIFF
--- a/packages/server/src/modules/Customers/dtos/CustomerResponse.dto.ts
+++ b/packages/server/src/modules/Customers/dtos/CustomerResponse.dto.ts
@@ -2,6 +2,9 @@ import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 
 export class CustomerResponseDto {
+  @ApiProperty({ example: 1, description: 'Customer id.' })
+  id: number;
+
   @ApiProperty({ example: 1500.0 })
   balance: number;
 

--- a/packages/server/src/modules/SaleEstimates/dtos/SaleEstimateResponse.dto.ts
+++ b/packages/server/src/modules/SaleEstimates/dtos/SaleEstimateResponse.dto.ts
@@ -5,6 +5,12 @@ import { AttachmentLinkDto } from '@/modules/Attachments/dtos/Attachment.dto';
 
 export class SaleEstimateResponseDto {
   // Model attributes
+  @ApiProperty({
+    description: 'Unique identifier of the sale estimate',
+    example: 1,
+  })
+  id: number;
+
   @ApiProperty({ description: 'Unique identifier of the customer', example: 1 })
   customerId: number;
 

--- a/packages/server/src/modules/Warehouses/dtos/WarehouseResponse.dto.ts
+++ b/packages/server/src/modules/Warehouses/dtos/WarehouseResponse.dto.ts
@@ -2,6 +2,12 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class WarehouseResponseDto {
   @ApiProperty({
+    description: 'The unique identifier of the warehouse',
+    example: 1,
+  })
+  id!: number;
+
+  @ApiProperty({
     description: 'The name of the warehouse',
     example: 'Main Warehouse',
   })

--- a/packages/webapp/src/containers/FinancialStatements/BalanceSheet/dynamicColumns.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/BalanceSheet/dynamicColumns.tsx
@@ -6,8 +6,22 @@ import { getColumnWidth } from '@/utils';
 interface ReportTableColumn {
   key: string;
   label: string;
-  cellIndex?: number;
+  cellIndex: number;
   children?: ReportTableColumn[];
+}
+
+interface TableColumn {
+  key: string;
+  Header: string;
+  accessor?: string;
+  className?: string;
+  textOverview?: boolean;
+  width?: number;
+  sticky?: Align;
+  align?: Align;
+  disableSortBy?: boolean;
+  money?: boolean;
+  columns?: TableColumn[];
 }
 
 const getTableCellValueAccessor = (index: number) => `cells[${index}].value`;
@@ -16,7 +30,7 @@ const getReportColWidth = (
   data: unknown[],
   accessor: string,
   headerText?: string,
-) => {
+): number => {
   return getColumnWidth(
     data,
     accessor,
@@ -28,34 +42,29 @@ const getReportColWidth = (
 /**
  * Account name column mapper.
  */
-const accountNameMapper = R.curry((data, column) => {
-  const accessor = getTableCellValueAccessor(column.cellIndex);
-  const width = getReportColWidth(data, accessor, column.label);
+const accountNameMapper = R.curry(
+  (data: unknown[], column: ReportTableColumn): TableColumn => {
+    const accessor = getTableCellValueAccessor(column.cellIndex);
+    const width = getReportColWidth(data, accessor, column.label);
 
-  return {
-    key: column.key,
-    Header: column.label,
-    accessor,
-    className: column.key,
-    textOverview: true,
-    width: Math.max(width, 300),
-    sticky: Align.Left,
-  };
-});
-
-/**
- * Assoc columns to total column.
- */
-const assocColumnsToTotalColumn = R.curry((data, column, columnAccessor) => {
-  const columns = totalColumnsComposer(data, column);
-  return R.assoc('columns', columns, columnAccessor);
-});
+    return {
+      key: column.key,
+      Header: column.label,
+      accessor,
+      className: column.key,
+      textOverview: true,
+      width: Math.max(width, 300),
+      sticky: Align.Left,
+    };
+  },
+);
 
 /**
  * Detarmines whether the given column has children columns.
  * @returns {boolean}
  */
-const isColumnHasColumns = (column) => !isEmpty(column.children);
+const isColumnHasColumns = (column: ReportTableColumn): boolean =>
+  !isEmpty(column.children);
 
 /**
  *
@@ -63,7 +72,10 @@ const isColumnHasColumns = (column) => !isEmpty(column.children);
  * @param {*} column
  * @returns
  */
-const dateRangeSoloColumnAttrs = (data, column) => {
+const dateRangeSoloColumnAttrs = (
+  data: unknown[],
+  column: ReportTableColumn,
+): Partial<TableColumn> => {
   const accessor = getTableCellValueAccessor(column.cellIndex);
 
   return {
@@ -73,205 +85,197 @@ const dateRangeSoloColumnAttrs = (data, column) => {
 };
 
 /**
- * Date range columns mapper.
- */
-const dateRangeMapper = R.curry((data, column) => {
-  const isDateColumnHasColumns = isColumnHasColumns(column);
-
-  const columnAccessor = {
-    Header: column.label,
-    key: column.key,
-    disableSortBy: true,
-    textOverview: true,
-    money: true,
-    align: isDateColumnHasColumns ? Align.Center : Align.Right,
-  };
-  return R.compose(
-    R.when(
-      R.always(isDateColumnHasColumns),
-      assocColumnsToTotalColumn(data, column),
-    ),
-    R.when(
-      R.always(!isDateColumnHasColumns),
-      R.mergeLeft(dateRangeSoloColumnAttrs(data, column)),
-    ),
-  )(columnAccessor);
-});
-
-/**
  * Total column mapper.
  */
-const totalMapper = R.curry((data, column) => {
-  const hasChildren = !isEmpty(column.children);
-  const accessor = getTableCellValueAccessor(column.cellIndex);
-  const width = getReportColWidth(data, accessor, column.label);
+const totalMapper = R.curry(
+  (data: unknown[], column: ReportTableColumn): TableColumn => {
+    const hasChildren = !isEmpty(column.children);
+    const accessor = getTableCellValueAccessor(column.cellIndex);
+    const width = getReportColWidth(data, accessor, column.label);
 
-  const columnAccessor = {
-    key: column.key,
-    Header: column.label,
-    accessor,
-    textOverview: true,
-    width,
-    disableSortBy: true,
-    money: true,
-    align: hasChildren ? Align.Center : Align.Right,
-  };
-  return R.compose(
-    R.when(R.always(hasChildren), assocColumnsToTotalColumn(data, column)),
-  )(columnAccessor);
-});
+    const columnAccessor: TableColumn = {
+      key: column.key,
+      Header: column.label,
+      accessor,
+      textOverview: true,
+      width,
+      disableSortBy: true,
+      money: true,
+      align: hasChildren ? Align.Center : Align.Right,
+    };
+    return R.compose(
+      R.when(R.always(hasChildren), assocColumnsToTotalColumn(data, column)),
+    )(columnAccessor);
+  },
+);
 
 /**
  * `Percentage of column` column accessor.
  */
-const percentageOfColumnAccessor = R.curry((data, column) => {
-  const accessor = getTableCellValueAccessor(column.cellIndex);
-  const width = getReportColWidth(data, accessor, column.label);
+const percentageOfColumnAccessor = R.curry(
+  (data: unknown[], column: ReportTableColumn): TableColumn => {
+    const accessor = getTableCellValueAccessor(column.cellIndex);
+    const width = getReportColWidth(data, accessor, column.label);
 
-  return {
-    Header: column.label,
-    key: column.key,
-    accessor,
-    width,
-    align: Align.Right,
-    disableSortBy: true,
-    textOverview: true,
-    money: true,
-  };
-});
+    return {
+      Header: column.label,
+      key: column.key,
+      accessor,
+      width,
+      align: Align.Right,
+      disableSortBy: true,
+      textOverview: true,
+      money: true,
+    };
+  },
+);
 
 /**
  * `Percentage of row` column accessor.
  */
-const percentageOfRowAccessor = R.curry((data, column) => {
-  const accessor = getTableCellValueAccessor(column.cellIndex);
-  const width = getReportColWidth(data, accessor, column.label);
+const percentageOfRowAccessor = R.curry(
+  (data: unknown[], column: ReportTableColumn): TableColumn => {
+    const accessor = getTableCellValueAccessor(column.cellIndex);
+    const width = getReportColWidth(data, accessor, column.label);
 
-  return {
-    Header: column.label,
-    key: column.key,
-    accessor,
-    width,
-    align: Align.Right,
-    disableSortBy: true,
-    textOverview: true,
-    money: true,
-  };
-});
+    return {
+      Header: column.label,
+      key: column.key,
+      accessor,
+      width,
+      align: Align.Right,
+      disableSortBy: true,
+      textOverview: true,
+      money: true,
+    };
+  },
+);
 
 /**
  * Previous year column accessor.
  */
-const previousYearAccessor = R.curry((data, column) => {
-  const accessor = getTableCellValueAccessor(column.cellIndex);
-  const width = getReportColWidth(data, accessor, column.label);
+const previousYearAccessor = R.curry(
+  (data: unknown[], column: ReportTableColumn): TableColumn => {
+    const accessor = getTableCellValueAccessor(column.cellIndex);
+    const width = getReportColWidth(data, accessor, column.label);
 
-  return {
-    Header: column.label,
-    key: column.key,
-    accessor,
-    width,
-    align: Align.Right,
-    disableSortBy: true,
-    textOverview: true,
-    money: true,
-  };
-});
+    return {
+      Header: column.label,
+      key: column.key,
+      accessor,
+      width,
+      align: Align.Right,
+      disableSortBy: true,
+      textOverview: true,
+      money: true,
+    };
+  },
+);
 
 /**
  * Pervious year change column accessor.
  */
-const previousYearChangeAccessor = R.curry((data, column) => {
-  const accessor = getTableCellValueAccessor(column.cellIndex);
-  const width = getReportColWidth(data, accessor, column.label);
+const previousYearChangeAccessor = R.curry(
+  (data: unknown[], column: ReportTableColumn): TableColumn => {
+    const accessor = getTableCellValueAccessor(column.cellIndex);
+    const width = getReportColWidth(data, accessor, column.label);
 
-  return {
-    Header: column.label,
-    key: column.key,
-    accessor,
-    width,
-    align: Align.Right,
-    disableSortBy: true,
-    textOverview: true,
-    money: true,
-  };
-});
+    return {
+      Header: column.label,
+      key: column.key,
+      accessor,
+      width,
+      align: Align.Right,
+      disableSortBy: true,
+      textOverview: true,
+      money: true,
+    };
+  },
+);
 
 /**
  * Previous year percentage column accessor.
  */
-const previousYearPercentageAccessor = R.curry((data, column) => {
-  const accessor = getTableCellValueAccessor(column.cellIndex);
-  const width = getReportColWidth(data, accessor, column.label);
+const previousYearPercentageAccessor = R.curry(
+  (data: unknown[], column: ReportTableColumn): TableColumn => {
+    const accessor = getTableCellValueAccessor(column.cellIndex);
+    const width = getReportColWidth(data, accessor, column.label);
 
-  return {
-    Header: column.label,
-    key: column.key,
-    accessor,
-    width,
-    align: Align.Right,
-    disableSortBy: true,
-    textOverview: true,
-    money: true,
-  };
-});
+    return {
+      Header: column.label,
+      key: column.key,
+      accessor,
+      width,
+      align: Align.Right,
+      disableSortBy: true,
+      textOverview: true,
+      money: true,
+    };
+  },
+);
 
 /**
  * Previous period column accessor.
  */
-const previousPeriodAccessor = R.curry((data, column) => {
-  const accessor = getTableCellValueAccessor(column.cellIndex);
-  const width = getReportColWidth(data, accessor, column.label);
+const previousPeriodAccessor = R.curry(
+  (data: unknown[], column: ReportTableColumn): TableColumn => {
+    const accessor = getTableCellValueAccessor(column.cellIndex);
+    const width = getReportColWidth(data, accessor, column.label);
 
-  return {
-    Header: column.label,
-    key: column.key,
-    accessor,
-    width,
-    align: Align.Right,
-    disableSortBy: true,
-    textOverview: true,
-    money: true,
-  };
-});
+    return {
+      Header: column.label,
+      key: column.key,
+      accessor,
+      width,
+      align: Align.Right,
+      disableSortBy: true,
+      textOverview: true,
+      money: true,
+    };
+  },
+);
 
 /**
  * Previous period change column accessor.
  */
-const previousPeriodChangeAccessor = R.curry((data, column) => {
-  const accessor = getTableCellValueAccessor(column.cellIndex);
-  const width = getReportColWidth(data, accessor, column.label);
+const previousPeriodChangeAccessor = R.curry(
+  (data: unknown[], column: ReportTableColumn): TableColumn => {
+    const accessor = getTableCellValueAccessor(column.cellIndex);
+    const width = getReportColWidth(data, accessor, column.label);
 
-  return {
-    Header: column.label,
-    key: column.key,
-    accessor,
-    width,
-    align: Align.Right,
-    disableSortBy: true,
-    textOverview: true,
-    money: true,
-  };
-});
+    return {
+      Header: column.label,
+      key: column.key,
+      accessor,
+      width,
+      align: Align.Right,
+      disableSortBy: true,
+      textOverview: true,
+      money: true,
+    };
+  },
+);
 
 /**
  * Previous period percentage column accessor.
  */
-const previousPeriodPercentageAccessor = R.curry((data, column) => {
-  const accessor = getTableCellValueAccessor(column.cellIndex);
-  const width = getReportColWidth(data, accessor, column.label);
+const previousPeriodPercentageAccessor = R.curry(
+  (data: unknown[], column: ReportTableColumn): TableColumn => {
+    const accessor = getTableCellValueAccessor(column.cellIndex);
+    const width = getReportColWidth(data, accessor, column.label);
 
-  return {
-    Header: column.label,
-    key: column.key,
-    accessor,
-    width,
-    align: Align.Right,
-    disableSortBy: true,
-    textOverview: true,
-    money: true,
-  };
-});
+    return {
+      Header: column.label,
+      key: column.key,
+      accessor,
+      width,
+      align: Align.Right,
+      disableSortBy: true,
+      textOverview: true,
+      money: true,
+    };
+  },
+);
 
 /**
  *
@@ -279,68 +283,123 @@ const previousPeriodPercentageAccessor = R.curry((data, column) => {
  * @param {*} index
  * @returns
  */
-const totalColumnsMapper = R.curry((data, column) => {
-  return R.compose(
-    R.when(R.pathEq(['key'], 'total'), totalMapper(data)),
-    // Percetage of column/row.
-    R.when(
-      R.pathEq(['key'], 'percentageOfColumn'),
-      percentageOfColumnAccessor(data),
-    ),
-    R.when(R.pathEq(['key'], 'percentageOfRow'), percentageOfRowAccessor(data)),
-    // Previous year.
-    R.when(R.pathEq(['key'], 'previousYear'), previousYearAccessor(data)),
-    R.when(
-      R.pathEq(['key'], 'previousYearChange'),
-      previousYearChangeAccessor(data),
-    ),
-    R.when(
-      R.pathEq(['key'], 'previousYearPercentage'),
-      previousYearPercentageAccessor(data),
-    ),
-    // Pervious period.
-    R.when(R.pathEq(['key'], 'previousPeriod'), previousPeriodAccessor(data)),
-    R.when(
-      R.pathEq(['key'], 'previousPeriodChange'),
-      previousPeriodChangeAccessor(data),
-    ),
-    R.when(
-      R.pathEq(['key'], 'previousPeriodPercentage'),
-      previousPeriodPercentageAccessor(data),
-    ),
-  )(column);
-});
+const totalColumnsMapper = R.curry(
+  (data: unknown[], column: ReportTableColumn): TableColumn => {
+    return R.compose(
+      R.when(R.pathEq(['key'], 'total'), totalMapper(data)),
+      // Percetage of column/row.
+      R.when(
+        R.pathEq(['key'], 'percentageOfColumn'),
+        percentageOfColumnAccessor(data),
+      ),
+      R.when(
+        R.pathEq(['key'], 'percentageOfRow'),
+        percentageOfRowAccessor(data),
+      ),
+      // Previous year.
+      R.when(R.pathEq(['key'], 'previousYear'), previousYearAccessor(data)),
+      R.when(
+        R.pathEq(['key'], 'previousYearChange'),
+        previousYearChangeAccessor(data),
+      ),
+      R.when(
+        R.pathEq(['key'], 'previousYearPercentage'),
+        previousYearPercentageAccessor(data),
+      ),
+      // Pervious period.
+      R.when(R.pathEq(['key'], 'previousPeriod'), previousPeriodAccessor(data)),
+      R.when(
+        R.pathEq(['key'], 'previousPeriodChange'),
+        previousPeriodChangeAccessor(data),
+      ),
+      R.when(
+        R.pathEq(['key'], 'previousPeriodPercentage'),
+        previousPeriodPercentageAccessor(data),
+      ),
+    )(column);
+  },
+);
 
 /**
  * Total sub-columns composer.
  */
-const totalColumnsComposer = R.curry((data, column) => {
-  return R.map(totalColumnsMapper(data), column.children);
-});
+const totalColumnsComposer = R.curry(
+  (data: unknown[], column: ReportTableColumn): TableColumn[] => {
+    return R.map(totalColumnsMapper(data), column.children ?? []);
+  },
+);
+
+/**
+ * Assoc columns to total column.
+ */
+const assocColumnsToTotalColumn = R.curry(
+  (
+    data: unknown[],
+    column: ReportTableColumn,
+    columnAccessor: TableColumn,
+  ): TableColumn => {
+    const columns = totalColumnsComposer(data, column);
+    return R.assoc('columns', columns, columnAccessor);
+  },
+);
+
+/**
+ * Date range columns mapper.
+ */
+const dateRangeMapper = R.curry(
+  (data: unknown[], column: ReportTableColumn): TableColumn => {
+    const isDateColumnHasColumns = isColumnHasColumns(column);
+
+    const columnAccessor: TableColumn = {
+      Header: column.label,
+      key: column.key,
+      disableSortBy: true,
+      textOverview: true,
+      money: true,
+      align: isDateColumnHasColumns ? Align.Center : Align.Right,
+    };
+    return R.compose(
+      R.when(
+        R.always(isDateColumnHasColumns),
+        assocColumnsToTotalColumn(data, column),
+      ),
+      R.when(
+        R.always(!isDateColumnHasColumns),
+        R.mergeLeft(dateRangeSoloColumnAttrs(data, column)),
+      ),
+    )(columnAccessor);
+  },
+);
 
 /**
  * Detarmines the given string starts with `date-range` string.
  */
-const isMatchesDateRange = (r) => R.match(/^date-range/g, r).length > 0;
+const isMatchesDateRange = (r: string): boolean =>
+  R.match(/^date-range/g, r).length > 0;
 
 /**
  * Dynamic column mapper.
  */
-const dynamicColumnMapper = R.curry((data, column) => {
-  const indexTotalMapper = totalMapper(data);
-  const indexAccountNameMapper = accountNameMapper(data);
-  const indexDatePeriodMapper = dateRangeMapper(data);
+const dynamicColumnMapper = R.curry(
+  (data: unknown[], column: ReportTableColumn): TableColumn => {
+    const indexTotalMapper = totalMapper(data);
+    const indexAccountNameMapper = accountNameMapper(data);
+    const indexDatePeriodMapper = dateRangeMapper(data);
 
-  return R.compose(
-    R.when(R.pathSatisfies(isMatchesDateRange, ['key']), indexDatePeriodMapper),
-    R.when(R.pathEq(['key'], 'name'), indexAccountNameMapper),
-    R.when(R.pathEq(['key'], 'total'), indexTotalMapper),
-  )(column);
-});
+    return R.compose(
+      R.when(
+        R.pathSatisfies(isMatchesDateRange, ['key']),
+        indexDatePeriodMapper,
+      ),
+      R.when(R.pathEq(['key'], 'name'), indexAccountNameMapper),
+      R.when(R.pathEq(['key'], 'total'), indexTotalMapper),
+    )(column);
+  },
+);
 
 export const dynamicColumns = (
   columns: ReportTableColumn[],
   data: unknown[],
-) => {
+): TableColumn[] => {
   return R.map(dynamicColumnMapper(data), columns);
 };

--- a/packages/webapp/src/containers/FinancialStatements/InventoryValuation/InventoryValuation.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/InventoryValuation/InventoryValuation.tsx
@@ -61,7 +61,7 @@ function InventoryValuationInner({
   return (
     <InventoryValuationProvider query={query}>
       <InventoryValuationActionsBar
-        numberFormat={query.numberFormat as Record<string, unknown>}
+        numberFormat={query.numberFormat}
         onNumberFormatSubmit={handleNumberFormatSubmit}
       />
       <InventoryValuationLoadingBar />

--- a/packages/webapp/src/containers/FinancialStatements/InventoryValuation/utils.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/InventoryValuation/utils.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import moment from 'moment';
 import { castArray } from 'lodash';
 import * as Yup from 'yup';
-
+import { InventoryValuationTableQuery } from '@bigcapital/sdk-ts';
 import { useAppQueryString } from '@/hooks';
 import { transformToForm } from '@/utils';
 
@@ -21,9 +21,9 @@ export const getInventoryValuationQuerySchema = () => {
 export const getInventoryValuationQuery = () => ({
   asDate: moment().format('YYYY-MM-DD'),
   filterByOption: 'with-transactions',
-  itemsIds: [] as string[],
-  branchesIds: [] as string[],
-  warehousesIds: [] as string[],
+  itemsIds: [] as number[],
+  branchesIds: [] as number[],
+  warehousesIds: [] as number[],
 });
 
 /**
@@ -31,9 +31,8 @@ export const getInventoryValuationQuery = () => ({
  */
 const parseInventoryValuationQuery = (
   locationQuery: Record<string, unknown>,
-) => {
+): InventoryValuationTableQuery => {
   const defaultQuery = getInventoryValuationQuery();
-
   const transformed = {
     ...defaultQuery,
     ...transformToForm(locationQuery, defaultQuery),
@@ -42,9 +41,9 @@ const parseInventoryValuationQuery = (
     ...transformed,
 
     // Ensures the branches/warehouses ids is always array.
-    itemsIds: castArray(transformed.itemsIds),
-    branchesIds: castArray(transformed.branchesIds),
-    warehousesIds: castArray(transformed.warehousesIds),
+    itemsIds: castArray(transformed.itemsIds).map(Number),
+    branchesIds: castArray(transformed.branchesIds).map(Number),
+    warehousesIds: castArray(transformed.warehousesIds).map(Number),
   };
 };
 

--- a/packages/webapp/src/containers/FinancialStatements/ProfitLossSheet/components.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/ProfitLossSheet/components.tsx
@@ -56,7 +56,7 @@ export function ProfitLossSheetAlerts() {
     return null;
   }
   // Can't continue if the cost compute job is not running.
-  if (!profitLossSheet.meta.isCostComputeRunning) {
+  if (!profitLossSheet?.meta?.isCostComputeRunning) {
     return null;
   }
   return (

--- a/packages/webapp/src/containers/FinancialStatements/PurchasesByItems/PurchasesByItems.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/PurchasesByItems/PurchasesByItems.tsx
@@ -57,7 +57,7 @@ function PurchasesByItemsInner({
   return (
     <PurchasesByItemsProvider query={query}>
       <PurchasesByItemsActionsBar
-        numberFormat={query.numberFormat as Record<string, unknown>}
+        numberFormat={query.numberFormat}
         onNumberFormatSubmit={handleNumberFormatSubmit}
       />
       <PurchasesByItemsLoadingBar />

--- a/packages/webapp/src/containers/FinancialStatements/PurchasesByItems/utils.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/PurchasesByItems/utils.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import moment from 'moment';
 import * as Yup from 'yup';
 import intl from 'react-intl-universal';
+import { PurchasesByItemsTableQuery } from '@bigcapital/sdk-ts';
 import { useAppQueryString } from '@/hooks';
 import { transformToForm } from '@/utils';
 import { castArray } from 'lodash';
@@ -13,7 +14,7 @@ export const getDefaultPurchasesByItemsQuery = () => ({
   fromDate: moment().startOf('month').format('YYYY-MM-DD'),
   toDate: moment().format('YYYY-MM-DD'),
   filterByOption: 'with-transactions',
-  itemsIds: [] as string[],
+  itemsIds: [] as number[],
 });
 
 /**
@@ -32,16 +33,17 @@ export const getPurchasesByItemsQuerySchema = () => {
 /**
  * Parses the purchases by items query.
  */
-const parsePurchasesByItemsQuery = (locationQuery: Record<string, unknown>) => {
+const parsePurchasesByItemsQuery = (
+  locationQuery: Record<string, unknown>,
+): PurchasesByItemsTableQuery => {
   const defaultQuery = getDefaultPurchasesByItemsQuery();
-
   const transformed = {
     ...defaultQuery,
     ...transformToForm(locationQuery, defaultQuery),
   };
   return {
     ...transformed,
-    itemsIds: castArray(transformed.itemsIds),
+    itemsIds: castArray(transformed.itemsIds).map(Number),
   };
 };
 

--- a/packages/webapp/src/containers/FinancialStatements/SalesByItems/SalesByItems.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/SalesByItems/SalesByItems.tsx
@@ -1,18 +1,15 @@
-import React, { useEffect, useCallback } from 'react';
+import { useEffect, useCallback } from 'react';
 import moment from 'moment';
-
 import { SalesByItemsBody } from './SalesByItemsBody';
 import { SalesByItemProvider } from './SalesByItemProvider';
 import { SalesByItemsLoadingBar } from './components';
 import { FinancialStatement, DashboardPageContent } from '@/components';
 import { SalesByItemsActionsBar } from './SalesByItemsActionsBar';
 import { SalesByItemsHeader } from './SalesByItemsHeader';
-
 import {
   withSalesByItemsActions,
   WithSalesByItemsActionsProps,
 } from './withSalesByItemsActions';
-
 import { useSalesByItemsQuery } from './utils';
 import { compose } from '@/utils';
 import { SalesByItemsDialogs } from './SalesByitemsDialogs';
@@ -59,7 +56,7 @@ function SalesByItemsInner({
   return (
     <SalesByItemProvider query={query}>
       <SalesByItemsActionsBar
-        numberFormat={query.numberFormat as Record<string, unknown>}
+        numberFormat={query.numberFormat}
         onNumberFormatSubmit={handleNumberFormatSubmit}
       />
       <SalesByItemsLoadingBar />

--- a/packages/webapp/src/containers/FinancialStatements/SalesByItems/utils.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/SalesByItems/utils.tsx
@@ -3,6 +3,7 @@ import moment from 'moment';
 import * as Yup from 'yup';
 import intl from 'react-intl-universal';
 import { castArray } from 'lodash';
+import { SalesByItemsTableQuery } from '@bigcapital/sdk-ts';
 import { useAppQueryString } from '@/hooks';
 import { transformToForm } from '@/utils';
 
@@ -26,22 +27,23 @@ export const getDefaultSalesByItemsQuery = () => ({
   fromDate: moment().startOf('month').format('YYYY-MM-DD'),
   toDate: moment().format('YYYY-MM-DD'),
   filterByOption: 'with-transactions',
-  itemsIds: [] as string[],
+  itemsIds: [],
 });
 
 /**
  * Parses sales by items query of browser location.
  */
-const parseSalesByItemsQuery = (locationQuery: Record<string, unknown>) => {
+const parseSalesByItemsQuery = (
+  locationQuery: Record<string, unknown>,
+): SalesByItemsTableQuery => {
   const defaultQuery = getDefaultSalesByItemsQuery();
-
   const transformed = {
     ...defaultQuery,
     ...transformToForm(locationQuery, defaultQuery),
   };
   return {
     ...transformed,
-    itemsIds: castArray(transformed.itemsIds),
+    itemsIds: castArray(transformed.itemsIds).map(Number),
   };
 };
 

--- a/packages/webapp/src/containers/FinancialStatements/VendorsTransactions/VendorsTransactions.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/VendorsTransactions/VendorsTransactions.tsx
@@ -1,19 +1,15 @@
 import React, { useEffect } from 'react';
 import moment from 'moment';
-
 import { FinancialStatement, DashboardPageContent } from '@/components';
 import { VendorsTransactionsBody } from './VendorsTransactionsBody';
 import { VendorsTransactionsProvider } from './VendorsTransactionsProvider';
 import { VendorsTransactionsLoadingBar } from './components';
-
 import { VendorsTransactionsHeader } from './VendorsTransactionsHeader';
 import { VendorsTransactionsActionsBar } from './VendorsTransactionsActionsBar';
-
 import {
   withVendorsTransactionsActions,
   WithVendorsTransactionsActionsProps,
 } from './withVendorsTransactionsActions';
-
 import { compose } from '@/utils';
 import { useVendorsTransactionsQuery } from './_utils';
 import { VendorTransactionsDialogs } from './VendorTransactionsDialogs';
@@ -40,7 +36,6 @@ function VendorsTransactionsInner({
     };
     setFilter({ ..._filter });
   };
-
   // Handle number format submit.
   const handleNumberFormatSubmit = (values: Record<string, unknown>) => {
     setFilter({
@@ -59,7 +54,7 @@ function VendorsTransactionsInner({
   return (
     <VendorsTransactionsProvider filter={filter}>
       <VendorsTransactionsActionsBar
-        numberFormat={filter.numberFormat as Record<string, unknown>}
+        numberFormat={filter.numberFormat}
         onNumberFormatSubmit={handleNumberFormatSubmit}
       />
       <VendorsTransactionsLoadingBar />

--- a/packages/webapp/src/containers/FinancialStatements/VendorsTransactions/_utils.ts
+++ b/packages/webapp/src/containers/FinancialStatements/VendorsTransactions/_utils.ts
@@ -4,6 +4,7 @@ import moment from 'moment';
 import { useMemo } from 'react';
 import { transformToForm } from '@/utils';
 import { useAppQueryString } from '@/hooks';
+import { TransactionsByVendorsTableQuery } from '@bigcapital/sdk-ts';
 
 /**
  * The validation schema of vendors transactions.
@@ -30,7 +31,9 @@ export const getVendorsTransactionsDefaultQuery = () => ({
 /**
  * Parses the query of vendors transactions.
  */
-const parseVendorsTransactionsQuery = (query: Record<string, unknown>) => {
+const parseVendorsTransactionsQuery = (
+  query: Record<string, unknown>,
+): TransactionsByVendorsTableQuery => {
   const defaultQuery = getVendorsTransactionsDefaultQuery();
   const transformed = {
     ...defaultQuery,

--- a/shared/sdk-ts/openapi.json
+++ b/shared/sdk-ts/openapi.json
@@ -25465,6 +25465,11 @@
       "WarehouseResponseDto": {
         "type": "object",
         "properties": {
+          "id": {
+            "type": "number",
+            "description": "The unique identifier of the warehouse",
+            "example": 1
+          },
           "name": {
             "type": "string",
             "description": "The name of the warehouse",
@@ -25497,6 +25502,7 @@
           }
         },
         "required": [
+          "id",
           "name",
           "code",
           "city",
@@ -29104,6 +29110,11 @@
       "CustomerResponseDto": {
         "type": "object",
         "properties": {
+          "id": {
+            "type": "number",
+            "example": 1,
+            "description": "Customer id."
+          },
           "balance": {
             "type": "number",
             "example": 1500
@@ -29257,6 +29268,7 @@
           }
         },
         "required": [
+          "id",
           "balance",
           "currencyCode",
           "openingBalance",
@@ -30226,6 +30238,11 @@
       "SaleEstimateResponseDto": {
         "type": "object",
         "properties": {
+          "id": {
+            "type": "number",
+            "description": "Unique identifier of the sale estimate",
+            "example": 1
+          },
           "customerId": {
             "type": "number",
             "description": "Unique identifier of the customer",
@@ -30427,6 +30444,7 @@
           }
         },
         "required": [
+          "id",
           "customerId",
           "estimateDate",
           "expirationDate",

--- a/shared/sdk-ts/src/schema.ts
+++ b/shared/sdk-ts/src/schema.ts
@@ -5948,6 +5948,11 @@ export interface components {
         };
         WarehouseResponseDto: {
             /**
+             * @description The unique identifier of the warehouse
+             * @example 1
+             */
+            id: number;
+            /**
              * @description The name of the warehouse
              * @example Main Warehouse
              */
@@ -8465,6 +8470,11 @@ export interface components {
             nonDeletableIds: number[];
         };
         CustomerResponseDto: {
+            /**
+             * @description Customer id.
+             * @example 1
+             */
+            id: number;
             /** @example 1500 */
             balance: number;
             /** @example USD */
@@ -9083,6 +9093,11 @@ export interface components {
             skipUndeletable: boolean;
         };
         SaleEstimateResponseDto: {
+            /**
+             * @description Unique identifier of the sale estimate
+             * @example 1
+             */
+            id: number;
             /**
              * @description Unique identifier of the customer
              * @example 1


### PR DESCRIPTION
## Summary

- Add `id` field to `CustomerResponseDto`, `SaleEstimateResponseDto`, and `WarehouseResponseDto` and regenerate the SDK schema so these previously-undocumented identifiers are exposed to clients.
- Type the financial-statement query parsers (`InventoryValuation`, `PurchasesByItems`, `SalesByItems`, `VendorsTransactions`) against their SDK query types and coerce `itemsIds`/`branchesIds`/`warehousesIds` to `number[]` rather than leaving them as `string[]`.
- Remove unsafe `as Record<string, unknown>` casts on `numberFormat` across the affected financial statements, and guard `ProfitLossSheet` meta access with optional chaining.

## Test plan

- [ ] `pnpm typecheck` passes in `packages/webapp` and `packages/server`
- [ ] `pnpm run sdk:generate` (or equivalent) produces a schema matching the committed `shared/sdk-ts/schema.ts`
- [ ] Manually verify SalesByItems / PurchasesByItems / InventoryValuation filters still accept multiple items and round-trip through the URL
- [ ] Verify VendorsTransactions number format dialog still applies formatting changes
- [ ] Confirm `GET /customers/:id`, `GET /sale-estimates/:id`, and `GET /warehouses/:id` responses now include `id` in the OpenAPI spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)
