### PR TITLE
fix(server): only pass SMTP auth when credentials are configured

### DIFF
--- a/packages/server/src/modules/Mail/Mail.module.ts
+++ b/packages/server/src/modules/Mail/Mail.module.ts
@@ -10,15 +10,17 @@ import { MailTransporter } from './MailTransporter.service';
       provide: MAIL_TRANSPORTER_PROVIDER,
       inject: [ConfigService],
       useFactory: (configService: ConfigService) => {
-        // Create reusable transporter object using the default SMTP transport
+        const username = configService.get('mail.username');
+        const password = configService.get('mail.password');
+
+        // Create reusable transporter object using the default SMTP transport.
+        // Only pass `auth` when credentials are configured, so no-auth SMTP
+        // relays (e.g. internal Postfix/SES) are not forced to authenticate.
         const transporter = createTransport({
           host: configService.get('mail.host'),
           port: configService.get('mail.port'),
           secure: configService.get('mail.secure'), // true for 465, false for other ports
-          auth: {
-            user: configService.get('mail.username'),
-            pass: configService.get('mail.password'),
-          },
+          ...(username ? { auth: { user: username, pass: password } } : {}),
         });
         return transporter;
       },


### PR DESCRIPTION
## Problem

`Mail.module.ts` unconditionally passes an `auth` object to `createTransport`, even when `mail.username` and `mail.password` are not set. Nodemailer treats any `auth` object (even with `undefined` values) as a signal to attempt authentication, which causes SMTP connections to fail on no-auth relays (e.g. internal Postfix, SES in a VPC, MailHog in dev).

Fixes #1072.

## Change

Only attach `auth` to the transporter config when a username is actually configured:

```ts
const username = configService.get('mail.username');
const password = configService.get('mail.password');

const transporter = createTransport({
  host: ...,
  port: ...,
  secure: ...,
  ...(username ? { auth: { user: username, pass: password } } : {}),
});
```

## Testing

- With credentials set → `auth` is passed as before, authenticated SMTP works normally.
- Without credentials set → `auth` is omitted, no-auth SMTP relays (e.g. MailHog, internal Postfix) connect successfully.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)