### PR TITLE
fix(webapp): surface delete-error toasts after SDK migration

### DIFF
--- a/packages/webapp/src/containers/Accounting/MakeJournal/MakeJournalEntriesForm.tsx
+++ b/packages/webapp/src/containers/Accounting/MakeJournal/MakeJournalEntriesForm.tsx
@@ -126,11 +126,7 @@ function MakeJournalEntriesFormInner({
       attachments,
     };
     // Handle the request error.
-    const handleError = ({
-      response: {
-        data: { errors },
-      },
-    }) => {
+    const handleError = ({ data: { errors } }) => {
       transformErrors(errors, { setErrors });
       setSubmitting(false);
     };

--- a/packages/webapp/src/containers/Alerts/Accounts/AccountBulkInactivateAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Accounts/AccountBulkInactivateAlert.tsx
@@ -19,7 +19,8 @@ function AccountBulkInactivateAlertInner({
   // #withAlertActions
   closeAlert,
 }) {
-  const { mutateAsync: bulkInactivate, isPending } = useBulkInactivateAccounts();
+  const { mutateAsync: bulkInactivate, isPending } =
+    useBulkInactivateAccounts();
 
   // Handle alert cancel.
   const handleCancel = () => {

--- a/packages/webapp/src/containers/Alerts/Accounts/AccountDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Accounts/AccountDeleteAlert.tsx
@@ -51,16 +51,10 @@ function AccountDeleteAlertInner({
         closeAlert(name);
         closeDrawer(DRAWERS.ACCOUNT_DETAILS);
       })
-      .catch(
-        ({
-          response: {
-            data: { errors },
-          },
-        }) => {
-          handleDeleteErrors(errors);
-          closeAlert(name);
-        },
-      );
+      .catch(({ data: { errors } }) => {
+        handleDeleteErrors(errors);
+        closeAlert(name);
+      });
   };
 
   return (

--- a/packages/webapp/src/containers/Alerts/Bills/BillDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Bills/BillDeleteAlert.tsx
@@ -46,15 +46,9 @@ function BillDeleteAlertInner({
         });
         closeDrawer(DRAWERS.BILL_DETAILS);
       })
-      .catch(
-        ({
-          response: {
-            data: { errors },
-          },
-        }) => {
-          handleDeleteErrors(errors);
-        },
-      )
+      .catch(({ data: { errors } }) => {
+        handleDeleteErrors(errors);
+      })
       .finally(() => {
         closeAlert(name);
       });

--- a/packages/webapp/src/containers/Alerts/Branches/BranchDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Branches/BranchDeleteAlert.tsx
@@ -45,15 +45,9 @@ function BranchDeleteAlertInner({
           intent: Intent.SUCCESS,
         });
       })
-      .catch(
-        ({
-          response: {
-            data: { errors },
-          },
-        }) => {
-          handleDeleteErrors(errors);
-        },
-      )
+      .catch(({ data: { errors } }) => {
+        handleDeleteErrors(errors);
+      })
       .finally(() => {
         closeAlert(name);
       });

--- a/packages/webapp/src/containers/Alerts/CashFlow/AccountDeleteTransactionAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/CashFlow/AccountDeleteTransactionAlert.tsx
@@ -51,35 +51,29 @@ function AccountDeleteTransactionAlertInner({
         });
         closeDrawer(DRAWERS.CASHFLOW_TRNASACTION_DETAILS);
       })
-      .catch(
-        ({
-          response: {
-            data: { errors },
-          },
-        }) => {
-          if (
-            errors.find(
-              (e) =>
-                e.type ===
-                'CANNOT_DELETE_TRANSACTION_CONVERTED_FROM_UNCATEGORIZED',
-            )
-          ) {
-            AppToaster.show({
-              message:
-                'Cannot delete transaction converted from uncategorized transaction but you uncategorize it.',
-              intent: Intent.DANGER,
-            });
-          } else if (
-            errors.find((e) => e.type === 'CANNOT_DELETE_TRANSACTION_MATCHED')
-          ) {
-            AppToaster.show({
-              message:
-                'Cannot delete a transaction matched to the bank transaction',
-              intent: Intent.DANGER,
-            });
-          }
-        },
-      )
+      .catch(({ data: { errors } }) => {
+        if (
+          errors.find(
+            (e) =>
+              e.type ===
+              'CANNOT_DELETE_TRANSACTION_CONVERTED_FROM_UNCATEGORIZED',
+          )
+        ) {
+          AppToaster.show({
+            message:
+              'Cannot delete transaction converted from uncategorized transaction but you uncategorize it.',
+            intent: Intent.DANGER,
+          });
+        } else if (
+          errors.find((e) => e.type === 'CANNOT_DELETE_TRANSACTION_MATCHED')
+        ) {
+          AppToaster.show({
+            message:
+              'Cannot delete a transaction matched to the bank transaction',
+            intent: Intent.DANGER,
+          });
+        }
+      })
       .finally(() => {
         closeAlert(name);
       });

--- a/packages/webapp/src/containers/Alerts/CreditNotes/CreditNoteDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/CreditNotes/CreditNoteDeleteAlert.tsx
@@ -49,15 +49,9 @@ function CreditNoteDeleteAlertInner({
         });
         closeDrawer(DRAWERS.CREDIT_NOTE_DETAILS);
       })
-      .catch(
-        ({
-          response: {
-            data: { errors },
-          },
-        }) => {
-          handleDeleteErrors(errors);
-        },
-      )
+      .catch(({ data: { errors } }) => {
+        handleDeleteErrors(errors);
+      })
       .finally(() => {
         closeAlert(name);
       });

--- a/packages/webapp/src/containers/Alerts/CreditNotes/ReconcileCreditNoteDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/CreditNotes/ReconcileCreditNoteDeleteAlert.tsx
@@ -47,15 +47,9 @@ function ReconcileCreditNoteDeleteAlertInner({
           intent: Intent.SUCCESS,
         });
       })
-      .catch(
-        ({
-          response: {
-            data: { errors },
-          },
-        }) => {
-          // handleDeleteErrors(errors);
-        },
-      )
+      .catch(({ data: { errors } }) => {
+        // handleDeleteErrors(errors);
+      })
       .finally(() => {
         closeAlert(name);
       });

--- a/packages/webapp/src/containers/Alerts/Currencies/CurrencyDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Currencies/CurrencyDeleteAlert.tsx
@@ -43,21 +43,15 @@ function CurrencyDeleteAlertInner({
         });
         closeAlert(name);
       })
-      .catch(
-        ({
-          response: {
-            data: { errors },
-          },
-        }) => {
-          if (errors.find((e) => e.type === 'CANNOT_DELETE_BASE_CURRENCY')) {
-            AppToaster.show({
-              intent: Intent.DANGER,
-              message: 'Cannot delete the base currency.',
-            });
-          }
-          closeAlert(name);
-        },
-      );
+      .catch(({ data: { errors } }) => {
+        if (errors.find((e) => e.type === 'CANNOT_DELETE_BASE_CURRENCY')) {
+          AppToaster.show({
+            intent: Intent.DANGER,
+            message: 'Cannot delete the base currency.',
+          });
+        }
+        closeAlert(name);
+      });
   };
 
   return (

--- a/packages/webapp/src/containers/Alerts/Customers/CustomerDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Customers/CustomerDeleteAlert.tsx
@@ -50,15 +50,9 @@ function CustomerDeleteAlertInner({
         });
         closeDrawer(DRAWERS.CUSTOMER_DETAILS);
       })
