### PR TITLE
feat(accounts): add bulk activate/inactivate accounts

### DIFF
--- a/packages/server/src/modules/Accounts/Accounts.controller.ts
+++ b/packages/server/src/modules/Accounts/Accounts.controller.ts
@@ -33,6 +33,7 @@ import {
   BulkDeleteDto,
   ValidateBulkDeleteResponseDto,
 } from '@/common/dtos/BulkDelete.dto';
+import { BulkActivateAccountsDto } from './dtos/BulkActivateAccounts.dto';
 import { RequirePermission } from '@/modules/Roles/RequirePermission.decorator';
 import { PermissionGuard } from '@/modules/Roles/Permission.guard';
 import { AuthorizationGuard } from '@/modules/Roles/Authorization.guard';
@@ -87,6 +88,34 @@ export class AccountsController {
     return this.accountsApplication.bulkDeleteAccounts(bulkDeleteDto.ids, {
       skipUndeletable: bulkDeleteDto.skipUndeletable ?? false,
     });
+  }
+
+  @Post('bulk-activate')
+  @HttpCode(200)
+  @RequirePermission(AccountAction.EDIT, AbilitySubject.Account)
+  @ApiOperation({ summary: 'Activates multiple accounts in bulk.' })
+  @ApiResponse({
+    status: 200,
+    description: 'The accounts have been successfully activated.',
+  })
+  async bulkActivateAccounts(
+    @Body() dto: BulkActivateAccountsDto,
+  ): Promise<void> {
+    return this.accountsApplication.bulkActivateAccounts(dto.ids);
+  }
+
+  @Post('bulk-inactivate')
+  @HttpCode(200)
+  @RequirePermission(AccountAction.EDIT, AbilitySubject.Account)
+  @ApiOperation({ summary: 'Inactivates multiple accounts in bulk.' })
+  @ApiResponse({
+    status: 200,
+    description: 'The accounts have been successfully inactivated.',
+  })
+  async bulkInactivateAccounts(
+    @Body() dto: BulkActivateAccountsDto,
+  ): Promise<void> {
+    return this.accountsApplication.bulkInactivateAccounts(dto.ids);
   }
 
   @Post()

--- a/packages/server/src/modules/Accounts/Accounts.module.ts
+++ b/packages/server/src/modules/Accounts/Accounts.module.ts
@@ -18,6 +18,7 @@ import { GetAccountsService } from './GetAccounts.service';
 import { DynamicListModule } from '../DynamicListing/DynamicList.module';
 import { AccountsExportable } from './AccountsExportable.service';
 import { AccountsImportable } from './AccountsImportable.service';
+import { BulkActivateAccountsService } from './BulkActivateAccounts.service';
 import { BulkDeleteAccountsService } from './BulkDeleteAccounts.service';
 import { ValidateBulkDeleteAccountsService } from './ValidateBulkDeleteAccounts.service';
 import { AccountsSettingsService } from './AccountsSettings.service';
@@ -43,6 +44,7 @@ const models = [RegisterTenancyModel(BankAccount)];
     AccountsExportable,
     AccountsImportable,
     BulkDeleteAccountsService,
