### PR TITLE
fix(server): include sub-accounts in P&L and Balance Sheet period/comparison columns

### DIFF
--- a/packages/server/src/modules/FinancialStatements/modules/BalanceSheet/BalanceSheetComparsionPreviousPeriod.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/BalanceSheet/BalanceSheetComparsionPreviousPeriod.ts
@@ -38,8 +38,14 @@ export const BalanceSheetComparsionPreviousPeriod = <
     public assocPreviousPeriodAccountNode = (
       node: IBalanceSheetDataNode,
     ): IBalanceSheetDataNode => {
-      const total = this.repository.PPTotalAccountsLedger.whereAccountId(
-        node.id,
+      const accountIds = R.uniq(
+        R.append(
+          node.id,
+          this.repository.accountsGraph.dependenciesOf(node.id),
+        ),
+      );
+      const total = this.repository.PPTotalAccountsLedger.whereAccountsIds(
+        accountIds,
       ).getClosingBalance();
 
       return R.assoc('previousPeriod', this.getAmountMeta(total), node);
@@ -129,14 +135,20 @@ export const BalanceSheetComparsionPreviousPeriod = <
      */
     private getAccountPPDatePeriodTotal = R.curry(
       (accountId: number, fromDate: Date, toDate: Date): number => {
+        const accountIds = R.uniq(
+          R.append(
+            accountId,
+            this.repository.accountsGraph.dependenciesOf(accountId),
+          ),
+        );
         const PPPeriodsTotal =
-          this.repository.PPPeriodsAccountsLedger.whereAccountId(accountId)
+          this.repository.PPPeriodsAccountsLedger.whereAccountsIds(accountIds)
             .whereToDate(toDate)
             .getClosingBalance();
 
         const PPPeriodsOpeningTotal =
-          this.repository.PPPeriodsOpeningAccountLedger.whereAccountId(
-            accountId,
+          this.repository.PPPeriodsOpeningAccountLedger.whereAccountsIds(
+            accountIds,
           ).getClosingBalance();
 
         return PPPeriodsOpeningTotal + PPPeriodsTotal;

--- a/packages/server/src/modules/FinancialStatements/modules/BalanceSheet/BalanceSheetComparsionPreviousYear.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/BalanceSheet/BalanceSheetComparsionPreviousYear.ts
@@ -35,9 +35,15 @@ export const BalanceSheetComparsionPreviousYear = <
     protected assocPreviousYearAccountNode = (
       node: IBalanceSheetDataNode,
     ): IBalanceSheetDataNode => {
-      const closingBalance =
-        this.repository.PYTotalAccountsLedger.whereAccountId(
+      const accountIds = R.uniq(
+        R.append(
           node.id,
+          this.repository.accountsGraph.dependenciesOf(node.id),
+        ),
+      );
+      const closingBalance =
+        this.repository.PYTotalAccountsLedger.whereAccountsIds(
+          accountIds,
         ).getClosingBalance();
 
       return R.assoc('previousYear', this.getAmountMeta(closingBalance), node);
@@ -189,14 +195,20 @@ export const BalanceSheetComparsionPreviousYear = <
      */
     private getAccountPYDatePeriodTotal = R.curry(
       (accountId: number, fromDate: Date, toDate: Date): number => {
+        const accountIds = R.uniq(
+          R.append(
+            accountId,
+            this.repository.accountsGraph.dependenciesOf(accountId),
+          ),
+        );
         const PYPeriodsTotal =
-          this.repository.PYPeriodsAccountsLedger.whereAccountId(accountId)
+          this.repository.PYPeriodsAccountsLedger.whereAccountsIds(accountIds)
             .whereToDate(toDate)
             .getClosingBalance();
 
         const PYPeriodsOpeningTotal =
-          this.repository.PYPeriodsOpeningAccountLedger.whereAccountId(
-            accountId,
+          this.repository.PYPeriodsOpeningAccountLedger.whereAccountsIds(
+            accountIds,
           ).getClosingBalance();
 
         return PYPeriodsOpeningTotal + PYPeriodsTotal;

--- a/packages/server/src/modules/FinancialStatements/modules/BalanceSheet/BalanceSheetDatePeriods.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/BalanceSheet/BalanceSheetDatePeriods.ts
@@ -93,13 +93,19 @@ export const BalanceSheetDatePeriods = <T extends GConstructor<FinancialSheet>>(
       accountId: number,
       toDate: Date,
     ): number => {
+      const accountIds = R.uniq(
+        R.append(
+          accountId,
+          this.repository.accountsGraph.dependenciesOf(accountId),
+        ),
+      );
       const periodTotalBetween = this.repository.periodsAccountsLedger
-        .whereAccountId(accountId)
+        .whereAccountsIds(accountIds)
         .whereToDate(toDate)
         .getClosingBalance();
 
       const periodOpening = this.repository.periodsOpeningAccountLedger
-        .whereAccountId(accountId)
+        .whereAccountsIds(accountIds)
         .getClosingBalance();
 
       return periodOpening + periodTotalBetween;

--- a/packages/server/src/modules/FinancialStatements/modules/ProfitLossSheet/ProfitLossSheetDatePeriods.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/ProfitLossSheet/ProfitLossSheetDatePeriods.ts
@@ -76,8 +76,14 @@ export const ProfitLossSheetDatePeriods = <
       fromDate: Date,
       toDate: Date,
     ) => {
+      const accountIds = R.uniq(
+        R.append(
+          node.id,
+          this.repository.accountsGraph.dependenciesOf(node.id),
+        ),
+      );
       const periodTotal = this.repository.periodsAccountsLedger
-        .whereAccountId(node.id)
+        .whereAccountsIds(accountIds)
         .whereFromDate(fromDate)
         .whereToDate(toDate)
         .getClosingBalance();

--- a/packages/server/src/modules/FinancialStatements/modules/ProfitLossSheet/ProfitLossSheetPreviousPeriod.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/ProfitLossSheet/ProfitLossSheetPreviousPeriod.ts
@@ -35,8 +35,14 @@ export const ProfitLossSheetPreviousPeriod = <
     protected assocPreviousPeriodTotalAccountNode = (
       node: IProfitLossSheetAccountNode,
     ): IProfitLossSheetAccountNode => {
-      const total = this.repository.PPTotalAccountsLedger.whereAccountId(
-        node.id,
+      const accountIds = R.uniq(
+        R.append(
+          node.id,
+          this.repository.accountsGraph.dependenciesOf(node.id),
+        ),
+      );
+      const total = this.repository.PPTotalAccountsLedger.whereAccountsIds(
+        accountIds,
       ).getClosingBalance();
 
       return R.assoc('previousPeriod', this.getAmountMeta(total), node);
@@ -181,8 +187,14 @@ export const ProfitLossSheetPreviousPeriod = <
         node: IProfitLossSheetAccountNode,
         totalNode: IProfitLossHorizontalDatePeriodNode,
       ): IProfitLossHorizontalDatePeriodNode => {
-        const total = this.repository.PPPeriodsAccountsLedger.whereAccountId(
-          node.id,
+        const accountIds = R.uniq(
+          R.append(
+            node.id,
+            this.repository.accountsGraph.dependenciesOf(node.id),
+          ),
+        );
+        const total = this.repository.PPPeriodsAccountsLedger.whereAccountsIds(
+          accountIds,
         )
           .whereFromDate(totalNode.previousPeriodFromDate.date)
           .whereToDate(totalNode.previousPeriodToDate.date)

--- a/packages/server/src/modules/FinancialStatements/modules/ProfitLossSheet/ProfitLossSheetPreviousYear.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/ProfitLossSheet/ProfitLossSheetPreviousYear.ts
@@ -35,8 +35,14 @@ export const ProfitLossSheetPreviousYear = <
     private assocPreviousYearTotalAccountNode = (
       accountNode: IProfitLossSheetAccountNode,
     ) => {
-      const total = this.repository.PYTotalAccountsLedger.whereAccountId(
-        accountNode.id,
+      const accountIds = R.uniq(
+        R.append(
+          accountNode.id,
+          this.repository.accountsGraph.dependenciesOf(accountNode.id),
+        ),
+      );
+      const total = this.repository.PYTotalAccountsLedger.whereAccountsIds(
+        accountIds,
       ).getClosingBalance();
 
       return R.assoc('previousYear', this.getAmountMeta(total), accountNode);
@@ -177,8 +183,14 @@ export const ProfitLossSheetPreviousYear = <
      */
     private assocPreviousYearAccountHorizTotal = R.curry(
       (node: IProfitLossSheetAccountNode, totalNode) => {
-        const total = this.repository.PYPeriodsAccountsLedger.whereAccountId(
-          node.id,
+        const accountIds = R.uniq(
+          R.append(
+            node.id,
+            this.repository.accountsGraph.dependenciesOf(node.id),
+          ),
+        );
+        const total = this.repository.PYPeriodsAccountsLedger.whereAccountsIds(
+          accountIds,
         )
           .whereFromDate(totalNode.previousYearFromDate.date)
           .whereToDate(totalNode.previousYearToDate.date)


### PR DESCRIPTION
## Summary

Fixes #1147.

Parent accounts with sub-accounts showed `0` in P&L and Balance Sheet period columns (Month/Quarter/Year) and Previous-Period / Previous-Year comparison columns, even though the single grand-total column was correct. Aggregate rows (`Total Expenses`, `Net Income`, etc.) cascaded to 0 because they sum their children.

### Root cause

The *total* column aggregated over an account **and its descendants** via `accountsGraph.dependenciesOf(id)` + `whereAccountsIds([...])`, but the *per-period* and *comparison* ledger queries filtered with `whereAccountId(node.id)` — own id only, excluding descendants.

### Fix

Mirror the total-column logic in every per-period and comparison ledger query across 6 files:

- `ProfitLossSheet/ProfitLossSheetDatePeriods.ts` — `getAccountNodeDatePeriodTotal`
- `ProfitLossSheet/ProfitLossSheetPreviousPeriod.ts` — `assocPreviousPeriodTotalAccountNode`, `assocPerviousPeriodAccountHorizTotal`
- `ProfitLossSheet/ProfitLossSheetPreviousYear.ts` — `assocPreviousYearTotalAccountNode`, `assocPreviousYearAccountHorizTotal`
- `BalanceSheet/BalanceSheetDatePeriods.ts` — `getAccountDatePeriodTotal` (both period + opening ledgers)
- `BalanceSheet/BalanceSheetComparsionPreviousPeriod.ts` — `assocPreviousPeriodAccountNode`, `getAccountPPDatePeriodTotal`
- `BalanceSheet/BalanceSheetComparsionPreviousYear.ts` — `assocPreviousYearAccountNode`, `getAccountPYDatePeriodTotal`

For each, descendants are resolved through the existing `repository.accountsGraph.dependenciesOf(id)` and passed to the already-available `Ledger.whereAccountsIds(accountIds)`.

## Test plan

- [ ] `tsc --noEmit` passes (✅ verified locally)
- [ ] Seed an expense parent account with sub-accounts; post transactions to the sub-accounts across multiple months
- [ ] P&L with **Display columns by → Month**: parent account, `Total Expenses`, `Net Operating Income`, `Net Income` show correct per-month amounts (no longer 0); Total column unchanged
- [ ] P&L with **Previous Period** / **Previous Year** comparisons: parent rows populate correctly
- [ ] Balance Sheet with Date Periods + Previous Period + Previous Year columns: parent accounts populate correctly
- [ ] Leaf-account rows (no descendants) unchanged — `dependenciesOf(leafId) === []` so `accountIds === [id]`
- [ ] `pnpm test:e2e -- financial-statements` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)