### PR TITLE
fix(webapp): extract flattenInfinityPages utility and harden Account select types

### DIFF
--- a/packages/server/src/modules/PaymentReceived/PaymentsReceived.controller.ts
+++ b/packages/server/src/modules/PaymentReceived/PaymentsReceived.controller.ts
@@ -1,5 +1,6 @@
 import { Response } from 'express';
 import {
+  ApiBody,
   ApiExtraModels,
   ApiOperation,
   ApiResponse,
@@ -34,6 +35,9 @@ import { PaginatedResponseDto } from '@/common/dtos/PaginatedResults.dto';
 import { PaymentReceivedStateResponseDto } from './dtos/PaymentReceivedStateResponse.dto';
 import { PaymentReceivedHtmlContentResponseDto } from './dtos/PaymentReceivedHtmlResponse.dto';
 import { PaymentReceiveEditPageResponseDto } from './dtos/PaymentReceiveEditPageResponse.dto';
+import { PaymentReceiveMailOptsDto } from './dtos/PaymentReceiveMailOpts.dto';
+import { PaymentReceiveMailStateResponseDto } from './dtos/PaymentReceiveMailStateResponse.dto';
+import { PaymentReceiveMailResponseDto } from './dtos/PaymentReceiveMailResponse.dto';
 import { ApiCommonHeaders } from '@/common/decorators/ApiCommonHeaders';
 import {
   BulkDeleteDto,
@@ -52,6 +56,9 @@ import { PaymentReceiveAction } from './types/PaymentReceived.types';
 @ApiExtraModels(PaymentReceivedStateResponseDto)
 @ApiExtraModels(PaymentReceivedHtmlContentResponseDto)
 @ApiExtraModels(PaymentReceiveEditPageResponseDto)
+@ApiExtraModels(PaymentReceiveMailOptsDto)
+@ApiExtraModels(PaymentReceiveMailStateResponseDto)
+@ApiExtraModels(PaymentReceiveMailResponseDto)
 @ApiExtraModels(ValidateBulkDeleteResponseDto)
 @ApiCommonHeaders()
 @UseGuards(AuthorizationGuard, PermissionGuard)
@@ -60,9 +67,14 @@ export class PaymentReceivesController {
 
   @Post(':id/mail')
   @HttpCode(200)
+  @ApiBody({
+    description: 'The payment receive mail options',
+    type: PaymentReceiveMailOptsDto,
+  })
   @ApiResponse({
     status: 200,
     description: 'The payment receive mail has been successfully sent.',
+    schema: { $ref: getSchemaPath(PaymentReceiveMailResponseDto) },
   })
   public sendPaymentReceiveMail(
     @Param('id', ParseIntPipe) paymentReceiveId: number,
@@ -93,6 +105,7 @@ export class PaymentReceivesController {
     status: 200,
     description:
       'The payment receive mail options have been successfully retrieved.',
+    schema: { $ref: getSchemaPath(PaymentReceiveMailStateResponseDto) },
   })
   public getPaymentReceiveMailOptions(
     @Param('id', ParseIntPipe) paymentReceiveId: number,

--- a/packages/server/src/modules/PaymentReceived/dtos/PaymentReceiveMailOpts.dto.ts
+++ b/packages/server/src/modules/PaymentReceived/dtos/PaymentReceiveMailOpts.dto.ts
@@ -1,0 +1,86 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { AddressItem } from '@/modules/MailNotification/MailNotification.types';
+
+export class PaymentReceiveMailAddressItemDto implements AddressItem {
+  @ApiProperty({ description: 'The email address', example: 'john@example.com' })
+  mail: string;
+
+  @ApiProperty({
+    description: 'The display label for the address',
+    example: 'John Doe',
+  })
+  label: string;
+
+  @ApiProperty({
+    description: 'Whether this is the primary address',
+    example: true,
+    required: false,
+  })
+  primary?: boolean;
+}
+
+export class PaymentReceiveMailOptsDto {
+  @ApiProperty({
+    description: 'Sender email addresses',
+    example: ['billing@company.com'],
+    type: [String],
+  })
+  from: Array<string>;
+
+  @ApiProperty({
+    description: 'Recipient email addresses',
+    example: ['customer@example.com'],
+    type: [String],
+  })
+  to: Array<string>;
+
+  @ApiProperty({
+    description: 'CC recipient email addresses',
+    example: ['accounting@company.com'],
+    type: [String],
+    required: false,
+  })
+  cc?: Array<string>;
+
+  @ApiProperty({
+    description: 'BCC recipient email addresses',
+    type: [String],
+    required: false,
+  })
+  bcc?: Array<string>;
+
+  @ApiProperty({ description: 'The email subject', example: 'Payment Received' })
+  subject: string;
+
+  @ApiProperty({
+    description: 'The email body message',
+    example: 'We have received your payment.',
+  })
+  message: string;
+
+  @ApiProperty({
+    description: 'Available recipient address options',
+    type: [PaymentReceiveMailAddressItemDto],
+  })
+  toOptions: Array<PaymentReceiveMailAddressItemDto>;
+
+  @ApiProperty({
+    description: 'Available sender address options',
+    type: [PaymentReceiveMailAddressItemDto],
+  })
+  fromOptions: Array<PaymentReceiveMailAddressItemDto>;
+
+  @ApiProperty({
+    description: 'Template format arguments',
+    type: Object,
+    required: false,
+  })
+  formatArgs?: Record<string, unknown>;
+
+  @ApiProperty({
+    description: 'Whether to attach the payment PDF',
+    example: true,
+    required: false,
+  })
+  attachPdf?: boolean;
+}

--- a/packages/server/src/modules/PaymentReceived/dtos/PaymentReceiveMailOpts.dto.ts
+++ b/packages/server/src/modules/PaymentReceived/dtos/PaymentReceiveMailOpts.dto.ts
@@ -2,7 +2,10 @@ import { ApiProperty } from '@nestjs/swagger';
 import { AddressItem } from '@/modules/MailNotification/MailNotification.types';
 
 export class PaymentReceiveMailAddressItemDto implements AddressItem {
-  @ApiProperty({ description: 'The email address', example: 'john@example.com' })
+  @ApiProperty({
+    description: 'The email address',
+    example: 'john@example.com',
+  })
   mail: string;
 
   @ApiProperty({
@@ -49,7 +52,10 @@ export class PaymentReceiveMailOptsDto {
   })
   bcc?: Array<string>;
 
-  @ApiProperty({ description: 'The email subject', example: 'Payment Received' })
+  @ApiProperty({
+    description: 'The email subject',
+    example: 'Payment Received',
+  })
   subject: string;
 
   @ApiProperty({

--- a/packages/server/src/modules/PaymentReceived/dtos/PaymentReceiveMailResponse.dto.ts
+++ b/packages/server/src/modules/PaymentReceived/dtos/PaymentReceiveMailResponse.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class PaymentReceiveMailResponseDto {
+  @ApiProperty({
+    description: 'Whether the mail was successfully queued/sent',
+    example: true,
+  })
+  success: boolean;
+
+  @ApiProperty({
+    description: 'Optional status message',
+    required: false,
+  })
+  message?: string;
+}

--- a/packages/server/src/modules/PaymentReceived/dtos/PaymentReceiveMailStateResponse.dto.ts
+++ b/packages/server/src/modules/PaymentReceived/dtos/PaymentReceiveMailStateResponse.dto.ts
@@ -1,0 +1,143 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { PaymentReceiveMailAddressItemDto } from './PaymentReceiveMailOpts.dto';
+
+export class PaymentReceiveMailEntryDto {
+  @ApiProperty({
+    description: 'The invoice number',
+    example: 'INV-001',
+  })
+  invoiceNumber: string;
+
+  @ApiProperty({
+    description: 'The formatted paid amount',
+    example: '$500.00',
+  })
+  paidAmount: string;
+}
+
+export class PaymentReceiveMailStateResponseDto {
+  @ApiProperty({
+    description: 'The organization company name',
+    example: 'Acme Inc.',
+  })
+  companyName: string;
+
+  @ApiProperty({
+    description: 'The company logo URI',
+    example: 'https://example.com/logo.png',
+    required: false,
+  })
+  companyLogoUri?: string;
+
+  @ApiProperty({
+    description: 'The primary brand color',
+    example: '#2563eb',
+    required: false,
+  })
+  primaryColor?: string;
+
+  @ApiProperty({
+    description: 'The customer display name',
+    example: 'John Doe',
+  })
+  customerName: string;
+
+  @ApiProperty({
+    description: 'The payment invoice entries',
+    type: [PaymentReceiveMailEntryDto],
+  })
+  entries: Array<PaymentReceiveMailEntryDto>;
+
+  @ApiProperty({
+    description: 'Sender email addresses',
+    type: [String],
+  })
+  from: Array<string>;
+
+  @ApiProperty({
+    description: 'Recipient email addresses',
+    type: [String],
+  })
+  to: Array<string>;
+
+  @ApiProperty({
+    description: 'CC recipient email addresses',
+    type: [String],
+    required: false,
+  })
+  cc?: Array<string>;
+
+  @ApiProperty({
+    description: 'BCC recipient email addresses',
+    type: [String],
+    required: false,
+  })
+  bcc?: Array<string>;
+
+  @ApiProperty({ description: 'The email subject' })
+  subject: string;
+
+  @ApiProperty({ description: 'The email body message' })
+  message: string;
+
+  @ApiProperty({
+    description: 'Available sender address options',
+    type: [PaymentReceiveMailAddressItemDto],
+  })
+  fromOptions: Array<PaymentReceiveMailAddressItemDto>;
+
+  @ApiProperty({
+    description: 'Available recipient address options',
+    type: [PaymentReceiveMailAddressItemDto],
+  })
+  toOptions: Array<PaymentReceiveMailAddressItemDto>;
+
+  @ApiProperty({
+    description: 'The ISO payment date',
+    example: '2024-03-15',
+  })
+  paymentDate: string;
+
+  @ApiProperty({
+    description: 'The human-readable payment date',
+    example: 'March 15, 2024',
+  })
+  paymentDateFormatted: string;
+
+  @ApiProperty({
+    description: 'The numeric payment total',
+    example: 500,
+  })
+  total: number;
+
+  @ApiProperty({
+    description: 'The formatted payment total',
+    example: '$500.00',
+  })
+  totalFormatted: string;
+
+  @ApiProperty({
+    description: 'The numeric payment subtotal',
+    example: 500,
+  })
+  subtotal: number;
+
+  @ApiProperty({
+    description: 'The formatted payment subtotal',
+    example: '$500.00',
+  })
+  subtotalFormatted: string;
+
+  @ApiProperty({
+    description: 'The payment receive number',
+    example: 'PR-0001',
+  })
+  paymentNumber: string;
+
+  @ApiProperty({
+    description: 'Template format arguments',
+    type: Object,
+    required: false,
+  })
+  formatArgs?: Record<string, unknown>;
+}

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -9,7 +9,7 @@
     "@bigcapital/utils": "workspace:*",
     "@blueprintjs-formik/core": "^0.3.8",
     "@blueprintjs-formik/datetime": "^0.4.1",
-    "@blueprintjs-formik/select": "^0.4.6",
+    "@blueprintjs-formik/select": "^0.4.9",
     "@blueprintjs/colors": "4.1.19",
     "@blueprintjs/core": "^4.20.2",
     "@blueprintjs/datetime": "^4.4.37",

--- a/packages/webapp/src/components/Accounts/AccountsMultiSelect.tsx
+++ b/packages/webapp/src/components/Accounts/AccountsMultiSelect.tsx
@@ -7,24 +7,13 @@ import { usePreprocessingAccounts } from './_hooks';
 import { DialogsName } from '@/constants/dialogs';
 import { useDialogActions } from '@/hooks/state/dashboard';
 import { SelectOptionProps } from '@blueprintjs-formik/select';
+import { Account } from '@bigcapital/sdk-ts';
 
-interface Account {
-  id: number;
-  name: string;
-  code: string;
-  account_level: number;
-  account_type?: string;
-  account_parent_type?: string;
-  account_root_type?: string;
-  account_normal?: string;
-}
-
-export interface AccountSelect extends Partial<Account>, SelectOptionProps {}
-
+export interface AccountSelectModel extends Partial<Account>, SelectOptionProps {}
 type MultiSelectProps = React.ComponentProps<typeof FMultiSelect>;
 
 interface AccountsMultiSelectProps extends Omit<MultiSelectProps, 'items'> {
-  items: AccountSelect[];
+  items: AccountSelectModel[];
   allowCreate?: boolean;
   filterByRootTypes?: string[];
   filterByParentTypes?: string[];
@@ -49,7 +38,7 @@ const createNewItemRenderer = (
 };
 
 // Create new item from the given query string.
-const createNewItemFromQuery = (query: string): AccountSelect => ({
+const createNewItemFromQuery = (query: string): AccountSelectModel => ({
   label: query,
   value: query,
   text: query,
@@ -96,7 +85,7 @@ export function AccountsMultiSelect({
   };
 
   return (
-    <FMultiSelect
+    <FMultiSelect<AccountSelectModel>
       {...rest}
       items={filteredAccounts}
       valueAccessor={'id'}

--- a/packages/webapp/src/components/Accounts/AccountsMultiSelect.tsx
+++ b/packages/webapp/src/components/Accounts/AccountsMultiSelect.tsx
@@ -9,7 +9,9 @@ import { useDialogActions } from '@/hooks/state/dashboard';
 import { SelectOptionProps } from '@blueprintjs-formik/select';
 import { Account } from '@bigcapital/sdk-ts';
 
-export interface AccountSelectModel extends Partial<Account>, SelectOptionProps {}
+export interface AccountSelectModel
+  extends Partial<Account>,
+    SelectOptionProps {}
 type MultiSelectProps = React.ComponentProps<typeof FMultiSelect>;
 
 interface AccountsMultiSelectProps extends Omit<MultiSelectProps, 'items'> {

--- a/packages/webapp/src/components/Accounts/AccountsSelect.tsx
+++ b/packages/webapp/src/components/Accounts/AccountsSelect.tsx
@@ -1,16 +1,31 @@
-// @ts-nocheck
 import React from 'react';
-import * as R from 'ramda';
-import intl from 'react-intl-universal';
 import { MenuItem } from '@blueprintjs/core';
+import type { ItemRenderer } from '@blueprintjs/select';
+import intl from 'react-intl-universal';
 import { MenuItemNestedText, FSelect } from '@/components';
 import { accountPredicate } from './_components';
-import { DialogsName } from '@/constants/dialogs';
-import { withDialogActions } from '@/containers/Dialog/withDialogActions';
 import { usePreprocessingAccounts } from './_hooks';
+import { DialogsName } from '@/constants/dialogs';
+import { useDialogActions } from '@/hooks/state/dashboard';
+import { AccountSelectModel } from './AccountsMultiSelect';
+
+type FSelectProps = React.ComponentProps<typeof FSelect>;
+
+interface AccountsSelectProps extends Omit<FSelectProps, 'items'> {
+  items: AccountSelectModel[];
+  allowCreate?: boolean;
+  filterByRootTypes?: string[];
+  filterByParentTypes?: string[];
+  filterByTypes?: string[];
+  filterByNormal?: string[];
+}
 
 // Create new account renderer.
-const createNewItemRenderer = (query, active, handleClick) => {
+const createNewItemRenderer = (
+  query: string,
+  active: boolean,
+  handleClick: (event: React.MouseEvent<HTMLElement>) => void,
+): React.ReactElement => {
   return (
     <MenuItem
       icon="add"
@@ -22,13 +37,20 @@ const createNewItemRenderer = (query, active, handleClick) => {
 };
 
 // Create new item from the given query string.
-const createNewItemFromQuery = (name) => ({ name });
+const createNewItemFromQuery = (query: string): AccountSelectModel => ({
+  label: query,
+  value: query,
+  text: query,
+  id: 0,
+  name: query,
+  code: query,
+});
 
-/**
- * Default account item renderer.
- * @returns {JSX.Element}
- */
-const accountRenderer = (item, { handleClick, modifiers, query }) => {
+// Default account item renderer.
+const accountRenderer: ItemRenderer<AccountSelectModel> = (
+  item,
+  { handleClick, modifiers },
+) => {
   if (!modifiers.matchesPredicate) {
     return null;
   }
@@ -38,7 +60,7 @@ const accountRenderer = (item, { handleClick, modifiers, query }) => {
       disabled={modifiers.disabled}
       label={item.code}
       key={item.id}
-      text={<MenuItemNestedText level={item.account_level} text={item.name} />}
+      text={<MenuItemNestedText level={item.accountLevel} text={item.name} />}
       onClick={handleClick}
     />
   );
@@ -48,41 +70,42 @@ const accountRenderer = (item, { handleClick, modifiers, query }) => {
  * Accounts select field binded with Formik form.
  * @returns {JSX.Element}
  */
-function AccountsSelectRoot({
-  // #withDialogActions
-  openDialog,
-
-  // #ownProps
+export function AccountsSelect({
   items,
   allowCreate,
 
+  filterByRootTypes,
   filterByParentTypes,
   filterByTypes,
   filterByNormal,
-  filterByRootTypes,
 
-  ...restProps
-}) {
+  ...rest
+}: AccountsSelectProps): React.ReactElement {
+  const { openDialog } = useDialogActions();
+
   // Filters accounts based on filter props.
   const filteredAccounts = usePreprocessingAccounts(items, {
-    filterByParentTypes,
-    filterByTypes,
-    filterByNormal,
-    filterByRootTypes,
+    filterByParentTypes: filterByParentTypes || [],
+    filterByTypes: filterByTypes || [],
+    filterByNormal: filterByNormal || [],
+    filterByRootTypes: filterByRootTypes || [],
   });
   // Maybe inject new item props to select component.
-  const maybeCreateNewItemRenderer = allowCreate ? createNewItemRenderer : null;
+  const maybeCreateNewItemRenderer = allowCreate
+    ? createNewItemRenderer
+    : undefined;
   const maybeCreateNewItemFromQuery = allowCreate
     ? createNewItemFromQuery
-    : null;
+    : undefined;
 
   // Handles the create item click.
-  const handleCreateItemClick = () => {
+  const handleCreateItemClick = (): void => {
     openDialog(DialogsName.AccountForm);
   };
 
   return (
-    <FSelect
+    <FSelect<AccountSelectModel>
+      {...rest}
       items={filteredAccounts}
       textAccessor={'name'}
       labelAccessor={'code'}
@@ -93,9 +116,6 @@ function AccountsSelectRoot({
       createNewItemRenderer={maybeCreateNewItemRenderer}
       createNewItemFromQuery={maybeCreateNewItemFromQuery}
       onCreateItemSelect={handleCreateItemClick}
-      {...restProps}
     />
   );
 }
-
-export const AccountsSelect = R.compose(withDialogActions)(AccountsSelectRoot);

--- a/packages/webapp/src/components/Accounts/AccountsSuggestField.tsx
+++ b/packages/webapp/src/components/Accounts/AccountsSuggestField.tsx
@@ -3,25 +3,13 @@ import intl from 'react-intl-universal';
 import { MenuItem } from '@blueprintjs/core';
 import { ItemRenderer, ItemPredicate } from '@blueprintjs/select';
 import { DialogsName } from '@/constants/dialogs';
-import { FSuggest, Suggest, FormattedMessage as T } from '@/components';
+import { AccountSelectModel, FSuggest, Suggest, FormattedMessage as T } from '@/components';
 import { withDialogActions } from '@/containers/Dialog/withDialogActions';
 import { usePreprocessingAccounts } from './_hooks';
 
-// Account interface
-interface Account {
-  id: number;
-  name: string;
-  code: string;
-  account_level?: number;
-  account_type?: string;
-  account_parent_type?: string;
-  account_root_type?: string;
-  account_normal?: string;
-}
-
 // Types for renderers and predicates
-type AccountItemRenderer = ItemRenderer<Account>;
-type AccountItemPredicate = ItemPredicate<Account>;
+type AccountItemRenderer = ItemRenderer<AccountSelectModel>;
+type AccountItemPredicate = ItemPredicate<AccountSelectModel>;
 
 // Create new account renderer.
 const createNewItemRenderer = (
@@ -40,18 +28,15 @@ const createNewItemRenderer = (
 };
 
 // Create new item from the given query string.
-const createNewItemFromQuery = (name: string): Partial<Account> => {
-  return { name };
-};
-
+const createNewItemFromQuery = (name: string): Partial<AccountSelectModel> => ({ name });
 // Filters accounts items.
 const filterAccountsPredicater: AccountItemPredicate = (
   query: string,
-  account: Account,
+  account: AccountSelectModel,
   _index?: number,
   exactMatch?: boolean,
 ): boolean => {
-  const normalizedTitle = account.name.toLowerCase();
+  const normalizedTitle = account?.name?.toLowerCase();
   const normalizedQuery = query.toLowerCase();
 
   if (exactMatch) {
@@ -63,7 +48,7 @@ const filterAccountsPredicater: AccountItemPredicate = (
 
 // Account item renderer for Suggest (non-Formik)
 const accountItemRenderer: AccountItemRenderer = (
-  item: Account,
+  item: AccountSelectModel,
   { handleClick, modifiers },
 ): React.ReactElement | null => {
   if (!modifiers.matchesPredicate) {
@@ -82,7 +67,7 @@ const accountItemRenderer: AccountItemRenderer = (
 };
 
 // Input value renderer for Suggest (non-Formik)
-const inputValueRenderer = (item: Account | null): string => {
+const inputValueRenderer = (item: AccountSelectModel | null): string => {
   if (item) {
     return item.name || '';
   }
@@ -95,7 +80,7 @@ interface AccountsSuggestFieldOwnProps {
   openDialog: (name: string, payload?: any) => void;
 
   // #ownProps
-  items: Account[];
+  items: AccountSelectModel[];
   defaultSelectText?: string;
   filterByParentTypes?: string[];
   filterByTypes?: string[];
@@ -154,7 +139,7 @@ function withAccountsSuggestFieldLogic<C extends ComponentType<any>>(
       filterByRootTypes,
     });
     const handleCreateItemSelect = useCallback(
-      (item: Account | Partial<Account>) => {
+      (item: AccountSelectModel | Partial<AccountSelectModel>) => {
         if (!('id' in item) || !item.id) {
           openDialog(DialogsName.AccountForm);
         }

--- a/packages/webapp/src/components/Accounts/AccountsSuggestField.tsx
+++ b/packages/webapp/src/components/Accounts/AccountsSuggestField.tsx
@@ -3,7 +3,12 @@ import intl from 'react-intl-universal';
 import { MenuItem } from '@blueprintjs/core';
 import { ItemRenderer, ItemPredicate } from '@blueprintjs/select';
 import { DialogsName } from '@/constants/dialogs';
-import { AccountSelectModel, FSuggest, Suggest, FormattedMessage as T } from '@/components';
+import {
+  AccountSelectModel,
+  FSuggest,
+  Suggest,
+  FormattedMessage as T,
+} from '@/components';
 import { withDialogActions } from '@/containers/Dialog/withDialogActions';
 import { usePreprocessingAccounts } from './_hooks';
 
@@ -28,7 +33,9 @@ const createNewItemRenderer = (
 };
 
 // Create new item from the given query string.
-const createNewItemFromQuery = (name: string): Partial<AccountSelectModel> => ({ name });
+const createNewItemFromQuery = (name: string): Partial<AccountSelectModel> => ({
+  name,
+});
 // Filters accounts items.
 const filterAccountsPredicater: AccountItemPredicate = (
   query: string,

--- a/packages/webapp/src/components/Accounts/AccountsTypesSelect.tsx
+++ b/packages/webapp/src/components/Accounts/AccountsTypesSelect.tsx
@@ -1,9 +1,19 @@
-// @ts-nocheck
+import React from 'react';
 import { FSelect } from '@/components/Forms';
+import type { AccountTypesList } from '@bigcapital/sdk-ts';
 
-export function AccountsTypesSelect({ ...props }) {
+type FSelectProps = React.ComponentProps<typeof FSelect>;
+type AccountType = AccountTypesList[number];
+
+interface AccountsTypesSelectProps extends Omit<FSelectProps, 'items'> {
+  items: AccountTypesList;
+}
+
+export function AccountsTypesSelect({
+  ...props
+}: AccountsTypesSelectProps): React.ReactElement {
   return (
-    <FSelect
+    <FSelect<AccountType>
       valueAccessor={'key'}
       labelAccessor={'label'}
       textAccessor={'label'}

--- a/packages/webapp/src/components/Accounts/_components.tsx
+++ b/packages/webapp/src/components/Accounts/_components.tsx
@@ -1,15 +1,13 @@
-// @ts-nocheck
-
-import { AccountSelect } from './AccountsMultiSelect';
+import { AccountSelectModel } from './AccountsMultiSelect';
 
 // Filters accounts items.
 export const accountPredicate = (
   query: string,
-  account: AccountSelect,
+  account: AccountSelectModel,
   _index?: number,
   exactMatch?: boolean,
-) => {
-  const normalizedTitle = account.name.toLowerCase();
+): boolean => {
+  const normalizedTitle = account?.name?.toLowerCase();
   const normalizedQuery = query.toLowerCase();
 
   if (exactMatch) {

--- a/packages/webapp/src/components/Forms/Select.tsx
+++ b/packages/webapp/src/components/Forms/Select.tsx
@@ -5,7 +5,7 @@ import { FormikSelect } from '@blueprintjs-formik/select';
 import styled from 'styled-components';
 import clsx from 'classnames';
 
-export function FSelect({ ...props }) {
+export function FSelect<T extends SelectOptionProps = SelectOptionProps>({ ...props }) {
   const input = ({ activeItem, text, label, value }) => (
     <SelectButton
       text={text || props.placeholder || 'Select an item ...'}
@@ -14,7 +14,7 @@ export function FSelect({ ...props }) {
       className={clsx({ 'is-selected': !!text }, props.className)}
     />
   );
-  return <FormikSelect input={input} fill={true} {...props} />;
+  return <FormikSelect<T> input={input} fill={true} {...props} />;
 }
 
 export const SelectButton = styled(Button)`

--- a/packages/webapp/src/components/Forms/Select.tsx
+++ b/packages/webapp/src/components/Forms/Select.tsx
@@ -5,7 +5,9 @@ import { FormikSelect } from '@blueprintjs-formik/select';
 import styled from 'styled-components';
 import clsx from 'classnames';
 
-export function FSelect<T extends SelectOptionProps = SelectOptionProps>({ ...props }) {
+export function FSelect<T extends SelectOptionProps = SelectOptionProps>({
+  ...props
+}) {
   const input = ({ activeItem, text, label, value }) => (
     <SelectButton
       text={text || props.placeholder || 'Select an item ...'}

--- a/packages/webapp/src/containers/CashFlow/AccountTransactions/AccountTransactionsActionsBar.tsx
+++ b/packages/webapp/src/containers/CashFlow/AccountTransactions/AccountTransactionsActionsBar.tsx
@@ -36,7 +36,6 @@ import { useRefreshCashflowTransactions } from '@/hooks/query';
 import { useAccountTransactionsContext } from './AccountTransactionsProvider';
 import { useMediaQuery } from '@/hooks/useMediaQuery';
 import { useAppShellContext } from '@/components/AppShell/AppContentShell/AppContentShellProvider';
-
 import { withDialogActions } from '@/containers/Dialog/withDialogActions';
 import { withSettings } from '@/containers/Settings/withSettings';
 import { withSettingsActions } from '@/containers/Settings/withSettingsActions';
@@ -48,7 +47,6 @@ import {
   useExcludeUncategorizedTransactions,
   useUnexcludeUncategorizedTransactions,
 } from '@/hooks/query/banking';
-
 import { DialogsName } from '@/constants/dialogs';
 import { compose } from '@/utils';
 

--- a/packages/webapp/src/containers/CashFlow/AccountTransactions/AccountTransactionsAllBoot.tsx
+++ b/packages/webapp/src/containers/CashFlow/AccountTransactions/AccountTransactionsAllBoot.tsx
@@ -1,15 +1,11 @@
 // @ts-nocheck
 import React from 'react';
-import { flatten, map } from 'lodash';
 import { IntersectionObserver } from '@/components';
 import { useAccountTransactionsInfinity } from '@/hooks/query';
+import { useFlattenInfinityPages } from '@/hooks/utils';
 import { useAccountTransactionsContext } from './AccountTransactionsProvider';
 
 const AccountTransactionsAllBootContext = React.createContext();
-
-function flattenInfinityPages(data) {
-  return flatten(map(data.pages, (page) => page.transactions));
-}
 
 interface AccountTransactionsAllPoviderProps {
   children: React.ReactNode;
@@ -37,12 +33,9 @@ function AccountTransactionsAllProvider({
     account_id: accountId,
   });
   // Memorized the cashflow account transactions.
-  const cashflowTransactions = React.useMemo(
-    () =>
-      isCashflowTransactionsSuccess
-        ? flattenInfinityPages(cashflowTransactionsPages)
-        : [],
-    [cashflowTransactionsPages, isCashflowTransactionsSuccess],
+  const cashflowTransactions = useFlattenInfinityPages(
+    isCashflowTransactionsSuccess ? cashflowTransactionsPages : undefined,
+    (page) => page.transactions,
   );
   // Handle the observer ineraction.
   const handleObserverInteract = React.useCallback(() => {

--- a/packages/webapp/src/containers/CashFlow/AccountTransactions/AllTransactionsUncategorizedBoot.tsx
+++ b/packages/webapp/src/containers/CashFlow/AccountTransactions/AllTransactionsUncategorizedBoot.tsx
@@ -1,18 +1,14 @@
 // @ts-nocheck
 
 import React from 'react';
-import { flatten, map } from 'lodash';
 import * as R from 'ramda';
 import { IntersectionObserver } from '@/components';
 import { useAccountUncategorizedTransactionsInfinity } from '@/hooks/query';
+import { useFlattenInfinityPages } from '@/hooks/utils';
 import { useAccountTransactionsContext } from './AccountTransactionsProvider';
 import { withBanking } from '../withBanking';
 
 const AccountUncategorizedTransactionsContext = React.createContext();
-
-function flattenInfinityPagesData(data) {
-  return flatten(map(data.pages, (page) => page.data));
-}
 
 /**
  * Account un-categorized transactions provider.
@@ -41,12 +37,8 @@ function AccountUncategorizedTransactionsBootRoot({
     max_date: uncategorizedTransactionsFilter?.toDate || null,
   });
   // Memorized the cashflow account transactions.
-  const uncategorizedTransactions = React.useMemo(
-    () =>
-      isUncategorizedTransactionsSuccess
-        ? flattenInfinityPagesData(uncategorizedTransactionsPage)
-        : [],
-    [uncategorizedTransactionsPage, isUncategorizedTransactionsSuccess],
+  const uncategorizedTransactions = useFlattenInfinityPages(
+    isUncategorizedTransactionsSuccess ? uncategorizedTransactionsPage : undefined,
   );
   // Handle the observer ineraction.
   const handleObserverInteract = React.useCallback(() => {

--- a/packages/webapp/src/containers/CashFlow/AccountTransactions/AllTransactionsUncategorizedBoot.tsx
+++ b/packages/webapp/src/containers/CashFlow/AccountTransactions/AllTransactionsUncategorizedBoot.tsx
@@ -38,7 +38,9 @@ function AccountUncategorizedTransactionsBootRoot({
   });
   // Memorized the cashflow account transactions.
   const uncategorizedTransactions = useFlattenInfinityPages(
-    isUncategorizedTransactionsSuccess ? uncategorizedTransactionsPage : undefined,
+    isUncategorizedTransactionsSuccess
+      ? uncategorizedTransactionsPage
+      : undefined,
   );
   // Handle the observer ineraction.
   const handleObserverInteract = React.useCallback(() => {

--- a/packages/webapp/src/containers/CashFlow/AccountTransactions/ExcludedTransactions/ExcludedTransactionsTableBoot.tsx
+++ b/packages/webapp/src/containers/CashFlow/AccountTransactions/ExcludedTransactions/ExcludedTransactionsTableBoot.tsx
@@ -1,10 +1,10 @@
 // @ts-nocheck
 import React from 'react';
-import { flatten, map } from 'lodash';
 import * as R from 'ramda';
 import { IntersectionObserver } from '@/components';
 import { useAccountTransactionsContext } from '../AccountTransactionsProvider';
 import { useExcludedBankTransactionsInfinity } from '@/hooks/query/banking';
+import { useFlattenInfinityPages } from '@/hooks/utils';
 import { withBanking } from '../../withBanking';
 
 interface ExcludedBankTransactionsContextValue {
@@ -17,10 +17,6 @@ const ExcludedTransactionsContext =
   React.createContext<ExcludedBankTransactionsContextValue>(
     {} as ExcludedBankTransactionsContextValue,
   );
-
-function flattenInfinityPagesData(data) {
-  return flatten(map(data.pages, (page) => page.data));
-}
 
 interface ExcludedBankTransactionsTableBootProps {
   children: React.ReactNode;
@@ -54,12 +50,8 @@ function ExcludedBankTransactionsTableBootRoot({
     max_date: uncategorizedTransactionsFilter.toDate || null,
   });
   // Memorized the cashflow account transactions.
-  const excludedBankTransactions = React.useMemo(
-    () =>
-      isRecognizedTransactionsSuccess
-        ? flattenInfinityPagesData(recognizedTransactionsPage)
-        : [],
-    [recognizedTransactionsPage, isRecognizedTransactionsSuccess],
+  const excludedBankTransactions = useFlattenInfinityPages(
+    isRecognizedTransactionsSuccess ? recognizedTransactionsPage : undefined,
   );
   // Handle the observer ineraction.
   const handleObserverInteract = React.useCallback(() => {

--- a/packages/webapp/src/containers/CashFlow/AccountTransactions/PendingTransactions/PendingTransactionsTableBoot.tsx
+++ b/packages/webapp/src/containers/CashFlow/AccountTransactions/PendingTransactions/PendingTransactionsTableBoot.tsx
@@ -1,15 +1,11 @@
 // @ts-nocheck
 import React from 'react';
-import { flatten, map } from 'lodash';
 import { IntersectionObserver } from '@/components';
 import { useAccountTransactionsContext } from '../AccountTransactionsProvider';
 import { usePendingBankTransactionsInfinity } from '@/hooks/query/banking';
+import { useFlattenInfinityPages } from '@/hooks/utils';
 
 const PendingTransactionsContext = React.createContext();
-
-function flattenInfinityPagesData(data) {
-  return flatten(map(data.pages, (page) => page.data));
-}
 
 /**
  * Account pending transctions provider.
@@ -31,12 +27,8 @@ function PendingTransactionsBoot({ children }) {
     page_size: 50,
   });
   // Memorized the cashflow account transactions.
-  const pendingTransactions = React.useMemo(
-    () =>
-      isPendingTransactionsSuccess
-        ? flattenInfinityPagesData(pendingTransactionsPage)
-        : [],
-    [pendingTransactionsPage, isPendingTransactionsSuccess],
+  const pendingTransactions = useFlattenInfinityPages(
+    isPendingTransactionsSuccess ? pendingTransactionsPage : undefined,
   );
   // Handle the observer ineraction.
   const handleObserverInteract = React.useCallback(() => {

--- a/packages/webapp/src/containers/CashFlow/AccountTransactions/RecognizedTransactions/RecognizedTransactionsTableBoot.tsx
+++ b/packages/webapp/src/containers/CashFlow/AccountTransactions/RecognizedTransactions/RecognizedTransactionsTableBoot.tsx
@@ -1,10 +1,10 @@
 // @ts-nocheck
 import React from 'react';
-import { flatten, map } from 'lodash';
 import * as R from 'ramda';
 import { IntersectionObserver, NumericInputCell } from '@/components';
 import { useAccountTransactionsContext } from '../AccountTransactionsProvider';
 import { useRecognizedBankTransactionsInfinity } from '@/hooks/query/banking';
+import { useFlattenInfinityPages } from '@/hooks/utils';
 import { withBanking } from '../../withBanking';
 
 interface RecognizedTransactionsContextValue {
@@ -17,10 +17,6 @@ const RecognizedTransactionsContext =
   React.createContext<RecognizedTransactionsContextValue>(
     {} as RecognizedTransactionsContextValue,
   );
-
-function flattenInfinityPagesData(data) {
-  return flatten(map(data.pages, (page) => page.data));
-}
 
 interface RecognizedTransactionsTableBootProps {
   children: React.ReactNode;
@@ -53,12 +49,8 @@ function RecognizedTransactionsTableBootRoot({
     max_date: uncategorizedTransactionsFilter?.toDate || null,
   });
   // Memorized the cashflow account transactions.
-  const recognizedTransactions = React.useMemo(
-    () =>
-      isRecognizedTransactionsSuccess
-        ? flattenInfinityPagesData(recognizedTransactionsPage)
-        : [],
-    [recognizedTransactionsPage, isRecognizedTransactionsSuccess],
+  const recognizedTransactions = useFlattenInfinityPages(
+    isRecognizedTransactionsSuccess ? recognizedTransactionsPage : undefined,
   );
   // Handle the observer ineraction.
   const handleObserverInteract = React.useCallback(() => {

--- a/packages/webapp/src/containers/FinancialStatements/AuditLog/AuditLogHeader.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/AuditLog/AuditLogHeader.tsx
@@ -170,7 +170,7 @@ export function AuditLogHeader({
                       itemPredicate={auditLogSelectItemPredicate}
                       placeholder={'All'}
                       popoverProps={{ minimal: true }}
-                      disabled={isFilterOptionsLoading}
+                      tagInputProps={{ inputProps: { disabled: isFilterOptionsLoading } }}
                       fill
                       resetOnSelect
                       fastField
@@ -187,7 +187,7 @@ export function AuditLogHeader({
                       itemPredicate={auditLogSelectItemPredicate}
                       placeholder={'All'}
                       popoverProps={{ minimal: true }}
-                      disabled={isFilterOptionsLoading}
+                      tagInputProps={{ inputProps: { disabled: isFilterOptionsLoading } }}
                       fill
                       resetOnSelect
                       fastField

--- a/packages/webapp/src/containers/FinancialStatements/AuditLog/AuditLogHeader.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/AuditLog/AuditLogHeader.tsx
@@ -170,7 +170,9 @@ export function AuditLogHeader({
                       itemPredicate={auditLogSelectItemPredicate}
                       placeholder={'All'}
                       popoverProps={{ minimal: true }}
-                      tagInputProps={{ inputProps: { disabled: isFilterOptionsLoading } }}
+                      tagInputProps={{
+                        inputProps: { disabled: isFilterOptionsLoading },
+                      }}
                       fill
                       resetOnSelect
                       fastField
@@ -187,7 +189,9 @@ export function AuditLogHeader({
                       itemPredicate={auditLogSelectItemPredicate}
                       placeholder={'All'}
                       popoverProps={{ minimal: true }}
-                      tagInputProps={{ inputProps: { disabled: isFilterOptionsLoading } }}
+                      tagInputProps={{
+                        inputProps: { disabled: isFilterOptionsLoading },
+                      }}
                       fill
                       resetOnSelect
                       fastField

--- a/packages/webapp/src/containers/FinancialStatements/AuditLog/AuditLogProvider.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/AuditLog/AuditLogProvider.tsx
@@ -1,13 +1,8 @@
 import React, { createContext, useCallback, useContext, useMemo } from 'react';
-import { flatten, map } from 'lodash';
-import type { InfiniteData } from '@tanstack/react-query';
 import type { AuditLogsResponse } from '@bigcapital/sdk-ts';
 import { useAuditLogsInfinityQuery } from '@/hooks/query';
+import { useFlattenInfinityPages } from '@/hooks/utils';
 import { IntersectionObserver } from '@/components';
-
-function flattenInfinityPagesData(data: InfiniteData<AuditLogsResponse>) {
-  return flatten(map(data.pages, (page) => page.data));
-}
 
 interface AuditLogQuery {
   subject?: string | string[];
@@ -81,10 +76,10 @@ function AuditLogProvider({ query, children }: AuditLogProviderProps) {
     refetch,
   } = useAuditLogsInfinityQuery(httpQuery);
 
-  const auditLogs = useMemo(
-    () => (auditLogsPages ? flattenInfinityPagesData(auditLogsPages) : []),
-    [auditLogsPages],
-  );
+  const auditLogs = useFlattenInfinityPages<
+    AuditLogsResponse,
+    Record<string, any>
+  >(auditLogsPages, (page) => page.data);
 
   const handleObserverInteract = useCallback(() => {
     if (!isFetching && hasNextPage) {

--- a/packages/webapp/src/containers/FinancialStatements/GeneralLedger/GeneralLedgerHeaderGeneralPane.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/GeneralLedger/GeneralLedgerHeaderGeneralPane.tsx
@@ -29,7 +29,7 @@ function GLHeaderGeneralPaneContent() {
   if (!accounts) {
     return null;
   }
-  
+
   return (
     <React.Fragment>
       <FinancialStatementDateRange />

--- a/packages/webapp/src/containers/FinancialStatements/GeneralLedger/GeneralLedgerHeaderGeneralPane.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/GeneralLedger/GeneralLedgerHeaderGeneralPane.tsx
@@ -26,6 +26,10 @@ export function GLHeaderGeneralPane() {
 function GLHeaderGeneralPaneContent() {
   const { accounts } = useGLGeneralPanelContext();
 
+  if (!accounts) {
+    return null;
+  }
+  
   return (
     <React.Fragment>
       <FinancialStatementDateRange />

--- a/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentReceivedMailDrawer/PaymentReceivedMailBoot.tsx
+++ b/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentReceivedMailDrawer/PaymentReceivedMailBoot.tsx
@@ -1,15 +1,13 @@
 import React, { createContext, useContext } from 'react';
 import { Spinner } from '@blueprintjs/core';
-import {
-  GetPaymentReceivedMailStateResponse,
-  usePaymentReceivedMailState,
-} from '@/hooks/query';
+import type { PaymentReceiveMailStateResponse } from '@bigcapital/sdk-ts';
+import { usePaymentReceivedMailState } from '@/hooks/query';
 import { useDrawerContext } from '@/components/Drawer/DrawerProvider';
 
 interface PaymentReceivedSendMailBootValues {
   paymentReceivedId: number;
 
-  paymentReceivedMailState: GetPaymentReceivedMailStateResponse | undefined;
+  paymentReceivedMailState: PaymentReceiveMailStateResponse | undefined;
   isPaymentReceivedStateLoading: boolean;
 }
 interface InvoiceSendMailBootProps {

--- a/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentReceivedMailDrawer/_hooks.ts
+++ b/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentReceivedMailDrawer/_hooks.ts
@@ -17,7 +17,7 @@ export const usePaymentReceivedMailFormatArgs = (): Record<string, string> => {
   const { paymentReceivedMailState } = usePaymentReceivedSendMailBoot();
 
   return useMemo(() => {
-    return transformEmailArgs(paymentReceivedMailState?.formatArgs || {});
+    return transformEmailArgs(paymentReceivedMailState?.formatArgs ?? {});
   }, [paymentReceivedMailState]);
 };
 

--- a/packages/webapp/src/hooks/query/payment-receives/queries.ts
+++ b/packages/webapp/src/hooks/query/payment-receives/queries.ts
@@ -17,6 +17,9 @@ import type {
   PaymentReceivedStateResponse,
   PaymentReceivedHtmlContentResponse,
   PaymentReceiveEditPageResponse,
+  PaymentReceiveMailStateResponse,
+  SendPaymentReceiveMailBody,
+  SendPaymentReceiveMailResponse,
 } from '@bigcapital/sdk-ts';
 import {
   fetchPaymentsReceived,
@@ -253,31 +256,16 @@ export function usePdfPaymentReceive(paymentReceiveId: number) {
   return useRequestPdf({ url: `payments-received/${paymentReceiveId}` });
 }
 
-interface SendPaymentReceiveMailValues {
-  to: string[] | string;
-  cc?: string[] | string;
-  bcc?: string[] | string;
-  subject: string;
-  message: string;
-  from?: string[] | string;
-  attachPdf?: boolean;
-}
-
-interface SendPaymentReceiveMailResponse {
-  success: boolean;
-  message?: string;
-}
-
 export function useSendPaymentReceiveMail(
   props?: UseMutationOptions<
     SendPaymentReceiveMailResponse,
     Error,
-    [number, SendPaymentReceiveMailValues]
+    [number, SendPaymentReceiveMailBody]
   >,
 ): UseMutationResult<
   SendPaymentReceiveMailResponse,
   Error,
-  [number, SendPaymentReceiveMailValues],
+  [number, SendPaymentReceiveMailBody],
   unknown
 > {
   const queryClient = useQueryClient();
@@ -285,50 +273,22 @@ export function useSendPaymentReceiveMail(
 
   return useMutation({
     ...props,
-    mutationFn: ([id, values]: [number, SendPaymentReceiveMailValues]) =>
-      sendPaymentReceiveMail(
-        fetcher,
-        id,
-        values as unknown as Record<string, unknown>,
-      ) as Promise<SendPaymentReceiveMailResponse>,
+    mutationFn: ([id, values]: [number, SendPaymentReceiveMailBody]) =>
+      sendPaymentReceiveMail(fetcher, id, values),
     onSuccess: () => commonInvalidateQueries(queryClient),
   });
 }
 
-export interface GetPaymentReceivedMailStateResponse {
-  companyName: string;
-  companyLogoUri?: string;
-  primaryColor?: string;
-  customerName: string;
-  entries: Array<{ invoiceNumber: string; paidAmount: string }>;
-  from: Array<string>;
-  fromOptions: Array<{ mail: string; label: string; primary: boolean }>;
-  paymentDate: string;
-  paymentDateFormatted: string;
-  to: Array<string>;
-  toOptions: Array<{ mail: string; label: string; primary: boolean }>;
-  total: number;
-  totalFormatted: string;
-  subtotal: number;
-  subtotalFormatted: string;
-  paymentNumber: string;
-  formatArgs: Record<string, unknown>;
-}
-
 export function usePaymentReceivedMailState(
   paymentReceiveId: number,
-  props?: UseQueryOptions<GetPaymentReceivedMailStateResponse, Error>,
-): UseQueryResult<GetPaymentReceivedMailStateResponse, Error> {
+  props?: UseQueryOptions<PaymentReceiveMailStateResponse, Error>,
+): UseQueryResult<PaymentReceiveMailStateResponse, Error> {
   const fetcher = useApiFetcher({ enableCamelCaseTransform: true });
 
   return useQuery({
     ...props,
     queryKey: paymentReceivesKeys.mailOptions(paymentReceiveId),
-    queryFn: () =>
-      fetchPaymentReceiveMail(
-        fetcher,
-        paymentReceiveId,
-      ) as Promise<GetPaymentReceivedMailStateResponse>,
+    queryFn: () => fetchPaymentReceiveMail(fetcher, paymentReceiveId),
   });
 }
 

--- a/packages/webapp/src/hooks/utils/index.tsx
+++ b/packages/webapp/src/hooks/utils/index.tsx
@@ -8,3 +8,4 @@ export * from './useIntersectionObserver';
 export * from './useAbilityContext';
 export * from './useCustomCompareEffect';
 export * from './useDeepCompareEffect';
+export * from './useFlattenInfinityPages';

--- a/packages/webapp/src/hooks/utils/useFlattenInfinityPages.ts
+++ b/packages/webapp/src/hooks/utils/useFlattenInfinityPages.ts
@@ -1,0 +1,23 @@
+import { useMemo } from 'react';
+import type { InfiniteData } from '@tanstack/react-query';
+import { flattenInfinityPages } from '@/utils';
+
+export function useFlattenInfinityPages<TItem>(
+  data: InfiniteData<{ data: TItem[] }> | undefined | null,
+): TItem[];
+export function useFlattenInfinityPages<TPage, TItem>(
+  data: InfiniteData<TPage> | undefined | null,
+  selector: (page: TPage) => TItem[],
+): TItem[];
+export function useFlattenInfinityPages<TPage, TItem>(
+  data: InfiniteData<TPage> | undefined | null,
+  selector?: (page: TPage) => TItem[],
+): TItem[] {
+  return useMemo(
+    () =>
+      selector
+        ? flattenInfinityPages(data, selector)
+        : (flattenInfinityPages(data as any) as TItem[]),
+    [data, selector],
+  );
+}

--- a/packages/webapp/src/utils/flatten-infinity-pages.ts
+++ b/packages/webapp/src/utils/flatten-infinity-pages.ts
@@ -1,0 +1,17 @@
+import { flatten, map } from 'lodash';
+import type { InfiniteData } from '@tanstack/react-query';
+
+export function flattenInfinityPages<TItem>(
+  data: InfiniteData<{ data: TItem[] }> | undefined | null,
+): TItem[];
+export function flattenInfinityPages<TPage, TItem>(
+  data: InfiniteData<TPage> | undefined | null,
+  selector: (page: TPage) => TItem[],
+): TItem[];
+export function flattenInfinityPages<TPage, TItem>(
+  data: InfiniteData<TPage> | undefined | null,
+  selector: (page: TPage) => TItem[] = (page: any) => page.data,
+): TItem[] {
+  if (!data?.pages) return [];
+  return flatten(map(data.pages, selector));
+}

--- a/packages/webapp/src/utils/index.tsx
+++ b/packages/webapp/src/utils/index.tsx
@@ -12,6 +12,7 @@ import { isEqual, castArray, isEmpty, includes, pickBy } from 'lodash';
 import jsCookie from 'js-cookie';
 import { deepMapKeys } from './map-key-deep';
 export * from './deep';
+export * from './flatten-infinity-pages';
 
 /** Strips leading slash from a path segment to avoid double slashes when joining with a base (e.g. `/api/` + path). */
 export const normalizeApiPath = (path) => (path || '').replace(/^\//, '');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -434,8 +434,8 @@ importers:
         specifier: ^0.4.1
         version: 0.4.1(@babel/core@7.28.5)(@blueprintjs-formik/core@0.3.8(@babel/core@7.28.5)(@blueprintjs/core@4.20.2(@types/react@18.3.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@blueprintjs/select@4.9.24(@types/react@18.3.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(formik@2.4.6(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))(@blueprintjs/core@4.20.2(@types/react@18.3.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@blueprintjs/datetime2@0.9.37(@types/react@18.3.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@blueprintjs/datetime@4.4.37(@types/react@18.3.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@blueprintjs/select@4.9.24(@types/react@18.3.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(formik@2.4.6(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)
       '@blueprintjs-formik/select':
-        specifier: ^0.4.6
-        version: 0.4.6(@blueprintjs/core@4.20.2(@types/react@18.3.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@blueprintjs/select@4.9.24(@types/react@18.3.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(formik@2.4.6(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^0.4.9
+        version: 0.4.9(@blueprintjs/core@4.20.2(@types/react@18.3.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@blueprintjs/select@4.9.24(@types/react@18.3.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(formik@2.4.6(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@blueprintjs/colors':
         specifier: 4.1.19
         version: 4.1.19
@@ -2173,8 +2173,8 @@ packages:
       react: 16 || ^17.0.2 || ^18.2.0
       react-dom: 16 || ^17.0.2 || ^18.2.0
 
-  '@blueprintjs-formik/select@0.4.6':
-    resolution: {integrity: sha512-W/fCih/NFAeckfpGk4KkDCsht470qxCl7bkal2FGFs8m3q8RdmdQ/ekhzr+K6XYDv6rMSM/k7GDRn33riUatow==}
+  '@blueprintjs-formik/select@0.4.9':
+    resolution: {integrity: sha512-tex8DqEVncxFdfy+keiJwUHDX/xDMUEuqlaC8XFZ8Dx74mDqqVFwLCNrffErm4IZ7gtktgJCMiZI7f8/FaN4Hw==}
     peerDependencies:
       '@blueprintjs/core': ^3.52.0 || 4 || 5
       '@blueprintjs/select': ^3.18.12 || 4 || 5
@@ -13581,8 +13581,8 @@ snapshots:
       '@aws-crypto/sha1-browser': 3.0.0
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.583.0(@aws-sdk/client-sts@3.583.0)
-      '@aws-sdk/client-sts': 3.583.0
+      '@aws-sdk/client-sso-oidc': 3.583.0
+      '@aws-sdk/client-sts': 3.583.0(@aws-sdk/client-sso-oidc@3.583.0)
       '@aws-sdk/core': 3.582.0
       '@aws-sdk/credential-provider-node': 3.583.0(@aws-sdk/client-sso-oidc@3.583.0)(@aws-sdk/client-sts@3.583.0)
       '@aws-sdk/middleware-bucket-endpoint': 3.577.0
@@ -13639,11 +13639,11 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sso-oidc@3.583.0(@aws-sdk/client-sts@3.583.0)':
+  '@aws-sdk/client-sso-oidc@3.583.0':
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sts': 3.583.0
+      '@aws-sdk/client-sts': 3.583.0(@aws-sdk/client-sso-oidc@3.583.0)
       '@aws-sdk/core': 3.582.0
       '@aws-sdk/credential-provider-node': 3.583.0(@aws-sdk/client-sso-oidc@3.583.0)(@aws-sdk/client-sts@3.583.0)
       '@aws-sdk/middleware-host-header': 3.577.0
@@ -13682,7 +13682,6 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.8.1
     transitivePeerDependencies:
-      - '@aws-sdk/client-sts'
       - aws-crt
 
   '@aws-sdk/client-sso@3.583.0':
@@ -13728,11 +13727,11 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sts@3.583.0':
+  '@aws-sdk/client-sts@3.583.0(@aws-sdk/client-sso-oidc@3.583.0)':
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.583.0(@aws-sdk/client-sts@3.583.0)
+      '@aws-sdk/client-sso-oidc': 3.583.0
       '@aws-sdk/core': 3.582.0
       '@aws-sdk/credential-provider-node': 3.583.0(@aws-sdk/client-sso-oidc@3.583.0)(@aws-sdk/client-sts@3.583.0)
       '@aws-sdk/middleware-host-header': 3.577.0
@@ -13771,6 +13770,7 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.8.1
     transitivePeerDependencies:
+      - '@aws-sdk/client-sso-oidc'
       - aws-crt
 
   '@aws-sdk/core@3.582.0':
@@ -13804,7 +13804,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-ini@3.583.0(@aws-sdk/client-sso-oidc@3.583.0)(@aws-sdk/client-sts@3.583.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.583.0
+      '@aws-sdk/client-sts': 3.583.0(@aws-sdk/client-sso-oidc@3.583.0)
       '@aws-sdk/credential-provider-env': 3.577.0
       '@aws-sdk/credential-provider-process': 3.577.0
       '@aws-sdk/credential-provider-sso': 3.583.0(@aws-sdk/client-sso-oidc@3.583.0)
@@ -13861,7 +13861,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-web-identity@3.577.0(@aws-sdk/client-sts@3.583.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.583.0
+      '@aws-sdk/client-sts': 3.583.0(@aws-sdk/client-sso-oidc@3.583.0)
       '@aws-sdk/types': 3.577.0
       '@smithy/property-provider': 3.0.0
       '@smithy/types': 3.0.0
@@ -13999,7 +13999,7 @@ snapshots:
 
   '@aws-sdk/token-providers@3.577.0(@aws-sdk/client-sso-oidc@3.583.0)':
     dependencies:
-      '@aws-sdk/client-sso-oidc': 3.583.0(@aws-sdk/client-sts@3.583.0)
+      '@aws-sdk/client-sso-oidc': 3.583.0
       '@aws-sdk/types': 3.577.0
       '@smithy/property-provider': 3.0.0
       '@smithy/shared-ini-file-loader': 3.0.0
@@ -14101,11 +14101,11 @@ snapshots:
       '@babel/helpers': 7.28.4
       '@babel/parser': 7.28.5
       '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.5(supports-color@5.5.0)
+      '@babel/traverse': 7.28.5
       '@babel/types': 7.28.5
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@10.2.2)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -14201,7 +14201,7 @@ snapshots:
       '@babel/helper-optimise-call-expression': 7.27.1
       '@babel/helper-replace-supers': 7.27.1(@babel/core@7.26.0)
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/traverse': 7.28.5(supports-color@5.5.0)
+      '@babel/traverse': 7.28.5
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -14214,7 +14214,7 @@ snapshots:
       '@babel/helper-optimise-call-expression': 7.27.1
       '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.5)
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/traverse': 7.28.5(supports-color@5.5.0)
+      '@babel/traverse': 7.28.5
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -14238,7 +14238,7 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@10.2.2)
       lodash.debounce: 4.0.8
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -14249,7 +14249,7 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@10.2.2)
       lodash.debounce: 4.0.8
       resolve: 1.22.11
     transitivePeerDependencies:
@@ -14260,7 +14260,7 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@10.2.2)
       lodash.debounce: 4.0.8
       resolve: 1.22.11
     transitivePeerDependencies:
@@ -14285,7 +14285,7 @@ snapshots:
 
   '@babel/helper-member-expression-to-functions@7.28.5':
     dependencies:
-      '@babel/traverse': 7.28.5(supports-color@5.5.0)
+      '@babel/traverse': 7.28.5
       '@babel/types': 7.28.5
     transitivePeerDependencies:
       - supports-color
@@ -14293,6 +14293,13 @@ snapshots:
   '@babel/helper-module-imports@7.24.3':
     dependencies:
       '@babel/types': 7.24.5
+
+  '@babel/helper-module-imports@7.25.9':
+    dependencies:
+      '@babel/traverse': 7.28.5
+      '@babel/types': 7.28.5
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/helper-module-imports@7.25.9(supports-color@5.5.0)':
     dependencies:
@@ -14303,7 +14310,7 @@ snapshots:
 
   '@babel/helper-module-imports@7.27.1':
     dependencies:
-      '@babel/traverse': 7.28.5(supports-color@5.5.0)
+      '@babel/traverse': 7.28.5
       '@babel/types': 7.28.5
     transitivePeerDependencies:
       - supports-color
@@ -14311,9 +14318,9 @@ snapshots:
   '@babel/helper-module-transforms@7.26.0(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/helper-module-imports': 7.25.9(supports-color@5.5.0)
+      '@babel/helper-module-imports': 7.25.9
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.5(supports-color@5.5.0)
+      '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
@@ -14322,7 +14329,7 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-module-imports': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.5(supports-color@5.5.0)
+      '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
@@ -14331,7 +14338,7 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-module-imports': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.5(supports-color@5.5.0)
+      '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
@@ -14350,7 +14357,7 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-wrap-function': 7.28.3
-      '@babel/traverse': 7.28.5(supports-color@5.5.0)
+      '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
@@ -14359,7 +14366,7 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-wrap-function': 7.28.3
-      '@babel/traverse': 7.28.5(supports-color@5.5.0)
+      '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
@@ -14382,7 +14389,7 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/traverse': 7.28.5(supports-color@5.5.0)
+      '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
@@ -14391,7 +14398,7 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/traverse': 7.28.5(supports-color@5.5.0)
+      '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
@@ -14401,7 +14408,7 @@ snapshots:
 
   '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
     dependencies:
-      '@babel/traverse': 7.28.5(supports-color@5.5.0)
+      '@babel/traverse': 7.28.5
       '@babel/types': 7.28.5
     transitivePeerDependencies:
       - supports-color
@@ -14423,7 +14430,7 @@ snapshots:
   '@babel/helper-wrap-function@7.28.3':
     dependencies:
       '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.5(supports-color@5.5.0)
+      '@babel/traverse': 7.28.5
       '@babel/types': 7.28.5
     transitivePeerDependencies:
       - supports-color
@@ -14454,7 +14461,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.5(supports-color@5.5.0)
+      '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
@@ -14462,7 +14469,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.5(supports-color@5.5.0)
+      '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
@@ -14508,7 +14515,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.5(supports-color@5.5.0)
+      '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
@@ -14516,7 +14523,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.5(supports-color@5.5.0)
+      '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
@@ -14760,7 +14767,7 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.26.0)
-      '@babel/traverse': 7.28.5(supports-color@5.5.0)
+      '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
@@ -14769,7 +14776,7 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.28.5)
-      '@babel/traverse': 7.28.5(supports-color@5.5.0)
+      '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
@@ -14851,7 +14858,7 @@ snapshots:
       '@babel/helper-globals': 7.28.0
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-replace-supers': 7.27.1(@babel/core@7.26.0)
-      '@babel/traverse': 7.28.5(supports-color@5.5.0)
+      '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
@@ -14863,7 +14870,7 @@ snapshots:
       '@babel/helper-globals': 7.28.0
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.5)
-      '@babel/traverse': 7.28.5(supports-color@5.5.0)
+      '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
@@ -14883,7 +14890,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.5(supports-color@5.5.0)
+      '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
@@ -14891,7 +14898,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.5(supports-color@5.5.0)
+      '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
@@ -15008,7 +15015,7 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.5(supports-color@5.5.0)
+      '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
@@ -15017,7 +15024,7 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.5(supports-color@5.5.0)
+      '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
@@ -15099,7 +15106,7 @@ snapshots:
       '@babel/helper-module-transforms': 7.28.3(@babel/core@7.26.0)
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.5(supports-color@5.5.0)
+      '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
@@ -15109,7 +15116,7 @@ snapshots:
       '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.5(supports-color@5.5.0)
+      '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
@@ -15178,7 +15185,7 @@ snapshots:
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.26.0)
       '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.26.0)
-      '@babel/traverse': 7.28.5(supports-color@5.5.0)
+      '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
@@ -15189,7 +15196,7 @@ snapshots:
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.28.5)
       '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.28.5)
-      '@babel/traverse': 7.28.5(supports-color@5.5.0)
+      '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
@@ -15399,7 +15406,7 @@ snapshots:
   '@babel/plugin-transform-runtime@7.24.3(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/helper-module-imports': 7.25.9(supports-color@5.5.0)
+      '@babel/helper-module-imports': 7.25.9
       '@babel/helper-plugin-utils': 7.27.1
       babel-plugin-polyfill-corejs2: 0.4.11(@babel/core@7.26.0)
       babel-plugin-polyfill-corejs3: 0.10.4(@babel/core@7.26.0)
@@ -15790,8 +15797,20 @@ snapshots:
       '@babel/parser': 7.28.5
       '@babel/template': 7.25.9
       '@babel/types': 7.28.5
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@10.2.2)
       globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/traverse@7.28.5':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/generator': 7.28.5
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.28.5
+      '@babel/template': 7.27.2
+      '@babel/types': 7.28.5
+      debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -15860,7 +15879,7 @@ snapshots:
       - '@babel/core'
       - react-is
 
-  '@blueprintjs-formik/select@0.4.6(@blueprintjs/core@4.20.2(@types/react@18.3.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@blueprintjs/select@4.9.24(@types/react@18.3.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(formik@2.4.6(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@blueprintjs-formik/select@0.4.9(@blueprintjs/core@4.20.2(@types/react@18.3.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@blueprintjs/select@4.9.24(@types/react@18.3.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(formik@2.4.6(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@blueprintjs/core': 4.20.2(@types/react@18.3.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@blueprintjs/select': 4.9.24(@types/react@18.3.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -16156,7 +16175,7 @@ snapshots:
 
   '@emotion/babel-plugin@11.12.0':
     dependencies:
-      '@babel/helper-module-imports': 7.25.9(supports-color@5.5.0)
+      '@babel/helper-module-imports': 7.25.9
       '@babel/runtime': 7.24.5
       '@emotion/hash': 0.9.2
       '@emotion/memoize': 0.9.0
@@ -16539,7 +16558,7 @@ snapshots:
   '@eslint/config-array@0.18.0':
     dependencies:
       '@eslint/object-schema': 2.1.4
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@10.2.2)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -16563,7 +16582,7 @@ snapshots:
   '@eslint/eslintrc@3.1.0':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@10.2.2)
       espree: 10.2.0
       globals: 14.0.0
       ignore: 5.3.1
@@ -19380,7 +19399,7 @@ snapshots:
     dependencies:
       '@babel/generator': 7.28.5
       '@babel/parser': 7.28.5
-      '@babel/traverse': 7.28.5(supports-color@5.5.0)
+      '@babel/traverse': 7.28.5
       '@babel/types': 7.28.5
       '@storybook/csf': 0.1.11
       '@storybook/types': 7.2.2
@@ -20563,7 +20582,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.9.5)
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@4.9.5)
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@10.2.2)
       eslint: 8.57.0
       tsutils: 3.21.0(typescript@4.9.5)
     optionalDependencies:
@@ -20575,7 +20594,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 8.11.0(typescript@5.6.3)
       '@typescript-eslint/utils': 8.11.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.6.3)
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@10.2.2)
       ts-api-utils: 1.3.0(typescript@5.6.3)
     optionalDependencies:
       typescript: 5.6.3
@@ -20605,7 +20624,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@10.2.2)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.6.3
@@ -20619,7 +20638,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@10.2.2)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.6.3
@@ -20633,7 +20652,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.11.0
       '@typescript-eslint/visitor-keys': 8.11.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@10.2.2)
       fast-glob: 3.3.2
       is-glob: 4.0.3
       minimatch: 9.0.4
@@ -21058,13 +21077,13 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
   agent-base@7.1.1:
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -21389,7 +21408,7 @@ snapshots:
 
   babel-plugin-emotion@10.2.2:
     dependencies:
-      '@babel/helper-module-imports': 7.25.9(supports-color@5.5.0)
+      '@babel/helper-module-imports': 7.25.9
       '@emotion/hash': 0.8.0
       '@emotion/memoize': 0.7.4
       '@emotion/serialize': 0.11.16
@@ -22638,7 +22657,7 @@ snapshots:
   detect-port@1.6.1:
     dependencies:
       address: 1.2.2
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -22996,7 +23015,7 @@ snapshots:
 
   esbuild-register@3.6.0(esbuild@0.18.20):
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@10.2.2)
       esbuild: 0.18.20
     transitivePeerDependencies:
       - supports-color
@@ -23427,7 +23446,7 @@ snapshots:
 
   estree-to-babel@3.2.1:
     dependencies:
-      '@babel/traverse': 7.28.5(supports-color@5.5.0)
+      '@babel/traverse': 7.28.5
       '@babel/types': 7.28.5
       c8: 7.14.0
     transitivePeerDependencies:
@@ -24249,35 +24268,35 @@ snapshots:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.1
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@4.0.0:
     dependencies:
       agent-base: 5.1.1
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@7.0.4:
     dependencies:
       agent-base: 7.1.1
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -24464,7 +24483,7 @@ snapshots:
     dependencies:
       '@ioredis/commands': 1.2.0
       cluster-key-slot: 1.1.2
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@10.2.2)
       denque: 1.5.1
       lodash.defaults: 4.2.0
       lodash.flatten: 4.4.0
@@ -24729,7 +24748,7 @@ snapshots:
 
   istanbul-lib-source-maps@4.0.1:
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@10.2.2)
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -27197,7 +27216,7 @@ snapshots:
   puppeteer-core@2.1.1:
     dependencies:
       '@types/mime-types': 2.1.4
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@10.2.2)
       extract-zip: 1.7.0
       https-proxy-agent: 4.0.0
       mime: 2.6.0
@@ -28342,7 +28361,7 @@ snapshots:
   socks-proxy-agent@7.0.0:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@10.2.2)
       socks: 2.8.3
     transitivePeerDependencies:
       - supports-color
@@ -28350,7 +28369,7 @@ snapshots:
   socks-proxy-agent@8.0.3:
     dependencies:
       agent-base: 7.1.1
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@10.2.2)
       socks: 2.8.3
     transitivePeerDependencies:
       - supports-color
@@ -28673,7 +28692,7 @@ snapshots:
     dependencies:
       component-emitter: 1.3.1
       cookiejar: 2.1.4
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@10.2.2)
       fast-safe-stringify: 2.1.1
       form-data: 4.0.0
       formidable: 3.5.2
@@ -29144,7 +29163,7 @@ snapshots:
   tuf-js@1.1.7:
     dependencies:
       '@tufjs/models': 1.0.4
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@10.2.2)
       make-fetch-happen: 11.1.1
     transitivePeerDependencies:
       - supports-color
@@ -29152,7 +29171,7 @@ snapshots:
   tuf-js@2.2.1:
     dependencies:
       '@tufjs/models': 2.0.1
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@10.2.2)
       make-fetch-happen: 13.0.1
     transitivePeerDependencies:
       - supports-color
@@ -29437,7 +29456,7 @@ snapshots:
   vite-node@2.1.3(@types/node@20.19.25)(less@4.2.0)(sass@1.77.2)(terser@5.31.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@10.2.2)
       pathe: 1.1.2
       vite: 5.4.10(@types/node@20.19.25)(less@4.2.0)(sass@1.77.2)(terser@5.31.0)
     transitivePeerDependencies:

--- a/shared/sdk-ts/openapi.json
+++ b/shared/sdk-ts/openapi.json
@@ -4734,9 +4734,27 @@
             }
           }
         ],
+        "requestBody": {
+          "required": true,
+          "description": "The payment receive mail options",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PaymentReceiveMailOptsDto"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
-            "description": "The payment receive mail has been successfully sent."
+            "description": "The payment receive mail has been successfully sent.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentReceiveMailResponseDto"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -4776,7 +4794,14 @@
         ],
         "responses": {
           "200": {
-            "description": "The payment receive mail options have been successfully retrieved."
+            "description": "The payment receive mail options have been successfully retrieved.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentReceiveMailStateResponseDto"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -27080,6 +27105,288 @@
           "isNonRecoverable",
           "isCompound",
           "active"
+        ]
+      },
+      "PaymentReceiveMailResponseDto": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "description": "Whether the mail was successfully queued/sent",
+            "example": true
+          },
+          "message": {
+            "type": "string",
+            "description": "Optional status message"
+          }
+        },
+        "required": [
+          "success"
+        ]
+      },
+      "PaymentReceiveMailEntryDto": {
+        "type": "object",
+        "properties": {
+          "invoiceNumber": {
+            "type": "string",
+            "description": "The invoice number",
+            "example": "INV-001"
+          },
+          "paidAmount": {
+            "type": "string",
+            "description": "The formatted paid amount",
+            "example": "$500.00"
+          }
+        },
+        "required": [
+          "invoiceNumber",
+          "paidAmount"
+        ]
+      },
+      "PaymentReceiveMailAddressItemDto": {
+        "type": "object",
+        "properties": {
+          "mail": {
+            "type": "string",
+            "description": "The email address",
+            "example": "john@example.com"
+          },
+          "label": {
+            "type": "string",
+            "description": "The display label for the address",
+            "example": "John Doe"
+          },
+          "primary": {
+            "type": "boolean",
+            "description": "Whether this is the primary address",
+            "example": true
+          }
+        },
+        "required": [
+          "mail",
+          "label"
+        ]
+      },
+      "PaymentReceiveMailStateResponseDto": {
+        "type": "object",
+        "properties": {
+          "companyName": {
+            "type": "string",
+            "description": "The organization company name",
+            "example": "Acme Inc."
+          },
+          "companyLogoUri": {
+            "type": "string",
+            "description": "The company logo URI",
+            "example": "https://example.com/logo.png"
+          },
+          "primaryColor": {
+            "type": "string",
+            "description": "The primary brand color",
+            "example": "#2563eb"
+          },
+          "customerName": {
+            "type": "string",
+            "description": "The customer display name",
+            "example": "John Doe"
+          },
+          "entries": {
+            "description": "The payment invoice entries",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentReceiveMailEntryDto"
+            }
+          },
+          "from": {
+            "description": "Sender email addresses",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "to": {
+            "description": "Recipient email addresses",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "cc": {
+            "description": "CC recipient email addresses",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "bcc": {
+            "description": "BCC recipient email addresses",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "subject": {
+            "type": "string",
+            "description": "The email subject"
+          },
+          "message": {
+            "type": "string",
+            "description": "The email body message"
+          },
+          "fromOptions": {
+            "description": "Available sender address options",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentReceiveMailAddressItemDto"
+            }
+          },
+          "toOptions": {
+            "description": "Available recipient address options",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentReceiveMailAddressItemDto"
+            }
+          },
+          "paymentDate": {
+            "type": "string",
+            "description": "The ISO payment date",
+            "example": "2024-03-15"
+          },
+          "paymentDateFormatted": {
+            "type": "string",
+            "description": "The human-readable payment date",
+            "example": "March 15, 2024"
+          },
+          "total": {
+            "type": "number",
+            "description": "The numeric payment total",
+            "example": 500
+          },
+          "totalFormatted": {
+            "type": "string",
+            "description": "The formatted payment total",
+            "example": "$500.00"
+          },
+          "subtotal": {
+            "type": "number",
+            "description": "The numeric payment subtotal",
+            "example": 500
+          },
+          "subtotalFormatted": {
+            "type": "string",
+            "description": "The formatted payment subtotal",
+            "example": "$500.00"
+          },
+          "paymentNumber": {
+            "type": "string",
+            "description": "The payment receive number",
+            "example": "PR-0001"
+          },
+          "formatArgs": {
+            "type": "object",
+            "description": "Template format arguments"
+          }
+        },
+        "required": [
+          "companyName",
+          "customerName",
+          "entries",
+          "from",
+          "to",
+          "subject",
+          "message",
+          "fromOptions",
+          "toOptions",
+          "paymentDate",
+          "paymentDateFormatted",
+          "total",
+          "totalFormatted",
+          "subtotal",
+          "subtotalFormatted",
+          "paymentNumber"
+        ]
+      },
+      "PaymentReceiveMailOptsDto": {
+        "type": "object",
+        "properties": {
+          "from": {
+            "description": "Sender email addresses",
+            "example": [
+              "billing@company.com"
+            ],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "to": {
+            "description": "Recipient email addresses",
+            "example": [
+              "customer@example.com"
+            ],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "cc": {
+            "description": "CC recipient email addresses",
+            "example": [
+              "accounting@company.com"
+            ],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "bcc": {
+            "description": "BCC recipient email addresses",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "subject": {
+            "type": "string",
+            "description": "The email subject",
+            "example": "Payment Received"
+          },
+          "message": {
+            "type": "string",
+            "description": "The email body message",
+            "example": "We have received your payment."
+          },
+          "toOptions": {
+            "description": "Available recipient address options",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentReceiveMailAddressItemDto"
+            }
+          },
+          "fromOptions": {
+            "description": "Available sender address options",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentReceiveMailAddressItemDto"
+            }
+          },
+          "formatArgs": {
+            "type": "object",
+            "description": "Template format arguments"
+          },
+          "attachPdf": {
+            "type": "boolean",
+            "description": "Whether to attach the payment PDF",
+            "example": true
+          }
+        },
+        "required": [
+          "from",
+          "to",
+          "subject",
+          "message",
+          "toOptions",
+          "fromOptions"
         ]
       },
       "PaymentReceivedEntryResponseDto": {

--- a/shared/sdk-ts/src/payment-receives.ts
+++ b/shared/sdk-ts/src/payment-receives.ts
@@ -19,6 +19,9 @@ export type CreatePaymentReceivedBody = OpRequestBody<OpForPath<typeof PAYMENTS_
 export type EditPaymentReceivedBody = OpRequestBody<OpForPath<typeof PAYMENTS_RECEIVED_ROUTES.BY_ID, 'put'>>;
 export type PaymentReceivedStateResponse = OpResponseBody<OpForPath<typeof PAYMENTS_RECEIVED_ROUTES.STATE, 'get'>>;
 export type PaymentReceiveEditPageResponse = OpResponseBody<OpForPath<typeof PAYMENTS_RECEIVED_ROUTES.EDIT_PAGE, 'get'>>;
+export type PaymentReceiveMailStateResponse = OpResponseBody<OpForPath<typeof PAYMENTS_RECEIVED_ROUTES.MAIL, 'get'>>;
+export type SendPaymentReceiveMailBody = OpRequestBody<OpForPath<typeof PAYMENTS_RECEIVED_ROUTES.MAIL, 'post'>>;
+export type SendPaymentReceiveMailResponse = OpResponseBody<OpForPath<typeof PAYMENTS_RECEIVED_ROUTES.MAIL, 'post'>>;
 export type PaymentReceivedHtmlContentResponse = { htmlContent: string };
 
 export async function fetchPaymentsReceived(fetcher: ApiFetcher): Promise<PaymentsReceivedListResponse> {
@@ -92,20 +95,20 @@ export async function fetchPaymentReceiveEditPage(
 export async function fetchPaymentReceiveMail(
   fetcher: ApiFetcher,
   id: number
-): Promise<unknown> {
+): Promise<PaymentReceiveMailStateResponse> {
   const get = fetcher.path(PAYMENTS_RECEIVED_ROUTES.MAIL).method('get').create();
   const { data } = await get({ id });
-  return data;
+  return data as PaymentReceiveMailStateResponse;
 }
 
 export async function sendPaymentReceiveMail(
   fetcher: ApiFetcher,
   id: number,
-  body: Record<string, unknown>
-): Promise<unknown> {
+  body: SendPaymentReceiveMailBody
+): Promise<SendPaymentReceiveMailResponse> {
   const post = fetcher.path(PAYMENTS_RECEIVED_ROUTES.MAIL).method('post').create();
-  const { data } = await post({ id, ...body } as never);
-  return data;
+  const { data } = await post({ id, ...body });
+  return data as SendPaymentReceiveMailResponse;
 }
 
 export async function fetchPaymentReceivedState(

--- a/shared/sdk-ts/src/schema.ts
+++ b/shared/sdk-ts/src/schema.ts
@@ -7130,6 +7130,167 @@ export interface components {
              */
             active: boolean;
         };
+        PaymentReceiveMailResponseDto: {
+            /**
+             * @description Whether the mail was successfully queued/sent
+             * @example true
+             */
+            success: boolean;
+            /** @description Optional status message */
+            message?: string;
+        };
+        PaymentReceiveMailEntryDto: {
+            /**
+             * @description The invoice number
+             * @example INV-001
+             */
+            invoiceNumber: string;
+            /**
+             * @description The formatted paid amount
+             * @example $500.00
+             */
+            paidAmount: string;
+        };
+        PaymentReceiveMailAddressItemDto: {
+            /**
+             * @description The email address
+             * @example john@example.com
+             */
+            mail: string;
+            /**
+             * @description The display label for the address
+             * @example John Doe
+             */
+            label: string;
+            /**
+             * @description Whether this is the primary address
+             * @example true
+             */
+            primary?: boolean;
+        };
+        PaymentReceiveMailStateResponseDto: {
+            /**
+             * @description The organization company name
+             * @example Acme Inc.
+             */
+            companyName: string;
+            /**
+             * @description The company logo URI
+             * @example https://example.com/logo.png
+             */
+            companyLogoUri?: string;
+            /**
+             * @description The primary brand color
+             * @example #2563eb
+             */
+            primaryColor?: string;
+            /**
+             * @description The customer display name
+             * @example John Doe
+             */
+            customerName: string;
+            /** @description The payment invoice entries */
+            entries: components["schemas"]["PaymentReceiveMailEntryDto"][];
+            /** @description Sender email addresses */
+            from: string[];
+            /** @description Recipient email addresses */
+            to: string[];
+            /** @description CC recipient email addresses */
+            cc?: string[];
+            /** @description BCC recipient email addresses */
+            bcc?: string[];
+            /** @description The email subject */
+            subject: string;
+            /** @description The email body message */
+            message: string;
+            /** @description Available sender address options */
+            fromOptions: components["schemas"]["PaymentReceiveMailAddressItemDto"][];
+            /** @description Available recipient address options */
+            toOptions: components["schemas"]["PaymentReceiveMailAddressItemDto"][];
+            /**
+             * @description The ISO payment date
+             * @example 2024-03-15
+             */
+            paymentDate: string;
+            /**
+             * @description The human-readable payment date
+             * @example March 15, 2024
+             */
+            paymentDateFormatted: string;
+            /**
+             * @description The numeric payment total
+             * @example 500
+             */
+            total: number;
+            /**
+             * @description The formatted payment total
+             * @example $500.00
+             */
+            totalFormatted: string;
+            /**
+             * @description The numeric payment subtotal
+             * @example 500
+             */
+            subtotal: number;
+            /**
+             * @description The formatted payment subtotal
+             * @example $500.00
+             */
+            subtotalFormatted: string;
+            /**
+             * @description The payment receive number
+             * @example PR-0001
+             */
+            paymentNumber: string;
+            /** @description Template format arguments */
+            formatArgs?: Record<string, never>;
+        };
+        PaymentReceiveMailOptsDto: {
+            /**
+             * @description Sender email addresses
+             * @example [
+             *       "billing@company.com"
+             *     ]
+             */
+            from: string[];
+            /**
+             * @description Recipient email addresses
+             * @example [
+             *       "customer@example.com"
+             *     ]
+             */
+            to: string[];
+            /**
+             * @description CC recipient email addresses
+             * @example [
+             *       "accounting@company.com"
+             *     ]
+             */
+            cc?: string[];
+            /** @description BCC recipient email addresses */
+            bcc?: string[];
+            /**
+             * @description The email subject
+             * @example Payment Received
+             */
+            subject: string;
+            /**
+             * @description The email body message
+             * @example We have received your payment.
+             */
+            message: string;
+            /** @description Available recipient address options */
+            toOptions: components["schemas"]["PaymentReceiveMailAddressItemDto"][];
+            /** @description Available sender address options */
+            fromOptions: components["schemas"]["PaymentReceiveMailAddressItemDto"][];
+            /** @description Template format arguments */
+            formatArgs?: Record<string, never>;
+            /**
+             * @description Whether to attach the payment PDF
+             * @example true
+             */
+            attachPdf?: boolean;
+        };
         PaymentReceivedEntryResponseDto: {
             /**
              * @description ID of the entry
@@ -18128,7 +18289,9 @@ export interface operations {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["PaymentReceiveMailStateResponseDto"];
+                };
             };
         };
     };
@@ -18146,14 +18309,21 @@ export interface operations {
             };
             cookie?: never;
         };
-        requestBody?: never;
+        /** @description The payment receive mail options */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PaymentReceiveMailOptsDto"];
+            };
+        };
         responses: {
             /** @description The payment receive mail has been successfully sent. */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["PaymentReceiveMailResponseDto"];
+                };
             };
         };
     };


### PR DESCRIPTION
## Summary

- Extract the duplicated `flattenInfinityPages` logic from 6 components (CashFlow AccountTransactions boots, Recognized/Pending/Excluded table boots, AllTransactionsUncategorizedBoot, AuditLogProvider) into a shared `utils/flatten-infinity-pages.ts` and a `useFlattenInfinityPages` hook, then migrate all call sites to the hook.
- Convert `AccountsSelect`, `AccountsMultiSelect`, `AccountsSuggestField`, and `_components` to TypeScript using SDK-compliant types (remove `@ts-nocheck`).
- Make `FSelect` generic over its option type and bump `@blueprintjs-formik/select`.
- Add a null guard in `GeneralLedgerHeaderGeneralPane` for `accounts`.

## Test plan

- [ ] `pnpm typecheck` passes in `packages/webapp`
- [ ] Manual: Cash Flow → All / Recognized / Pending / Excluded / Uncategorized transaction tables render and paginate correctly
- [ ] Manual: Audit Log loads entries across pages
- [ ] Manual: Account select / multi-select / suggest fields behave as before across the app
- [ ] Manual: General Ledger header pane renders without crash when `accounts` is undefined