+    BulkActivateAccountsService,
     ValidateBulkDeleteAccountsService,
   ],
   exports: [

--- a/packages/server/src/modules/Accounts/AccountsApplication.service.ts
+++ b/packages/server/src/modules/Accounts/AccountsApplication.service.ts
@@ -15,6 +15,7 @@ import { GetAccountsService } from './GetAccounts.service';
 import { IFilterMeta } from '@/interfaces/Model';
 import { GetAccountTransactionResponseDto } from './dtos/GetAccountTransactionResponse.dto';
 import { GetAccountsQueryDto } from './dtos/GetAccountsQuery.dto';
+import { BulkActivateAccountsService } from './BulkActivateAccounts.service';
 import { BulkDeleteAccountsService } from './BulkDeleteAccounts.service';
 import { ValidateBulkDeleteAccountsService } from './ValidateBulkDeleteAccounts.service';
 import { ValidateBulkDeleteResponseDto } from '@/common/dtos/BulkDelete.dto';
@@ -41,6 +42,7 @@ export class AccountsApplication {
     private readonly getAccountTransactionsService: GetAccountTransactionsService,
     private readonly getAccountsService: GetAccountsService,
     private readonly bulkDeleteAccountsService: BulkDeleteAccountsService,
+    private readonly bulkActivateAccountsService: BulkActivateAccountsService,
     private readonly validateBulkDeleteAccountsService: ValidateBulkDeleteAccountsService,
   ) {}
 
@@ -132,6 +134,26 @@ export class AccountsApplication {
     filter: IAccountsTransactionsFilter,
   ): Promise<Array<GetAccountTransactionResponseDto>> => {
     return this.getAccountTransactionsService.getAccountsTransactions(filter);
+  };
+
+  /**
+   * Activates multiple accounts in bulk.
+   */
+  public bulkActivateAccounts = (accountIds: number[]): Promise<void> => {
+    return this.bulkActivateAccountsService.bulkActivateAccounts(
+      accountIds,
+      true,
+    );
+  };
+
+  /**
+   * Inactivates multiple accounts in bulk.
+   */
+  public bulkInactivateAccounts = (accountIds: number[]): Promise<void> => {
+    return this.bulkActivateAccountsService.bulkActivateAccounts(
+      accountIds,
+      false,
+    );
   };
 
   /**

--- a/packages/server/src/modules/Accounts/BulkActivateAccounts.service.ts
+++ b/packages/server/src/modules/Accounts/BulkActivateAccounts.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@nestjs/common';
+import { PromisePool } from '@supercharge/promise-pool';
+import { castArray, uniq } from 'lodash';
+import { ActivateAccount } from './ActivateAccount.service';
+
+@Injectable()
+export class BulkActivateAccountsService {
+  constructor(private readonly activateAccountService: ActivateAccount) {}
+
+  /**
+   * Activates/Inactivates multiple accounts.
+   * @param {number | Array<number>} accountIds - The account id or ids.
+   * @param {boolean} activate - Activate or inactivate the accounts.
+   */
+  async bulkActivateAccounts(
+    accountIds: number | Array<number>,
+    activate: boolean,
+  ): Promise<void> {
+    const accountsIds = uniq(castArray(accountIds));
+
+    const results = await PromisePool.withConcurrency(1)
+      .for(accountsIds)
+      .process(async (accountId: number) => {
+        await this.activateAccountService.activateAccount(accountId, activate);
+      });
+
+    if (results.errors && results.errors.length > 0) {
+      throw results.errors[0].raw;
+    }
+  }
+}

--- a/packages/server/src/modules/Accounts/dtos/BulkActivateAccounts.dto.ts
+++ b/packages/server/src/modules/Accounts/dtos/BulkActivateAccounts.dto.ts
@@ -1,0 +1,14 @@
+import { IsArray, IsInt, ArrayNotEmpty } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class BulkActivateAccountsDto {
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsInt({ each: true })
+  @ApiProperty({
+    description: 'Array of account IDs to activate or inactivate',
+    type: [Number],
+    example: [1, 2, 3],
+  })
+  ids: number[];
+}

--- a/packages/webapp/src/containers/Alerts/Accounts/AccountBulkActivateAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Accounts/AccountBulkActivateAlert.tsx
@@ -1,13 +1,12 @@
 // @ts-nocheck
-import React, { useState } from 'react';
+import React from 'react';
+import { FormattedMessage as T } from '@/components';
 import intl from 'react-intl-universal';
 import { Intent, Alert } from '@blueprintjs/core';
-import { useQueryClient } from '@tanstack/react-query';
-import { FormattedMessage as T, AppToaster } from '@/components';
-
+import { AppToaster } from '@/components';
 import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
