### PR TITLE
fix(webapp): co-locate page-scoped drawers and dialogs with their pages

### DIFF
--- a/packages/webapp/src/components/Customers/CustomerDrawerLink.tsx
+++ b/packages/webapp/src/components/Customers/CustomerDrawerLink.tsx
@@ -3,8 +3,14 @@ import React from 'react';
 import * as R from 'ramda';
 
 import { ButtonLink } from '../Button';
-import { withDrawerActions } from '@/containers/Drawer/withDrawerActions';
+import { withDrawerActions, WithDrawerActionsProps } from '@/containers/Drawer/withDrawerActions';
 import { DRAWERS } from '@/constants/drawers';
+
+interface CustomerDrawerLinkComponentProps extends WithDrawerActionsProps {
+  children?: React.ReactNode;
+  customerId?: number;
+  className?: string;
+}
 
 function CustomerDrawerLinkComponent({
   // #ownProps
@@ -14,9 +20,9 @@ function CustomerDrawerLinkComponent({
 
   // #withDrawerActions
   openDrawer,
-}) {
+}: CustomerDrawerLinkComponentProps) {
   // Handle view customer drawer.
-  const handleCustomerDrawer = (event) => {
+  const handleCustomerDrawer = (event: React.MouseEvent) => {
     openDrawer(DRAWERS.CUSTOMER_DETAILS, { customerId });
     event.preventDefault();
   };

--- a/packages/webapp/src/components/Customers/CustomerDrawerLink.tsx
+++ b/packages/webapp/src/components/Customers/CustomerDrawerLink.tsx
@@ -3,7 +3,10 @@ import React from 'react';
 import * as R from 'ramda';
 
 import { ButtonLink } from '../Button';
-import { withDrawerActions, WithDrawerActionsProps } from '@/containers/Drawer/withDrawerActions';
+import {
+  withDrawerActions,
+  WithDrawerActionsProps,
+} from '@/containers/Drawer/withDrawerActions';
 import { DRAWERS } from '@/constants/drawers';
 
 interface CustomerDrawerLinkComponentProps extends WithDrawerActionsProps {

--- a/packages/webapp/src/components/Dashboard/DashboardAbilityProvider.tsx
+++ b/packages/webapp/src/components/Dashboard/DashboardAbilityProvider.tsx
@@ -1,23 +1,43 @@
-// @ts-nocheck
 import React from 'react';
-import { Ability } from '@casl/ability';
+import { Ability, AnyAbility } from '@casl/ability';
 import { createContextualCan } from '@casl/react';
 
 import { useDashboardMetaBoot } from './DashboardBoot';
 
-export const AbilityContext = React.createContext();
-export const Can = createContextualCan(AbilityContext.Consumer);
+export const AbilityContext = React.createContext<AnyAbility | undefined>(
+  undefined,
+);
+
+type CanProps = {
+  I?: unknown;
+  do?: unknown;
+  a?: unknown;
+  an?: unknown;
+  this?: unknown;
+  on?: unknown;
+  field?: string;
+  not?: boolean;
+  passThrough?: boolean;
+  render?: (...args: unknown[]) => React.ReactNode;
+  children?: React.ReactNode;
+};
+
+export const Can = createContextualCan(
+  AbilityContext.Consumer as React.Consumer<AnyAbility>,
+) as React.FC<CanProps>;
 
 /**
  * Dashboard ability provider.
  */
-export function DashboardAbilityProvider({ children }) {
-  const {
-    meta: { abilities },
-  } = useDashboardMetaBoot();
+export function DashboardAbilityProvider({
+  children,
+}: {
+  children?: React.ReactNode;
+}) {
+  const { meta } = useDashboardMetaBoot();
 
   // Ability instance.
-  const ability = new Ability(abilities);
+  const ability = new Ability(meta?.abilities ?? []);
 
   return (
     <AbilityContext.Provider value={ability}>

--- a/packages/webapp/src/components/Details/index.tsx
+++ b/packages/webapp/src/components/Details/index.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import React from 'react';
 import clsx from 'classnames';
 
@@ -7,9 +6,19 @@ import '@/style/components/Details.scss';
 const DIRECTION = {
   VERTICAL: 'vertical',
   HORIZANTAL: 'horizantal',
-};
+} as const;
 
-const DetailsMenuContext = React.createContext();
+interface DetailsMenuProps {
+  children?: React.ReactNode;
+  direction?: string;
+  textAlign?: string;
+  minLabelSize?: number | string;
+  className?: string;
+}
+
+const DetailsMenuContext = React.createContext<{
+  minLabelSize?: number | string;
+}>({});
 const useDetailsMenuContext = () => React.useContext(DetailsMenuContext);
 
 /**
@@ -21,7 +30,7 @@ export function DetailsMenu({
   textAlign,
   minLabelSize,
   className,
-}) {
+}: DetailsMenuProps) {
   return (
     <div
       className={clsx(
@@ -41,6 +50,15 @@ export function DetailsMenu({
   );
 }
 
+interface DetailItemProps {
+  label?: React.ReactNode;
+  children?: React.ReactNode;
+  name?: string;
+  align?: string;
+  multiline?: boolean;
+  className?: string;
+}
+
 /**
  * Detail item.
  */
@@ -51,7 +69,7 @@ export function DetailItem({
   align,
   multiline,
   className,
-}) {
+}: DetailItemProps) {
   const { minLabelSize } = useDetailsMenuContext();
 
   return (
@@ -68,9 +86,9 @@ export function DetailItem({
     >
       <div
         style={{
-          'min-width': minLabelSize,
+          minWidth: minLabelSize,
         }}
-        class="detail-item__label"
+        className="detail-item__label"
       >
         {label}
       </div>

--- a/packages/webapp/src/components/DialogsContainer.tsx
+++ b/packages/webapp/src/components/DialogsContainer.tsx
@@ -9,8 +9,6 @@ import { index as ContactDuplicateDialog } from '@/containers/Dialogs/ContactDup
 import { index as QuickPaymentReceiveFormDialog } from '@/containers/Dialogs/QuickPaymentReceiveFormDialog';
 import { index as QuickPaymentMadeFormDialog } from '@/containers/Dialogs/QuickPaymentMadeFormDialog';
 import { index as AllocateLandedCostDialog } from '@/containers/Dialogs/AllocateLandedCostDialog';
-import { index as InvoicePdfPreviewDialog } from '@/containers/Dialogs/InvoicePdfPreviewDialog';
-import { index as EstimatePdfPreviewDialog } from '@/containers/Dialogs/EstimatePdfPreviewDialog';
 import { index as MoneyInDialog } from '@/containers/CashFlow/MoneyInDialog';
 import { index as MoneyOutDialog } from '@/containers/CashFlow/MoneyOutDialog';
 import { index as BadDebtDialog } from '@/containers/Dialogs/BadDebtDialog';
@@ -26,8 +24,6 @@ import { index as ReconcileVendorCreditDialog } from '@/containers/Dialogs/Recon
 import { index as LockingTransactionsDialog } from '@/containers/Dialogs/LockingTransactionsDialog';
 import { index as UnlockingTransactionsDialog } from '@/containers/Dialogs/UnlockingTransactionsDialog';
 import { index as UnlockingPartialTransactionsDialog } from '@/containers/Dialogs/UnlockingPartialTransactionsDialog';
-import { index as CreditNotePdfPreviewDialog } from '@/containers/Dialogs/CreditNotePdfPreviewDialog';
-import { index as PaymentReceivePdfPreviewDialog } from '@/containers/Dialogs/PaymentReceivePdfPreviewDialog';
 import { index as WarehouseFormDialog } from '@/containers/Dialogs/WarehouseFormDialog';
 import { index as BranchFormDialog } from '@/containers/Dialogs/BranchFormDialog';
 import { index as BranchActivateDialog } from '@/containers/Dialogs/BranchActivateDialog';
@@ -43,7 +39,6 @@ import { index as ProjectInvoicingFormDialog } from '@/containers/Projects/conta
 import { index as ProjectBillableEntriesFormDialog } from '@/containers/Projects/containers/ProjectBillableEntriesFormDialog';
 import { TaxRateFormDialog } from '@/containers/TaxRates/dialogs/TaxRateFormDialog/TaxRateFormDialog';
 import { DialogsName } from '@/constants/dialogs';
-import { InvoiceExchangeRateChangeDialog } from '@/containers/Sales/Invoices/InvoiceForm/Dialogs/InvoiceExchangeRateChangeDialog';
 import { ExportDialog } from '@/containers/Dialogs/ExportDialog';
 import { RuleFormDialog } from '@/containers/Banking/Rules/RuleFormDialog/RuleFormDialog';
 import { DisconnectBankAccountDialog } from '@/containers/CashFlow/AccountTransactions/dialogs/DisconnectBankAccountDialog/DisconnectBankAccountDialog';
@@ -52,22 +47,13 @@ import { SelectPaymentMethodsDialog } from '@/containers/PaymentLink/dialogs/Sel
 import { ApiKeysGenerateDialog } from '@/containers/Dialogs/ApiKeysGenerateDialog';
 import WorkspaceDeleteDialog from '@/ee/workspaces/containers/Dialogs/WorkspaceDeleteDialog';
 import WorkspaceInactivateDialog from '@/ee/workspaces/containers/Dialogs/WorkspaceInactivateDialog';
-import { InvoiceBulkDeleteDialog } from '@/containers/Dialogs/Invoices/InvoiceBulkDeleteDialog';
-import { EstimateBulkDeleteDialog } from '@/containers/Dialogs/Estimates/EstimateBulkDeleteDialog';
-import { ReceiptBulkDeleteDialog } from '@/containers/Dialogs/Receipts/ReceiptBulkDeleteDialog';
-import { CreditNoteBulkDeleteDialog } from '@/containers/Dialogs/CreditNotes/CreditNoteBulkDeleteDialog';
-import { PaymentReceivedBulkDeleteDialog } from '@/containers/Dialogs/PaymentsReceived/PaymentReceivedBulkDeleteDialog';
-import { BillBulkDeleteDialog } from '@/containers/Dialogs/Bills/BillBulkDeleteDialog';
-import { VendorCreditBulkDeleteDialog } from '@/containers/Dialogs/VendorCredits/VendorCreditBulkDeleteDialog';
-import { ManualJournalBulkDeleteDialog } from '@/containers/Dialogs/ManualJournals/ManualJournalBulkDeleteDialog';
-import { ExpenseBulkDeleteDialog } from '@/containers/Dialogs/Expenses/ExpenseBulkDeleteDialog';
-import { AccountBulkDeleteDialog } from '@/containers/Dialogs/Accounts/AccountBulkDeleteDialog';
-import { ItemBulkDeleteDialog } from '@/containers/Dialogs/Items/ItemBulkDeleteDialog';
-import { CustomerBulkDeleteDialog } from '@/containers/Dialogs/Customers/CustomerBulkDeleteDialog';
-import { VendorBulkDeleteDialog } from '@/containers/Dialogs/Vendors/VendorBulkDeleteDialog';
 
 /**
  * Dialogs container.
+ *
+ * Hosts dialogs that are cross-cutting or feature-scoped without a single
+ * clear page home. Page-scoped and form-scoped dialogs are mounted in
+ * co-located `<Page>Dialogs` / `<PageForm>Dialogs` components.
  */
 export default function DialogsContainer() {
   return (
@@ -91,8 +77,6 @@ export default function DialogsContainer() {
       <AllocateLandedCostDialog
         dialogName={DialogsName.AllocateLandedCostForm}
       />
-      <InvoicePdfPreviewDialog dialogName={DialogsName.InvoicePdfForm} />
-      <EstimatePdfPreviewDialog dialogName={DialogsName.EstimatePdfForm} />
       <MoneyInDialog dialogName={DialogsName.MoneyInForm} />
       <MoneyOutDialog dialogName={DialogsName.MoneyOutForm} />
 
@@ -123,8 +107,6 @@ export default function DialogsContainer() {
       <UnlockingPartialTransactionsDialog
         dialogName={DialogsName.PartialTransactionsUnlocking}
       />
-      <CreditNotePdfPreviewDialog dialogName={DialogsName.CreditNotePdfForm} />
-      <PaymentReceivePdfPreviewDialog dialogName={DialogsName.PaymentPdfForm} />
       <WarehouseFormDialog dialogName={DialogsName.WarehouseForm} />
       <BranchFormDialog dialogName={DialogsName.BranchForm} />
       <BranchActivateDialog dialogName={DialogsName.BranchActivateForm} />
@@ -151,30 +133,6 @@ export default function DialogsContainer() {
         dialogName={DialogsName.ProjectBillableEntriesForm}
       />
       <TaxRateFormDialog dialogName={DialogsName.TaxRateForm} />
-      <InvoiceExchangeRateChangeDialog
-        dialogName={DialogsName.InvoiceExchangeRateChangeNotice}
-      />
-      <InvoiceBulkDeleteDialog dialogName={DialogsName.InvoiceBulkDelete} />
-      <EstimateBulkDeleteDialog dialogName={DialogsName.EstimateBulkDelete} />
-      <ReceiptBulkDeleteDialog dialogName={DialogsName.ReceiptBulkDelete} />
-      <CreditNoteBulkDeleteDialog
-        dialogName={DialogsName.CreditNoteBulkDelete}
-      />
-      <PaymentReceivedBulkDeleteDialog
-        dialogName={DialogsName.PaymentReceivedBulkDelete}
-      />
-      <BillBulkDeleteDialog dialogName={DialogsName.BillBulkDelete} />
-      <VendorCreditBulkDeleteDialog
-        dialogName={DialogsName.VendorCreditBulkDelete}
-      />
-      <ManualJournalBulkDeleteDialog
-        dialogName={DialogsName.ManualJournalBulkDelete}
-      />
-      <ExpenseBulkDeleteDialog dialogName={DialogsName.ExpenseBulkDelete} />
-      <AccountBulkDeleteDialog dialogName={DialogsName.AccountBulkDelete} />
-      <ItemBulkDeleteDialog dialogName={DialogsName.ItemBulkDelete} />
-      <CustomerBulkDeleteDialog dialogName={DialogsName.CustomerBulkDelete} />
-      <VendorBulkDeleteDialog dialogName={DialogsName.VendorBulkDelete} />
       <ExportDialog dialogName={DialogsName.Export} />
       <RuleFormDialog dialogName={DialogsName.BankRuleForm} />
       <DisconnectBankAccountDialog

--- a/packages/webapp/src/components/Drawer/DrawerBody.tsx
+++ b/packages/webapp/src/components/Drawer/DrawerBody.tsx
@@ -1,10 +1,15 @@
-// @ts-nocheck
 import React from 'react';
 import clsx from 'classnames';
 import { Classes } from '@blueprintjs/core';
 import { LoadingIndicator } from '../Indicator';
 
-export function DrawerLoading({ loading, mount = false, children }) {
+interface DrawerLoadingProps {
+  loading?: boolean;
+  mount?: boolean;
+  children?: React.ReactNode;
+}
+
+export function DrawerLoading({ loading, mount = false, children }: DrawerLoadingProps) {
   return (
     <LoadingIndicator loading={loading} mount={mount}>
       {children}
@@ -12,7 +17,12 @@ export function DrawerLoading({ loading, mount = false, children }) {
   );
 }
 
-export function DrawerBody({ children, className }) {
+interface DrawerBodyProps {
+  children?: React.ReactNode;
+  className?: string;
+}
+
+export function DrawerBody({ children, className }: DrawerBodyProps) {
   return <div className={clsx(Classes.DRAWER_BODY, className)}>{children}</div>;
 }
 

--- a/packages/webapp/src/components/Drawer/DrawerBody.tsx
+++ b/packages/webapp/src/components/Drawer/DrawerBody.tsx
@@ -9,7 +9,11 @@ interface DrawerLoadingProps {
   children?: React.ReactNode;
 }
 
-export function DrawerLoading({ loading, mount = false, children }: DrawerLoadingProps) {
+export function DrawerLoading({
+  loading,
+  mount = false,
+  children,
+}: DrawerLoadingProps) {
   return (
     <LoadingIndicator loading={loading} mount={mount}>
       {children}

--- a/packages/webapp/src/components/DrawersContainer.tsx
+++ b/packages/webapp/src/components/DrawersContainer.tsx
@@ -1,81 +1,35 @@
-import { index as AccountDrawer } from '@/containers/Drawers/AccountDrawer';
-import { index as ManualJournalDrawer } from '@/containers/Drawers/ManualJournalDrawer';
-import { index as ExpenseDrawer } from '@/containers/Drawers/ExpenseDrawer';
-import { index as BillDrawer } from '@/containers/Drawers/BillDrawer';
-import { index as InvoiceDetailDrawer } from '@/containers/Drawers/InvoiceDetailDrawer';
-import { index as ReceiptDetailDrawer } from '@/containers/Drawers/ReceiptDetailDrawer';
-import { index as PaymentReceiveDetailDrawer } from '@/containers/Drawers/PaymentReceiveDetailDrawer';
-import { index as PaymentMadeDetailDrawer } from '@/containers/Drawers/PaymentMadeDetailDrawer';
-import { index as EstimateDetailDrawer } from '@/containers/Drawers/EstimateDetailDrawer';
-import { index as ItemDetailDrawer } from '@/containers/Drawers/ItemDetailDrawer';
 import { index as CustomerDetailsDrawer } from '@/containers/Drawers/CustomerDetailsDrawer';
 import { index as VendorDetailsDrawer } from '@/containers/Drawers/VendorDetailsDrawer';
-import { index as InventoryAdjustmentDetailDrawer } from '@/containers/Drawers/InventoryAdjustmentDetailDrawer';
-import { index as CashflowTransactionDetailDrawer } from '@/containers/Drawers/CashflowTransactionDetailDrawer';
 import { index as QuickCreateCustomerDrawer } from '@/containers/Drawers/QuickCreateCustomerDrawer';
 import { index as QuickCreateItemDrawer } from '@/containers/Drawers/QuickCreateItemDrawer';
 import { index as QuickWriteVendorDrawer } from '@/containers/Drawers/QuickWriteVendorDrawer';
-import { index as CreditNoteDetailDrawer } from '@/containers/Drawers/CreditNoteDetailDrawer';
-import { index as VendorCreditDetailDrawer } from '@/containers/Drawers/VendorCreditDetailDrawer';
-import { index as RefundCreditNoteDetailDrawer } from '@/containers/Drawers/RefundCreditNoteDetailDrawer';
-import { index as RefundVendorCreditDetailDrawer } from '@/containers/Drawers/RefundVendorCreditDetailDrawer';
-import { index as WarehouseTransferDetailDrawer } from '@/containers/Drawers/WarehouseTransferDetailDrawer';
-import { TaxRateDetailsDrawer } from '@/containers/TaxRates/drawers/TaxRateDetailsDrawer/TaxRateDetailsDrawer';
-import { CategorizeTransactionDrawer } from '@/containers/CashFlow/CategorizeTransaction/drawers/CategorizeTransactionDrawer/CategorizeTransactionDrawer';
-import { ChangeSubscriptionPlanDrawer } from '@/containers/Subscriptions/drawers/ChangeSubscriptionPlanDrawer/ChangeSubscriptionPlanDrawer';
 import { InvoiceCustomizeDrawer } from '@/containers/Sales/Invoices/InvoiceCustomize/InvoiceCustomizeDrawer';
 import { EstimateCustomizeDrawer } from '@/containers/Sales/Estimates/EstimateCustomize/EstimateCustomizeDrawer';
 import { ReceiptCustomizeDrawer } from '@/containers/Sales/Receipts/ReceiptCustomize/ReceiptCustomizeDrawer';
 import { CreditNoteCustomizeDrawer } from '@/containers/Sales/CreditNotes/CreditNoteCustomize/CreditNoteCustomizeDrawer';
 import { PaymentReceivedCustomizeDrawer } from '@/containers/Sales/PaymentsReceived/PaymentReceivedCustomize/PaymentReceivedCustomizeDrawer';
 import { BrandingTemplatesDrawer } from '@/containers/BrandingTemplates/BrandingTemplatesDrawer';
-import { DRAWERS } from '@/constants/drawers';
-import { InvoiceSendMailDrawer } from '@/containers/Sales/Invoices/InvoiceSendMailDrawer/InvoiceSendMailDrawer';
-import { EstimateSendMailDrawer } from '@/containers/Sales/Estimates/EstimateSendMailDrawer';
-import { ReceiptSendMailDrawer } from '@/containers/Sales/Receipts/ReceiptSendMailDrawer';
-import { PaymentReceivedSendMailDrawer } from '@/containers/Sales/PaymentsReceived/PaymentReceivedMailDrawer';
 import { CreateWorkspaceDrawer } from '@/ee/workspaces/containers/CreateWorkspaceDrawer/CreateWorkspaceDrawer';
 import { OrganizationsListDrawer } from '@/ee/workspaces/containers/OrganizationsListDrawer';
+import { DRAWERS } from '@/constants/drawers';
 
 /**
- * Drawers container of the dashboard.
+ * Global drawers container.
+ *
+ * Hosts drawers that are cross-cutting: opened from shared form components
+ * (quick-create selectors, customer/vendor links), sales document actions
+ * bars (branding/customize), or app-level UI (workspace switcher). Each
+ * feature page mounts its own page-scoped drawers in a co-located
+ * `<Page>Drawers` component.
  */
 export default function DrawersContainer() {
   return (
     <div>
-      <AccountDrawer name={DRAWERS.ACCOUNT_DETAILS} />
-      <ManualJournalDrawer name={DRAWERS.JOURNAL_DETAILS} />
-      <ExpenseDrawer name={DRAWERS.EXPENSE_DETAILS} />
-      <BillDrawer name={DRAWERS.BILL_DETAILS} />
-      <InvoiceDetailDrawer name={DRAWERS.INVOICE_DETAILS} />
-      <EstimateDetailDrawer name={DRAWERS.ESTIMATE_DETAILS} />
-      <ReceiptDetailDrawer name={DRAWERS.RECEIPT_DETAILS} />
-      <PaymentReceiveDetailDrawer name={DRAWERS.PAYMENT_RECEIVED_DETAILS} />
-      <PaymentMadeDetailDrawer name={DRAWERS.PAYMENT_MADE_DETAILS} />
-      <ItemDetailDrawer name={DRAWERS.ITEM_DETAILS} />
       <CustomerDetailsDrawer name={DRAWERS.CUSTOMER_DETAILS} />
       <VendorDetailsDrawer name={DRAWERS.VENDOR_DETAILS} />
-      <InventoryAdjustmentDetailDrawer
-        name={DRAWERS.INVENTORY_ADJUSTMENT_DETAILS}
-      />
-      <CashflowTransactionDetailDrawer
-        name={DRAWERS.CASHFLOW_TRNASACTION_DETAILS}
-      />
       <QuickCreateCustomerDrawer name={DRAWERS.QUICK_CREATE_CUSTOMER} />
       <QuickCreateItemDrawer name={DRAWERS.QUICK_CREATE_ITEM} />
       <QuickWriteVendorDrawer name={DRAWERS.QUICK_WRITE_VENDOR} />
-      <CreditNoteDetailDrawer name={DRAWERS.CREDIT_NOTE_DETAILS} />
-      <VendorCreditDetailDrawer name={DRAWERS.VENDOR_CREDIT_DETAILS} />
-      <RefundCreditNoteDetailDrawer name={DRAWERS.REFUND_CREDIT_NOTE_DETAILS} />
-      <RefundVendorCreditDetailDrawer
-        name={DRAWERS.REFUND_VENDOR_CREDIT_DETAILS}
-      />
-      <WarehouseTransferDetailDrawer
-        name={DRAWERS.WAREHOUSE_TRANSFER_DETAILS}
-      />
-      <TaxRateDetailsDrawer name={DRAWERS.TAX_RATE_DETAILS} />
-      <CategorizeTransactionDrawer name={DRAWERS.CATEGORIZE_TRANSACTION} />
-      <ChangeSubscriptionPlanDrawer name={DRAWERS.CHANGE_SUBSCARIPTION_PLAN} />
       <InvoiceCustomizeDrawer name={DRAWERS.INVOICE_CUSTOMIZE} />
       <EstimateCustomizeDrawer name={DRAWERS.ESTIMATE_CUSTOMIZE} />
       <ReceiptCustomizeDrawer name={DRAWERS.RECEIPT_CUSTOMIZE} />
@@ -84,12 +38,6 @@ export default function DrawersContainer() {
         name={DRAWERS.PAYMENT_RECEIVED_CUSTOMIZE}
       />
       <BrandingTemplatesDrawer name={DRAWERS.BRANDING_TEMPLATES} />
-      <InvoiceSendMailDrawer name={DRAWERS.INVOICE_SEND_MAIL} />
-      <EstimateSendMailDrawer name={DRAWERS.ESTIMATE_SEND_MAIL} />
-      <ReceiptSendMailDrawer name={DRAWERS.RECEIPT_SEND_MAIL} />
-      <PaymentReceivedSendMailDrawer
-        name={DRAWERS.PAYMENT_RECEIVED_SEND_MAIL}
-      />
       <CreateWorkspaceDrawer name={DRAWERS.CREATE_WORKSPACE} />
       <OrganizationsListDrawer name={DRAWERS.ORGANIZATIONS_LIST} />
     </div>

--- a/packages/webapp/src/components/TotalLines/index.tsx
+++ b/packages/webapp/src/components/TotalLines/index.tsx
@@ -13,12 +13,19 @@ export const TotalLineTextStyle = {
   Bold: 'Bold',
 };
 
+interface TotalLinesProps {
+  children?: React.ReactNode;
+  amountColWidth?: string | number;
+  labelColWidth?: string | number;
+  className?: string;
+}
+
 export function TotalLines({
   children,
   amountColWidth,
   labelColWidth,
   className,
-}) {
+}: TotalLinesProps) {
   return (
     <TotalLinesRoot
       className={className}
@@ -30,7 +37,15 @@ export function TotalLines({
   );
 }
 
-export function TotalLine({ title, value, borderStyle, textStyle, className }) {
+interface TotalLineProps {
+  title?: React.ReactNode;
+  value?: React.ReactNode;
+  borderStyle?: string;
+  textStyle?: string;
+  className?: string;
+}
+
+export function TotalLine({ title, value, borderStyle, textStyle, className }: TotalLineProps) {
   return (
     <TotalLinePrimitive
       borderStyle={borderStyle}

--- a/packages/webapp/src/components/TotalLines/index.tsx
+++ b/packages/webapp/src/components/TotalLines/index.tsx
@@ -45,7 +45,13 @@ interface TotalLineProps {
   className?: string;
 }
 
-export function TotalLine({ title, value, borderStyle, textStyle, className }: TotalLineProps) {
+export function TotalLine({
+  title,
+  value,
+  borderStyle,
+  textStyle,
+  className,
+}: TotalLineProps) {
   return (
     <TotalLinePrimitive
       borderStyle={borderStyle}

--- a/packages/webapp/src/components/Utils/Choose.tsx
+++ b/packages/webapp/src/components/Utils/Choose.tsx
@@ -24,7 +24,16 @@ Choose.propTypes = {
 
 Choose.When = If;
 
-Choose.Otherwise = ({ render, children }) => (render ? render() : children);
+Choose.Otherwise = ({
+  render,
+  children,
+}: {
+  render?: () => React.ReactNode;
+  children?: React.ReactNode;
+}): React.ReactElement | null => {
+  const result = render ? render() : children;
+  return result as React.ReactElement | null;
+};
 
 Choose.Otherwise.propTypes = {
   children: PropTypes.node,

--- a/packages/webapp/src/containers/Accounting/JournalsLanding/ManualJournalsList.tsx
+++ b/packages/webapp/src/containers/Accounting/JournalsLanding/ManualJournalsList.tsx
@@ -9,6 +9,8 @@ import { transformTableStateToQuery, compose } from '@/utils';
 import { ManualJournalsListProvider } from './ManualJournalsListProvider';
 import { ManualJournalsDataTable } from './ManualJournalsDataTable';
 import { ManualJournalActionsBar as ManualJournalsActionsBar } from './ManualJournalActionsBar';
+import { ManualJournalsListDrawers } from './ManualJournalsListDrawers';
+import { ManualJournalsListDialogs } from './ManualJournalsListDialogs';
 import { withManualJournals } from './withManualJournals';
 
 /**
@@ -25,6 +27,8 @@ function ManualJournalsTable({
       tableStateChanged={journalsTableStateChanged}
     >
       <ManualJournalsActionsBar />
+      <ManualJournalsListDrawers />
+      <ManualJournalsListDialogs />
 
       <DashboardPageContent>
         <ManualJournalsDataTable />

--- a/packages/webapp/src/containers/Accounting/JournalsLanding/ManualJournalsListDialogs.tsx
+++ b/packages/webapp/src/containers/Accounting/JournalsLanding/ManualJournalsListDialogs.tsx
@@ -1,0 +1,12 @@
+import { ManualJournalBulkDeleteDialog } from '@/containers/Dialogs/ManualJournals/ManualJournalBulkDeleteDialog';
+import { DialogsName } from '@/constants/dialogs';
+
+export function ManualJournalsListDialogs() {
+  return (
+    <>
+      <ManualJournalBulkDeleteDialog
+        dialogName={DialogsName.ManualJournalBulkDelete}
+      />
+    </>
+  );
+}

--- a/packages/webapp/src/containers/Accounting/JournalsLanding/ManualJournalsListDrawers.tsx
+++ b/packages/webapp/src/containers/Accounting/JournalsLanding/ManualJournalsListDrawers.tsx
@@ -1,0 +1,10 @@
+import { index as ManualJournalDrawer } from '@/containers/Drawers/ManualJournalDrawer';
+import { DRAWERS } from '@/constants/drawers';
+
+export function ManualJournalsListDrawers() {
+  return (
+    <>
+      <ManualJournalDrawer name={DRAWERS.JOURNAL_DETAILS} />
+    </>
+  );
+}

--- a/packages/webapp/src/containers/Accounts/AccountsChart.tsx
+++ b/packages/webapp/src/containers/Accounts/AccountsChart.tsx
@@ -4,6 +4,8 @@ import { DashboardPageContent, DashboardContentTable } from '@/components';
 import { AccountsChartProvider } from './AccountsChartProvider';
 import { AccountsActionsBar } from './AccountsActionsBar';
 import { AccountsDataTable } from './AccountsDataTable';
+import { AccountsChartDrawers } from './AccountsChartDrawers';
+import { AccountsChartDialogs } from './AccountsChartDialogs';
 import { withAccounts } from '@/containers/Accounts/withAccounts';
 import { withAccountsTableActions } from './withAccountsTableActions';
 import { transformAccountsStateToQuery } from './utils';
@@ -40,6 +42,8 @@ function AccountsChartInner({
       tableStateChanged={accountsTableStateChanged}
     >
       <AccountsActionsBar />
+      <AccountsChartDrawers />
+      <AccountsChartDialogs />
 
       <DashboardPageContent>
         <DashboardContentTable>

--- a/packages/webapp/src/containers/Accounts/AccountsChartDialogs.tsx
+++ b/packages/webapp/src/containers/Accounts/AccountsChartDialogs.tsx
@@ -1,0 +1,10 @@
+import { AccountBulkDeleteDialog } from '@/containers/Dialogs/Accounts/AccountBulkDeleteDialog';
+import { DialogsName } from '@/constants/dialogs';
+
+export function AccountsChartDialogs() {
+  return (
+    <>
+      <AccountBulkDeleteDialog dialogName={DialogsName.AccountBulkDelete} />
+    </>
+  );
+}

--- a/packages/webapp/src/containers/Accounts/AccountsChartDrawers.tsx
+++ b/packages/webapp/src/containers/Accounts/AccountsChartDrawers.tsx
@@ -1,0 +1,10 @@
+import { index as AccountDrawer } from '@/containers/Drawers/AccountDrawer';
+import { DRAWERS } from '@/constants/drawers';
+
+export function AccountsChartDrawers() {
+  return (
+    <>
+      <AccountDrawer name={DRAWERS.ACCOUNT_DETAILS} />
+    </>
+  );
+}

--- a/packages/webapp/src/containers/CashFlow/AccountTransactions/AccountTransactionsList.tsx
+++ b/packages/webapp/src/containers/CashFlow/AccountTransactions/AccountTransactionsList.tsx
@@ -18,6 +18,7 @@ import { AppContentShell } from '@/components/AppShell';
 import { AccountTransactionsAside } from './AccountTransactionsAside';
 import { AccountTransactionsLoadingBar } from './components';
 import { withBanking } from '../withBanking';
+import { CashFlowDrawers } from '@/containers/CashFlow/CashFlowDrawers';
 
 /**
  * Account transactions list.
@@ -28,6 +29,8 @@ function AccountTransactionsListRoot({
 }) {
   return (
     <AccountTransactionsProvider>
+      <CashFlowDrawers />
+
       <AppContentShell hideAside={!openMatchingTransactionAside}>
         <AccountTransactionsMain />
         <AccountTransactionsAside />

--- a/packages/webapp/src/containers/CashFlow/CashFlowAccounts/CashFlowAccountsList.tsx
+++ b/packages/webapp/src/containers/CashFlow/CashFlowAccounts/CashFlowAccountsList.tsx
@@ -1,19 +1,16 @@
 // @ts-nocheck
 import React, { useEffect } from 'react';
 import { compose } from 'lodash/fp';
-
 import '@/style/pages/CashFlow/CashFlowAccounts/List.scss';
-
 import { DashboardPageContent } from '@/components';
 import { CashFlowAccountsProvider } from './CashFlowAccountsProvider';
-
 import { CashflowAccountsGrid } from './CashflowAccountsGrid';
 import { CashFlowAccountsActionsBar } from './CashFlowAccountsActionsBar';
 import { CashflowAccountsPlaidLink } from './CashflowAccountsPlaidLink';
 import { CashflowAccountsLoadingBar } from './CashFlowAccountsLoadingBar';
-
 import { withCashflowAccounts } from '@/containers/CashFlow/AccountTransactions/withCashflowAccounts';
 import { withCashflowAccountsTableActions } from '@/containers/CashFlow/AccountTransactions/withCashflowAccountsTableActions';
+import { CashFlowDrawers } from '@/containers/CashFlow/CashFlowDrawers';
 
 /**
  * Cashflow accounts list.
@@ -35,6 +32,7 @@ function CashFlowAccountsListInner({
 
   return (
     <CashFlowAccountsProvider tableState={cashflowAccountsTableState}>
+      <CashFlowDrawers />
       <CashFlowAccountsActionsBar />
       <CashflowAccountsLoadingBar />
 

--- a/packages/webapp/src/containers/CashFlow/CashFlowDrawers.tsx
+++ b/packages/webapp/src/containers/CashFlow/CashFlowDrawers.tsx
@@ -1,0 +1,42 @@
+import { index as AccountDrawer } from '@/containers/Drawers/AccountDrawer';
+import { index as ManualJournalDrawer } from '@/containers/Drawers/ManualJournalDrawer';
+import { index as ExpenseDrawer } from '@/containers/Drawers/ExpenseDrawer';
+import { index as ReceiptDetailDrawer } from '@/containers/Drawers/ReceiptDetailDrawer';
+import { index as PaymentReceiveDetailDrawer } from '@/containers/Drawers/PaymentReceiveDetailDrawer';
+import { index as PaymentMadeDetailDrawer } from '@/containers/Drawers/PaymentMadeDetailDrawer';
+import { index as InventoryAdjustmentDetailDrawer } from '@/containers/Drawers/InventoryAdjustmentDetailDrawer';
+import { index as CashflowTransactionDetailDrawer } from '@/containers/Drawers/CashflowTransactionDetailDrawer';
+import { index as RefundCreditNoteDetailDrawer } from '@/containers/Drawers/RefundCreditNoteDetailDrawer';
+import { index as RefundVendorCreditDetailDrawer } from '@/containers/Drawers/RefundVendorCreditDetailDrawer';
+import { CategorizeTransactionDrawer } from '@/containers/CashFlow/CategorizeTransaction/drawers/CategorizeTransactionDrawer/CategorizeTransactionDrawer';
+import { DRAWERS } from '@/constants/drawers';
+
+export function CashFlowDrawers() {
+  return (
+    <>
+      <AccountDrawer name={DRAWERS.ACCOUNT_DETAILS} />
+      <ManualJournalDrawer name={DRAWERS.JOURNAL_DETAILS} />
+      <ExpenseDrawer name={DRAWERS.EXPENSE_DETAILS} />
+      <ReceiptDetailDrawer name={DRAWERS.RECEIPT_DETAILS} />
+      <PaymentReceiveDetailDrawer
+        name={DRAWERS.PAYMENT_RECEIVED_DETAILS}
+      />
+      <PaymentMadeDetailDrawer name={DRAWERS.PAYMENT_MADE_DETAILS} />
+      <InventoryAdjustmentDetailDrawer
+        name={DRAWERS.INVENTORY_ADJUSTMENT_DETAILS}
+      />
+      <CashflowTransactionDetailDrawer
+        name={DRAWERS.CASHFLOW_TRNASACTION_DETAILS}
+      />
+      <RefundCreditNoteDetailDrawer
+        name={DRAWERS.REFUND_CREDIT_NOTE_DETAILS}
+      />
+      <RefundVendorCreditDetailDrawer
+        name={DRAWERS.REFUND_VENDOR_CREDIT_DETAILS}
+      />
+      <CategorizeTransactionDrawer
+        name={DRAWERS.CATEGORIZE_TRANSACTION}
+      />
+    </>
+  );
+}

--- a/packages/webapp/src/containers/CashFlow/CashFlowDrawers.tsx
+++ b/packages/webapp/src/containers/CashFlow/CashFlowDrawers.tsx
@@ -18,9 +18,7 @@ export function CashFlowDrawers() {
       <ManualJournalDrawer name={DRAWERS.JOURNAL_DETAILS} />
       <ExpenseDrawer name={DRAWERS.EXPENSE_DETAILS} />
       <ReceiptDetailDrawer name={DRAWERS.RECEIPT_DETAILS} />
-      <PaymentReceiveDetailDrawer
-        name={DRAWERS.PAYMENT_RECEIVED_DETAILS}
-      />
+      <PaymentReceiveDetailDrawer name={DRAWERS.PAYMENT_RECEIVED_DETAILS} />
       <PaymentMadeDetailDrawer name={DRAWERS.PAYMENT_MADE_DETAILS} />
       <InventoryAdjustmentDetailDrawer
         name={DRAWERS.INVENTORY_ADJUSTMENT_DETAILS}
@@ -28,15 +26,11 @@ export function CashFlowDrawers() {
       <CashflowTransactionDetailDrawer
         name={DRAWERS.CASHFLOW_TRNASACTION_DETAILS}
       />
-      <RefundCreditNoteDetailDrawer
-        name={DRAWERS.REFUND_CREDIT_NOTE_DETAILS}
-      />
+      <RefundCreditNoteDetailDrawer name={DRAWERS.REFUND_CREDIT_NOTE_DETAILS} />
       <RefundVendorCreditDetailDrawer
         name={DRAWERS.REFUND_VENDOR_CREDIT_DETAILS}
       />
-      <CategorizeTransactionDrawer
-        name={DRAWERS.CATEGORIZE_TRANSACTION}
-      />
+      <CategorizeTransactionDrawer name={DRAWERS.CATEGORIZE_TRANSACTION} />
     </>
   );
 }

--- a/packages/webapp/src/containers/Customers/CustomersLanding/CustomersList.tsx
+++ b/packages/webapp/src/containers/Customers/CustomersLanding/CustomersList.tsx
@@ -8,6 +8,7 @@ import { DashboardPageContent } from '@/components';
 import { CustomersActionsBar } from './CustomersActionsBar';
 import { CustomersTable } from './CustomersTable';
 import { CustomersListProvider } from './CustomersListProvider';
+import { CustomersListDialogs } from './CustomersListDialogs';
 
 import { withCustomers } from './withCustomers';
 import { withCustomersActions } from './withCustomersActions';
@@ -41,6 +42,7 @@ function CustomersListInner({
       tableStateChanged={customersTableStateChanged}
     >
       <CustomersActionsBar />
+      <CustomersListDialogs />
 
       <DashboardPageContent>
         <CustomersTable />

--- a/packages/webapp/src/containers/Customers/CustomersLanding/CustomersListDialogs.tsx
+++ b/packages/webapp/src/containers/Customers/CustomersLanding/CustomersListDialogs.tsx
@@ -1,0 +1,12 @@
+import { CustomerBulkDeleteDialog } from '@/containers/Dialogs/Customers/CustomerBulkDeleteDialog';
+import { DialogsName } from '@/constants/dialogs';
+
+export function CustomersListDialogs() {
+  return (
+    <>
+      <CustomerBulkDeleteDialog
+        dialogName={DialogsName.CustomerBulkDelete}
+      />
+    </>
+  );
+}

--- a/packages/webapp/src/containers/Customers/CustomersLanding/CustomersListDialogs.tsx
+++ b/packages/webapp/src/containers/Customers/CustomersLanding/CustomersListDialogs.tsx
@@ -4,9 +4,7 @@ import { DialogsName } from '@/constants/dialogs';
 export function CustomersListDialogs() {
   return (
     <>
-      <CustomerBulkDeleteDialog
-        dialogName={DialogsName.CustomerBulkDelete}
-      />
+      <CustomerBulkDeleteDialog dialogName={DialogsName.CustomerBulkDelete} />
     </>
   );
 }

--- a/packages/webapp/src/containers/Drawers/EstimateDetailDrawer/EstimateDetail.tsx
+++ b/packages/webapp/src/containers/Drawers/EstimateDetailDrawer/EstimateDetail.tsx
@@ -1,5 +1,3 @@
-// @ts-nocheck
-import React from 'react';
 import styled from 'styled-components';
 import intl from 'react-intl-universal';
 import { Tab } from '@blueprintjs/core';
@@ -11,7 +9,6 @@ import { EstimateDetailTab as EstimateDetailPanel } from './EstimateDetailPanel'
 
 /**
  * Estimate details tabs.
- * @returns {React.JSX}
  */
 function EstimateDetailsTabs() {
   return (

--- a/packages/webapp/src/containers/Drawers/EstimateDetailDrawer/EstimateDetailActionsBar.tsx
+++ b/packages/webapp/src/containers/Drawers/EstimateDetailDrawer/EstimateDetailActionsBar.tsx
@@ -1,6 +1,4 @@
-// @ts-nocheck
 import { useHistory } from 'react-router-dom';
-
 import {
   Button,
   NavbarGroup,
@@ -8,12 +6,10 @@ import {
   NavbarDivider,
   Intent,
 } from '@blueprintjs/core';
-
 import { useEstimateDetailDrawerContext } from './EstimateDetailDrawerProvider';
-
-import { withDialogActions } from '@/containers/Dialog/withDialogActions';
-import { withAlertActions } from '@/containers/Alert/withAlertActions';
-import { withDrawerActions } from '@/containers/Drawer/withDrawerActions';
+import { withDialogActions, WithDialogActionsProps } from '@/containers/Dialog/withDialogActions';
+import { withAlertActions, WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
+import { withDrawerActions, WithDrawerActionsProps } from '@/containers/Drawer/withDrawerActions';
 import {
   SaleEstimateAction,
   AbilitySubject,
@@ -27,9 +23,13 @@ import {
   Can,
   If,
 } from '@/components';
-
 import { compose } from '@/utils';
 import { DRAWERS } from '@/constants/drawers';
+
+interface EstimateDetailActionsBarInnerProps
+  extends WithDialogActionsProps,
+    WithAlertActionsProps,
+    WithDrawerActionsProps {}
 
 /**
  * Estimate read-only details actions bar of the drawer.
@@ -44,7 +44,7 @@ function EstimateDetailActionsBarInner({
   // #withDrawerActions
   closeDrawer,
   openDrawer,
-}) {
+}: EstimateDetailActionsBarInnerProps) {
   // Estimate details drawer context.
   const { estimateId, estimate } = useEstimateDetailDrawerContext();
 
@@ -83,6 +83,10 @@ function EstimateDetailActionsBarInner({
     openDrawer(DRAWERS.ESTIMATE_SEND_MAIL, { estimateId });
   };
 
+  if (!estimate) {
+    return null;
+  }
+
   return (
     <DrawerActionsBar>
       <NavbarGroup>
@@ -96,7 +100,7 @@ function EstimateDetailActionsBarInner({
           <NavbarDivider />
         </Can>
         <Can I={SaleInvoiceAction.Create} a={AbilitySubject.Invoice}>
-          <If condition={!estimate.is_converted_to_invoice}>
+          <If condition={!estimate.isConvertedToInvoice}>
             <Button
               className={Classes.MINIMAL}
               intent={Intent.SUCCESS}

--- a/packages/webapp/src/containers/Drawers/EstimateDetailDrawer/EstimateDetailActionsBar.tsx
+++ b/packages/webapp/src/containers/Drawers/EstimateDetailDrawer/EstimateDetailActionsBar.tsx
@@ -7,9 +7,18 @@ import {
   Intent,
 } from '@blueprintjs/core';
 import { useEstimateDetailDrawerContext } from './EstimateDetailDrawerProvider';
-import { withDialogActions, WithDialogActionsProps } from '@/containers/Dialog/withDialogActions';
-import { withAlertActions, WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
-import { withDrawerActions, WithDrawerActionsProps } from '@/containers/Drawer/withDrawerActions';
+import {
+  withDialogActions,
+  WithDialogActionsProps,
+} from '@/containers/Dialog/withDialogActions';
+import {
+  withAlertActions,
+  WithAlertActionsProps,
+} from '@/containers/Alert/withAlertActions';
+import {
+  withDrawerActions,
+  WithDrawerActionsProps,
+} from '@/containers/Drawer/withDrawerActions';
 import {
   SaleEstimateAction,
   AbilitySubject,

--- a/packages/webapp/src/containers/Drawers/EstimateDetailDrawer/EstimateDetailDrawerContent.tsx
+++ b/packages/webapp/src/containers/Drawers/EstimateDetailDrawer/EstimateDetailDrawerContent.tsx
@@ -1,17 +1,18 @@
-// @ts-nocheck
-import React from 'react';
 import { DrawerBody } from '@/components';
 
 import { EstimateDetail } from './EstimateDetail';
 import { EstimateDetailDrawerProvider } from './EstimateDetailDrawerProvider';
 
+interface EstimateDetailDrawerContentProps {
+  estimateId: number | undefined;
+}
+
 /**
  * Estimate detail drawer content.
  */
 export function EstimateDetailDrawerContent({
-  // #ownProp
   estimateId,
-}) {
+}: EstimateDetailDrawerContentProps) {
   return (
     <EstimateDetailDrawerProvider estimateId={estimateId}>
       <DrawerBody>

--- a/packages/webapp/src/containers/Drawers/EstimateDetailDrawer/EstimateDetailDrawerProvider.tsx
+++ b/packages/webapp/src/containers/Drawers/EstimateDetailDrawer/EstimateDetailDrawerProvider.tsx
@@ -1,28 +1,72 @@
-// @ts-nocheck
 import React from 'react';
 import intl from 'react-intl-universal';
 import { Features } from '@/constants';
-import { useEstimate } from '@/hooks/query';
+import { useEstimateDetail } from '@/hooks/query';
 import { useFeatureCan } from '@/hooks/state';
 import { DrawerHeaderContent, DrawerLoading } from '@/components';
 import { DRAWERS } from '@/constants/drawers';
+import type { SaleEstimate } from '@bigcapital/sdk-ts';
 
-const EstimateDetailDrawerContext = React.createContext();
+/**
+ * The SDK's ItemEntryDto shape, plus the formatted fields the backend actually
+ * returns and the detail drawer's table columns read.
+ */
+export type EstimateDetailEntry = SaleEstimate['entries'][number] & {
+  item?: { name?: string };
+  quantityFormatted?: string;
+  rateFormatted?: string;
+  discountFormatted?: string;
+  totalFormatted?: string;
+};
+
+/**
+ * Fields the OpenAPI schema's `SaleEstimateResponseDto` does not surface but
+ * the backend returns and the detail drawer consumes. Augmented locally until
+ * the schema is updated.
+ */
+export interface EstimateDetail extends Omit<SaleEstimate, 'entries'> {
+  isApproved?: boolean;
+  isRejected?: boolean;
+  isDelivered?: boolean;
+  isExpired?: boolean;
+  isConvertedToInvoice?: boolean;
+  subtotal?: number;
+  branch?: { name?: string };
+  customer?: { displayName?: string };
+  entries: EstimateDetailEntry[];
+}
+
+export interface EstimateDetailDrawerContextValue {
+  estimateId: number | undefined;
+  estimate: EstimateDetail | undefined;
+}
+
+const EstimateDetailDrawerContext = React.createContext<
+  EstimateDetailDrawerContextValue | undefined
+>(undefined);
+
+interface EstimateDetailDrawerProviderProps {
+  estimateId: number | undefined;
+}
 
 /**
  * Estimate detail provider.
  */
-function EstimateDetailDrawerProvider({ estimateId, ...props }) {
+function EstimateDetailDrawerProvider({
+  estimateId,
+  ...props
+}: EstimateDetailDrawerProviderProps & { children?: React.ReactNode }) {
   // Features guard.
   const { featureCan } = useFeatureCan();
 
   // Fetches the estimate by the given id.
-  const { data: estimate, isLoading: isEstimateLoading } = useEstimate(
+  const { data, isLoading: isEstimateLoading } = useEstimateDetail(
     estimateId,
     { enabled: !!estimateId },
   );
+  const estimate = data as EstimateDetail | undefined;
 
-  const provider = {
+  const provider: EstimateDetailDrawerContextValue = {
     estimateId,
     estimate,
   };
@@ -32,12 +76,12 @@ function EstimateDetailDrawerProvider({ estimateId, ...props }) {
       <DrawerHeaderContent
         name={DRAWERS.ESTIMATE_DETAILS}
         title={intl.get('estimate.drawer.title', {
-          number: estimate.estimate_number,
+          number: estimate?.estimateNumber,
         })}
         subTitle={
           featureCan(Features.Branches)
             ? intl.get('estimate.drawer.subtitle', {
-                value: estimate.branch?.name,
+                value: estimate?.branch?.name,
               })
             : null
         }
@@ -47,7 +91,14 @@ function EstimateDetailDrawerProvider({ estimateId, ...props }) {
   );
 }
 
-const useEstimateDetailDrawerContext = () =>
-  React.useContext(EstimateDetailDrawerContext);
+const useEstimateDetailDrawerContext = (): EstimateDetailDrawerContextValue => {
+  const ctx = React.useContext(EstimateDetailDrawerContext);
+  if (ctx === undefined) {
+    throw new Error(
+      'useEstimateDetailDrawerContext must be used within an EstimateDetailDrawerProvider',
+    );
+  }
+  return ctx;
+};
 
 export { EstimateDetailDrawerProvider, useEstimateDetailDrawerContext };

--- a/packages/webapp/src/containers/Drawers/EstimateDetailDrawer/EstimateDetailDrawerProvider.tsx
+++ b/packages/webapp/src/containers/Drawers/EstimateDetailDrawer/EstimateDetailDrawerProvider.tsx
@@ -60,10 +60,9 @@ function EstimateDetailDrawerProvider({
   const { featureCan } = useFeatureCan();
 
   // Fetches the estimate by the given id.
-  const { data, isLoading: isEstimateLoading } = useEstimateDetail(
-    estimateId,
-    { enabled: !!estimateId },
-  );
+  const { data, isLoading: isEstimateLoading } = useEstimateDetail(estimateId, {
+    enabled: !!estimateId,
+  });
   const estimate = data as EstimateDetail | undefined;
 
   const provider: EstimateDetailDrawerContextValue = {

--- a/packages/webapp/src/containers/Drawers/EstimateDetailDrawer/EstimateDetailFooter.tsx
+++ b/packages/webapp/src/containers/Drawers/EstimateDetailDrawer/EstimateDetailFooter.tsx
@@ -1,9 +1,7 @@
-// @ts-nocheck
 import React from 'react';
 
 import {
   CommercialDocFooter,
-  T,
   If,
   DetailsMenu,
   DetailItem,
@@ -13,23 +11,26 @@ import intl from 'react-intl-universal';
 
 /**
  * Estimate details footer.
- * @returns {React.JSX}
  */
 export function EstimateDetailFooter() {
   const { estimate } = useEstimateDetailDrawerContext();
 
+  if (!estimate) {
+    return null;
+  }
+
   return (
     <CommercialDocFooter>
       <DetailsMenu direction={'horizantal'} minLabelSize={'180px'}>
-        <If condition={estimate.terms_conditions}>
+        <If condition={!!estimate.termsConditions}>
           <DetailItem
             label={intl.get('estimate.details.terms_conditions')}
             multiline
           >
-            {estimate.terms_conditions}
+            {estimate.termsConditions}
           </DetailItem>
         </If>
-        <If condition={estimate.note}>
+        <If condition={!!estimate.note}>
           <DetailItem label={intl.get('estimate.details.note')} multiline>
             {estimate.note}
           </DetailItem>

--- a/packages/webapp/src/containers/Drawers/EstimateDetailDrawer/EstimateDetailFooter.tsx
+++ b/packages/webapp/src/containers/Drawers/EstimateDetailDrawer/EstimateDetailFooter.tsx
@@ -1,11 +1,6 @@
 import React from 'react';
 
-import {
-  CommercialDocFooter,
-  If,
-  DetailsMenu,
-  DetailItem,
-} from '@/components';
+import { CommercialDocFooter, If, DetailsMenu, DetailItem } from '@/components';
 import { useEstimateDetailDrawerContext } from './EstimateDetailDrawerProvider';
 import intl from 'react-intl-universal';
 

--- a/packages/webapp/src/containers/Drawers/EstimateDetailDrawer/EstimateDetailHeader.tsx
+++ b/packages/webapp/src/containers/Drawers/EstimateDetailDrawer/EstimateDetailHeader.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import React from 'react';
 import intl from 'react-intl-universal';
 import styled from 'styled-components';
@@ -7,8 +6,6 @@ import { defaultTo } from 'lodash';
 import {
   CommercialDocHeader,
   CommercialDocTopHeader,
-  FormatDate,
-  T,
   DetailsMenu,
   DetailItem,
   Row,
@@ -25,12 +22,16 @@ import { EstimateDetailsStatus } from './components';
 export function EstimateDetailHeader() {
   const { estimate } = useEstimateDetailDrawerContext();
 
+  if (!estimate) {
+    return null;
+  }
+
   return (
     <CommercialDocHeader>
       <CommercialDocTopHeader>
         <DetailsMenu>
           <AmountEstimateDetail label={intl.get('amount')}>
-            <span class="big-number">{estimate.total_formatted}</span>
+            <span className="big-number">{estimate.totalFormatted}</span>
           </AmountEstimateDetail>
 
           <EstimateStatusDetail>
@@ -44,27 +45,27 @@ export function EstimateDetailHeader() {
           <DetailsMenu direction={'horizantal'} minLabelSize={'180px'}>
             <DetailItem
               label={intl.get('estimate.details.estimate_number')}
-              children={defaultTo(estimate.estimate_number, '-')}
+              children={defaultTo(estimate.estimateNumber, '-')}
             />
 
             <DetailItem label={intl.get('customer_name')}>
-              <CustomerDrawerLink customerId={estimate.customer_id}>
-                {estimate.customer?.display_name}
+              <CustomerDrawerLink customerId={estimate.customerId}>
+                {estimate.customer?.displayName}
               </CustomerDrawerLink>
             </DetailItem>
 
             <DetailItem
               label={intl.get('estimate_date')}
-              children={estimate.formatted_estimate_date}
+              children={estimate.formattedEstimateDate}
             />
 
             <DetailItem
               label={intl.get('expiration_date')}
-              children={estimate.formatted_expiration_date}
+              children={estimate.formattedExpirationDate}
             />
             <ExchangeRateDetailItem
-              exchangeRate={estimate?.exchange_rate}
-              toCurrency={estimate?.currency_code}
+              exchangeRate={estimate?.exchangeRate}
+              toCurrency={estimate?.currencyCode}
             />
           </DetailsMenu>
         </Col>
@@ -81,7 +82,7 @@ export function EstimateDetailHeader() {
             />
             <DetailItem
               label={intl.get('estimate.details.created_at')}
-              children={estimate.formatted_created_at}
+              children={estimate.formattedCreatedAt}
             />
           </DetailsMenu>
         </Col>

--- a/packages/webapp/src/containers/Drawers/EstimateDetailDrawer/EstimateDetailPanel.tsx
+++ b/packages/webapp/src/containers/Drawers/EstimateDetailDrawer/EstimateDetailPanel.tsx
@@ -1,6 +1,3 @@
-// @ts-nocheck
-import React from 'react';
-
 import { CommercialDocBox } from '@/components';
 
 import { EstimateDetailHeader } from './EstimateDetailHeader';

--- a/packages/webapp/src/containers/Drawers/EstimateDetailDrawer/EstimateDetailTable.tsx
+++ b/packages/webapp/src/containers/Drawers/EstimateDetailDrawer/EstimateDetailTable.tsx
@@ -1,6 +1,3 @@
-// @ts-nocheck
-import React from 'react';
-
 import { CommercialDocEntriesTable } from '@/components';
 
 import { useEstimateDetailDrawerContext } from './EstimateDetailDrawerProvider';
@@ -12,9 +9,8 @@ import { TableStyle } from '@/constants';
  * Estimate detail table.
  */
 export function EstimateDetailTable() {
-  const {
-    estimate: { entries },
-  } = useEstimateDetailDrawerContext();
+  const { estimate } = useEstimateDetailDrawerContext();
+  const entries = estimate?.entries || [];
 
   // Estimate entries table columns.
   const columns = useEstimateReadonlyEntriesColumns();
@@ -25,7 +21,7 @@ export function EstimateDetailTable() {
       data={entries}
       initialHiddenColumns={
         // If any entry has no discount, hide the discount column.
-        entries?.some((e) => e.discount_formatted) ? [] : ['discount']
+        entries?.some((e) => e.discountFormatted) ? [] : ['discount']
       }
       styleName={TableStyle.Constrant}
     />

--- a/packages/webapp/src/containers/Drawers/EstimateDetailDrawer/EstimateDetailTableFooter.tsx
+++ b/packages/webapp/src/containers/Drawers/EstimateDetailDrawer/EstimateDetailTableFooter.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import React from 'react';
 import styled from 'styled-components';
 
@@ -17,35 +16,39 @@ import { useEstimateDetailDrawerContext } from './EstimateDetailDrawerProvider';
 export function EstimateDetailTableFooter() {
   const { estimate } = useEstimateDetailDrawerContext();
 
+  if (!estimate) {
+    return null;
+  }
+
   return (
     <EstimateDetailsFooterRoot>
       <EstimateTotalLines labelColWidth={'180px'} amountColWidth={'180px'}>
         <TotalLine
           title={<T id={'estimate.details.subtotal'} />}
-          value={estimate.formatted_subtotal}
+          value={estimate.formattedSubtotal}
           borderStyle={TotalLineBorderStyle.SingleDark}
         />
-        {estimate?.discount_amount_formatted && (
+        {estimate?.discountAmountFormatted && (
           <TotalLine
             title={
-              estimate.discount_percentage_formatted
-                ? `Discount [${estimate.discount_percentage_formatted}]`
+              estimate.discountPercentageFormatted
+                ? `Discount [${estimate.discountPercentageFormatted}]`
                 : 'Discount'
             }
-            value={estimate.discount_amount_formatted}
+            value={estimate.discountAmountFormatted}
             textStyle={TotalLineTextStyle.Regular}
           />
         )}
-        {estimate?.adjustment_formatted && (
+        {estimate?.adjustmentFormatted && (
           <TotalLine
             title="Adjustment"
-            value={estimate.adjustment_formatted}
+            value={estimate.adjustmentFormatted}
             textStyle={TotalLineTextStyle.Regular}
           />
         )}
         <TotalLine
           title={<T id={'estimate.details.total'} />}
-          value={estimate.total_formatted}
+          value={estimate.totalFormatted}
           borderStyle={TotalLineBorderStyle.DoubleDark}
           textStyle={TotalLineTextStyle.Bold}
         />

--- a/packages/webapp/src/containers/Drawers/EstimateDetailDrawer/EstimateDrawerClasses.tsx
+++ b/packages/webapp/src/containers/Drawers/EstimateDetailDrawer/EstimateDrawerClasses.tsx
@@ -1,5 +1,4 @@
-// @ts-nocheck
-const globalStateClassesMapping = {
+const globalStateClassesMapping: Record<string, string> = {
   active: 'active',
   checked: 'checked',
   completed: 'completed',
@@ -12,13 +11,16 @@ const globalStateClassesMapping = {
   selected: 'selected',
 };
 
-function generateUtilityClass(componentName, slot) {
+function generateUtilityClass(componentName: string, slot: string): string {
   const globalStateClass = globalStateClassesMapping[slot];
   return globalStateClass || `${componentName}__${slot}`;
 }
 
-function generateUtilityClasses(componentName, modifiers) {
-  const result = {
+function generateUtilityClasses(
+  componentName: string,
+  modifiers: string[],
+): Record<string, string> {
+  const result: Record<string, string> = {
     root: componentName,
   };
   modifiers.forEach((modifier) => {

--- a/packages/webapp/src/containers/Drawers/EstimateDetailDrawer/components.tsx
+++ b/packages/webapp/src/containers/Drawers/EstimateDetailDrawer/components.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import {
   Intent,
   Button,
@@ -11,36 +10,41 @@ import {
   MenuDivider,
   Classes,
 } from '@blueprintjs/core';
-import * as R from 'ramda';
 
 import { Icon, T, Choose, Can } from '@/components';
 import { AbilitySubject, SaleEstimateAction } from '@/constants/abilityOption';
-import { withAlertActions } from '@/containers/Alert/withAlertActions';
-import { useEstimateDetailDrawerContext } from './EstimateDetailDrawerProvider';
+import { withAlertActions, WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
+import { useEstimateDetailDrawerContext, EstimateDetail } from './EstimateDetailDrawerProvider';
+
+interface EstimateDetailsStatusProps {
+  estimate: Pick<
+    EstimateDetail,
+    'isApproved' | 'isRejected' | 'isExpired' | 'isDelivered'
+  >;
+}
 
 /**
  * Estimate details status.
- * @return {React.JSX}
  */
-export function EstimateDetailsStatus({ estimate }) {
+export function EstimateDetailsStatus({ estimate }: EstimateDetailsStatusProps) {
   return (
     <Choose>
-      <Choose.When condition={estimate.is_approved}>
+      <Choose.When condition={!!estimate.isApproved}>
         <Tag intent={Intent.SUCCESS} round={true}>
           <T id={'approved'} />
         </Tag>
       </Choose.When>
-      <Choose.When condition={estimate.is_rejected}>
+      <Choose.When condition={!!estimate.isRejected}>
         <Tag intent={Intent.DANGER} round={true}>
           <T id={'rejected'} />
         </Tag>
       </Choose.When>
-      <Choose.When condition={estimate.is_expired}>
+      <Choose.When condition={!!estimate.isExpired}>
         <Tag intent={Intent.WARNING} round={true}>
           <T id={'estimate.status.expired'} />
         </Tag>
       </Choose.When>
-      <Choose.When condition={estimate.is_delivered}>
+      <Choose.When condition={!!estimate.isDelivered}>
         <Tag intent={Intent.SUCCESS} round={true}>
           <T id={'delivered'} />
         </Tag>
@@ -54,14 +58,22 @@ export function EstimateDetailsStatus({ estimate }) {
   );
 }
 
-export const EstimateMoreMenuItems = R.compose(withAlertActions)(({
+interface EstimateMoreMenuItemsInnerProps extends WithAlertActionsProps {
+  payload: { onNotifyViaSMS: () => void };
+}
+
+function EstimateMoreMenuItemsInner({
   // # withAlertActions,
   openAlert,
 
   // # rest
   payload: { onNotifyViaSMS },
-}) => {
+}: EstimateMoreMenuItemsInnerProps) {
   const { estimateId, estimate } = useEstimateDetailDrawerContext();
+
+  if (!estimate) {
+    return null;
+  }
 
   // Handle cancel/confirm estimate approve.
   const handleApproveEstimate = () => {
@@ -84,7 +96,7 @@ export const EstimateMoreMenuItems = R.compose(withAlertActions)(({
           <MenuDivider />
           <Choose>
             <Choose.When
-              condition={estimate.is_delivered && estimate.is_rejected}
+              condition={!!estimate.isDelivered && !!estimate.isRejected}
             >
               <Can I={SaleEstimateAction.Edit} a={AbilitySubject.Estimate}>
                 <MenuItem
@@ -95,7 +107,7 @@ export const EstimateMoreMenuItems = R.compose(withAlertActions)(({
               </Can>
             </Choose.When>
             <Choose.When
-              condition={estimate.is_delivered && estimate.is_approved}
+              condition={!!estimate.isDelivered && !!estimate.isApproved}
             >
               <Can I={SaleEstimateAction.Edit} a={AbilitySubject.Estimate}>
                 <MenuItem
@@ -105,7 +117,7 @@ export const EstimateMoreMenuItems = R.compose(withAlertActions)(({
                 />
               </Can>
             </Choose.When>
-            <Choose.When condition={estimate.is_delivered}>
+            <Choose.When condition={!!estimate.isDelivered}>
               <Can I={SaleEstimateAction.Edit} a={AbilitySubject.Estimate}>
                 <MenuItem
                   className={Classes.MINIMAL}
@@ -133,4 +145,6 @@ export const EstimateMoreMenuItems = R.compose(withAlertActions)(({
       <Button icon={<Icon icon="more-vert" iconSize={16} />} minimal={true} />
     </Popover>
   );
-});
+}
+
+export const EstimateMoreMenuItems = withAlertActions(EstimateMoreMenuItemsInner);

--- a/packages/webapp/src/containers/Drawers/EstimateDetailDrawer/components.tsx
+++ b/packages/webapp/src/containers/Drawers/EstimateDetailDrawer/components.tsx
@@ -13,8 +13,14 @@ import {
 
 import { Icon, T, Choose, Can } from '@/components';
 import { AbilitySubject, SaleEstimateAction } from '@/constants/abilityOption';
-import { withAlertActions, WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
-import { useEstimateDetailDrawerContext, EstimateDetail } from './EstimateDetailDrawerProvider';
+import {
+  withAlertActions,
+  WithAlertActionsProps,
+} from '@/containers/Alert/withAlertActions';
+import {
+  useEstimateDetailDrawerContext,
+  EstimateDetail,
+} from './EstimateDetailDrawerProvider';
 
 interface EstimateDetailsStatusProps {
   estimate: Pick<
@@ -26,7 +32,9 @@ interface EstimateDetailsStatusProps {
 /**
  * Estimate details status.
  */
-export function EstimateDetailsStatus({ estimate }: EstimateDetailsStatusProps) {
+export function EstimateDetailsStatus({
+  estimate,
+}: EstimateDetailsStatusProps) {
   return (
     <Choose>
       <Choose.When condition={!!estimate.isApproved}>
@@ -147,4 +155,6 @@ function EstimateMoreMenuItemsInner({
   );
 }
 
-export const EstimateMoreMenuItems = withAlertActions(EstimateMoreMenuItemsInner);
+export const EstimateMoreMenuItems = withAlertActions(
+  EstimateMoreMenuItemsInner,
+);

--- a/packages/webapp/src/containers/Drawers/EstimateDetailDrawer/index.tsx
+++ b/packages/webapp/src/containers/Drawers/EstimateDetailDrawer/index.tsx
@@ -1,7 +1,6 @@
-// @ts-nocheck
 import React from 'react';
 import { Drawer, DrawerSuspense } from '@/components';
-import { withDrawers } from '@/containers/Drawer/withDrawers';
+import { withDrawers, WithDrawersProps } from '@/containers/Drawer/withDrawers';
 
 import { compose } from '@/utils';
 
@@ -11,12 +10,18 @@ const EstimateDetailDrawerContent = React.lazy(() =>
   })),
 );
 
+interface EstimateDetailDrawerProps extends WithDrawersProps {
+  name: string;
+}
+
 function EstimateDetailDrawer({
   name,
   // #withDrawer
   isOpen,
-  payload: { estimateId },
-}) {
+  payload,
+}: EstimateDetailDrawerProps) {
+  const estimateId = payload?.estimateId as number | undefined;
+
   return (
     <Drawer
       isOpen={isOpen}

--- a/packages/webapp/src/containers/Drawers/EstimateDetailDrawer/utils.tsx
+++ b/packages/webapp/src/containers/Drawers/EstimateDetailDrawer/utils.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import React from 'react';
 import intl from 'react-intl-universal';
 import { getColumnWidth } from '@/utils';
@@ -9,10 +8,8 @@ import { useEstimateDetailDrawerContext } from './EstimateDetailDrawerProvider';
  * Retrieve table columns of estimate readonly entries details.
  */
 export const useEstimateReadonlyEntriesColumns = () => {
-  // estimate details drawer context.
-  const {
-    estimate: { entries },
-  } = useEstimateDetailDrawerContext();
+  const { estimate } = useEstimateDetailDrawerContext();
+  const entries = estimate?.entries ?? [];
 
   return React.useMemo(
     () => [
@@ -35,8 +32,8 @@ export const useEstimateReadonlyEntriesColumns = () => {
       },
       {
         Header: intl.get('quantity'),
-        accessor: 'quantity_formatted',
-        width: getColumnWidth(entries, 'quantity_formatted', {
+        accessor: 'quantityFormatted',
+        width: getColumnWidth(entries, 'quantityFormatted', {
           minWidth: 60,
           magicSpacing: 5,
         }),
@@ -46,8 +43,8 @@ export const useEstimateReadonlyEntriesColumns = () => {
       },
       {
         Header: intl.get('rate'),
-        accessor: 'rate_formatted',
-        width: getColumnWidth(entries, 'rate_formatted', {
+        accessor: 'rateFormatted',
+        width: getColumnWidth(entries, 'rateFormatted', {
           minWidth: 60,
           magicSpacing: 5,
         }),
@@ -58,19 +55,19 @@ export const useEstimateReadonlyEntriesColumns = () => {
       {
         id: 'discount',
         Header: 'Discount',
-        accessor: 'discount_formatted',
+        accessor: 'discountFormatted',
         align: 'right',
         disableSortBy: true,
         textOverview: true,
-        width: getColumnWidth(entries, 'discount_formatted', {
+        width: getColumnWidth(entries, 'discountFormatted', {
           minWidth: 60,
           magicSpacing: 5,
         }),
       },
       {
         Header: intl.get('amount'),
-        accessor: 'total_formatted',
-        width: getColumnWidth(entries, 'total_formatted', {
+        accessor: 'totalFormatted',
+        width: getColumnWidth(entries, 'totalFormatted', {
           minWidth: 60,
           magicSpacing: 5,
         }),
@@ -79,6 +76,6 @@ export const useEstimateReadonlyEntriesColumns = () => {
         textOverview: true,
       },
     ],
-    [],
+    [entries],
   );
 };

--- a/packages/webapp/src/containers/Drawers/ItemDetailDrawer/ItemContentDetails.tsx
+++ b/packages/webapp/src/containers/Drawers/ItemDetailDrawer/ItemContentDetails.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import React from 'react';
 
 import { ItemDetailTab } from './ItemDetailTab';

--- a/packages/webapp/src/containers/Drawers/ItemDetailDrawer/ItemDetailActionsBar.tsx
+++ b/packages/webapp/src/containers/Drawers/ItemDetailDrawer/ItemDetailActionsBar.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import React from 'react';
 import { useHistory } from 'react-router-dom';
 import {
@@ -14,6 +13,8 @@ import { ItemAction, AbilitySubject } from '@/constants/abilityOption';
 
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
 import { withDrawerActions } from '@/containers/Drawer/withDrawerActions';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
+import type { WithDrawerActionsProps } from '@/containers/Drawer/withDrawerActions';
 
 import {
   Icon,
@@ -26,16 +27,17 @@ import { ItemDetailActionsMoreBtn } from './ItemDetailActionsMoreBtn';
 import { compose } from '@/utils';
 import { DRAWERS } from '@/constants/drawers';
 
+interface ItemDetailActionsBarInnerProps
+  extends Pick<WithAlertActionsProps, 'openAlert'>,
+    Pick<WithDrawerActionsProps, 'closeDrawer'> {}
+
 /**
  * Item action-bar of readonly details drawer.
  */
 function ItemDetailActionsBarInner({
-  // #withAlertActions
   openAlert,
-
-  // #withDrawerActions
   closeDrawer,
-}) {
+}: ItemDetailActionsBarInnerProps) {
   // Item readonly drawer context.
   const { itemId } = useItemDetailDrawerContext();
 

--- a/packages/webapp/src/containers/Drawers/ItemDetailDrawer/ItemDetailDrawerProvider.tsx
+++ b/packages/webapp/src/containers/Drawers/ItemDetailDrawer/ItemDetailDrawerProvider.tsx
@@ -1,16 +1,34 @@
-// @ts-nocheck
 import React from 'react';
+import type { Item } from '@bigcapital/sdk-ts';
 import { DrawerHeaderContent, DrawerLoading } from '@/components';
 import { useItem } from '@/hooks/query';
 import { inactiveStatus } from './utlis';
 import { DRAWERS } from '@/constants/drawers';
 
-const ItemDetailDrawerContext = React.createContext();
+export interface ItemDetailDrawerContextValue {
+  item: Item | undefined;
+  itemId: number;
+  isItemLoading: boolean;
+  value: string;
+  setValue: React.Dispatch<React.SetStateAction<string>>;
+}
+
+interface ItemDetailDrawerProviderProps {
+  itemId: number;
+  children?: React.ReactNode;
+}
+
+const ItemDetailDrawerContext = React.createContext<
+  ItemDetailDrawerContextValue | undefined
+>(undefined);
 
 /**
  * Item detail provider
  */
-function ItemDetailDrawerProvider({ itemId, ...props }) {
+function ItemDetailDrawerProvider({
+  itemId,
+  children,
+}: ItemDetailDrawerProviderProps) {
   // transaction type payload.
   const [value, setValue] = React.useState('invoices');
 
@@ -20,7 +38,7 @@ function ItemDetailDrawerProvider({ itemId, ...props }) {
   });
 
   //provider.
-  const provider = {
+  const provider: ItemDetailDrawerContextValue = {
     item,
     itemId,
     isItemLoading,
@@ -34,11 +52,21 @@ function ItemDetailDrawerProvider({ itemId, ...props }) {
         name={DRAWERS.ITEM_DETAILS}
         title={inactiveStatus(item)}
       />
-      <ItemDetailDrawerContext.Provider value={provider} {...props} />
+      <ItemDetailDrawerContext.Provider value={provider}>
+        {children}
+      </ItemDetailDrawerContext.Provider>
     </DrawerLoading>
   );
 }
-const useItemDetailDrawerContext = () =>
-  React.useContext(ItemDetailDrawerContext);
+
+const useItemDetailDrawerContext = (): ItemDetailDrawerContextValue => {
+  const ctx = React.useContext(ItemDetailDrawerContext);
+  if (!ctx) {
+    throw new Error(
+      'useItemDetailDrawerContext must be used within ItemDetailDrawerProvider',
+    );
+  }
+  return ctx;
+};
 
 export { ItemDetailDrawerProvider, useItemDetailDrawerContext };

--- a/packages/webapp/src/containers/Drawers/ItemDetailDrawer/ItemDetailHeader.tsx
+++ b/packages/webapp/src/containers/Drawers/ItemDetailDrawer/ItemDetailHeader.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import React from 'react';
 import intl from 'react-intl-universal';
 import classNames from 'classnames';
@@ -15,21 +14,21 @@ export function ItemDetailHeader() {
 
   return (
     <Card>
-      <div class="item-drawer__content">
+      <div className="item-drawer__content">
         <DetailsMenu direction={'vertical'}>
           <DetailItem
             name={'name'}
             label={intl.get('item_name')}
-            children={item.name}
+            children={item?.name}
           />
           <DetailItem
             label={intl.get('sell_price')}
-            children={item.sell_price_formatted}
+            children={item?.sellPriceFormatted}
             align={'right'}
           />
           <DetailItem
             label={intl.get('cost_price')}
-            children={item.cost_price_formatted}
+            children={item?.costPriceFormatted}
             align={'right'}
           />
         </DetailsMenu>
@@ -37,57 +36,57 @@ export function ItemDetailHeader() {
         <DetailsMenu direction={'horizantal'}>
           <DetailItem
             label={intl.get('item_type')}
-            children={item.type_formatted}
+            children={item?.typeFormatted}
           />
           <DetailItem
             label={intl.get('item_code')}
-            children={defaultTo(item.code, '-')}
+            children={defaultTo(item?.code, '-')}
           />
-          <If condition={item.type === 'inventory'}>
+          <If condition={item?.type === 'inventory'}>
             <DetailItem name={'quantity'} label={intl.get('quantity_on_hand')}>
               <span
                 className={classNames({
-                  mines: item.quantity_on_hand <= 0,
-                  plus: item.quantity_on_hand > 0,
+                  mines: (item?.quantityOnHand ?? 0) <= 0,
+                  plus: (item?.quantityOnHand ?? 0) > 0,
                 })}
               >
-                {defaultTo(item.quantity_on_hand, '-')}
+                {defaultTo(item?.quantityOnHand, '-')}
               </span>
             </DetailItem>
           </If>
           <DetailItem
             label={intl.get('category_name')}
-            children={defaultTo(item.category?.name, '-')}
+            children={defaultTo(item?.category?.name, '-')}
           />
           <DetailItem
             label={intl.get('sell_account_id')}
-            children={defaultTo(item?.sell_account?.name, '-')}
+            children={defaultTo(item?.sellAccount?.name, '-')}
           />
           <DetailItem
             label={intl.get('cost_account_id')}
-            children={defaultTo(item.cost_account?.name, '-')}
+            children={defaultTo(item?.costAccount?.name, '-')}
           />
           <DetailItem
             label={intl.get('item.details.sell_tax_rate')}
-            children={item?.sell_tax_rate?.name}
+            children={item?.sellTaxRate?.name}
           />
           <DetailItem
             label={intl.get('item.details.purchase_tax_rate')}
-            children={item?.purchase_tax_rate?.name}
+            children={item?.purchaseTaxRate?.name}
           />
-          <If condition={item.type === 'inventory'}>
+          <If condition={item?.type === 'inventory'}>
             <DetailItem
               label={intl.get('inventory_account')}
-              children={defaultTo(item?.inventory_account?.name, '-')}
+              children={defaultTo(item?.inventoryAccount?.name, '-')}
             />
           </If>
           <DetailItem
             label={intl.get('item.sell_description')}
-            children={defaultTo(item.sell_description, '-')}
+            children={defaultTo(item?.sellDescription, '-')}
           />
           <DetailItem
             label={intl.get('item.purchase_description')}
-            children={defaultTo(item.purchase_description, '-')}
+            children={defaultTo(item?.purchaseDescription, '-')}
           />
         </DetailsMenu>
       </div>

--- a/packages/webapp/src/containers/Drawers/ItemDetailDrawer/ItemDetailTab.tsx
+++ b/packages/webapp/src/containers/Drawers/ItemDetailDrawer/ItemDetailTab.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import React from 'react';
 import { Tab } from '@blueprintjs/core';
 

--- a/packages/webapp/src/containers/Expenses/ExpensesLanding/ExpensesList.tsx
+++ b/packages/webapp/src/containers/Expenses/ExpensesLanding/ExpensesList.tsx
@@ -7,6 +7,8 @@ import { withExpenses } from './withExpenses';
 import { withExpensesActions } from './withExpensesActions';
 import { compose, transformTableStateToQuery } from '@/utils';
 import { ExpensesListProvider } from './ExpensesListProvider';
+import { ExpensesListDrawers } from './ExpensesListDrawers';
+import { ExpensesListDialogs } from './ExpensesListDialogs';
 import type { WithExpensesProps } from './withExpenses';
 import type { WithExpensesActionsProps } from './withExpensesActions';
 
@@ -42,6 +44,8 @@ function ExpensesListInner({
       tableStateChanged={expensesTableStateChanged}
     >
       <ExpenseActionsBar />
+      <ExpensesListDrawers />
+      <ExpensesListDialogs />
 
       <DashboardPageContent>
         <ExpenseDataTable />

--- a/packages/webapp/src/containers/Expenses/ExpensesLanding/ExpensesListDialogs.tsx
+++ b/packages/webapp/src/containers/Expenses/ExpensesLanding/ExpensesListDialogs.tsx
@@ -1,0 +1,10 @@
+import { ExpenseBulkDeleteDialog } from '@/containers/Dialogs/Expenses/ExpenseBulkDeleteDialog';
+import { DialogsName } from '@/constants/dialogs';
+
+export function ExpensesListDialogs() {
+  return (
+    <>
+      <ExpenseBulkDeleteDialog dialogName={DialogsName.ExpenseBulkDelete} />
+    </>
+  );
+}

--- a/packages/webapp/src/containers/Expenses/ExpensesLanding/ExpensesListDrawers.tsx
+++ b/packages/webapp/src/containers/Expenses/ExpensesLanding/ExpensesListDrawers.tsx
@@ -1,0 +1,10 @@
+import { index as ExpenseDrawer } from '@/containers/Drawers/ExpenseDrawer';
+import { DRAWERS } from '@/constants/drawers';
+
+export function ExpensesListDrawers() {
+  return (
+    <>
+      <ExpenseDrawer name={DRAWERS.EXPENSE_DETAILS} />
+    </>
+  );
+}

--- a/packages/webapp/src/containers/InventoryAdjustments/InventoryAdjustmentList.tsx
+++ b/packages/webapp/src/containers/InventoryAdjustments/InventoryAdjustmentList.tsx
@@ -7,6 +7,7 @@ import { DashboardContentTable, DashboardPageContent } from '@/components';
 
 import { InventoryAdjustmentsProvider } from './InventoryAdjustmentsProvider';
 import { InventoryAdjustmentTable } from './InventoryAdjustmentTable';
+import { InventoryAdjustmentListDrawers } from './InventoryAdjustmentListDrawers';
 
 import { withInventoryAdjustments } from './withInventoryAdjustments';
 
@@ -23,6 +24,8 @@ function InventoryAdjustmentListInner({
     <InventoryAdjustmentsProvider
       query={transformTableStateToQuery(inventoryAdjustmentTableState)}
     >
+      <InventoryAdjustmentListDrawers />
+      
       <DashboardPageContent>
         <DashboardContentTable>
           <InventoryAdjustmentTable />

--- a/packages/webapp/src/containers/InventoryAdjustments/InventoryAdjustmentList.tsx
+++ b/packages/webapp/src/containers/InventoryAdjustments/InventoryAdjustmentList.tsx
@@ -25,7 +25,7 @@ function InventoryAdjustmentListInner({
       query={transformTableStateToQuery(inventoryAdjustmentTableState)}
     >
       <InventoryAdjustmentListDrawers />
-      
+
       <DashboardPageContent>
         <DashboardContentTable>
           <InventoryAdjustmentTable />

--- a/packages/webapp/src/containers/InventoryAdjustments/InventoryAdjustmentListDrawers.tsx
+++ b/packages/webapp/src/containers/InventoryAdjustments/InventoryAdjustmentListDrawers.tsx
@@ -1,0 +1,12 @@
+import { index as InventoryAdjustmentDetailDrawer } from '@/containers/Drawers/InventoryAdjustmentDetailDrawer';
+import { DRAWERS } from '@/constants/drawers';
+
+export function InventoryAdjustmentListDrawers() {
+  return (
+    <>
+      <InventoryAdjustmentDetailDrawer
+        name={DRAWERS.INVENTORY_ADJUSTMENT_DETAILS}
+      />
+    </>
+  );
+}

--- a/packages/webapp/src/containers/Items/ItemsList.tsx
+++ b/packages/webapp/src/containers/Items/ItemsList.tsx
@@ -9,6 +9,8 @@ import { ItemsListProvider } from './ItemsListProvider';
 
 import { ItemsActionsBar } from './ItemsActionsBar';
 import { ItemsDataTable } from './ItemsDataTable';
+import { ItemsListDrawers } from './ItemsListDrawers';
+import { ItemsListDialogs } from './ItemsListDialogs';
 
 import { withItems } from './withItems';
 import { withItemsActions } from './withItemsActions';
@@ -38,6 +40,8 @@ function ItemsListInner({
       tableStateChanged={itemsTableStateChanged}
     >
       <ItemsActionsBar />
+      <ItemsListDrawers />
+      <ItemsListDialogs />
 
       <DashboardPageContent>
         <ItemsDataTable />

--- a/packages/webapp/src/containers/Items/ItemsListDialogs.tsx
+++ b/packages/webapp/src/containers/Items/ItemsListDialogs.tsx
@@ -1,0 +1,10 @@
+import { ItemBulkDeleteDialog } from '@/containers/Dialogs/Items/ItemBulkDeleteDialog';
+import { DialogsName } from '@/constants/dialogs';
+
+export function ItemsListDialogs() {
+  return (
+    <>
+      <ItemBulkDeleteDialog dialogName={DialogsName.ItemBulkDelete} />
+    </>
+  );
+}

--- a/packages/webapp/src/containers/Items/ItemsListDrawers.tsx
+++ b/packages/webapp/src/containers/Items/ItemsListDrawers.tsx
@@ -1,0 +1,10 @@
+import { index as ItemDetailDrawer } from '@/containers/Drawers/ItemDetailDrawer';
+import { DRAWERS } from '@/constants/drawers';
+
+export function ItemsListDrawers() {
+  return (
+    <>
+      <ItemDetailDrawer name={DRAWERS.ITEM_DETAILS} />
+    </>
+  );
+}

--- a/packages/webapp/src/containers/Purchases/Bills/BillsLanding/BillsList.tsx
+++ b/packages/webapp/src/containers/Purchases/Bills/BillsLanding/BillsList.tsx
@@ -8,6 +8,8 @@ import { BillsListProvider } from './BillsListProvider';
 
 import { BillsActionsBar } from './BillsActionsBar';
 import { BillsTable } from './BillsTable';
+import { BillsListDrawers } from './BillsListDrawers';
+import { BillsListDialogs } from './BillsListDialogs';
 
 import { withBills } from './withBills';
 import { withBillsActions } from './withBillsActions';
@@ -39,6 +41,8 @@ function BillsListInner({
       tableStateChanged={billsTableStateChanged}
     >
       <BillsActionsBar />
+      <BillsListDrawers />
+      <BillsListDialogs />
 
       <DashboardPageContent>
         <BillsTable />

--- a/packages/webapp/src/containers/Purchases/Bills/BillsLanding/BillsListDialogs.tsx
+++ b/packages/webapp/src/containers/Purchases/Bills/BillsLanding/BillsListDialogs.tsx
@@ -1,0 +1,10 @@
+import { BillBulkDeleteDialog } from '@/containers/Dialogs/Bills/BillBulkDeleteDialog';
+import { DialogsName } from '@/constants/dialogs';
+
+export function BillsListDialogs() {
+  return (
+    <>
+      <BillBulkDeleteDialog dialogName={DialogsName.BillBulkDelete} />
+    </>
+  );
+}

--- a/packages/webapp/src/containers/Purchases/Bills/BillsLanding/BillsListDrawers.tsx
+++ b/packages/webapp/src/containers/Purchases/Bills/BillsLanding/BillsListDrawers.tsx
@@ -1,0 +1,12 @@
+import { index as BillDrawer } from '@/containers/Drawers/BillDrawer';
+import { index as ExpenseDrawer } from '@/containers/Drawers/ExpenseDrawer';
+import { DRAWERS } from '@/constants/drawers';
+
+export function BillsListDrawers() {
+  return (
+    <>
+      <BillDrawer name={DRAWERS.BILL_DETAILS} />
+      <ExpenseDrawer name={DRAWERS.EXPENSE_DETAILS} />
+    </>
+  );
+}

--- a/packages/webapp/src/containers/Purchases/CreditNotes/CreditNotesLanding/VendorsCreditNotesList.tsx
+++ b/packages/webapp/src/containers/Purchases/CreditNotes/CreditNotesLanding/VendorsCreditNotesList.tsx
@@ -1,16 +1,14 @@
 // @ts-nocheck
 import React from 'react';
-
 import '@/style/pages/VendorsCreditNote/List.scss';
-
 import { DashboardPageContent } from '@/components';
 import { VendorsCreditNoteActionsBar } from './VendorsCreditNoteActionsBar';
 import { VendorsCreditNoteDataTable } from './VendorsCreditNoteDataTable';
-
 import { withVendorsCreditNotes } from './withVendorsCreditNotes';
 import { withVendorsCreditNotesActions } from './withVendorsCreditNotesActions';
-
 import { VendorsCreditNoteListProvider } from './VendorsCreditNoteListProvider';
+import { VendorsCreditNotesListDrawers } from './VendorsCreditNotesListDrawers';
+import { VendorsCreditNotesListDialogs } from './VendorsCreditNotesListDialogs';
 import { transformTableStateToQuery, compose } from '@/utils';
 
 function VendorsCreditNotesListInner({
@@ -35,6 +33,9 @@ function VendorsCreditNotesListInner({
       tableStateChanged={vendorsCreditNoteTableStateChanged}
     >
       <VendorsCreditNoteActionsBar />
+      <VendorsCreditNotesListDrawers />
+      <VendorsCreditNotesListDialogs />
+
       <DashboardPageContent>
         <VendorsCreditNoteDataTable />
       </DashboardPageContent>

--- a/packages/webapp/src/containers/Purchases/CreditNotes/CreditNotesLanding/VendorsCreditNotesListDialogs.tsx
+++ b/packages/webapp/src/containers/Purchases/CreditNotes/CreditNotesLanding/VendorsCreditNotesListDialogs.tsx
@@ -1,0 +1,12 @@
+import { VendorCreditBulkDeleteDialog } from '@/containers/Dialogs/VendorCredits/VendorCreditBulkDeleteDialog';
+import { DialogsName } from '@/constants/dialogs';
+
+export function VendorsCreditNotesListDialogs() {
+  return (
+    <>
+      <VendorCreditBulkDeleteDialog
+        dialogName={DialogsName.VendorCreditBulkDelete}
+      />
+    </>
+  );
+}

--- a/packages/webapp/src/containers/Purchases/CreditNotes/CreditNotesLanding/VendorsCreditNotesListDrawers.tsx
+++ b/packages/webapp/src/containers/Purchases/CreditNotes/CreditNotesLanding/VendorsCreditNotesListDrawers.tsx
@@ -1,0 +1,10 @@
+import { index as VendorCreditDetailDrawer } from '@/containers/Drawers/VendorCreditDetailDrawer';
+import { DRAWERS } from '@/constants/drawers';
+
+export function VendorsCreditNotesListDrawers() {
+  return (
+    <>
+      <VendorCreditDetailDrawer name={DRAWERS.VENDOR_CREDIT_DETAILS} />
+    </>
+  );
+}

--- a/packages/webapp/src/containers/Purchases/PaymentsMade/PaymentsLanding/PaymentMadeList.tsx
+++ b/packages/webapp/src/containers/Purchases/PaymentsMade/PaymentsLanding/PaymentMadeList.tsx
@@ -7,6 +7,7 @@ import { DashboardPageContent } from '@/components';
 import { PaymentMadesListProvider } from './PaymentMadesListProvider';
 import { PaymentMadeActionsBar } from './PaymentMadeActionsBar';
 import { PaymentMadesTable } from './PaymentMadesTable';
+import { PaymentMadeListDrawers } from './PaymentMadeListDrawers';
 
 import { withPaymentMade } from './withPaymentMade';
 import { withPaymentMadeActions } from './withPaymentMadeActions';
@@ -38,6 +39,7 @@ function PaymentMadeListInner({
       tableStateChanged={paymentsTableStateChanged}
     >
       <PaymentMadeActionsBar />
+      <PaymentMadeListDrawers />
 
       <DashboardPageContent>
         <PaymentMadesTable />

--- a/packages/webapp/src/containers/Purchases/PaymentsMade/PaymentsLanding/PaymentMadeListDrawers.tsx
+++ b/packages/webapp/src/containers/Purchases/PaymentsMade/PaymentsLanding/PaymentMadeListDrawers.tsx
@@ -1,0 +1,10 @@
+import { index as PaymentMadeDetailDrawer } from '@/containers/Drawers/PaymentMadeDetailDrawer';
+import { DRAWERS } from '@/constants/drawers';
+
+export function PaymentMadeListDrawers() {
+  return (
+    <>
+      <PaymentMadeDetailDrawer name={DRAWERS.PAYMENT_MADE_DETAILS} />
+    </>
+  );
+}

--- a/packages/webapp/src/containers/Sales/CreditNotes/CreditNoteForm/CreditNoteFormDialogs.tsx
+++ b/packages/webapp/src/containers/Sales/CreditNotes/CreditNoteForm/CreditNoteFormDialogs.tsx
@@ -2,6 +2,8 @@
 import React from 'react';
 import { useFormikContext } from 'formik';
 import { index as CreditNoteNumberDialog } from '@/containers/Dialogs/CreditNoteNumberDialog';
+import { InvoiceExchangeRateChangeDialog } from '@/containers/Sales/Invoices/InvoiceForm/Dialogs/InvoiceExchangeRateChangeDialog';
+import { DialogsName } from '@/constants/dialogs';
 
 /**
  * Credit note form dialogs.
@@ -22,9 +24,14 @@ export function CreditNoteFormDialogs() {
   };
 
   return (
-    <CreditNoteNumberDialog
-      dialogName={'credit-number-form'}
-      onConfirm={handleCreditNumberFormConfirm}
-    />
+    <>
+      <CreditNoteNumberDialog
+        dialogName={'credit-number-form'}
+        onConfirm={handleCreditNumberFormConfirm}
+      />
+      <InvoiceExchangeRateChangeDialog
+        dialogName={DialogsName.InvoiceExchangeRateChangeNotice}
+      />
+    </>
   );
 }

--- a/packages/webapp/src/containers/Sales/CreditNotes/CreditNotesLanding/CreditNotesList.tsx
+++ b/packages/webapp/src/containers/Sales/CreditNotes/CreditNotesLanding/CreditNotesList.tsx
@@ -11,6 +11,8 @@ import { withCreditNotes } from './withCreditNotes';
 import { withCreditNotesActions } from './withCreditNotesActions';
 
 import { CreditNotesListProvider } from './CreditNotesListProvider';
+import { CreditNotesListDrawers } from './CreditNotesListDrawers';
+import { CreditNotesListDialogs } from './CreditNotesListDialogs';
 import { transformTableStateToQuery, compose } from '@/utils';
 
 function CreditNotesListInner({
@@ -35,6 +37,8 @@ function CreditNotesListInner({
       tableStateChanged={creditNoteTableStateChanged}
     >
       <CreditNotesActionsBar />
+      <CreditNotesListDrawers />
+      <CreditNotesListDialogs />
 
       <DashboardPageContent>
         <CreditNotesDataTable />

--- a/packages/webapp/src/containers/Sales/CreditNotes/CreditNotesLanding/CreditNotesListDialogs.tsx
+++ b/packages/webapp/src/containers/Sales/CreditNotes/CreditNotesLanding/CreditNotesListDialogs.tsx
@@ -1,0 +1,16 @@
+import { CreditNoteBulkDeleteDialog } from '@/containers/Dialogs/CreditNotes/CreditNoteBulkDeleteDialog';
+import { index as CreditNotePdfPreviewDialog } from '@/containers/Dialogs/CreditNotePdfPreviewDialog';
+import { DialogsName } from '@/constants/dialogs';
+
+export function CreditNotesListDialogs() {
+  return (
+    <>
+      <CreditNoteBulkDeleteDialog
+        dialogName={DialogsName.CreditNoteBulkDelete}
+      />
+      <CreditNotePdfPreviewDialog
+        dialogName={DialogsName.CreditNotePdfForm}
+      />
+    </>
+  );
+}

--- a/packages/webapp/src/containers/Sales/CreditNotes/CreditNotesLanding/CreditNotesListDialogs.tsx
+++ b/packages/webapp/src/containers/Sales/CreditNotes/CreditNotesLanding/CreditNotesListDialogs.tsx
@@ -8,9 +8,7 @@ export function CreditNotesListDialogs() {
       <CreditNoteBulkDeleteDialog
         dialogName={DialogsName.CreditNoteBulkDelete}
       />
-      <CreditNotePdfPreviewDialog
-        dialogName={DialogsName.CreditNotePdfForm}
-      />
+      <CreditNotePdfPreviewDialog dialogName={DialogsName.CreditNotePdfForm} />
     </>
   );
 }

--- a/packages/webapp/src/containers/Sales/CreditNotes/CreditNotesLanding/CreditNotesListDrawers.tsx
+++ b/packages/webapp/src/containers/Sales/CreditNotes/CreditNotesLanding/CreditNotesListDrawers.tsx
@@ -1,0 +1,10 @@
+import { index as CreditNoteDetailDrawer } from '@/containers/Drawers/CreditNoteDetailDrawer';
+import { DRAWERS } from '@/constants/drawers';
+
+export function CreditNotesListDrawers() {
+  return (
+    <>
+      <CreditNoteDetailDrawer name={DRAWERS.CREDIT_NOTE_DETAILS} />
+    </>
+  );
+}

--- a/packages/webapp/src/containers/Sales/Estimates/EstimateForm/EstimateFormDialogs.tsx
+++ b/packages/webapp/src/containers/Sales/Estimates/EstimateForm/EstimateFormDialogs.tsx
@@ -2,6 +2,8 @@
 import React from 'react';
 import { useFormikContext } from 'formik';
 import { index as EstimateNumberDialog } from '@/containers/Dialogs/EstimateNumberDialog';
+import { InvoiceExchangeRateChangeDialog } from '@/containers/Sales/Invoices/InvoiceForm/Dialogs/InvoiceExchangeRateChangeDialog';
+import { DialogsName } from '@/constants/dialogs';
 
 /**
  * Estimate form dialogs.
@@ -24,6 +26,9 @@ export function EstimateFormDialogs() {
       <EstimateNumberDialog
         dialogName={'estimate-number-form'}
         onConfirm={handleEstimateNumberFormConfirm}
+      />
+      <InvoiceExchangeRateChangeDialog
+        dialogName={DialogsName.InvoiceExchangeRateChangeNotice}
       />
     </>
   );

--- a/packages/webapp/src/containers/Sales/Estimates/EstimatesLanding/EstimatesList.tsx
+++ b/packages/webapp/src/containers/Sales/Estimates/EstimatesLanding/EstimatesList.tsx
@@ -1,16 +1,14 @@
 // @ts-nocheck
 import React from 'react';
 import { DashboardPageContent } from '@/components';
-
 import '@/style/pages/SaleEstimate/List.scss';
-
 import { EstimatesActionsBar } from './EstimatesActionsBar';
 import { EstimatesDataTable } from './EstimatesDataTable';
-
 import { withEstimates } from './withEstimates';
 import { withEstimatesActions } from './withEstimatesActions';
-
 import { EstimatesListProvider } from './EstimatesListProvider';
+import { EstimatesListDrawers } from './EstimatesListDrawers';
+import { EstimatesListDialogs } from './EstimatesListDialogs';
 import { compose, transformTableStateToQuery } from '@/utils';
 
 /**
@@ -38,6 +36,8 @@ function EstimatesListInner({
       tableStateChanged={estimatesTableStateChanged}
     >
       <EstimatesActionsBar />
+      <EstimatesListDrawers />
+      <EstimatesListDialogs />
 
       <DashboardPageContent>
         <EstimatesDataTable />

--- a/packages/webapp/src/containers/Sales/Estimates/EstimatesLanding/EstimatesListDialogs.tsx
+++ b/packages/webapp/src/containers/Sales/Estimates/EstimatesLanding/EstimatesListDialogs.tsx
@@ -1,0 +1,12 @@
+import { EstimateBulkDeleteDialog } from '@/containers/Dialogs/Estimates/EstimateBulkDeleteDialog';
+import { index as EstimatePdfPreviewDialog } from '@/containers/Dialogs/EstimatePdfPreviewDialog';
+import { DialogsName } from '@/constants/dialogs';
+
+export function EstimatesListDialogs() {
+  return (
+    <>
+      <EstimateBulkDeleteDialog dialogName={DialogsName.EstimateBulkDelete} />
+      <EstimatePdfPreviewDialog dialogName={DialogsName.EstimatePdfForm} />
+    </>
+  );
+}

--- a/packages/webapp/src/containers/Sales/Estimates/EstimatesLanding/EstimatesListDrawers.tsx
+++ b/packages/webapp/src/containers/Sales/Estimates/EstimatesLanding/EstimatesListDrawers.tsx
@@ -1,0 +1,12 @@
+import { index as EstimateDetailDrawer } from '@/containers/Drawers/EstimateDetailDrawer';
+import { EstimateSendMailDrawer } from '@/containers/Sales/Estimates/EstimateSendMailDrawer';
+import { DRAWERS } from '@/constants/drawers';
+
+export function EstimatesListDrawers() {
+  return (
+    <>
+      <EstimateDetailDrawer name={DRAWERS.ESTIMATE_DETAILS} />
+      <EstimateSendMailDrawer name={DRAWERS.ESTIMATE_SEND_MAIL} />
+    </>
+  );
+}

--- a/packages/webapp/src/containers/Sales/Invoices/InvoiceForm/InvoiceFormDialogs.tsx
+++ b/packages/webapp/src/containers/Sales/Invoices/InvoiceForm/InvoiceFormDialogs.tsx
@@ -1,6 +1,7 @@
 // @ts-nocheck
 import { useFormikContext } from 'formik';
 import { index as InvoiceNumberDialog } from '@/containers/Dialogs/InvoiceNumberDialog';
+import { InvoiceExchangeRateChangeDialog } from '@/containers/Sales/Invoices/InvoiceForm/Dialogs/InvoiceExchangeRateChangeDialog';
 import { DialogsName } from '@/constants/dialogs';
 
 /**
@@ -26,6 +27,9 @@ export function InvoiceFormDialogs() {
       <InvoiceNumberDialog
         dialogName={DialogsName.InvoiceNumberSettings}
         onConfirm={handleInvoiceNumberFormConfirm}
+      />
+      <InvoiceExchangeRateChangeDialog
+        dialogName={DialogsName.InvoiceExchangeRateChangeNotice}
       />
     </>
   );

--- a/packages/webapp/src/containers/Sales/Invoices/InvoicesLanding/InvoicesList.tsx
+++ b/packages/webapp/src/containers/Sales/Invoices/InvoicesLanding/InvoicesList.tsx
@@ -8,6 +8,8 @@ import { InvoicesListProvider } from './InvoicesListProvider';
 
 import { InvoicesDataTable } from './InvoicesDataTable';
 import { InvoicesActionsBar } from './InvoicesActionsBar';
+import { InvoicesListDrawers } from './InvoicesListDrawers';
+import { InvoicesListDialogs } from './InvoicesListDialogs';
 
 import { withInvoices } from './withInvoices';
 import { withInvoiceActions } from './withInvoiceActions';
@@ -40,6 +42,8 @@ function InvoicesListInner({
       tableStateChanged={invoicesTableStateChanged}
     >
       <InvoicesActionsBar />
+      <InvoicesListDrawers />
+      <InvoicesListDialogs />
 
       <DashboardPageContent>
         <InvoicesDataTable />

--- a/packages/webapp/src/containers/Sales/Invoices/InvoicesLanding/InvoicesListDialogs.tsx
+++ b/packages/webapp/src/containers/Sales/Invoices/InvoicesLanding/InvoicesListDialogs.tsx
@@ -1,0 +1,12 @@
+import { InvoiceBulkDeleteDialog } from '@/containers/Dialogs/Invoices/InvoiceBulkDeleteDialog';
+import { index as InvoicePdfPreviewDialog } from '@/containers/Dialogs/InvoicePdfPreviewDialog';
+import { DialogsName } from '@/constants/dialogs';
+
+export function InvoicesListDialogs() {
+  return (
+    <>
+      <InvoiceBulkDeleteDialog dialogName={DialogsName.InvoiceBulkDelete} />
+      <InvoicePdfPreviewDialog dialogName={DialogsName.InvoicePdfForm} />
+    </>
+  );
+}

--- a/packages/webapp/src/containers/Sales/Invoices/InvoicesLanding/InvoicesListDrawers.tsx
+++ b/packages/webapp/src/containers/Sales/Invoices/InvoicesLanding/InvoicesListDrawers.tsx
@@ -1,0 +1,12 @@
+import { index as InvoiceDetailDrawer } from '@/containers/Drawers/InvoiceDetailDrawer';
+import { InvoiceSendMailDrawer } from '@/containers/Sales/Invoices/InvoiceSendMailDrawer/InvoiceSendMailDrawer';
+import { DRAWERS } from '@/constants/drawers';
+
+export function InvoicesListDrawers() {
+  return (
+    <>
+      <InvoiceDetailDrawer name={DRAWERS.INVOICE_DETAILS} />
+      <InvoiceSendMailDrawer name={DRAWERS.INVOICE_SEND_MAIL} />
+    </>
+  );
+}

--- a/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentsLanding/PaymentsReceivedList.tsx
+++ b/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentsLanding/PaymentsReceivedList.tsx
@@ -7,10 +7,10 @@ import { DashboardPageContent } from '@/components';
 import { PaymentsReceivedListProvider } from './PaymentsReceivedListProvider';
 import { PaymentsReceivedTable as PaymentReceivesTable } from './PaymentsReceivedTable';
 import { PaymentsReceivedActionsBar } from './PaymentsReceivedActionsBar';
-
+import { PaymentsReceivedListDrawers } from './PaymentsReceivedListDrawers';
+import { PaymentsReceivedListDialogs } from './PaymentsReceivedListDialogs';
 import { withPaymentsReceived } from './withPaymentsReceived';
 import { withPaymentsReceivedActions } from './withPaymentsReceivedActions';
-
 import { compose, transformTableStateToQuery } from '@/utils';
 
 function PaymentsReceivedListInner({
@@ -35,6 +35,8 @@ function PaymentsReceivedListInner({
       tableStateChanged={paymentsTableStateChanged}
     >
       <PaymentsReceivedActionsBar />
+      <PaymentsReceivedListDrawers />
+      <PaymentsReceivedListDialogs />
 
       <DashboardPageContent>
         <PaymentReceivesTable />

--- a/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentsLanding/PaymentsReceivedListDialogs.tsx
+++ b/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentsLanding/PaymentsReceivedListDialogs.tsx
@@ -1,0 +1,16 @@
+import { PaymentReceivedBulkDeleteDialog } from '@/containers/Dialogs/PaymentsReceived/PaymentReceivedBulkDeleteDialog';
+import { index as PaymentReceivePdfPreviewDialog } from '@/containers/Dialogs/PaymentReceivePdfPreviewDialog';
+import { DialogsName } from '@/constants/dialogs';
+
+export function PaymentsReceivedListDialogs() {
+  return (
+    <>
+      <PaymentReceivedBulkDeleteDialog
+        dialogName={DialogsName.PaymentReceivedBulkDelete}
+      />
+      <PaymentReceivePdfPreviewDialog
+        dialogName={DialogsName.PaymentPdfForm}
+      />
+    </>
+  );
+}

--- a/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentsLanding/PaymentsReceivedListDialogs.tsx
+++ b/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentsLanding/PaymentsReceivedListDialogs.tsx
@@ -8,9 +8,7 @@ export function PaymentsReceivedListDialogs() {
       <PaymentReceivedBulkDeleteDialog
         dialogName={DialogsName.PaymentReceivedBulkDelete}
       />
-      <PaymentReceivePdfPreviewDialog
-        dialogName={DialogsName.PaymentPdfForm}
-      />
+      <PaymentReceivePdfPreviewDialog dialogName={DialogsName.PaymentPdfForm} />
     </>
   );
 }

--- a/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentsLanding/PaymentsReceivedListDrawers.tsx
+++ b/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentsLanding/PaymentsReceivedListDrawers.tsx
@@ -1,0 +1,16 @@
+import { index as PaymentReceiveDetailDrawer } from '@/containers/Drawers/PaymentReceiveDetailDrawer';
+import { PaymentReceivedSendMailDrawer } from '@/containers/Sales/PaymentsReceived/PaymentReceivedMailDrawer';
+import { DRAWERS } from '@/constants/drawers';
+
+export function PaymentsReceivedListDrawers() {
+  return (
+    <>
+      <PaymentReceiveDetailDrawer
+        name={DRAWERS.PAYMENT_RECEIVED_DETAILS}
+      />
+      <PaymentReceivedSendMailDrawer
+        name={DRAWERS.PAYMENT_RECEIVED_SEND_MAIL}
+      />
+    </>
+  );
+}

--- a/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentsLanding/PaymentsReceivedListDrawers.tsx
+++ b/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentsLanding/PaymentsReceivedListDrawers.tsx
@@ -5,9 +5,7 @@ import { DRAWERS } from '@/constants/drawers';
 export function PaymentsReceivedListDrawers() {
   return (
     <>
-      <PaymentReceiveDetailDrawer
-        name={DRAWERS.PAYMENT_RECEIVED_DETAILS}
-      />
+      <PaymentReceiveDetailDrawer name={DRAWERS.PAYMENT_RECEIVED_DETAILS} />
       <PaymentReceivedSendMailDrawer
         name={DRAWERS.PAYMENT_RECEIVED_SEND_MAIL}
       />

--- a/packages/webapp/src/containers/Sales/Receipts/ReceiptForm/ReceiptFormDialogs.tsx
+++ b/packages/webapp/src/containers/Sales/Receipts/ReceiptForm/ReceiptFormDialogs.tsx
@@ -2,6 +2,8 @@
 import React from 'react';
 import { useFormikContext } from 'formik';
 import { index as ReceiptNumberDialog } from '@/containers/Dialogs/ReceiptNumberDialog';
+import { InvoiceExchangeRateChangeDialog } from '@/containers/Sales/Invoices/InvoiceForm/Dialogs/InvoiceExchangeRateChangeDialog';
+import { DialogsName } from '@/constants/dialogs';
 
 /**
  * Receipt form dialogs.
@@ -26,6 +28,9 @@ export function ReceiptFormDialogs() {
       <ReceiptNumberDialog
         dialogName={'receipt-number-form'}
         onConfirm={handleReceiptNumberFormConfirm}
+      />
+      <InvoiceExchangeRateChangeDialog
+        dialogName={DialogsName.InvoiceExchangeRateChangeNotice}
       />
     </>
   );

--- a/packages/webapp/src/containers/Sales/Receipts/ReceiptsLanding/ReceiptsList.tsx
+++ b/packages/webapp/src/containers/Sales/Receipts/ReceiptsLanding/ReceiptsList.tsx
@@ -11,6 +11,8 @@ import { withReceipts } from './withReceipts';
 import { withReceiptsActions } from './withReceiptsActions';
 
 import { ReceiptsListProvider } from './ReceiptsListProvider';
+import { ReceiptsListDrawers } from './ReceiptsListDrawers';
+import { ReceiptsListDialogs } from './ReceiptsListDialogs';
 import { transformTableStateToQuery, compose } from '@/utils';
 
 /**
@@ -37,6 +39,9 @@ function ReceiptsListInner({
       query={transformTableStateToQuery(receiptTableState)}
       tableStateChanged={receiptsTableStateChanged}
     >
+      <ReceiptsListDrawers />
+      <ReceiptsListDialogs />
+
       <DashboardPageContent>
         <ReceiptActionsBar />
 

--- a/packages/webapp/src/containers/Sales/Receipts/ReceiptsLanding/ReceiptsListDialogs.tsx
+++ b/packages/webapp/src/containers/Sales/Receipts/ReceiptsLanding/ReceiptsListDialogs.tsx
@@ -1,0 +1,10 @@
+import { ReceiptBulkDeleteDialog } from '@/containers/Dialogs/Receipts/ReceiptBulkDeleteDialog';
+import { DialogsName } from '@/constants/dialogs';
+
+export function ReceiptsListDialogs() {
+  return (
+    <>
+      <ReceiptBulkDeleteDialog dialogName={DialogsName.ReceiptBulkDelete} />
+    </>
+  );
+}

--- a/packages/webapp/src/containers/Sales/Receipts/ReceiptsLanding/ReceiptsListDrawers.tsx
+++ b/packages/webapp/src/containers/Sales/Receipts/ReceiptsLanding/ReceiptsListDrawers.tsx
@@ -1,0 +1,12 @@
+import { index as ReceiptDetailDrawer } from '@/containers/Drawers/ReceiptDetailDrawer';
+import { ReceiptSendMailDrawer } from '@/containers/Sales/Receipts/ReceiptSendMailDrawer';
+import { DRAWERS } from '@/constants/drawers';
+
+export function ReceiptsListDrawers() {
+  return (
+    <>
+      <ReceiptDetailDrawer name={DRAWERS.RECEIPT_DETAILS} />
+      <ReceiptSendMailDrawer name={DRAWERS.RECEIPT_SEND_MAIL} />
+    </>
+  );
+}

--- a/packages/webapp/src/containers/Subscriptions/BillingSubscription.tsx
+++ b/packages/webapp/src/containers/Subscriptions/BillingSubscription.tsx
@@ -11,6 +11,7 @@ import { DRAWERS } from '@/constants/drawers';
 import { useBillingPageBoot } from './BillingPageBoot';
 import { useLemonSubscription } from '@/hooks/query/subscription';
 import { getSubscriptionStatusText } from './_utils';
+import { SubscriptionsDrawers } from './SubscriptionsDrawers';
 
 function SubscriptionRoot({ openAlert, openDrawer }) {
   const { mainSubscription } = useBillingPageBoot();
@@ -36,6 +37,7 @@ function SubscriptionRoot({ openAlert, openDrawer }) {
 
   return (
     <Card className={styles.root}>
+      <SubscriptionsDrawers />
       <Stack spacing={6}>
         <h1 className={styles.title}>{mainSubscription.planName}</h1>
 

--- a/packages/webapp/src/containers/Subscriptions/SubscriptionsDrawers.tsx
+++ b/packages/webapp/src/containers/Subscriptions/SubscriptionsDrawers.tsx
@@ -1,0 +1,12 @@
+import { ChangeSubscriptionPlanDrawer } from '@/containers/Subscriptions/drawers/ChangeSubscriptionPlanDrawer/ChangeSubscriptionPlanDrawer';
+import { DRAWERS } from '@/constants/drawers';
+
+export function SubscriptionsDrawers() {
+  return (
+    <>
+      <ChangeSubscriptionPlanDrawer
+        name={DRAWERS.CHANGE_SUBSCARIPTION_PLAN}
+      />
+    </>
+  );
+}

--- a/packages/webapp/src/containers/Subscriptions/SubscriptionsDrawers.tsx
+++ b/packages/webapp/src/containers/Subscriptions/SubscriptionsDrawers.tsx
@@ -4,9 +4,7 @@ import { DRAWERS } from '@/constants/drawers';
 export function SubscriptionsDrawers() {
   return (
     <>
-      <ChangeSubscriptionPlanDrawer
-        name={DRAWERS.CHANGE_SUBSCARIPTION_PLAN}
-      />
+      <ChangeSubscriptionPlanDrawer name={DRAWERS.CHANGE_SUBSCARIPTION_PLAN} />
     </>
   );
 }

--- a/packages/webapp/src/containers/TaxRates/containers/TaxRatesLandingDrawers.tsx
+++ b/packages/webapp/src/containers/TaxRates/containers/TaxRatesLandingDrawers.tsx
@@ -1,0 +1,10 @@
+import { TaxRateDetailsDrawer } from '@/containers/TaxRates/drawers/TaxRateDetailsDrawer/TaxRateDetailsDrawer';
+import { DRAWERS } from '@/constants/drawers';
+
+export function TaxRatesLandingDrawers() {
+  return (
+    <>
+      <TaxRateDetailsDrawer name={DRAWERS.TAX_RATE_DETAILS} />
+    </>
+  );
+}

--- a/packages/webapp/src/containers/TaxRates/pages/TaxRatesLanding.tsx
+++ b/packages/webapp/src/containers/TaxRates/pages/TaxRatesLanding.tsx
@@ -5,6 +5,7 @@ import { DashboardPageContent } from '@/components';
 import { TaxRatesLandingProvider } from '../containers/TaxRatesLandingProvider';
 import { TaxRatesLandingActionsBar } from '../containers/TaxRatesLandingActionsBar';
 import { TaxRatesLandingTable as TaxRatesDataTable } from '../containers/TaxRatesLandingTable';
+import { TaxRatesLandingDrawers } from '../containers/TaxRatesLandingDrawers';
 
 /**
  * Tax rates landing page.
@@ -14,6 +15,7 @@ export function TaxRatesLanding() {
   return (
     <TaxRatesLandingProvider>
       <TaxRatesLandingActionsBar />
+      <TaxRatesLandingDrawers />
 
       <DashboardPageContent>
         <TaxRatesDataTable />

--- a/packages/webapp/src/containers/Vendors/VendorsLanding/VendorsList.tsx
+++ b/packages/webapp/src/containers/Vendors/VendorsLanding/VendorsList.tsx
@@ -6,6 +6,7 @@ import '@/style/pages/Vendors/List.scss';
 import { DashboardPageContent } from '@/components';
 
 import { VendorsListProvider } from './VendorsListProvider';
+import { VendorsListDialogs } from './VendorsListDialogs';
 import { VendorActionsBar } from './VendorActionsBar';
 import { VendorsTable } from './VendorsTable';
 
@@ -41,6 +42,7 @@ function VendorsListInner({
       tableStateChanged={vendorsTableStateChanged}
     >
       <VendorActionsBar />
+      <VendorsListDialogs />
 
       <DashboardPageContent>
         <VendorsTable />

--- a/packages/webapp/src/containers/Vendors/VendorsLanding/VendorsListDialogs.tsx
+++ b/packages/webapp/src/containers/Vendors/VendorsLanding/VendorsListDialogs.tsx
@@ -1,0 +1,10 @@
+import { VendorBulkDeleteDialog } from '@/containers/Dialogs/Vendors/VendorBulkDeleteDialog';
+import { DialogsName } from '@/constants/dialogs';
+
+export function VendorsListDialogs() {
+  return (
+    <>
+      <VendorBulkDeleteDialog dialogName={DialogsName.VendorBulkDelete} />
+    </>
+  );
+}

--- a/packages/webapp/src/containers/WarehouseTransfers/WarehouseTransfersLanding/WarehouseTransfersList.tsx
+++ b/packages/webapp/src/containers/WarehouseTransfers/WarehouseTransfersLanding/WarehouseTransfersList.tsx
@@ -1,13 +1,12 @@
 // @ts-nocheck
 import React from 'react';
-
 import { DashboardPageContent } from '@/components';
 import { WarehouseTransfersActionsBar } from './WarehouseTransfersActionsBar';
 import { WarehouseTransfersDataTable } from './WarehouseTransfersDataTable';
 import { withWarehouseTransfers } from './withWarehouseTransfers';
 import { withWarehouseTransfersActions } from './withWarehouseTransfersActions';
-
 import { WarehouseTransfersListProvider } from './WarehouseTransfersListProvider';
+import { WarehouseTransfersListDrawers } from './WarehouseTransfersListDrawers';
 import { transformTableStateToQuery, compose } from '@/utils';
 
 function WarehouseTransfersListInner({
@@ -32,6 +31,7 @@ function WarehouseTransfersListInner({
       tableStateChanged={warehouseTransferTableStateChanged}
     >
       <WarehouseTransfersActionsBar />
+      <WarehouseTransfersListDrawers />
 
       <DashboardPageContent>
         <WarehouseTransfersDataTable />

--- a/packages/webapp/src/containers/WarehouseTransfers/WarehouseTransfersLanding/WarehouseTransfersListDrawers.tsx
+++ b/packages/webapp/src/containers/WarehouseTransfers/WarehouseTransfersLanding/WarehouseTransfersListDrawers.tsx
@@ -1,0 +1,12 @@
+import { index as WarehouseTransferDetailDrawer } from '@/containers/Drawers/WarehouseTransferDetailDrawer';
+import { DRAWERS } from '@/constants/drawers';
+
+export function WarehouseTransfersListDrawers() {
+  return (
+    <>
+      <WarehouseTransferDetailDrawer
+        name={DRAWERS.WAREHOUSE_TRANSFER_DETAILS}
+      />
+    </>
+  );
+}

--- a/packages/webapp/src/hooks/query/estimates/queries.ts
+++ b/packages/webapp/src/hooks/query/estimates/queries.ts
@@ -97,6 +97,24 @@ export function useEstimate(
   });
 }
 
+/**
+ * Variant of {@link useEstimate} that enables the snake_case → camelCase
+ * response transform, so the returned data matches the `SaleEstimate` SDK type
+ * at runtime. Use this for new camelCase-consuming code (e.g. detail drawers).
+ */
+export function useEstimateDetail(
+  id: number | null | undefined,
+  props?: Omit<UseQueryOptions<SaleEstimate>, 'queryKey' | 'queryFn'>,
+) {
+  const fetcher = useApiFetcher({ enableCamelCaseTransform: true });
+  return useQuery({
+    ...props,
+    queryKey: estimatesKeys.detail(id),
+    queryFn: () => fetchSaleEstimate(fetcher, id!),
+    enabled: id != null,
+  });
+}
+
 export function useEstimates(
   query?: Record<string, unknown>,
   props?: Omit<


### PR DESCRIPTION
## Summary

- Move page-scoped drawer and dialog definitions out of the centralized `DrawersContainer` and `DialogsContainer` into co-located `<Page>Drawers` / `<Page>Dialogs` components that each page mounts itself.
- The global containers now host only cross-cutting drawers/dialogs (quick-create selectors, customer/vendor links, sales document branding/customize, workspace switcher, and other app-wide dialogs).
- Reduce the surface area of the global containers and bring drawer/dialog mounting closer to the feature code that owns them.

## Test plan

- [ ] Verify sales document drawers (invoice/estimate/receipt/credit note/payment) open correctly from their landing pages and action bars.
- [ ] Verify purchase document drawers (bill/vendor credit/payment made) open correctly.
- [ ] Verify global drawers still open from cross-cutting entry points (quick-create, customer/vendor links, branding/customize, workspace switcher).
- [ ] Verify bulk-delete and PDF-preview dialogs still open from each landing page.
- [ ] Verify estimate detail drawer (and other refactored detail drawers) still loads and functions correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)