-      .catch(
-        ({
-          response: {
-            data: { errors },
-          },
-        }) => {
-          transformErrors(errors);
-        },
-      )
+      .catch(({ data: { errors } }) => {
+        transformErrors(errors);
+      })
       .finally(() => {
         closeAlert(name);
       });

--- a/packages/webapp/src/containers/Alerts/Estimates/EstimateDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Estimates/EstimateDeleteAlert.tsx
@@ -50,24 +50,18 @@ function EstimateDeleteAlertInner({
         });
         closeDrawer(DRAWERS.ESTIMATE_DETAILS);
       })
-      .catch(
-        ({
-          response: {
-            data: { errors },
-          },
-        }) => {
-          if (
-            errors.find((e) => e.type === 'SALE_ESTIMATE_CONVERTED_TO_INVOICE')
-          ) {
-            AppToaster.show({
-              intent: Intent.DANGER,
-              message: intl.get(
-                'estimate.delete.error.estimate_converted_to_invoice',
-              ),
-            });
-          }
-        },
-      )
+      .catch(({ data: { errors } }) => {
+        if (
+          errors.find((e) => e.type === 'SALE_ESTIMATE_CONVERTED_TO_INVOICE')
+        ) {
+          AppToaster.show({
+            intent: Intent.DANGER,
+            message: intl.get(
+              'estimate.delete.error.estimate_converted_to_invoice',
+            ),
+          });
+        }
+      })
       .finally(() => {
         closeAlert(name);
       });

--- a/packages/webapp/src/containers/Alerts/Expenses/ExpenseDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Expenses/ExpenseDeleteAlert.tsx
@@ -46,15 +46,9 @@ function ExpenseDeleteAlertInner({
         });
         closeDrawer(DRAWERS.EXPENSE_DETAILS);
       })
-      .catch(
-        ({
-          response: {
-            data: { errors },
-          },
-        }) => {
-          handleDeleteErrors(errors);
-        },
-      )
+      .catch(({ data: { errors } }) => {
+        handleDeleteErrors(errors);
+      })
       .finally(() => {
         closeAlert('expense-delete');
       });

--- a/packages/webapp/src/containers/Alerts/Invoices/InvoiceDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Invoices/InvoiceDeleteAlert.tsx
@@ -51,15 +51,9 @@ function InvoiceDeleteAlertInner({
         });
         closeDrawer(DRAWERS.INVOICE_DETAILS);
       })
-      .catch(
-        ({
-          response: {
-            data: { errors },
-          },
-        }) => {
-          handleDeleteErrors(errors);
-        },
-      )
+      .catch(({ data: { errors } }) => {
+        handleDeleteErrors(errors);
+      })
       .finally(() => {
         closeAlert(name);
       });

--- a/packages/webapp/src/containers/Alerts/Items/ItemDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Items/ItemDeleteAlert.tsx
@@ -57,15 +57,9 @@ function ItemDeleteAlertInner({
         setItemsTableState({ page: 1 });
         closeDrawer(DRAWERS.ITEM_DETAILS);
       })
-      .catch(
-        ({
-          response: {
-            data: { errors },
-          },
-        }) => {
-          handleDeleteErrors(errors);
-        },
-      )
+      .catch(({ data: { errors } }) => {
+        handleDeleteErrors(errors);
+      })
       .finally(() => {
         closeAlert(name);
       });

--- a/packages/webapp/src/containers/Alerts/ManualJournals/JournalDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/ManualJournals/JournalDeleteAlert.tsx
@@ -49,16 +49,10 @@ function JournalDeleteAlertInner({
         closeAlert(name);
         closeDrawer(DRAWERS.JOURNAL_DETAILS);
       })
-      .catch(
-        ({
-          response: {
-            data: { errors },
-          },
-        }) => {
-          handleDeleteErrors(errors);
-          closeAlert(name);
-        },
-      );
+      .catch(({ data: { errors } }) => {
+        handleDeleteErrors(errors);
+        closeAlert(name);
+      });
   };
 
   return (

--- a/packages/webapp/src/containers/Alerts/PaymentMades/PaymentMadeDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/PaymentMades/PaymentMadeDeleteAlert.tsx
@@ -48,15 +48,9 @@ function PaymentMadeDeleteAlertInner({
         });
         closeDrawer(DRAWERS.PAYMENT_MADE_DETAILS);
       })
-      .catch(
-        ({
-          response: {
-            data: { errors },
-          },
-        }) => {
-          handleDeleteErrors(errors);
-        },
-      )
+      .catch(({ data: { errors } }) => {
+        handleDeleteErrors(errors);
+      })
       .finally(() => {
         closeAlert(name);
       });

--- a/packages/webapp/src/containers/Alerts/PaymentReceived/PaymentReceivedDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/PaymentReceived/PaymentReceivedDeleteAlert.tsx
@@ -54,15 +54,9 @@ function PaymentReceivedDeleteAlertInner({
         });
         closeDrawer(DRAWERS.PAYMENT_RECEIVED_DETAILS);
       })
-      .catch(
-        ({
-          response: {
-            data: { errors },
-          },
-        }) => {
-          handleDeleteErrors(errors);
-        },
-      )
+      .catch(({ data: { errors } }) => {
+        handleDeleteErrors(errors);
+      })
       .finally(() => {
         closeAlert(name);
       });

--- a/packages/webapp/src/containers/Alerts/Roles/RoleDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Roles/RoleDeleteAlert.tsx
@@ -45,15 +45,9 @@ function RoleDeleteAlertInner({
           intent: Intent.SUCCESS,
         });
       })
-      .catch(
-        ({
-          response: {
-            data: { errors },
-          },
-        }) => {
-          handleDeleteErrors(errors);
-        },
-      )
+      .catch(({ data: { errors } }) => {
+        handleDeleteErrors(errors);
+      })
       .finally(() => {
         closeAlert(name);
       });

--- a/packages/webapp/src/containers/Alerts/TransactionLocking/cancelUnlockingPartialAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/TransactionLocking/cancelUnlockingPartialAlert.tsx
@@ -46,13 +46,7 @@ function CancelUnlockingPartialTarnsactions({
           intent: Intent.SUCCESS,
         });
       })
-      .catch(
-        ({
-          response: {
-            data: { errors },
-          },
-        }) => {},
-      )
+      .catch(({ data: { errors } }) => {})
       .finally(() => {
         closeAlert(name);
       });

--- a/packages/webapp/src/containers/Alerts/Users/UserDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Users/UserDeleteAlert.tsx
@@ -40,21 +40,15 @@ function UserDeleteAlertInner({
         });
         closeAlert(name);
       })
-      .catch(
-        ({
-          response: {
-            data: { errors },
-          },
-        }) => {
-          if (errors.find((e) => e.type === 'CANNOT_DELETE_LAST_USER')) {
-            AppToaster.show({
-              message: 'Cannot delete the last user in the system.',
-              intent: Intent.DANGER,
-            });
-          }
-          closeAlert(name);
-        },
-      );
+      .catch(({ data: { errors } }) => {
+        if (errors.find((e) => e.type === 'CANNOT_DELETE_LAST_USER')) {
+          AppToaster.show({
+            message: 'Cannot delete the last user in the system.',
+            intent: Intent.DANGER,
+          });
+        }
+        closeAlert(name);
+      });
   };
 
   return (

--- a/packages/webapp/src/containers/Alerts/Users/UserInactivateAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Users/UserInactivateAlert.tsx
@@ -35,26 +35,20 @@ function UserInactivateAlertInner({
         });
         closeAlert(name);
       })