-
+import { useBulkActivateAccounts } from '@/hooks/query/accounts';
 import { compose } from '@/utils';
 
 function AccountBulkActivateAlertInner({
@@ -17,13 +16,8 @@ function AccountBulkActivateAlertInner({
 
   // #withAlertActions
   closeAlert,
-
-  // TODO: Implement bulk activate accounts hook and use it here
-  requestBulkActivateAccounts,
 }) {
-  const [isLoading, setLoading] = useState(false);
-  const queryClient = useQueryClient();
-  const selectedRowsCount = 0;
+  const { mutateAsync: bulkActivate, isPending } = useBulkActivateAccounts();
 
   // Handle alert cancel.
   const handleClose = () => {
@@ -31,32 +25,32 @@ function AccountBulkActivateAlertInner({
   };
 
   // Handle Bulk activate account confirm.
-  const handleConfirmBulkActivate = () => {
-    setLoading(true);
-    requestBulkActivateAccounts(accountsIds)
-      .then(() => {
-        AppToaster.show({
-          message: intl.get('the_accounts_has_been_successfully_activated'),
-          intent: Intent.SUCCESS,
-        });
-        queryClient.invalidateQueries({ queryKey: ['accounts-table'] });
-      })
-      .catch((errors) => {})
-      .finally(() => {
-        setLoading(false);
-        closeAlert(name);
+  const handleConfirmBulkActivate = async () => {
+    try {
+      await bulkActivate({ ids: accountsIds });
+      AppToaster.show({
+        message: intl.get('the_accounts_has_been_successfully_activated'),
+        intent: Intent.SUCCESS,
       });
+    } catch (error) {
+      AppToaster.show({
+        message: (error as Error)?.message,
+        intent: Intent.DANGER,
+      });
+    } finally {
+      closeAlert(name);
+    }
   };
 
   return (
     <Alert
       cancelButtonText={<T id={'cancel'} />}
-      confirmButtonText={`${intl.get('activate')} (${selectedRowsCount})`}
+      confirmButtonText={`${intl.get('activate')} (${accountsIds.length})`}
       intent={Intent.WARNING}
       isOpen={isOpen}
       onCancel={handleClose}
       onConfirm={handleConfirmBulkActivate}
-      loading={isLoading}
+      loading={isPending}
     >
       <p>
         <T id={'are_sure_to_activate_this_accounts'} />

--- a/packages/webapp/src/containers/Alerts/Accounts/AccountBulkInactivateAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Accounts/AccountBulkInactivateAlert.tsx
@@ -1,14 +1,13 @@
 // @ts-nocheck
-import React, { useState } from 'react';
+import React from 'react';
 import { FormattedMessage as T } from '@/components';
 import intl from 'react-intl-universal';
 import { Intent, Alert } from '@blueprintjs/core';
-import { useQueryClient } from '@tanstack/react-query';
 import { AppToaster } from '@/components';
 
-// import { withAccountsActions } from '@/containers/Accounts/withAccountsTableActions';
 import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
+import { useBulkInactivateAccounts } from '@/hooks/query/accounts';
 
 import { compose } from '@/utils';
 
@@ -17,46 +16,43 @@ function AccountBulkInactivateAlertInner({
   isOpen,
   payload: { accountsIds },
 
-  // #withAccountsActions
-  requestBulkInactiveAccounts,
-
+  // #withAlertActions
   closeAlert,
 }) {
-  const [isLoading, setLoading] = useState(false);
-  const queryClient = useQueryClient();
-  const selectedRowsCount = 0;
+  const { mutateAsync: bulkInactivate, isPending } = useBulkInactivateAccounts();
 
   // Handle alert cancel.
   const handleCancel = () => {
     closeAlert(name);
   };
+
   // Handle Bulk Inactive accounts confirm.
-  const handleConfirmBulkInactive = () => {
-    setLoading(true);
-    requestBulkInactiveAccounts(accountsIds)
-      .then(() => {
-        AppToaster.show({
-          message: intl.get('the_accounts_have_been_successfully_inactivated'),
-          intent: Intent.SUCCESS,
-        });
-        queryClient.invalidateQueries({ queryKey: ['accounts-table'] });
-      })
-      .catch((errors) => {})
-      .finally(() => {
-        setLoading(false);
-        closeAlert(name);
+  const handleConfirmBulkInactive = async () => {
+    try {
+      await bulkInactivate({ ids: accountsIds });
+      AppToaster.show({
+        message: intl.get('the_accounts_have_been_successfully_inactivated'),
+        intent: Intent.SUCCESS,
       });
+    } catch (error) {
+      AppToaster.show({
+        message: (error as Error)?.message,
+        intent: Intent.DANGER,
+      });
+    } finally {
+      closeAlert(name);
+    }
   };
 
   return (
     <Alert
       cancelButtonText={<T id={'cancel'} />}
-      confirmButtonText={`${intl.get('inactivate')} (${selectedRowsCount})`}
+      confirmButtonText={`${intl.get('inactivate')} (${accountsIds.length})`}
       intent={Intent.WARNING}
       isOpen={isOpen}
       onCancel={handleCancel}
       onConfirm={handleConfirmBulkInactive}
-      loading={isLoading}
+      loading={isPending}
     >
       <p>
         <T id={'are_sure_to_inactive_this_accounts'} />
@@ -68,5 +64,4 @@ function AccountBulkInactivateAlertInner({
 export const AccountBulkInactivateAlert = compose(
   withAlertStoreConnect(),
   withAlertActions,
-  // withAccountsActions,
 )(AccountBulkInactivateAlertInner);

--- a/packages/webapp/src/hooks/query/accounts/queries.ts
+++ b/packages/webapp/src/hooks/query/accounts/queries.ts
@@ -24,6 +24,8 @@ import {
   activateAccount,
   inactivateAccount,
   bulkDeleteAccounts,
+  bulkActivateAccounts,
+  bulkInactivateAccounts,
   validateBulkDeleteAccounts,
   AccountTypesList,
   AccountTransactionsList,
@@ -152,6 +154,32 @@ export function useBulkDeleteAccounts(
       ids: number[];
       skipUndeletable?: boolean;
     }) => bulkDeleteAccounts(fetcher, { ids, skipUndeletable }),
+    onSuccess: () => commonInvalidateQueries(queryClient),
+  });
+}
+
+export function useBulkActivateAccounts(
+  props?: UseMutationOptions<void, Error, { ids: number[] }>,
+) {
+  const queryClient = useQueryClient();
+  const fetcher = useApiFetcher();
+  return useMutation({
+    ...props,
+    mutationFn: ({ ids }: { ids: number[] }) =>
+      bulkActivateAccounts(fetcher, { ids }),
+    onSuccess: () => commonInvalidateQueries(queryClient),
+  });
+}
+
+export function useBulkInactivateAccounts(
+  props?: UseMutationOptions<void, Error, { ids: number[] }>,
+) {
+  const queryClient = useQueryClient();
+  const fetcher = useApiFetcher();
+  return useMutation({
+    ...props,
+    mutationFn: ({ ids }: { ids: number[] }) =>
+      bulkInactivateAccounts(fetcher, { ids }),
     onSuccess: () => commonInvalidateQueries(queryClient),
   });
 }

--- a/packages/webapp/src/lang/en/index.json
+++ b/packages/webapp/src/lang/en/index.json
@@ -230,6 +230,7 @@
   "cannot_delete_account_has_associated_transactions": "You cannot delete an account that has associated transactions.",
   "the_account_has_been_successfully_inactivated": "The account has been successfully inactivated.",
   "the_account_has_been_successfully_activated": "The account has been successfully activated.",
+  "the_accounts_has_been_successfully_activated": "The accounts have been successfully activated.",
   "the_account_has_been_successfully_deleted": "The account has been successfully deleted.",
   "the_accounts_has_been_successfully_deleted": "The accounts have been successfully deleted.",
   "are_sure_to_inactive_this_account": "Are you sure you want to inactive this account? You will be able to activate it later",

--- a/shared/sdk-ts/openapi.json
+++ b/shared/sdk-ts/openapi.json
@@ -2207,6 +2207,96 @@
         ]
       }
     },
+    "/api/accounts/bulk-activate": {
+      "post": {
+        "operationId": "AccountsController_bulkActivateAccounts",
+        "summary": "Activates multiple accounts in bulk.",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "Value must be 'Bearer <token>' where <token> is an API key prefixed with 'bc_' or a JWT token.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "Bearer bc_1234567890abcdef"
+            }
+          },
+          {
+            "name": "organization-id",
+            "in": "header",
+            "description": "Required if Authorization is a JWT token. The organization ID to operate within.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BulkActivateAccountsDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The accounts have been successfully activated."
+          }
+        },
+        "tags": [
+          "Accounts"
+        ]
+      }
+    },
+    "/api/accounts/bulk-inactivate": {
+      "post": {
+        "operationId": "AccountsController_bulkInactivateAccounts",
+        "summary": "Inactivates multiple accounts in bulk.",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "Value must be 'Bearer <token>' where <token> is an API key prefixed with 'bc_' or a JWT token.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "Bearer bc_1234567890abcdef"
+            }
+          },
+          {
+            "name": "organization-id",
+            "in": "header",
+            "description": "Required if Authorization is a JWT token. The organization ID to operate within.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BulkActivateAccountsDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The accounts have been successfully inactivated."
+          }
+        },
+        "tags": [
+          "Accounts"
+        ]
+      }
+    },
     "/api/accounts": {
       "post": {
         "operationId": "AccountsController_createAccount",
@@ -21854,7 +21944,36 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "List of subscriptions retrieved successfully"
+            "description": "List of subscriptions retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubscriptionsListResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Subscriptions"
+        ]
+      }
+    },
+    "/api/subscription/lemon": {
+      "get": {
+        "operationId": "SubscriptionsController_getLemonSubscriptions",
+        "summary": "Get Lemon Squeezy subscription details for the current tenant",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Lemon subscription details retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LemonSubscriptionsListResponseDto"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -26018,6 +26137,26 @@
             "type": "boolean",
             "description": "When true, undeletable items will be skipped and only deletable ones will be removed.",
             "default": false
+          }
+        },
+        "required": [
+          "ids"
+        ]
+      },
+      "BulkActivateAccountsDto": {
+        "type": "object",
+        "properties": {
+          "ids": {
+            "description": "Array of account IDs to activate or inactivate",
+            "example": [
+              1,
+              2,
+              3
+            ],
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
           }
         },
         "required": [
@@ -40615,6 +40754,201 @@
           "roleName",
           "roleDescription",
           "permissions"
+        ]
+      },
+      "SubscriptionResponseDto": {
+        "type": "object",
+        "properties": {
+          "slug": {
+            "type": "string",
+            "example": "main"
+          },
+          "status": {
+            "type": "string",
+            "example": "active",
+            "enum": [
+              "active",
+              "inactive",
+              "on_trial",
+              "canceled"
+            ]
+          },
+          "active": {
+            "type": "boolean",
+            "example": true
+          },
+          "inactive": {
+            "type": "boolean",
+            "example": false
+          },
+          "onTrial": {
+            "type": "boolean",
+            "example": false
+          },
+          "canceled": {
+            "type": "boolean",
+            "example": false
+          },
+          "ended": {
+            "type": "boolean",
+            "example": false
+          },
+          "paymentStatus": {
+            "type": "string",
+            "example": "succeed",
+            "enum": [
+              "succeed",
+              "failed"
+            ]
+          },
+          "startsAt": {
+            "format": "date-time",
+            "type": "string",
+            "example": "2024-01-01T00:00:00.000Z",
+            "nullable": true
+          },
+          "endsAt": {
+            "format": "date-time",
+            "type": "string",
+            "example": "2024-02-01T00:00:00.000Z",
+            "nullable": true
+          },
+          "canceledAt": {
+            "format": "date-time",
+            "type": "string",
+            "example": null,
+            "nullable": true
+          },
+          "trialEndsAt": {
+            "format": "date-time",
+            "type": "string",
+            "example": "2024-01-07T00:00:00.000Z",
+            "nullable": true
+          },
+          "statusFormatted": {
+            "type": "string",
+            "example": "Active"
+          },
+          "canceledAtFormatted": {
+            "type": "string",
+            "example": null,
+            "nullable": true
+          },
+          "endsAtFormatted": {
+            "type": "string",
+            "example": "Jan 1, 2024",
+            "nullable": true
+          },
+          "trialStartsAtFormatted": {
+            "type": "string",
+            "example": null,
+            "nullable": true
+          },
+          "trialEndsAtFormatted": {
+            "type": "string",
+            "example": "Jan 7, 2024",
+            "nullable": true
+          },
+          "planName": {
+            "type": "string",
+            "example": "Standard"
+          },
+          "planSlug": {
+            "type": "string",
+            "example": "standard"
+          },
+          "planPrice": {
+            "type": "number",
+            "example": 10
+          },
+          "planPriceCurrency": {
+            "type": "string",
+            "example": "USD"
+          },
+          "planPriceFormatted": {
+            "type": "string",
+            "example": "$10"
+          },
+          "planPeriod": {
+            "type": "string",
+            "example": "month"
+          }
+        },
+        "required": [
+          "slug",
+          "status",
+          "active",
+          "inactive",
+          "onTrial",
+          "canceled",
+          "ended",
+          "paymentStatus",
+          "statusFormatted",
+          "planName",
+          "planSlug",
+          "planPrice",
+          "planPriceCurrency",
+          "planPriceFormatted",
+          "planPeriod"
+        ]
+      },
+      "SubscriptionsListResponseDto": {
+        "type": "object",
+        "properties": {
+          "subscriptions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SubscriptionResponseDto"
+            }
+          }
+        },
+        "required": [
+          "subscriptions"
+        ]
+      },
+      "LemonSubscriptionUrlsDto": {
+        "type": "object",
+        "properties": {
+          "updatePaymentMethod": {
+            "type": "string",
+            "example": "https://.../update-payment-method",
+            "nullable": true
+          },
+          "customerPortal": {
+            "type": "string",
+            "example": "https://.../customer-portal",
+            "nullable": true
+          }
+        }
+      },
+      "LemonSubscriptionResponseDto": {
+        "type": "object",
+        "properties": {
+          "slug": {
+            "type": "string",
+            "example": "main"
+          },
+          "urls": {
+            "$ref": "#/components/schemas/LemonSubscriptionUrlsDto"
+          }
+        },
+        "required": [
+          "slug",
+          "urls"
+        ]
+      },
+      "LemonSubscriptionsListResponseDto": {
+        "type": "object",
+        "properties": {
+          "lemonSubscriptions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LemonSubscriptionResponseDto"
+            }
+          }
+        },
+        "required": [
+          "lemonSubscriptions"
         ]
       },
       "OrgBaseCurrencyMutateLockDto": {

--- a/shared/sdk-ts/src/accounts.ts
+++ b/shared/sdk-ts/src/accounts.ts
@@ -9,6 +9,8 @@ export const ACCOUNTS_ROUTES = {
   TRANSACTIONS: '/api/accounts/transactions',
   BULK_DELETE: '/api/accounts/bulk-delete',
   VALIDATE_BULK_DELETE: '/api/accounts/validate-bulk-delete',
+  BULK_ACTIVATE: '/api/accounts/bulk-activate',
+  BULK_INACTIVATE: '/api/accounts/bulk-inactivate',
   ACTIVATE: '/api/accounts/{id}/activate',
   INACTIVATE: '/api/accounts/{id}/inactivate',
 } as const satisfies Record<string, keyof paths>;
@@ -20,6 +22,8 @@ export type AccountTransactionsList = OpResponseBody<OpForPath<typeof ACCOUNTS_R
 export type CreateAccountBody = OpRequestBody<OpForPath<typeof ACCOUNTS_ROUTES.LIST, 'post'>>;
 export type EditAccountBody = OpRequestBody<OpForPath<typeof ACCOUNTS_ROUTES.BY_ID, 'put'>>;
 export type BulkDeleteBody = OpRequestBody<OpForPath<typeof ACCOUNTS_ROUTES.BULK_DELETE, 'post'>>;
+export type BulkActivateBody = OpRequestBody<OpForPath<typeof ACCOUNTS_ROUTES.BULK_ACTIVATE, 'post'>>;
+export type BulkInactivateBody = OpRequestBody<OpForPath<typeof ACCOUNTS_ROUTES.BULK_INACTIVATE, 'post'>>;
 export type ValidateBulkDeleteResponse = OpResponseBody<OpForPath<typeof ACCOUNTS_ROUTES.VALIDATE_BULK_DELETE, 'post'>>;
 export type GetAccountsQuery = OpQueryParams<OpForPath<typeof ACCOUNTS_ROUTES.LIST, 'get'>>;
 
@@ -111,6 +115,22 @@ export async function bulkDeleteAccounts(
 ): Promise<void> {
   const bulkDelete = fetcher.path(ACCOUNTS_ROUTES.BULK_DELETE).method('post').create();
   await bulkDelete(body);
+}
+
+export async function bulkActivateAccounts(
+  fetcher: ApiFetcher,
+  body: BulkActivateBody
+): Promise<void> {
+  const bulkActivate = fetcher.path(ACCOUNTS_ROUTES.BULK_ACTIVATE).method('post').create();
+  await bulkActivate(body);
+}
+
+export async function bulkInactivateAccounts(
+  fetcher: ApiFetcher,
+  body: BulkInactivateBody
+): Promise<void> {
+  const bulkInactivate = fetcher.path(ACCOUNTS_ROUTES.BULK_INACTIVATE).method('post').create();
+  await bulkInactivate(body);
 }
 
 export async function validateBulkDeleteAccounts(

--- a/shared/sdk-ts/src/schema.ts
+++ b/shared/sdk-ts/src/schema.ts
@@ -641,6 +641,40 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/accounts/bulk-activate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Activates multiple accounts in bulk. */
+        post: operations["AccountsController_bulkActivateAccounts"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/accounts/bulk-inactivate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Inactivates multiple accounts in bulk. */
+        post: operations["AccountsController_bulkInactivateAccounts"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/accounts": {
         parameters: {
             query?: never;
@@ -6335,6 +6369,17 @@ export interface components {
              * @default false
              */
             skipUndeletable: boolean;
+        };
+        BulkActivateAccountsDto: {
+            /**
+             * @description Array of account IDs to activate or inactivate
+             * @example [
+             *       1,
+             *       2,
+             *       3
+             *     ]
+             */
+            ids: number[];
         };
         CreateAccountDTO: {
             /**
@@ -14601,6 +14646,89 @@ export interface components {
             /** @description The permissions of the role */
             permissions: components["schemas"]["EditRolePermissionDto"][];
         };
+        SubscriptionResponseDto: {
+            /** @example main */
+            slug: string;
+            /**
+             * @example active
+             * @enum {string}
+             */
+            status: "active" | "inactive" | "on_trial" | "canceled";
+            /** @example true */
+            active: boolean;
+            /** @example false */
+            inactive: boolean;
+            /** @example false */
+            onTrial: boolean;
+            /** @example false */
+            canceled: boolean;
+            /** @example false */
+            ended: boolean;
+            /**
+             * @example succeed
+             * @enum {string}
+             */
+            paymentStatus: "succeed" | "failed";
+            /**
+             * Format: date-time
+             * @example 2024-01-01T00:00:00.000Z
+             */
+            startsAt?: string | null;
+            /**
+             * Format: date-time
+             * @example 2024-02-01T00:00:00.000Z
+             */
+            endsAt?: string | null;
+            /**
+             * Format: date-time
+             * @example null
+             */
+            canceledAt?: string | null;
+            /**
+             * Format: date-time
+             * @example 2024-01-07T00:00:00.000Z
+             */
+            trialEndsAt?: string | null;
+            /** @example Active */
+            statusFormatted: string;
+            /** @example null */
+            canceledAtFormatted?: string | null;
+            /** @example Jan 1, 2024 */
+            endsAtFormatted?: string | null;
+            /** @example null */
+            trialStartsAtFormatted?: string | null;
+            /** @example Jan 7, 2024 */
+            trialEndsAtFormatted?: string | null;
+            /** @example Standard */
+            planName: string;
+            /** @example standard */
+            planSlug: string;
+            /** @example 10 */
+            planPrice: number;
+            /** @example USD */
+            planPriceCurrency: string;
+            /** @example $10 */
+            planPriceFormatted: string;
+            /** @example month */
+            planPeriod: string;
+        };
+        SubscriptionsListResponseDto: {
+            subscriptions: components["schemas"]["SubscriptionResponseDto"][];
+        };
+        LemonSubscriptionUrlsDto: {
+            /** @example https://.../update-payment-method */
+            updatePaymentMethod?: string | null;
+            /** @example https://.../customer-portal */
+            customerPortal?: string | null;
+        };
+        LemonSubscriptionResponseDto: {
+            /** @example main */
+            slug: string;
+            urls: components["schemas"]["LemonSubscriptionUrlsDto"];
+        };
+        LemonSubscriptionsListResponseDto: {
+            lemonSubscriptions: components["schemas"]["LemonSubscriptionResponseDto"][];
+        };
         OrgBaseCurrencyMutateLockDto: {
             /**
              * @description The model name that prevents base currency mutation
@@ -14761,47 +14889,6 @@ export interface components {
              * @example false
              */
             isUpgradeRunning: boolean;
-        };
-        SubscriptionResponseDto: {
-            id?: number;
-            slug: string;
-            status: string;
-            active: boolean;
-            inactive: boolean;
-            onTrial: boolean;
-            canceled: boolean;
-            ended: boolean;
-            paymentStatus: string;
-            startsAt?: string | null;
-            endsAt?: string | null;
-            canceledAt?: string | null;
-            trialEndsAt?: string | null;
-            statusFormatted: string;
-            canceledAtFormatted?: string | null;
-            endsAtFormatted?: string | null;
-            trialStartsAtFormatted?: string | null;
-            trialEndsAtFormatted?: string | null;
-            planName: string;
-            planSlug: string;
-            planPrice: number;
-            planPriceCurrency: string;
-            planPriceFormatted: string;
-            planPeriod: string;
-        };
-        SubscriptionsListResponseDto: {
-            subscriptions: components["schemas"]["SubscriptionResponseDto"][];
-        };
-        LemonSubscriptionUrlsDto: {
-            updatePaymentMethod?: string;
-            customerPortal?: string;
-            [key: string]: unknown;
-        };
-        LemonSubscriptionResponseDto: {
-            slug: string;
-            urls: components["schemas"]["LemonSubscriptionUrlsDto"];
-        };
-        LemonSubscriptionsListResponseDto: {
-            lemonSubscriptions: components["schemas"]["LemonSubscriptionResponseDto"][];
         };
         BuildOrganizationDto: {
             /**
@@ -16858,6 +16945,60 @@ export interface operations {
         };
         responses: {
             /** @description The accounts have been successfully deleted. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    AccountsController_bulkActivateAccounts: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Value must be 'Bearer <token>' where <token> is an API key prefixed with 'bc_' or a JWT token. */
+                Authorization: string;
+                /** @description Required if Authorization is a JWT token. The organization ID to operate within. */
+                "organization-id": string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["BulkActivateAccountsDto"];
+            };
+        };
+        responses: {
+            /** @description The accounts have been successfully activated. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    AccountsController_bulkInactivateAccounts: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Value must be 'Bearer <token>' where <token> is an API key prefixed with 'bc_' or a JWT token. */
+                Authorization: string;
+                /** @description Required if Authorization is a JWT token. The organization ID to operate within. */
+                "organization-id": string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["BulkActivateAccountsDto"];
+            };
+        };
+        responses: {
+            /** @description The accounts have been successfully inactivated. */
             200: {
                 headers: {
                     [name: string]: unknown;


### PR DESCRIPTION
## Summary

- Adds backend bulk activate/inactivate: service, endpoints, DTO, OpenAPI schema entries
- Adds SDK fetch utils (`bulkActivateAccounts`, `bulkInactivateAccounts`) with regenerated types
- Adds React Query hooks (`useBulkActivateAccounts`, `useBulkInactivateAccounts`)
- Repairs the existing-but-broken `AccountBulkActivateAlert` and `AccountBulkInactivateAlert` so the Accounts Actions Bar buttons actually function
- Adds missing `the_accounts_has_been_successfully_activated` translation

The Accounts Actions Bar already exposed Bulk Activate / Bulk Inactivate buttons that opened confirmation alerts, but those alerts carried `@ts-nocheck`, referenced undefined Redux-action props, hardcoded `selectedRowsCount = 0`, and invalidated a stale `['accounts-table']` query key. There was no backend, SDK, or hook support either.

## Implementation notes

- **Bulk service**: iterates ids via `PromisePool.withConcurrency(1)` over `ActivateAccount.activateAccount(id, flag)`. This preserves dependency-graph expansion (child accounts toggle with their parents) and emits `events.accounts.onActivated` per account — consistent with the single-account semantics. Mirrors `BulkDeleteAccounts.service.ts`.
- **Endpoints**: two separate — `POST /accounts/bulk-activate` and `POST /accounts/bulk-inactivate`, each accepting `{ ids: number[] }`. Mirrors the existing `:id/activate` and `:id/inactivate` pair. Both gated on `AccountAction.EDIT`.
- **Hooks**: mirror `useBulkDeleteAccounts`. Invalidations handled by `commonInvalidateQueries` (`accountsKeys.all()`).
- **Alerts**: use `isPending` (React Query v5 dropped `isLoading` on mutations). Real error toasts via `AppToaster` (Intent.DANGER) instead of swallowing. Confirm button now shows the actual selected count.

## Test plan

- [ ] `pnpm run generate:sdk-types` completes cleanly (already run; `openapi.json` + `schema.ts` committed)
- [ ] `pnpm --filter @bigcapital/server build` passes
- [ ] `pnpm --filter webapp run typecheck` shows zero errors for accounts/bulk-activate paths
- [ ] Manual smoke: select 2+ accounts → click Activate → confirm → accounts stay active; toggle Inactive switch → select 2+ inactive → click Inactivate → confirm → accounts move to inactive
- [ ] Verify child accounts toggle with their parents (dependency-graph behavior)
- [ ] Verify single-account activate/inactivate and bulk delete still work (no regression)
- [ ] `/swagger` shows the two new POST paths with `ids` request body and 200 response

🤖 Generated with [Claude Code](https://claude.com/claude-code)