### PR TITLE
refactor(webapp): tighten query types across banking, cashflow and items

### DIFF
--- a/packages/webapp/src/containers/CashFlow/AccountTransactions/AccountTransactionsActionsBar.tsx
+++ b/packages/webapp/src/containers/CashFlow/AccountTransactions/AccountTransactionsActionsBar.tsx
@@ -84,9 +84,9 @@ function AccountTransactionsActionsBarInner({
   const addMoneyInOptions = useMemo(() => getAddMoneyInOptions(), []);
   const addMoneyOutOptions = useMemo(() => getAddMoneyOutOptions(), []);
 
-  const isFeedsActive = !!currentAccount.is_feeds_active;
-  const isFeedsPaused = currentAccount.is_feeds_paused;
-  const isSyncingOwner = currentAccount.is_syncing_owner;
+  const isFeedsActive = !!currentAccount?.is_feeds_active;
+  const isFeedsPaused = currentAccount?.is_feeds_paused;
+  const isSyncingOwner = currentAccount?.is_syncing_owner;
 
   // Handle table row size change.
   const handleTableRowSizeChange = (size) => {

--- a/packages/webapp/src/containers/CashFlow/AccountTransactions/AccountTransactionsAllBoot.tsx
+++ b/packages/webapp/src/containers/CashFlow/AccountTransactions/AccountTransactionsAllBoot.tsx
@@ -30,7 +30,6 @@ function AccountTransactionsAllProvider({
     hasNextPage: hasCashflowTransactionsNextPgae,
   } = useAccountTransactionsInfinity(accountId, {
     page_size: 50,
-    account_id: accountId,
   });
   // Memorized the cashflow account transactions.
   const cashflowTransactions = useFlattenInfinityPages(
@@ -49,7 +48,7 @@ function AccountTransactionsAllProvider({
   ]);
   // Provider payload.
   const provider = {
-    cashflowTransactions,
+    cashflowTransactions: cashflowTransactions ?? [],
     isCashFlowTransactionsFetching,
     isCashFlowTransactionsLoading,
   };

--- a/packages/webapp/src/containers/CashFlow/AccountTransactions/AccountTransactionsProvider.tsx
+++ b/packages/webapp/src/containers/CashFlow/AccountTransactions/AccountTransactionsProvider.tsx
@@ -47,13 +47,12 @@ function AccountTransactionsProvider({ query, ...props }) {
   // Provider payload.
   const provider = {
     accountId,
-    cashflowAccounts,
+    cashflowAccounts: cashflowAccounts ?? [],
     currentAccount,
     bankAccountMetaSummary,
 
     isCashFlowAccountsFetching,
     isCashFlowAccountsLoading,
-
     isCurrentAccountFetching,
     isCurrentAccountLoading,
 

--- a/packages/webapp/src/containers/CashFlow/AccountTransactions/AllTransactionsUncategorizedBoot.tsx
+++ b/packages/webapp/src/containers/CashFlow/AccountTransactions/AllTransactionsUncategorizedBoot.tsx
@@ -57,7 +57,7 @@ function AccountUncategorizedTransactionsBootRoot({
   ]);
   // Provider payload.
   const provider = {
-    uncategorizedTransactions,
+    uncategorizedTransactions: uncategorizedTransactions ?? [],
     isUncategorizedTransactionFetching,
     isUncategorizedTransactionsLoading,
   };

--- a/packages/webapp/src/containers/CashFlow/AccountTransactions/ExcludedTransactions/ExcludedTransactionsTableBoot.tsx
+++ b/packages/webapp/src/containers/CashFlow/AccountTransactions/ExcludedTransactions/ExcludedTransactionsTableBoot.tsx
@@ -68,7 +68,7 @@ function ExcludedBankTransactionsTableBootRoot({
   ]);
   // Provider payload.
   const provider = {
-    excludedBankTransactions,
+    excludedBankTransactions: excludedBankTransactions ?? [],
     isExcludedTransactionsFetching,
     isExcludedTransactionsLoading,
   };

--- a/packages/webapp/src/containers/CashFlow/AccountTransactions/PendingTransactions/PendingTransactionsTableBoot.tsx
+++ b/packages/webapp/src/containers/CashFlow/AccountTransactions/PendingTransactions/PendingTransactionsTableBoot.tsx
@@ -42,7 +42,7 @@ function PendingTransactionsBoot({ children }) {
   ]);
   // Provider payload.
   const provider = {
-    pendingTransactions,
+    pendingTransactionsL: pendingTransactions ?? [],
     isPendingTransactionFetching,
     isPendingTransactionsLoading,
   };

--- a/packages/webapp/src/containers/CashFlow/AccountTransactions/RecognizedTransactions/RecognizedTransactionsTableBoot.tsx
+++ b/packages/webapp/src/containers/CashFlow/AccountTransactions/RecognizedTransactions/RecognizedTransactionsTableBoot.tsx
@@ -67,7 +67,7 @@ function RecognizedTransactionsTableBootRoot({
   ]);
   // Provider payload.
   const provider = {
-    recognizedTransactions,
+    recognizedTransactions: recognizedTransactions ?? [],
     isRecognizedTransactionsFetching,
     isRecongizedTransactionsLoading,
   };

--- a/packages/webapp/src/containers/CashFlow/MoneyInDialog/MoneyInDialogProvider.tsx
+++ b/packages/webapp/src/containers/CashFlow/MoneyInDialog/MoneyInDialogProvider.tsx
@@ -55,8 +55,8 @@ function MoneyInDialogProvider({
 
   // Provider data.
   const provider = {
-    accounts,
-    branches,
+    accounts: accounts ?? [],
+    branches: branches ?? [],
 
     accountId,
     defaultAccountId,
@@ -66,7 +66,7 @@ function MoneyInDialogProvider({
     isAccountsLoading,
     isBranchesSuccess,
 
-    cashflowAccounts,
+    cashflowAccounts: cashflowAccounts ?? [],
 
     submitPayload,
     dialogName,

--- a/packages/webapp/src/containers/CashFlow/MoneyInDialog/MoneyInFormContent.tsx
+++ b/packages/webapp/src/containers/CashFlow/MoneyInDialog/MoneyInFormContent.tsx
@@ -1,7 +1,6 @@
 // @ts-nocheck
 import React from 'react';
 import { Form } from 'formik';
-
 import { MoneyInFormFields } from './MoneyInFormFields';
 import { MoneyInFormDialog } from './MoneyInFormDialog';
 import { MoneyInFloatingActions } from './MoneyInFloatingActions';

--- a/packages/webapp/src/containers/CashFlow/MoneyInDialog/OtherIncome/OtherIncomeFormFields.tsx
+++ b/packages/webapp/src/containers/CashFlow/MoneyInDialog/OtherIncome/OtherIncomeFormFields.tsx
@@ -105,7 +105,7 @@ export function OtherIncomeFormFields() {
             labelInfo={<FieldRequiredHint />}
           >
             <ControlGroup>
-              <InputPrependText text={account.currency_code} />
+              <InputPrependText text={account?.currency_code} />
               <FMoneyInputGroup name={'amount'} minimal={true} />
             </ControlGroup>
           </FFormGroup>

--- a/packages/webapp/src/containers/CashFlow/MoneyInDialog/TransferFromAccount/TransferFromAccountFormFields.tsx
+++ b/packages/webapp/src/containers/CashFlow/MoneyInDialog/TransferFromAccount/TransferFromAccountFormFields.tsx
@@ -81,6 +81,7 @@ export function TransferFromAccountFormFields() {
           <MoneyInOutTransactionNoField />
         </Col>
       </Row>
+
       {/*------------ Amount -----------*/}
       <Row>
         <Col xs={10}>
@@ -89,7 +90,7 @@ export function TransferFromAccountFormFields() {
             labelInfo={<FieldRequiredHint />}
           >
             <ControlGroup>
-              <InputPrependText text={account.currency_code || '--'} />
+              <InputPrependText text={account?.currency_code || '--'} />
               <FMoneyInputGroup name={'amount'} minimal={true} />
             </ControlGroup>
           </FormGroup>
@@ -111,7 +112,7 @@ export function TransferFromAccountFormFields() {
           >
             <FAccountsSuggestField
               name={'credit_account_id'}
-              items={accounts as any[]}
+              items={accounts}
               filterByTypes={[
                 ACCOUNT_TYPE.CASH,
                 ACCOUNT_TYPE.BANK,

--- a/packages/webapp/src/containers/CashFlow/_components.tsx
+++ b/packages/webapp/src/containers/CashFlow/_components.tsx
@@ -6,7 +6,7 @@ import * as R from 'ramda';
 
 import { FFormGroup, Icon, InputPrependButton } from '@/components';
 import { useUpdateEffect } from '@/hooks';
-
+import { FormattedMessage as T } from '@/components';
 import { withSettings } from '@/containers/Settings/withSettings';
 import { withDialogActions } from '@/containers/Dialog/withDialogActions';
 import { transactionNumber } from '@/utils';

--- a/packages/webapp/src/containers/Items/ItemFormBody.tsx
+++ b/packages/webapp/src/containers/Items/ItemFormBody.tsx
@@ -113,7 +113,7 @@ function ItemFormBodyInner({ organization: { base_currency } }) {
           >
             <TaxRatesSelect
               name={'sell_tax_rate_id'}
-              items={taxRates?.data}
+              items={taxRates}
               allowCreate
             />
           </FFormGroup>
@@ -214,7 +214,7 @@ function ItemFormBodyInner({ organization: { base_currency } }) {
           >
             <TaxRatesSelect
               name={'purchase_tax_rate_id'}
-              items={taxRates?.data}
+              items={taxRates}
               allowCreate={true}
               fastField={true}
               shouldUpdateDeps={{ taxRates }}

--- a/packages/webapp/src/containers/Items/ItemFormInventorySection.tsx
+++ b/packages/webapp/src/containers/Items/ItemFormInventorySection.tsx
@@ -1,5 +1,6 @@
 // @ts-nocheck
 import React from 'react';
+import intl from 'react-intl-universal';
 import {
   AccountsSelect,
   FFormGroup,
@@ -7,13 +8,11 @@ import {
   Col,
   Row,
 } from '@/components';
-
 import { withCurrentOrganization } from '@/containers/Organization/withCurrentOrganization';
 import { accountsFieldShouldUpdate } from './utils';
 import { ACCOUNT_TYPE } from '@/constants/accountTypes';
 import { useItemFormContext } from './ItemFormProvider';
 import { compose } from '@/utils';
-import intl from 'react-intl-universal';
 
 /**
  * Item form inventory sections.

--- a/packages/webapp/src/containers/Items/ItemFormPrimarySection.tsx
+++ b/packages/webapp/src/containers/Items/ItemFormPrimarySection.tsx
@@ -32,7 +32,6 @@ import intl from 'react-intl-universal';
 export function ItemFormPrimarySection() {
   // Item form context.
   const { isNewMode, item, itemsCategories } = useItemFormContext();
-
   const nameFieldRef = useRef(null);
 
   useEffect(() => {

--- a/packages/webapp/src/containers/Items/ItemFormProvider.tsx
+++ b/packages/webapp/src/containers/Items/ItemFormProvider.tsx
@@ -6,7 +6,7 @@ import type {
   TaxRatesListResponse,
   CreateItemBody,
   EditItemBody,
-  ItemsCategoriesListResult,
+  ItemCategoriesListResponse
 } from '@bigcapital/sdk-ts';
 import {
   useItem,
@@ -30,10 +30,10 @@ type ItemFormProviderProps = {
 
 type ItemFormContextValue = {
   itemId?: number;
-  accounts: AccountsList | undefined;
+  accounts: AccountsList;
   item: Item | undefined;
-  itemsCategories: ItemsCategoriesListResult['itemsCategories'];
-  taxRates: TaxRatesListResponse | undefined;
+  itemsCategories: ItemCategoriesListResponse;
+  taxRates: TaxRatesListResponse;
   submitPayload: ItemFormSubmitPayload;
   isNewMode: boolean;
 
@@ -63,7 +63,7 @@ function ItemFormProvider({ itemId, ...props }: ItemFormProviderProps) {
   const { isLoading: isAccountsLoading, data: accounts } = useAccounts();
 
   // Fetches the items categories list.
-  const { isLoading: isItemsCategoriesLoading, data: itemsCategoriesData } =
+  const { isLoading: isItemsCategoriesLoading, data: itemsCategories } =
     useItemsCategories();
 
   const { data: taxRates, isLoading: isTaxRatesLoading } = useTaxRates();
@@ -72,7 +72,6 @@ function ItemFormProvider({ itemId, ...props }: ItemFormProviderProps) {
   const itemQuery = useItem(itemId || (duplicateId as number | undefined), {
     enabled: !!itemId || !!duplicateId,
   });
-
   const { isLoading: isItemLoading, data: item } = itemQuery;
 
   // Watches and handles item not found response error.
@@ -102,10 +101,10 @@ function ItemFormProvider({ itemId, ...props }: ItemFormProviderProps) {
   // Provider state.
   const provider: ItemFormContextValue = {
     itemId,
-    accounts,
+    accounts: accounts ?? [],
     item,
-    itemsCategories: itemsCategoriesData?.itemsCategories ?? [],
-    taxRates,
+    itemsCategories: itemsCategories ?? [],
+    taxRates: taxRates ?? [],
     submitPayload,
     isNewMode,
 

--- a/packages/webapp/src/containers/Items/ItemFormProvider.tsx
+++ b/packages/webapp/src/containers/Items/ItemFormProvider.tsx
@@ -6,7 +6,7 @@ import type {
   TaxRatesListResponse,
   CreateItemBody,
   EditItemBody,
-  ItemCategoriesListResponse
+  ItemCategoriesListResponse,
 } from '@bigcapital/sdk-ts';
 import {
   useItem,

--- a/packages/webapp/src/hooks/query/banking/queries/bank-accounts.ts
+++ b/packages/webapp/src/hooks/query/banking/queries/bank-accounts.ts
@@ -76,8 +76,8 @@ type DisconnectBankAccountValues = {
 };
 
 export function useDisconnectBankAccount(
-  options?: UseMutationOptions<unknown, Error, DisconnectBankAccountValues>,
-): UseMutationResult<unknown, Error, DisconnectBankAccountValues> {
+  options?: UseMutationOptions<void, Error, DisconnectBankAccountValues>,
+): UseMutationResult<void, Error, DisconnectBankAccountValues> {
   const queryClient = useQueryClient();
   const fetcher = useApiFetcher();
 
@@ -99,8 +99,8 @@ type UpdateBankAccountValues = {
 };
 
 export function useUpdateBankAccount(
-  options?: UseMutationOptions<unknown, Error, UpdateBankAccountValues>,
-): UseMutationResult<unknown, Error, UpdateBankAccountValues> {
+  options?: UseMutationOptions<void, Error, UpdateBankAccountValues>,
+): UseMutationResult<void, Error, UpdateBankAccountValues> {
   const fetcher = useApiFetcher();
 
   return useMutation({

--- a/packages/webapp/src/hooks/query/banking/queries/bank-rules.ts
+++ b/packages/webapp/src/hooks/query/banking/queries/bank-rules.ts
@@ -8,7 +8,13 @@ import {
   useQuery,
   useQueryClient,
 } from '@tanstack/react-query';
-import type { CreateBankRuleBody, EditBankRuleBody } from '@bigcapital/sdk-ts';
+import type {
+  BankRuleResponse,
+  BankRulesListResponse,
+  CreateBankRuleBody,
+  CreateBankRuleResponse,
+  EditBankRuleBody,
+} from '@bigcapital/sdk-ts';
 import {
   createBankRule,
   deleteBankRule,
@@ -27,8 +33,8 @@ const commonInvalidateQueries = (queryClient: QueryClient) => {
 };
 
 export function useCreateBankRule(
-  options?: UseMutationOptions<unknown, Error, CreateBankRuleBody>,
-): UseMutationResult<unknown, Error, CreateBankRuleBody> {
+  options?: UseMutationOptions<CreateBankRuleResponse, Error, CreateBankRuleBody>,
+): UseMutationResult<CreateBankRuleResponse, Error, CreateBankRuleBody> {
   const queryClient = useQueryClient();
   const fetcher = useApiFetcher();
 
@@ -41,11 +47,11 @@ export function useCreateBankRule(
 
 export function useEditBankRule(
   options?: UseMutationOptions<
-    unknown,
+    void,
     Error,
     { id: number; value: EditBankRuleBody }
   >,
-): UseMutationResult<unknown, Error, { id: number; value: EditBankRuleBody }> {
+): UseMutationResult<void, Error, { id: number; value: EditBankRuleBody }> {
   const queryClient = useQueryClient();
   const fetcher = useApiFetcher();
 
@@ -58,8 +64,8 @@ export function useEditBankRule(
 }
 
 export function useDeleteBankRule(
-  options?: UseMutationOptions<unknown, Error, number>,
-): UseMutationResult<unknown, Error, number> {
+  options?: UseMutationOptions<void, Error, number>,
+): UseMutationResult<void, Error, number> {
   const queryClient = useQueryClient();
   const fetcher = useApiFetcher();
 
@@ -76,8 +82,8 @@ export function useDeleteBankRule(
 }
 
 export function useBankRules(
-  options?: UseQueryOptions<unknown, Error>,
-): UseQueryResult<unknown, Error> {
+  options?: UseQueryOptions<BankRulesListResponse, Error>,
+): UseQueryResult<BankRulesListResponse, Error> {
   const fetcher = useApiFetcher();
 
   return useQuery({
@@ -89,8 +95,8 @@ export function useBankRules(
 
 export function useBankRule(
   bankRuleId: number,
-  options?: Omit<UseQueryOptions<unknown, Error>, 'queryKey'>,
-): UseQueryResult<unknown, Error> {
+  options?: Omit<UseQueryOptions<BankRuleResponse, Error>, 'queryKey'>,
+): UseQueryResult<BankRuleResponse, Error> {
   const fetcher = useApiFetcher();
 
   return useQuery({

--- a/packages/webapp/src/hooks/query/banking/queries/bank-rules.ts
+++ b/packages/webapp/src/hooks/query/banking/queries/bank-rules.ts
@@ -33,7 +33,11 @@ const commonInvalidateQueries = (queryClient: QueryClient) => {
 };
 
 export function useCreateBankRule(
-  options?: UseMutationOptions<CreateBankRuleResponse, Error, CreateBankRuleBody>,
+  options?: UseMutationOptions<
+    CreateBankRuleResponse,
+    Error,
+    CreateBankRuleBody
+  >,
 ): UseMutationResult<CreateBankRuleResponse, Error, CreateBankRuleBody> {
   const queryClient = useQueryClient();
   const fetcher = useApiFetcher();

--- a/packages/webapp/src/hooks/query/banking/queries/bank-transactions.ts
+++ b/packages/webapp/src/hooks/query/banking/queries/bank-transactions.ts
@@ -37,10 +37,7 @@ export function useGetBankTransactionsMatches(
     ...options,
     queryKey: bankingKeys.transactionMatches(uncategorizedTransactionIds),
     queryFn: () =>
-      fetchMatchedTransactions(
-        fetcher,
-        uncategorizedTransactionIds,
-      ) as Promise<MatchedTransactionsResponse>,
+      fetchMatchedTransactions(fetcher, uncategorizedTransactionIds),
   });
 }
 
@@ -59,8 +56,8 @@ const onValidateExcludeUncategorizedTransaction = (
 };
 
 export function useExcludeUncategorizedTransaction(
-  options?: UseMutationOptions<unknown, Error, number>,
-): UseMutationResult<unknown, Error, number> {
+  options?: UseMutationOptions<void, Error, number>,
+): UseMutationResult<void, Error, number> {
   const queryClient = useQueryClient();
   const fetcher = useApiFetcher();
 
@@ -73,8 +70,8 @@ export function useExcludeUncategorizedTransaction(
 }
 
 export function useUnexcludeUncategorizedTransaction(
-  options?: UseMutationOptions<unknown, Error, number>,
-): UseMutationResult<unknown, Error, number> {
+  options?: UseMutationOptions<void, Error, number>,
+): UseMutationResult<void, Error, number> {
   const queryClient = useQueryClient();
   const fetcher = useApiFetcher();
 
@@ -87,8 +84,8 @@ export function useUnexcludeUncategorizedTransaction(
 }
 
 export function useExcludeUncategorizedTransactions(
-  options?: UseMutationOptions<unknown, Error, ExcludeBankTransactionsBulkBody>,
-): UseMutationResult<unknown, Error, ExcludeBankTransactionsBulkBody> {
+  options?: UseMutationOptions<void, Error, ExcludeBankTransactionsBulkBody>,
+): UseMutationResult<void, Error, ExcludeBankTransactionsBulkBody> {
   const queryClient = useQueryClient();
   const fetcher = useApiFetcher();
 
@@ -101,8 +98,8 @@ export function useExcludeUncategorizedTransactions(
 }
 
 export function useUnexcludeUncategorizedTransactions(
-  options?: UseMutationOptions<unknown, Error, ExcludeBankTransactionsBulkBody>,
-): UseMutationResult<unknown, Error, ExcludeBankTransactionsBulkBody> {
+  options?: UseMutationOptions<void, Error, ExcludeBankTransactionsBulkBody>,
+): UseMutationResult<void, Error, ExcludeBankTransactionsBulkBody> {
   const queryClient = useQueryClient();
   const fetcher = useApiFetcher();
 
@@ -115,8 +112,8 @@ export function useUnexcludeUncategorizedTransactions(
 }
 
 export function useMatchUncategorizedTransaction(
-  props?: UseMutationOptions<unknown, Error, MatchTransactionBody>,
-): UseMutationResult<unknown, Error, MatchTransactionBody> {
+  props?: UseMutationOptions<void, Error, MatchTransactionBody>,
+): UseMutationResult<void, Error, MatchTransactionBody> {
   const queryClient = useQueryClient();
   const fetcher = useApiFetcher();
 
@@ -139,11 +136,11 @@ type UnmatchUncategorizedTransactionValues = {
 
 export function useUnmatchMatchedUncategorizedTransaction(
   props?: UseMutationOptions<
-    unknown,
+    void,
     Error,
     UnmatchUncategorizedTransactionValues
   >,
-): UseMutationResult<unknown, Error, UnmatchUncategorizedTransactionValues> {
+): UseMutationResult<void, Error, UnmatchUncategorizedTransactionValues> {
   const queryClient = useQueryClient();
   const fetcher = useApiFetcher();
 

--- a/packages/webapp/src/hooks/query/banking/queries/pending-transactions.ts
+++ b/packages/webapp/src/hooks/query/banking/queries/pending-transactions.ts
@@ -8,7 +8,10 @@ import {
   QueryKey,
 } from '@tanstack/react-query';
 import { fetchPendingTransactions } from '@bigcapital/sdk-ts';
-import type { PendingBankTransactionsListPage } from '@bigcapital/sdk-ts';
+import type {
+  GetPendingTransactionsQuery,
+  PendingBankTransactionsListPage,
+} from '@bigcapital/sdk-ts';
 import { useApiFetcher } from '../../../useRequest';
 import { bankingKeys } from '../query-keys';
 import {
@@ -33,7 +36,7 @@ export function usePendingBankAccountTransactions(
 }
 
 export function usePendingBankTransactionsInfinity(
-  query: Record<string, unknown>,
+  query: GetPendingTransactionsQuery,
   infinityProps?: Omit<
     UseInfiniteQueryOptions<
       PendingBankTransactionsListPage,

--- a/packages/webapp/src/hooks/query/banking/queries/recognized-transactions.ts
+++ b/packages/webapp/src/hooks/query/banking/queries/recognized-transactions.ts
@@ -15,6 +15,8 @@ import {
 import type {
   BankTransactionsListPage,
   ExcludedBankTransactionsListPage,
+  GetExcludedBankTransactionsQuery,
+  RecognizedTransactionResponse,
 } from '@bigcapital/sdk-ts';
 import { useApiFetcher } from '../../../useRequest';
 import { bankingKeys } from '../query-keys';
@@ -25,8 +27,8 @@ import {
 
 export function useGetRecognizedBankTransaction(
   uncategorizedTransactionId: number,
-  options?: UseQueryOptions<unknown, Error>,
-): UseQueryResult<unknown, Error> {
+  options?: UseQueryOptions<RecognizedTransactionResponse, Error>,
+): UseQueryResult<RecognizedTransactionResponse, Error> {
   const fetcher = useApiFetcher({ enableCamelCaseTransform: true });
 
   return useQuery({
@@ -74,7 +76,7 @@ export function useRecognizedBankTransactionsInfinity(
 }
 
 export function useExcludedBankTransactionsInfinity(
-  query: Record<string, unknown>,
+  query: GetExcludedBankTransactionsQuery,
   infinityProps?: Omit<
     UseInfiniteQueryOptions<
       ExcludedBankTransactionsListPage,

--- a/packages/webapp/src/hooks/query/cashflow-accounts/queries.ts
+++ b/packages/webapp/src/hooks/query/cashflow-accounts/queries.ts
@@ -10,10 +10,13 @@ import {
   QueryKey,
 } from '@tanstack/react-query';
 import type {
+  BankingAccountsListResponse,
+  BankingTransactionResponse,
   CreateCashflowTransactionBody,
   CashflowAccountTransactionsQuery,
   CashflowAccountUncategorizedTransactionsQuery,
   CategorizeTransactionBody,
+  UncategorizedTransactionResponse,
 } from '@bigcapital/sdk-ts';
 import {
   fetchCashflowAccounts,
@@ -68,13 +71,16 @@ const commonInvalidateQueries = (
 
 export function useCashflowAccounts(
   query?: Record<string, unknown>,
-  props?: Omit<UseQueryOptions<unknown>, 'queryKey' | 'queryFn'>,
+  props?: Omit<
+    UseQueryOptions<BankingAccountsListResponse, Error, BankingAccountsListResponse>,
+    'queryKey' | 'queryFn'
+  >,
 ) {
   const fetcher = useApiFetcher();
-  return useQuery({
+  return useQuery<BankingAccountsListResponse, Error, BankingAccountsListResponse>({
     ...props,
     queryKey: cashflowAccountsKeys.list(query),
-    queryFn: () => fetchCashflowAccounts(fetcher, query ?? {}),
+    queryFn: () => fetchCashflowAccounts(fetcher),
   });
 }
 
@@ -96,11 +102,14 @@ export function useCreateCashflowTransaction(
 
 export function useCashflowTransaction(
   id: number | null | undefined,
-  props?: Omit<UseQueryOptions<unknown>, 'queryKey' | 'queryFn'>,
+  props?: Omit<
+    UseQueryOptions<BankingTransactionResponse, Error, BankingTransactionResponse>,
+    'queryKey' | 'queryFn'
+  >,
 ) {
   const fetcher = useApiFetcher();
 
-  return useQuery({
+  return useQuery<BankingTransactionResponse, Error, BankingTransactionResponse>({
     ...props,
     queryKey: cashflowAccountsKeys.transaction(id),
     queryFn: () => fetchCashflowTransaction(fetcher, id!),
@@ -161,7 +170,6 @@ export function useAccountTransactionsInfinity(
     queryFn: ({ pageParam }) =>
       fetchAccountTransactionsInfinity(fetcher, accountId, {
         ...query,
-        accountId,
         page: pageParam,
       }),
     initialPageParam: 1,
@@ -228,11 +236,14 @@ export function useRefreshCashflowTransactions() {
 
 export function useUncategorizedTransaction(
   id: number | null | undefined,
-  props?: Omit<UseQueryOptions<unknown>, 'queryKey' | 'queryFn'>,
+  props?: Omit<
+    UseQueryOptions<UncategorizedTransactionResponse, Error, UncategorizedTransactionResponse>,
+    'queryKey' | 'queryFn'
+  >,
 ) {
   const fetcher = useApiFetcher();
 
-  return useQuery({
+  return useQuery<UncategorizedTransactionResponse, Error, UncategorizedTransactionResponse>({
     ...props,
     queryKey: cashflowAccountsKeys.uncategorizedTransaction(id),
     queryFn: () => fetchUncategorizedTransaction(fetcher, id!),

--- a/packages/webapp/src/hooks/query/cashflow-accounts/queries.ts
+++ b/packages/webapp/src/hooks/query/cashflow-accounts/queries.ts
@@ -72,12 +72,20 @@ const commonInvalidateQueries = (
 export function useCashflowAccounts(
   query?: Record<string, unknown>,
   props?: Omit<
-    UseQueryOptions<BankingAccountsListResponse, Error, BankingAccountsListResponse>,
+    UseQueryOptions<
+      BankingAccountsListResponse,
+      Error,
+      BankingAccountsListResponse
+    >,
     'queryKey' | 'queryFn'
   >,
 ) {
   const fetcher = useApiFetcher();
-  return useQuery<BankingAccountsListResponse, Error, BankingAccountsListResponse>({
+  return useQuery<
+    BankingAccountsListResponse,
+    Error,
+    BankingAccountsListResponse
+  >({
     ...props,
     queryKey: cashflowAccountsKeys.list(query),
     queryFn: () => fetchCashflowAccounts(fetcher),
@@ -103,13 +111,21 @@ export function useCreateCashflowTransaction(
 export function useCashflowTransaction(
   id: number | null | undefined,
   props?: Omit<
-    UseQueryOptions<BankingTransactionResponse, Error, BankingTransactionResponse>,
+    UseQueryOptions<
+      BankingTransactionResponse,
+      Error,
+      BankingTransactionResponse
+    >,
     'queryKey' | 'queryFn'
   >,
 ) {
   const fetcher = useApiFetcher();
 
-  return useQuery<BankingTransactionResponse, Error, BankingTransactionResponse>({
+  return useQuery<
+    BankingTransactionResponse,
+    Error,
+    BankingTransactionResponse
+  >({
     ...props,
     queryKey: cashflowAccountsKeys.transaction(id),
     queryFn: () => fetchCashflowTransaction(fetcher, id!),
@@ -237,13 +253,21 @@ export function useRefreshCashflowTransactions() {
 export function useUncategorizedTransaction(
   id: number | null | undefined,
   props?: Omit<
-    UseQueryOptions<UncategorizedTransactionResponse, Error, UncategorizedTransactionResponse>,
+    UseQueryOptions<
+      UncategorizedTransactionResponse,
+      Error,
+      UncategorizedTransactionResponse
+    >,
     'queryKey' | 'queryFn'
   >,
 ) {
   const fetcher = useApiFetcher();
 
-  return useQuery<UncategorizedTransactionResponse, Error, UncategorizedTransactionResponse>({
+  return useQuery<
+    UncategorizedTransactionResponse,
+    Error,
+    UncategorizedTransactionResponse
+  >({
     ...props,
     queryKey: cashflowAccountsKeys.uncategorizedTransaction(id),
     queryFn: () => fetchUncategorizedTransaction(fetcher, id!),

--- a/packages/webapp/src/hooks/query/items-categories/queries.ts
+++ b/packages/webapp/src/hooks/query/items-categories/queries.ts
@@ -28,9 +28,6 @@ const commonInvalidateQueries = (
   queryClient.invalidateQueries({ queryKey: itemsCategoriesKeys.all() });
 };
 
-/**
- * Creates a new item category.
- */
 export function useCreateItemCategory(
   props?: UseMutationOptions<void, Error, CreateItemCategoryBody>,
 ) {
@@ -45,9 +42,6 @@ export function useCreateItemCategory(
   });
 }
 
-/**
- * Edits the item category.
- */
 export function useEditItemCategory(
   props?: UseMutationOptions<void, Error, [number, EditItemCategoryBody]>,
 ) {
@@ -67,9 +61,6 @@ export function useEditItemCategory(
   });
 }
 
-/**
- * Deletes the given item category.
- */
 export function useDeleteItemCategory(
   props?: UseMutationOptions<void, Error, number>,
 ) {
@@ -88,48 +79,27 @@ export function useDeleteItemCategory(
   });
 }
 
-function transformCategories(
-  data: ItemCategoriesListResponse,
-): ItemsCategoriesListResult {
-  const arr = Array.isArray(data)
-    ? data
-    : ((data as { data?: ItemCategory[] })?.data ?? []);
-  const pagination =
-    (data as { pagination?: Record<string, unknown> })?.pagination ?? {};
-  return {
-    itemsCategories: arr as ItemCategory[],
-    pagination,
-  };
-}
-
-/**
- * Retrieve the items categories.
- */
 export function useItemsCategories(
   query?: Record<string, unknown>,
   props?: Omit<
     UseQueryOptions<
       ItemCategoriesListResponse,
       Error,
-      ItemsCategoriesListResult
+      ItemCategoriesListResponse
     >,
     'queryKey' | 'queryFn' | 'select'
   >,
 ) {
   const fetcher = useApiFetcher();
-  return useQuery<ItemCategoriesListResponse, Error, ItemsCategoriesListResult>(
+  return useQuery<ItemCategoriesListResponse, Error, ItemCategoriesListResponse>(
     {
       ...props,
       queryKey: [...itemsCategoriesKeys.all(), query],
       queryFn: () => fetchItemCategories(fetcher),
-      select: transformCategories,
     },
   );
 }
 
-/**
- * Retrieve the item category details.
- */
 export function useItemCategory(
   id: number | null | undefined,
   props?: Omit<UseQueryOptions<ItemCategory>, 'queryKey' | 'queryFn'>,

--- a/packages/webapp/src/hooks/query/items-categories/queries.ts
+++ b/packages/webapp/src/hooks/query/items-categories/queries.ts
@@ -91,13 +91,15 @@ export function useItemsCategories(
   >,
 ) {
   const fetcher = useApiFetcher();
-  return useQuery<ItemCategoriesListResponse, Error, ItemCategoriesListResponse>(
-    {
-      ...props,
-      queryKey: [...itemsCategoriesKeys.all(), query],
-      queryFn: () => fetchItemCategories(fetcher),
-    },
-  );
+  return useQuery<
+    ItemCategoriesListResponse,
+    Error,
+    ItemCategoriesListResponse
+  >({
+    ...props,
+    queryKey: [...itemsCategoriesKeys.all(), query],
+    queryFn: () => fetchItemCategories(fetcher),
+  });
 }
 
 export function useItemCategory(

--- a/shared/sdk-ts/src/cashflow-accounts.ts
+++ b/shared/sdk-ts/src/cashflow-accounts.ts
@@ -15,6 +15,16 @@ export const BANKING_ACCOUNTS_ROUTES = {
 
 export type BankingAccountsListResponse = OpResponseBody<OpForPath<typeof BANKING_ACCOUNTS_ROUTES.LIST, 'get'>>;
 
+/** Response for GET /api/banking/transactions/{id}. */
+export type BankingTransactionResponse = OpResponseBody<
+  OpForPath<typeof BANKING_ACCOUNTS_ROUTES.TRANSACTION_BY_ID, 'get'>
+>;
+
+/** Response for GET /api/banking/uncategorized/{uncategorizedTransactionId}. */
+export type UncategorizedTransactionResponse = OpResponseBody<
+  OpForPath<typeof BANKING_ACCOUNTS_ROUTES.UNCATEGORIZED_BY_ID, 'get'>
+>;
+
 /** Bank account summary response (schema does not define response body). */
 export interface BankingAccountSummaryResponse {
   name: string;
@@ -74,7 +84,7 @@ export async function fetchBankingTransactions(
 export async function getBankingTransaction(
   fetcher: ApiFetcher,
   id: string | number
-): Promise<unknown> {
+): Promise<BankingTransactionResponse> {
   const get = fetcher.path(BANKING_ACCOUNTS_ROUTES.TRANSACTION_BY_ID).method('get').create();
   const { data } = await get({ id: String(id) });
   return data;
@@ -112,7 +122,7 @@ export async function fetchUncategorizedTransactions(
 export async function getUncategorizedTransaction(
   fetcher: ApiFetcher,
   uncategorizedTransactionId: number
-): Promise<unknown> {
+): Promise<UncategorizedTransactionResponse> {
   const get = fetcher
     .path(BANKING_ACCOUNTS_ROUTES.UNCATEGORIZED_BY_ID)
     .method('get')
@@ -147,10 +157,9 @@ export type CreateCashflowTransactionBody = CreateBankingTransactionBody;
 export type CashflowAccountTransactionsQuery = GetBankingTransactionsQuery;
 export type CashflowAccountUncategorizedTransactionsQuery = GetUncategorizedTransactionsQuery;
 
-/** Fetch cashflow accounts (alias for fetchBankingAccounts with optional query params). */
+/** Fetch cashflow accounts (alias for fetchBankingAccounts). */
 export async function fetchCashflowAccounts(
   fetcher: ApiFetcher,
-  _query?: Record<string, unknown>
 ): Promise<BankingAccountsListResponse> {
   return fetchBankingAccounts(fetcher);
 }

--- a/shared/sdk-ts/src/items-categories.ts
+++ b/shared/sdk-ts/src/items-categories.ts
@@ -12,11 +12,6 @@ export type ItemCategory = OpResponseBody<OpForPath<typeof ITEMS_CATEGORIES_ROUT
 export type CreateItemCategoryBody = OpRequestBody<OpForPath<typeof ITEMS_CATEGORIES_ROUTES.LIST, 'post'>>;
 export type EditItemCategoryBody = OpRequestBody<OpForPath<typeof ITEMS_CATEGORIES_ROUTES.BY_ID, 'put'>>;
 
-export type ItemsCategoriesListResult = {
-  itemsCategories: ItemCategory[];
-  pagination: Record<string, unknown>;
-};
-
 export async function fetchItemCategories(fetcher: ApiFetcher): Promise<ItemCategoriesListResponse> {
   const get = fetcher.path(ITEMS_CATEGORIES_ROUTES.LIST).method('get').create();
   const { data } = await get({});


### PR DESCRIPTION
## Summary

- Replaced `unknown` useQuery option types with concrete SDK response types across banking, cashflow, and items-categories query hooks.
- Removed redundant `select` callbacks and `as any` / `as unknown` casts in favor of typed fetcher return values.
- Propagated typed responses (`BankingTransactionResponse`, `UncategorizedTransactionResponse`) from sdk-ts fetchers.
- Dropped the unused `ItemsCategoriesListResult` type and the unused `query` parameter on `fetchCashflowAccounts`.

## Why

Improves end-to-end type safety for query consumers (CashFlow, Items containers) and removes unsafe casts that masked real type drift between the OpenAPI-derived SDK and the webapp.

## Test plan

- [ ] `pnpm typecheck` passes in `webapp` and `sdk-ts`
- [ ] Manually verify CashFlow account transactions, Money In dialog, and Items form load without runtime regressions
- [ ] Confirm pending/recognized/excluded/uncategorized transaction tabs still fetch and render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)