-      .catch(
-        ({
-          response: {
-            data: { errors },
-          },
-        }) => {
-          if (
-            errors.find(
-              (e) => e.type === 'CANNOT.TOGGLE.ACTIVATE.AUTHORIZED.USER',
-            )
-          ) {
-            AppToaster.show({
-              message:
-                'You could not activate/inactivate the same authorized user.',
-              intent: Intent.DANGER,
-            });
-          }
-          closeAlert(name);
-        },
-      );
+      .catch(({ data: { errors } }) => {
+        if (
+          errors.find(
+            (e) => e.type === 'CANNOT.TOGGLE.ACTIVATE.AUTHORIZED.USER',
+          )
+        ) {
+          AppToaster.show({
+            message:
+              'You could not activate/inactivate the same authorized user.',
+            intent: Intent.DANGER,
+          });
+        }
+        closeAlert(name);
+      });
   };
 
   const handleCancel = () => {

--- a/packages/webapp/src/containers/Alerts/VendorCeditNotes/ReconcileVendorCreditDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/VendorCeditNotes/ReconcileVendorCreditDeleteAlert.tsx
@@ -48,13 +48,7 @@ function ReconcileVendorCreditDeleteAlertInner({
         });
         // closeDrawer('vendor-credit-detail-drawer');
       })
-      .catch(
-        ({
-          response: {
-            data: { errors },
-          },
-        }) => {},
-      )
+      .catch(({ data: { errors } }) => {})
       .finally(() => {
         closeAlert(name);
       });

--- a/packages/webapp/src/containers/Alerts/VendorCeditNotes/VendorCreditDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/VendorCeditNotes/VendorCreditDeleteAlert.tsx
@@ -48,15 +48,9 @@ function VendorCreditDeleteAlertInner({
         });
         closeDrawer(DRAWERS.VENDOR_CREDIT_DETAILS);
       })
-      .catch(
-        ({
-          response: {
-            data: { errors },
-          },
-        }) => {
-          handleDeleteErrors(errors);
-        },
-      )
+      .catch(({ data: { errors } }) => {
+        handleDeleteErrors(errors);
+      })
       .finally(() => {
         closeAlert(name);
       });

--- a/packages/webapp/src/containers/Alerts/Vendors/VendorDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Vendors/VendorDeleteAlert.tsx
@@ -51,15 +51,9 @@ function VendorDeleteAlertInner({
         });
         closeDrawer(DRAWERS.VENDOR_DETAILS);
       })
-      .catch(
-        ({
-          response: {
-            data: { errors },
-          },
-        }) => {
-          transformErrors(errors);
-        },
-      )
+      .catch(({ data: { errors } }) => {
+        transformErrors(errors);
+      })
       .finally(() => {
         closeAlert(name);
       });

--- a/packages/webapp/src/containers/Alerts/Warehouses/WarehouseDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Warehouses/WarehouseDeleteAlert.tsx
@@ -47,15 +47,9 @@ function WarehouseDeleteAlertInner({
           intent: Intent.SUCCESS,
         });
       })
-      .catch(
-        ({
-          response: {
-            data: { errors },
-          },
-        }) => {
-          handleDeleteErrors(errors);
-        },
-      )
+      .catch(({ data: { errors } }) => {
+        handleDeleteErrors(errors);
+      })
       .finally(() => {
         closeAlert(name);
       });

--- a/packages/webapp/src/containers/Alerts/WarehousesTransfer/WarehouseTransferDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/WarehousesTransfer/WarehouseTransferDeleteAlert.tsx
@@ -51,13 +51,7 @@ function WarehouseTransferDeleteAlertInner({
         });
         closeDrawer(DRAWERS.WAREHOUSE_TRANSFER_DETAILS);
       })
-      .catch(
-        ({
-          response: {
-            data: { errors },
-          },
-        }) => {},
-      )
+      .catch(({ data: { errors } }) => {})
       .finally(() => {
         closeAlert(name);
       });

--- a/packages/webapp/src/containers/Authentication/InviteAcceptForm.tsx
+++ b/packages/webapp/src/containers/Authentication/InviteAcceptForm.tsx
@@ -52,28 +52,22 @@ export function InviteAcceptForm() {
         });
         history.push('/auth/login');
       })
-      .catch(
-        ({
-          response: {
-            data: { errors },
-          },
-        }) => {
-          if (errors.find((e) => e.type === 'INVITE_TOKEN_INVALID')) {
-            AppToaster.show({
-              message: intl.get('an_unexpected_error_occurred'),
-              intent: Intent.DANGER,
-              position: Position.BOTTOM,
-            });
-            history.push('/auth/login');
-          }
-          if (errors.find((e) => e.type === 'PHONE_MUMNER.ALREADY.EXISTS')) {
-            setErrors({
-              phone_number: 'This phone number is used in another account.',
-            });
-          }
-          setSubmitting(false);
-        },
-      );
+      .catch(({ data: { errors } }) => {
+        if (errors.find((e) => e.type === 'INVITE_TOKEN_INVALID')) {
+          AppToaster.show({
+            message: intl.get('an_unexpected_error_occurred'),
+            intent: Intent.DANGER,
+            position: Position.BOTTOM,
+          });
+          history.push('/auth/login');
+        }
+        if (errors.find((e) => e.type === 'PHONE_MUMNER.ALREADY.EXISTS')) {
+          setErrors({
+            phone_number: 'This phone number is used in another account.',
+          });
+        }
+        setSubmitting(false);
+      });
   };
 
   return (

--- a/packages/webapp/src/containers/Authentication/Register.tsx
+++ b/packages/webapp/src/containers/Authentication/Register.tsx
@@ -40,18 +40,12 @@ export function RegisterUserForm() {
         authLoginMutate({
           email: values.email,
           password: values.password,
-        }).catch(
-          ({
-            response: {
-              data: { errors },
-            },
-          }) => {
-            AppToaster.show({
-              message: intl.get('something_wentwrong'),
-              intent: Intent.SUCCESS,
-            });
-          },
-        );
+        }).catch(({ data: { errors } }) => {
+          AppToaster.show({
+            message: intl.get('something_wentwrong'),
+            intent: Intent.SUCCESS,
+          });
+        });
       })
       .catch(({ response }) => {
         const {

--- a/packages/webapp/src/containers/Authentication/ResetPassword.tsx
+++ b/packages/webapp/src/containers/Authentication/ResetPassword.tsx
@@ -44,23 +44,17 @@ export function ResetPassword() {
         history.push('/auth/login');
         setSubmitting(false);
       })
-      .catch(
-        ({
-          response: {
-            data: { errors },
-          },
-        }) => {
-          if (errors.find((e) => e.type === 'TOKEN_INVALID')) {
-            AppToaster.show({
-              message: intl.get('an_unexpected_error_occurred'),
-              intent: Intent.DANGER,
-              position: Position.BOTTOM,
-            });
-            history.push('/auth/login');
-          }
-          setSubmitting(false);
-        },
-      );
+      .catch(({ data: { errors } }) => {
+        if (errors.find((e) => e.type === 'TOKEN_INVALID')) {
+          AppToaster.show({
+            message: intl.get('an_unexpected_error_occurred'),
+            intent: Intent.DANGER,
+            position: Position.BOTTOM,
+          });
+          history.push('/auth/login');
+        }
+        setSubmitting(false);
+      });
   };
 
   return (

--- a/packages/webapp/src/containers/Banking/Rules/RulesList/alerts/DeleteBankRuleAlert.tsx
+++ b/packages/webapp/src/containers/Banking/Rules/RulesList/alerts/DeleteBankRuleAlert.tsx
@@ -44,18 +44,12 @@ function BankRuleDeleteAlert({
         });
         closeAlert(name);
       })
