### PR TITLE
fix(webapp): avoid unsafe destructuring of useJob data in BuildingWorkspaceStep

### DIFF
--- a/packages/webapp/src/ee/workspaces/containers/CreateWorkspaceDrawer/BuildingWorkspaceStep.tsx
+++ b/packages/webapp/src/ee/workspaces/containers/CreateWorkspaceDrawer/BuildingWorkspaceStep.tsx
@@ -19,12 +19,17 @@ export default function BuildingWorkspaceStep({
   const isDarkMode = useIsDarkMode();
 
   const {
-    data: { isRunning, isWaiting, isFailed, isCompleted },
+    data: jobState,
     isFetching: isJobFetching,
   } = useJob(jobId, {
     refetchInterval: 2000,
     enabled: !!jobId,
   });
+
+  const isRunning = jobState?.isRunning;
+  const isWaiting = jobState?.isWaiting; 
+  const isFailed = jobState?.isFailed;
+  const isCompleted = jobState?.isCompleted;
 
   useEffect(() => {
     if (isCompleted) {


### PR DESCRIPTION
## Summary
- `BuildingWorkspaceStep` destructured `{ isRunning, isWaiting, isFailed, isCompleted }` directly from `useJob(...).data`, which is `undefined` while the query is fetching, causing a runtime crash.
- Access these fields via optional chaining on the `jobState` object instead.

## Test plan
- [ ] Trigger the create-workspace flow and verify the building step renders without crashing while the job is still loading.
- [ ] Confirm the progress UI still transitions correctly through running / waiting / completed states.
- [ ] Verify the failure branch renders when the job fails.