-      .catch(
-        ({
-          response: {
-            data: { errors },
-          },
-        }) => {
-          AppToaster.show({
-            message: 'Something went wrong.',
-            intent: Intent.DANGER,
-          });
-        },
-      );
+      .catch(({ data: { errors } }) => {
+        AppToaster.show({
+          message: 'Something went wrong.',
+          intent: Intent.DANGER,
+        });
+      });
   };
 
   return (

--- a/packages/webapp/src/containers/BrandingTemplates/alerts/DeleteBrandingTemplateAlert.tsx
+++ b/packages/webapp/src/containers/BrandingTemplates/alerts/DeleteBrandingTemplateAlert.tsx
@@ -35,30 +35,24 @@ function DeleteBrandingTemplateAlertInner({
         });
         closeAlert(name);
       })
-      .catch(
-        ({
-          response: {
-            data: { errors },
-          },
-        }) => {
-          if (
-            errors.find(
-              (error) => error.type === 'CANNOT_DELETE_PREDEFINED_PDF_TEMPLATE',
-            )
-          ) {
-            AppToaster.show({
-              message: 'Cannot delete a predefined branding template.',
-              intent: Intent.DANGER,
-            });
-          } else {
-            AppToaster.show({
-              message: 'Something went wrong.',
-              intent: Intent.DANGER,
-            });
-          }
-          closeAlert(name);
-        },
-      );
+      .catch(({ data: { errors } }) => {
+        if (
+          errors.find(
+            (error) => error.type === 'CANNOT_DELETE_PREDEFINED_PDF_TEMPLATE',
+          )
+        ) {
+          AppToaster.show({
+            message: 'Cannot delete a predefined branding template.',
+            intent: Intent.DANGER,
+          });
+        } else {
+          AppToaster.show({
+            message: 'Something went wrong.',
+            intent: Intent.DANGER,
+          });
+        }
+        closeAlert(name);
+      });
   };
 
   const handleCancel = () => {

--- a/packages/webapp/src/containers/CashFlow/UncategorizeTransactionAlert/UncategorizeTransactionAlert.tsx
+++ b/packages/webapp/src/containers/CashFlow/UncategorizeTransactionAlert/UncategorizeTransactionAlert.tsx
@@ -47,18 +47,12 @@ function UncategorizeTransactionAlertInner({
         closeAlert(name);
         closeDrawer(DRAWERS.CASHFLOW_TRNASACTION_DETAILS);
       })
-      .catch(
-        ({
-          response: {
-            data: { errors },
-          },
-        }) => {
-          AppToaster.show({
-            message: 'Something went wrong.',
-            intent: Intent.DANGER,
-          });
-        },
-      );
+      .catch(({ data: { errors } }) => {
+        AppToaster.show({
+          message: 'Something went wrong.',
+          intent: Intent.DANGER,
+        });
+      });
   };
 
   return (

--- a/packages/webapp/src/containers/Dialogs/AccountDialog/AccountDialogForm.tsx
+++ b/packages/webapp/src/containers/Dialogs/AccountDialog/AccountDialogForm.tsx
@@ -80,9 +80,7 @@ function AccountFormDialogContent({
     // Handle request error.
     const handleError = (error) => {
       const {
-        response: {
-          data: { errors },
-        },
+        data: { errors },
       } = error;
 
       const errorsTransformed = transformApiErrors(errors);

--- a/packages/webapp/src/containers/Dialogs/BadDebtDialog/BadDebtForm.tsx
+++ b/packages/webapp/src/containers/Dialogs/BadDebtDialog/BadDebtForm.tsx
@@ -54,11 +54,7 @@ function BadDebtFormInner({
     };
 
     // Handle request response errors.
-    const onError = ({
-      response: {
-        data: { errors },
-      },
-    }) => {
+    const onError = ({ data: { errors } }) => {
       if (errors) {
         transformErrors(errors, { setErrors });
       }

--- a/packages/webapp/src/containers/Dialogs/BranchActivateDialog/BranchActivateForm.tsx
+++ b/packages/webapp/src/containers/Dialogs/BranchActivateDialog/BranchActivateForm.tsx
@@ -41,11 +41,7 @@ function BranchActivateFormInner({
     };
 
     // Handle request response errors.
-    const onError = ({
-      response: {
-        data: { errors },
-      },
-    }) => {
+    const onError = ({ data: { errors } }) => {
       if (errors) {
       }
       setSubmitting(false);

--- a/packages/webapp/src/containers/Dialogs/BranchFormDialog/BranchForm.tsx
+++ b/packages/webapp/src/containers/Dialogs/BranchFormDialog/BranchForm.tsx
@@ -53,11 +53,7 @@ function BranchFormInner({
     };
 
     // Handle request response errors.
-    const onError = ({
-      response: {
-        data: { errors },
-      },
-    }) => {
+    const onError = ({ data: { errors } }) => {
       if (errors) {
       }
       transformErrors(errors, { setErrors });

--- a/packages/webapp/src/containers/Dialogs/CurrencyFormDialog/CurrencyForm.tsx
+++ b/packages/webapp/src/containers/Dialogs/CurrencyFormDialog/CurrencyForm.tsx
@@ -71,11 +71,7 @@ function CurrencyFormInner({
       afterSubmit(response);
     };
     // Handle the response error.
-    const onError = ({
-      response: {
-        data: { errors },
-      },
-    }) => {
+    const onError = ({ data: { errors } }) => {
       if (errors.find((e) => e.type === 'CURRENCY_CODE_EXISTS')) {
         AppToaster.show({
           message: 'The given currency code is already exists.',

--- a/packages/webapp/src/containers/Dialogs/CustomerOpeningBalanceDialog/CustomerOpeningBalanceForm.tsx
+++ b/packages/webapp/src/containers/Dialogs/CustomerOpeningBalanceDialog/CustomerOpeningBalanceForm.tsx
@@ -59,11 +59,7 @@ function CustomerOpeningBalanceFormInner({
     };
 
     // Handle request response errors.
-    const onError = ({
-      response: {
-        data: { errors },
-      },
-    }) => {
+    const onError = ({ data: { errors } }) => {
       if (errors) {
       }
       setSubmitting(false);

--- a/packages/webapp/src/containers/Dialogs/InviteUserDialog/InviteUserForm.tsx
+++ b/packages/webapp/src/containers/Dialogs/InviteUserDialog/InviteUserForm.tsx
@@ -56,9 +56,7 @@ function InviteUserFormInner({
     // Handle the response error.
     const onError = (error) => {
       const {
-        response: {
-          data: { errors },
-        },
+        data: { errors },
       } = error;
 
       const errorsTransformed = transformApiErrors(errors);

--- a/packages/webapp/src/containers/Dialogs/ItemCategoryDialog/ItemCategoryForm.tsx
+++ b/packages/webapp/src/containers/Dialogs/ItemCategoryDialog/ItemCategoryForm.tsx
@@ -81,9 +81,7 @@ function ItemCategoryFormInner({
     // Handle the response error.
     const onError = (error) => {
       const {
-        response: {
-          data: { errors },
-        },
+        data: { errors },
       } = error;
 
       transformErrors(errors, { setErrors });

--- a/packages/webapp/src/containers/Dialogs/LockingTransactionsDialog/LockingTransactionsForm.tsx
+++ b/packages/webapp/src/containers/Dialogs/LockingTransactionsDialog/LockingTransactionsForm.tsx
@@ -67,11 +67,7 @@ function LockingTransactionsFormInner({
     };
 
     // Handle request response errors.
-    const onError = ({
-      response: {
-        data: { errors },
-      },
-    }) => {
+    const onError = ({ data: { errors } }) => {
       setSubmitting(false);
     };
 

--- a/packages/webapp/src/containers/Dialogs/NotifyEstimateViaSMSDialog/NotifyEstimateViaSMSForm.tsx
+++ b/packages/webapp/src/containers/Dialogs/NotifyEstimateViaSMSDialog/NotifyEstimateViaSMSForm.tsx
@@ -44,11 +44,7 @@ function NotifyEstimateViaSMSFormInner({
       setSubmitting(false);
     };
     // Handle request response errors.
-    const onError = ({
-      response: {
-        data: { errors },
-      },
-    }) => {
+    const onError = ({ data: { errors } }) => {
       if (errors) {
         transformErrors(errors, { setErrors, setCalloutCode });
       }

--- a/packages/webapp/src/containers/Dialogs/NotifyInvoiceViaSMSDialog/NotifyInvoiceViaSMSForm.tsx
+++ b/packages/webapp/src/containers/Dialogs/NotifyInvoiceViaSMSDialog/NotifyInvoiceViaSMSForm.tsx
@@ -60,11 +60,7 @@ function NotifyInvoiceViaSMSFormInner({
       closeDialog(dialogName);
     };
     // Handle request response errors.
-    const onError = ({
-      response: {
-        data: { errors },
-      },
-    }) => {
+    const onError = ({ data: { errors } }) => {
       if (errors) {
         transformErrors(errors, { setErrors, setCalloutCode });
       }

--- a/packages/webapp/src/containers/Dialogs/NotifyPaymentReceiveViaSMSDialog/NotifyPaymentReceiveViaSMSForm.tsx
+++ b/packages/webapp/src/containers/Dialogs/NotifyPaymentReceiveViaSMSDialog/NotifyPaymentReceiveViaSMSForm.tsx
@@ -47,11 +47,7 @@ function NotifyPaymentReceiveViaSMSFormInner({
     };
 
     // Handle request response errors.
-    const onError = ({
-      response: {
-        data: { errors },
-      },
-    }) => {
+    const onError = ({ data: { errors } }) => {
       if (errors) {
         transformErrors(errors, { setErrors, setCalloutCode });
       }

--- a/packages/webapp/src/containers/Dialogs/NotifyReceiptViaSMSDialog/NotifyReceiptViaSMSForm.tsx
+++ b/packages/webapp/src/containers/Dialogs/NotifyReceiptViaSMSDialog/NotifyReceiptViaSMSForm.tsx
@@ -45,11 +45,7 @@ function NotifyReceiptViaSMSFormInner({
     };
 
     // Handle request response errors.
-    const onError = ({
-      response: {
-        data: { errors },
-      },
-    }) => {
+    const onError = ({ data: { errors } }) => {
       if (errors) {
         transformErrors(errors, { setErrors, setCalloutCode });
       }

--- a/packages/webapp/src/containers/Dialogs/QuickPaymentMadeFormDialog/QuickPaymentMadeForm.tsx
+++ b/packages/webapp/src/containers/Dialogs/QuickPaymentMadeFormDialog/QuickPaymentMadeForm.tsx
@@ -54,11 +54,7 @@ function QuickPaymentMadeFormInner({
       closeDialog(dialogName);
     };
     // Handle request response errors.
-    const onError = ({
-      response: {
-        data: { errors },
-      },
-    }) => {
+    const onError = ({ data: { errors } }) => {
       if (errors) {
         transformErrors(errors, { setFieldError });
       }

--- a/packages/webapp/src/containers/Dialogs/QuickPaymentReceiveFormDialog/QuickPaymentReceiveForm.tsx
+++ b/packages/webapp/src/containers/Dialogs/QuickPaymentReceiveFormDialog/QuickPaymentReceiveForm.tsx
@@ -76,11 +76,7 @@ function QuickPaymentReceiveFormInner({
       closeDialog(dialogName);
     };
     // Handle request response errors.
-    const onError = ({
-      response: {
-        data: { errors },
-      },
-    }) => {
+    const onError = ({ data: { errors } }) => {
       if (errors) {
         transformErrors(errors, { setFieldError });
       }

--- a/packages/webapp/src/containers/Dialogs/ReconcileCreditNoteDialog/ReconcileCreditNoteForm.tsx
+++ b/packages/webapp/src/containers/Dialogs/ReconcileCreditNoteDialog/ReconcileCreditNoteForm.tsx
@@ -69,11 +69,7 @@ function ReconcileCreditNoteFormInner({
       closeDialog(dialogName);
     };
     // Handle the request error.
-    const onError = ({
-      response: {
-        data: { errors },
-      },
-    }) => {
+    const onError = ({ data: { errors } }) => {
       if (errors) {
         transformErrors(errors, { setErrors });
       }

--- a/packages/webapp/src/containers/Dialogs/ReconcileVendorCreditDialog/ReconcileVendorCreditForm.tsx
+++ b/packages/webapp/src/containers/Dialogs/ReconcileVendorCreditDialog/ReconcileVendorCreditForm.tsx
@@ -70,11 +70,7 @@ function ReconcileVendorCreditFormInner({
     };
 
     // Handle the request error.
-    const onError = ({
-      response: {
-        data: { errors },
-      },
-    }) => {
+    const onError = ({ data: { errors } }) => {
       // if (errors) {
       //   transformErrors(errors, { setErrors });
       // }

--- a/packages/webapp/src/containers/Dialogs/RefundCreditNoteDialog/RefundCreditNoteForm.tsx
+++ b/packages/webapp/src/containers/Dialogs/RefundCreditNoteDialog/RefundCreditNoteForm.tsx
@@ -54,11 +54,7 @@ function RefundCreditNoteFormInner({
       closeDialog(dialogName);
     };
     // Handle request response errors.
-    const onError = ({
-      response: {
-        data: { errors },
-      },
-    }) => {
+    const onError = ({ data: { errors } }) => {
       setSubmitting(false);
     };
     createRefundCreditNoteMutate([creditNote.id, form])

--- a/packages/webapp/src/containers/Dialogs/RefundVendorCreditDialog/RefundVendorCreditForm.tsx
+++ b/packages/webapp/src/containers/Dialogs/RefundVendorCreditDialog/RefundVendorCreditForm.tsx
@@ -54,11 +54,7 @@ function RefundVendorCreditFormInner({
       closeDialog(dialogName);
     };
     // Handle request response errors.
-    const onError = ({
-      response: {
-        data: { errors },
-      },
-    }) => {
+    const onError = ({ data: { errors } }) => {
       setSubmitting(false);
     };
 

--- a/packages/webapp/src/containers/Dialogs/SMSMessageDialog/SMSMessageForm.tsx
+++ b/packages/webapp/src/containers/Dialogs/SMSMessageDialog/SMSMessageForm.tsx
@@ -55,11 +55,7 @@ function SMSMessageFormInner({
       closeDialog(dialogName);
     };
     // Handle request response errors.
-    const onError = ({
-      response: {
-        data: { errors },
-      },
-    }) => {
+    const onError = ({ data: { errors } }) => {
       if (errors) {
         transformErrors(errors, { setErrors });
       }

--- a/packages/webapp/src/containers/Dialogs/UnlockingPartialTransactionsDialog/UnlockingPartialTransactionsForm.tsx
+++ b/packages/webapp/src/containers/Dialogs/UnlockingPartialTransactionsDialog/UnlockingPartialTransactionsForm.tsx
@@ -54,11 +54,7 @@ function UnlockingPartialTransactionsFormInner({
       closeDialog(dialogName);
     };
     // Handle request response errors.
-    const onError = ({
-      response: {
-        data: { errors },
-      },
-    }) => {
+    const onError = ({ data: { errors } }) => {
       setSubmitting(false);
     };
 

--- a/packages/webapp/src/containers/Dialogs/UnlockingTransactionsDialog/UnlockingTransactionsForm.tsx
+++ b/packages/webapp/src/containers/Dialogs/UnlockingTransactionsDialog/UnlockingTransactionsForm.tsx
@@ -54,11 +54,7 @@ function UnlockingTransactionsFormInner({
     };
 
     // Handle request response errors.
-    const onError = ({
-      response: {
-        data: { errors },
-      },
-    }) => {
+    const onError = ({ data: { errors } }) => {
       setSubmitting(false);
     };
 

--- a/packages/webapp/src/containers/Dialogs/UserFormDialog/UserForm.tsx
+++ b/packages/webapp/src/containers/Dialogs/UserFormDialog/UserForm.tsx
@@ -58,9 +58,7 @@ function UserFormInner({
     // Handle the response error.
     const onError = (error) => {
       const {
-        response: {
-          data: { errors },
-        },
+        data: { errors },
       } = error;
       transformErrors(errors, { setErrors, setCalloutCode });
       setSubmitting(false);

--- a/packages/webapp/src/containers/Dialogs/VendorOpeningBalanceDialog/VendorOpeningBalanceForm.tsx
+++ b/packages/webapp/src/containers/Dialogs/VendorOpeningBalanceDialog/VendorOpeningBalanceForm.tsx
@@ -59,11 +59,7 @@ function VendorOpeningBalanceFormInner({
     };
 
     // Handle request response errors.
-    const onError = ({
-      response: {
-        data: { errors },
-      },
-    }) => {
+    const onError = ({ data: { errors } }) => {
       if (errors) {
       }
       setSubmitting(false);

--- a/packages/webapp/src/containers/Dialogs/WarehouseActivateDialog/WarehouseActivateForm.tsx
+++ b/packages/webapp/src/containers/Dialogs/WarehouseActivateDialog/WarehouseActivateForm.tsx
@@ -41,11 +41,7 @@ function WarehouseActivateFormInner({
     };
 
     // Handle request response errors.
-    const onError = ({
-      response: {
-        data: { errors },
-      },
-    }) => {
+    const onError = ({ data: { errors } }) => {
       if (errors) {
       }
       setSubmitting(false);

--- a/packages/webapp/src/containers/Dialogs/WarehouseFormDialog/WarehouseForm.tsx
+++ b/packages/webapp/src/containers/Dialogs/WarehouseFormDialog/WarehouseForm.tsx
@@ -61,11 +61,7 @@ function WarehouseFormInner({
     };
 
     // Handle request response errors.
-    const onError = ({
-      response: {
-        data: { errors },
-      },
-    }) => {
+    const onError = ({ data: { errors } }) => {
       if (errors) {
       }
       transformErrors(errors, { setErrors });

--- a/packages/webapp/src/containers/Expenses/ExpenseForm/ExpenseForm.tsx
+++ b/packages/webapp/src/containers/Expenses/ExpenseForm/ExpenseForm.tsx
@@ -115,11 +115,7 @@ function ExpenseFormInner({
     };
 
     // Handle the request error.
-    const handleError = ({
-      response: {
-        data: { errors },
-      },
-    }) => {
+    const handleError = ({ data: { errors } }) => {
       transformErrors(errors, { setErrors });
       setSubmitting(false);
     };

--- a/packages/webapp/src/containers/Import/ImportFileMappingForm.tsx
+++ b/packages/webapp/src/containers/Import/ImportFileMappingForm.tsx
@@ -30,7 +30,7 @@ export function ImportFileMappingForm({
         setSubmitting(false);
         setStep(2);
       })
-      .catch(({ response: { data } }) => {
+      .catch(({ data }) => {
         if (data.errors.find((e) => e.type === 'DUPLICATED_FROM_MAP_ATTR')) {
           AppToaster.show({
             message: 'Selected the same sheet columns to multiple fields.',

--- a/packages/webapp/src/containers/Import/ImportFileUploadForm.tsx
+++ b/packages/webapp/src/containers/Import/ImportFileUploadForm.tsx
@@ -61,7 +61,7 @@ export function ImportFileUploadForm({
         setStep(ImportStepperStep.Mapping);
         setSubmitting(false);
       })
-      .catch(({ response: { data } }) => {
+      .catch(({ data }) => {
         if (
           data.errors.find(
             (er) => er.type === 'IMPORTED_FILE_EXTENSION_INVALID',

--- a/packages/webapp/src/containers/Items/utils.tsx
+++ b/packages/webapp/src/containers/Items/utils.tsx
@@ -229,9 +229,7 @@ export function transformItemsTableState(tableState) {
  */
 export const transformSubmitRequestErrors = (error) => {
   const {
-    response: {
-      data: { errors },
-    },
+    data: { errors },
   } = error;
   const fields = {};
 

--- a/packages/webapp/src/containers/Preferences/Users/Roles/RolesForm/RolesForm.tsx
+++ b/packages/webapp/src/containers/Preferences/Users/Roles/RolesForm/RolesForm.tsx
@@ -80,11 +80,7 @@ function RolesFormInner({
       history.push('/preferences/users');
     };
 
-    const onError = ({
-      response: {
-        data: { errors },
-      },
-    }) => {
+    const onError = ({ data: { errors } }) => {
       setSubmitting(false);
       handleDeleteErrors(errors);
     };

--- a/packages/webapp/src/containers/Preferences/Users/UsersDataTable.tsx
+++ b/packages/webapp/src/containers/Preferences/Users/UsersDataTable.tsx
@@ -66,21 +66,15 @@ function UsersDataTableInner({
           intent: Intent.SUCCESS,
         });
       })
-      .catch(
-        ({
-          response: {
-            data: { errors },
-          },
-        }) => {
-          if (errors.find((e) => e.type === 'USER_RECENTLY_INVITED')) {
-            AppToaster.show({
-              message:
-                'This person was recently invited. No need to invite them again just yet.',
-              intent: Intent.WARNING,
-            });
-          }
-        },
-      );
+      .catch(({ data: { errors } }) => {
+        if (errors.find((e) => e.type === 'USER_RECENTLY_INVITED')) {
+          AppToaster.show({
+            message:
+              'This person was recently invited. No need to invite them again just yet.',
+            intent: Intent.WARNING,
+          });
+        }
+      });
   });
 
   return (

--- a/packages/webapp/src/containers/Projects/containers/EstimatedExpenseFormDialog/EstimatedExpenseForm.tsx
+++ b/packages/webapp/src/containers/Projects/containers/EstimatedExpenseFormDialog/EstimatedExpenseForm.tsx
@@ -35,11 +35,7 @@ function EstimatedExpenseFormInner({
     };
 
     // Handle request response errors.
-    const onError = ({
-      response: {
-        data: { errors },
-      },
-    }) => {
+    const onError = ({ data: { errors } }) => {
       setSubmitting(false);
     };
   };

--- a/packages/webapp/src/containers/Projects/containers/ProjectAlerts/ProjectDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Projects/containers/ProjectAlerts/ProjectDeleteAlert.tsx
@@ -43,13 +43,7 @@ function ProjectDeleteAlertInner({
           intent: Intent.SUCCESS,
         });
       })
-      .catch(
-        ({
-          response: {
-            data: { errors },
-          },
-        }) => {},
-      )
+      .catch(({ data: { errors } }) => {})
       .finally(() => {
         closeAlert(name);
       });

--- a/packages/webapp/src/containers/Projects/containers/ProjectAlerts/ProjectStatusAlert.tsx
+++ b/packages/webapp/src/containers/Projects/containers/ProjectAlerts/ProjectStatusAlert.tsx
@@ -43,13 +43,7 @@ function ProjectStatusAlertInner({
           intent: Intent.SUCCESS,
         });
       })
-      .catch(
-        ({
-          response: {
-            data: { errors },
-          },
-        }) => {},
-      )
+      .catch(({ data: { errors } }) => {})
       .finally(() => {
         closeAlert(name);
       });

--- a/packages/webapp/src/containers/Projects/containers/ProjectAlerts/ProjectTaskDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Projects/containers/ProjectAlerts/ProjectTaskDeleteAlert.tsx
@@ -42,13 +42,7 @@ function ProjectTaskDeleteAlertInner({
           intent: Intent.SUCCESS,
         });
       })
-      .catch(
-        ({
-          response: {
-            data: { errors },
-          },
-        }) => {},
-      )
+      .catch(({ data: { errors } }) => {})
       .finally(() => {
         closeAlert(name);
       });

--- a/packages/webapp/src/containers/Projects/containers/ProjectAlerts/ProjectTimesheetDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Projects/containers/ProjectAlerts/ProjectTimesheetDeleteAlert.tsx
@@ -42,13 +42,7 @@ function ProjectTimesheetDeleteAlertInner({
           intent: Intent.SUCCESS,
         });
       })
-      .catch(
-        ({
-          response: {
-            data: { errors },
-          },
-        }) => {},
-      )
+      .catch(({ data: { errors } }) => {})
       .finally(() => {
         closeAlert(name);
       });

--- a/packages/webapp/src/containers/Projects/containers/ProjectBillableEntriesFormDialog/ProjectBillableEntriesForm.tsx
+++ b/packages/webapp/src/containers/Projects/containers/ProjectBillableEntriesFormDialog/ProjectBillableEntriesForm.tsx
@@ -34,11 +34,7 @@ function ProjectBillableEntriesFormInner({
     };
 
     // Handle request response errors.
-    const onError = ({
-      response: {
-        data: { errors },
-      },
-    }) => {
+    const onError = ({ data: { errors } }) => {
       setSubmitting(false);
     };
   };

--- a/packages/webapp/src/containers/Projects/containers/ProjectExpenseForm/ProjectExpenseForm.tsx
+++ b/packages/webapp/src/containers/Projects/containers/ProjectExpenseForm/ProjectExpenseForm.tsx
@@ -44,11 +44,7 @@ function ProjectExpenseFormInner({
     };
 
     // Handle request response errors.
-    const onError = ({
-      response: {
-        data: { errors },
-      },
-    }) => {
+    const onError = ({ data: { errors } }) => {
       setSubmitting(false);
     };
   };

--- a/packages/webapp/src/containers/Projects/containers/ProjectFormDialog/ProjectForm.tsx
+++ b/packages/webapp/src/containers/Projects/containers/ProjectFormDialog/ProjectForm.tsx
@@ -64,11 +64,7 @@ function ProjectFormInner({
     };
 
     // Handle request response errors.
-    const onError = ({
-      response: {
-        data: { errors },
-      },
-    }) => {
+    const onError = ({ data: { errors } }) => {
       setSubmitting(false);
     };
 

--- a/packages/webapp/src/containers/Projects/containers/ProjectInvoicingFormDialog/ProjectInvoicingForm.tsx
+++ b/packages/webapp/src/containers/Projects/containers/ProjectInvoicingFormDialog/ProjectInvoicingForm.tsx
@@ -38,11 +38,7 @@ function ProjectInvoicingFormInner({
     const onSuccess = (response) => {};
 
     // Handle request response errors.
-    const onError = ({
-      response: {
-        data: { errors },
-      },
-    }) => {
+    const onError = ({ data: { errors } }) => {
       setSubmitting(false);
     };
   };

--- a/packages/webapp/src/containers/Projects/containers/ProjectTaskFormDialog/ProjectTaskForm.tsx
+++ b/packages/webapp/src/containers/Projects/containers/ProjectTaskFormDialog/ProjectTaskForm.tsx
@@ -60,11 +60,7 @@ function ProjectTaskFormInner({
     };
 
     // Handle request response errors.
-    const onError = ({
-      response: {
-        data: { errors },
-      },
-    }) => {
+    const onError = ({ data: { errors } }) => {
       setSubmitting(false);
     };
     if (isNewMode) {

--- a/packages/webapp/src/containers/Projects/containers/ProjectTimeEntryFormDialog/ProjectTimeEntryForm.tsx
+++ b/packages/webapp/src/containers/Projects/containers/ProjectTimeEntryFormDialog/ProjectTimeEntryForm.tsx
@@ -66,11 +66,7 @@ function ProjectTimeEntryFormInner({
     };
 
     // Handle request response errors.
-    const onError = ({
-      response: {
-        data: { errors },
-      },
-    }) => {
+    const onError = ({ data: { errors } }) => {
       setSubmitting(false);
     };
     if (isNewMode) {

--- a/packages/webapp/src/containers/Purchases/Bills/BillForm/BillForm.tsx
+++ b/packages/webapp/src/containers/Purchases/Bills/BillForm/BillForm.tsx
@@ -97,11 +97,7 @@ function BillFormInner() {
       }
     };
     // Handle the request error.
-    const onError = ({
-      response: {
-        data: { errors },
-      },
-    }) => {
+    const onError = ({ data: { errors } }) => {
       handleErrors(errors, { setErrors });
       setSubmitting(false);
     };

--- a/packages/webapp/src/containers/Purchases/CreditNotes/CreditNoteForm/VendorCreditNoteForm.tsx
+++ b/packages/webapp/src/containers/Purchases/CreditNotes/CreditNoteForm/VendorCreditNoteForm.tsx
@@ -123,11 +123,7 @@ function VendorCreditNoteFormInner({
       }
     };
     // Handle the request error.
-    const onError = ({
-      response: {
-        data: { errors },
-      },
-    }) => {
+    const onError = ({ data: { errors } }) => {
       setSubmitting(false);
     };
     if (isNewMode) {

--- a/packages/webapp/src/containers/Purchases/PaymentsMade/PaymentForm/PaymentMadeForm.tsx
+++ b/packages/webapp/src/containers/Purchases/PaymentsMade/PaymentForm/PaymentMadeForm.tsx
@@ -125,11 +125,7 @@ function PaymentMadeFormInner({
       submitPayload.resetForm && resetForm();
     };
 
-    const onError = ({
-      response: {
-        data: { errors },
-      },
-    }) => {
+    const onError = ({ data: { errors } }) => {
       if (errors) {
         transformErrors(errors, { setFieldError });
       }

--- a/packages/webapp/src/containers/Sales/CreditNotes/CreditNoteForm/CreditNoteForm.tsx
+++ b/packages/webapp/src/containers/Sales/CreditNotes/CreditNoteForm/CreditNoteForm.tsx
@@ -131,11 +131,7 @@ function CreditNoteFormInner({
       }
     };
     // Handle the request error.
-    const onError = ({
-      response: {
-        data: { errors },
-      },
-    }) => {
+    const onError = ({ data: { errors } }) => {
       setSubmitting(false);
     };
     if (isNewMode) {

--- a/packages/webapp/src/containers/Sales/Estimates/EstimateForm/EstimateForm.tsx
+++ b/packages/webapp/src/containers/Sales/Estimates/EstimateForm/EstimateForm.tsx
@@ -129,11 +129,7 @@ function EstimateFormInner({
       }
     };
     // Handle the request error.
-    const onError = ({
-      response: {
-        data: { errors },
-      },
-    }) => {
+    const onError = ({ data: { errors } }) => {
       if (errors) {
         handleErrors(errors, { setErrors });
       }

--- a/packages/webapp/src/containers/Sales/Invoices/InvoiceForm/InvoiceForm.tsx
+++ b/packages/webapp/src/containers/Sales/Invoices/InvoiceForm/InvoiceForm.tsx
@@ -135,11 +135,7 @@ function InvoiceFormRoot({
       }
     };
     // Handle the request error.
-    const onError = ({
-      response: {
-        data: { errors },
-      },
-    }) => {
+    const onError = ({ data: { errors } }) => {
       if (errors) {
         transformErrors(errors, { setErrors });
       }

--- a/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentReceiveForm/PaymentReceiveForm.tsx
+++ b/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentReceiveForm/PaymentReceiveForm.tsx
@@ -137,11 +137,7 @@ function PaymentReceiveFormRoot({
       }
     };
     // Handle request response errors.
-    const onError = ({
-      response: {
-        data: { errors },
-      },
-    }) => {
+    const onError = ({ data: { errors } }) => {
       if (errors) {
         transformErrors(errors, { setFieldError });
       }

--- a/packages/webapp/src/containers/Sales/Receipts/ReceiptForm/ReceiptForm.tsx
+++ b/packages/webapp/src/containers/Sales/Receipts/ReceiptForm/ReceiptForm.tsx
@@ -131,11 +131,7 @@ function ReceiptFormRoot({
     };
 
     // Handle the request error.
-    const onError = ({
-      response: {
-        data: { errors },
-      },
-    }) => {
+    const onError = ({ data: { errors } }) => {
       if (errors) {
         handleErrors(errors, { setErrors });
       }

--- a/packages/webapp/src/containers/Subscriptions/alerts/CancelMainSubscriptionAlert.tsx
+++ b/packages/webapp/src/containers/Subscriptions/alerts/CancelMainSubscriptionAlert.tsx
@@ -41,13 +41,7 @@ function CancelMainSubscriptionAlertInner({
           intent: Intent.SUCCESS,
         });
       })
-      .catch(
-        ({
-          response: {
-            data: { errors },
-          },
-        }) => {},
-      )
+      .catch(({ data: { errors } }) => {})
       .finally(() => {
         closeAlert(name);
       });

--- a/packages/webapp/src/containers/Subscriptions/alerts/ResumeMainSubscriptionAlert.tsx
+++ b/packages/webapp/src/containers/Subscriptions/alerts/ResumeMainSubscriptionAlert.tsx
@@ -40,13 +40,7 @@ function ResumeMainSubscriptionAlertInner({
           intent: Intent.SUCCESS,
         });
       })
-      .catch(
-        ({
-          response: {
-            data: { errors },
-          },
-        }) => {},
-      )
+      .catch(({ data: { errors } }) => {})
       .finally(() => {
         closeAlert(name);
       });

--- a/packages/webapp/src/containers/TaxRates/alerts/TaxRateDeleteAlert.tsx
+++ b/packages/webapp/src/containers/TaxRates/alerts/TaxRateDeleteAlert.tsx
@@ -44,18 +44,12 @@ function TaxRateDeleteAlertInner({
         });
         closeDrawer(DRAWERS.TAX_RATE_DETAILS);
       })
-      .catch(
-        ({
-          response: {
-            data: { errors },
-          },
-        }) => {
-          AppToaster.show({
-            message: 'Something went wrong.',
-            intent: Intent.DANGER,
-          });
-        },
-      )
+      .catch(({ data: { errors } }) => {
+        AppToaster.show({
+          message: 'Something went wrong.',
+          intent: Intent.DANGER,
+        });
+      })
       .finally(() => {
         closeAlert(name);
       });

--- a/packages/webapp/src/containers/TaxRates/dialogs/TaxRateFormDialog/TaxRateFormDialogForm.tsx
+++ b/packages/webapp/src/containers/TaxRates/dialogs/TaxRateFormDialog/TaxRateFormDialogForm.tsx
@@ -83,9 +83,7 @@ function TaxRateFormDialogFormInner({
     // Handle request error.
     const handleError = (error) => {
       const {
-        response: {
-          data: { errors },
-        },
+        data: { errors },
       } = error;
 
       const errorsTransformed = transformApiErrors(errors);

--- a/packages/webapp/src/containers/WarehouseTransfers/WarehouseTransferForm/WarehouseTransferForm.tsx
+++ b/packages/webapp/src/containers/WarehouseTransfers/WarehouseTransferForm/WarehouseTransferForm.tsx
@@ -101,11 +101,7 @@ function WarehouseTransferFormInner({
     };
 
     // Handle the request error.
-    const onError = ({
-      response: {
-        data: { errors },
-      },
-    }) => {
+    const onError = ({ data: { errors } }) => {
       if (errors) {
         transformErrors(errors, { setErrors });
       }

--- a/packages/webapp/src/ee/workspaces/containers/CreateWorkspaceDrawer/BuildingWorkspaceStep.tsx
+++ b/packages/webapp/src/ee/workspaces/containers/CreateWorkspaceDrawer/BuildingWorkspaceStep.tsx
@@ -18,16 +18,13 @@ export default function BuildingWorkspaceStep({
 }: BuildingWorkspaceStepProps) {
   const isDarkMode = useIsDarkMode();
 
-  const {
-    data: jobState,
-    isFetching: isJobFetching,
-  } = useJob(jobId, {
+  const { data: jobState, isFetching: isJobFetching } = useJob(jobId, {
     refetchInterval: 2000,
     enabled: !!jobId,
   });
 
   const isRunning = jobState?.isRunning;
-  const isWaiting = jobState?.isWaiting; 
+  const isWaiting = jobState?.isWaiting;
   const isFailed = jobState?.isFailed;
   const isCompleted = jobState?.isCompleted;
 


### PR DESCRIPTION
## Summary

- Delete alerts and form error handlers destructured rejection values as `{response: {data: {errors}}}` (axios shape), but mutations now go through the `@bigcapital/sdk-ts` fetcher built on `openapi-typescript-fetch`. Its `ApiError` exposes the body directly as `error.data` — there is no `response` property.
- The old destructure threw a silent `TypeError` (`Cannot destructure property 'data' of 'undefined'`), which was swallowed, so `handleDeleteErrors` / `transformErrors` never ran. Server-protected deletes (e.g. `account_predefined`, customer/vendor with associated transactions, item with inventory) returned 400 with no toast.
- Replaces the destructure shape with `{data: {errors}}` across all 87 affected files (delete alerts, form dialogs, auth flows, subscription alerts, banking rules, items util). The shared error-type handlers were already correct — they just weren't being reached.

## Root cause

Trace: `useDelete*` hooks → `@bigcapital/sdk-ts` functions → `openapi-typescript-fetch` `ApiError` (shape `{ status, statusText, data, url, headers, message }`). The 5xx axios interceptor in `useRequest.tsx` does not apply to SDK calls, so the axios-style `{response: {data}}` shape never existed at the catch site.

## Test plan

- [ ] Start webapp, log in to an org with predefined accounts
- [ ] Try to delete a predefined account (e.g. Accounts Receivable) → confirm red "Cannot delete predefined accounts" toast appears
- [ ] Try to delete an account with associated transactions → confirm `cannot_delete_account_has_associated_transactions` toast
- [ ] Delete a normal account → confirm success toast still appears
- [ ] Repeat protected-delete flow for: Customer with invoices, Vendor with bills, Item with transactions, Invoice, Estimate, Bill, Manual Journal, Expense → each shows its respective error toast
- [ ] Trigger form submit validation errors (e.g. duplicate item name) → confirm field-level error messages still surface