### PR TITLE
fix(server): remove redundant whereToDate from beginning-cash ledger

### DIFF
--- a/packages/server/src/modules/FinancialStatements/modules/CashFlowStatement/CashFlow.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/CashFlowStatement/CashFlow.ts
@@ -380,10 +380,9 @@ export class CashFlowStatement extends R.pipe(
     relation: ICashFlowSchemaAccountRelation,
     account: ModelObject<Account>,
   ): ICashFlowStatementAccountMeta => {
-    const cashToDate = this.beginningCashFrom(this.query.fromDate);
-
+    // SQL already bounds cashLedger to [null, fromDate-1] via filterDateRange;
+    // whereToDate here was redundant and dropped undated aggregated rows.
     const closingBalance = this.cashLedger
-      .whereToDate(cashToDate)
       .whereAccountId(account.id)
       .getClosingBalance();
 


### PR DESCRIPTION
## Problem

Cash flow statement always shows **\$0.00** for \"Cash at beginning of period\", making \"Cash at end of period\" wrong too. Operating/investing/financing sections compute correctly.

Fixes #1118.

## Root cause

`cashAccountMetaMapper` in `CashFlow.ts` applied an in-memory date filter on the beginning-cash ledger that was both **redundant** and **broken**:

```ts
const closingBalance = this.cashLedger
  .whereToDate(cashToDate)   // ← the culprit
  .whereAccountId(account.id)
  .getClosingBalance();
```

The ledger is populated from `cashAtBeginningTotalTransactions`, which already uses `filterDateRange(null, fromDate - 1 day)` in SQL — so the date bound is correctly applied at the DB level.

The problem: `cashAtBeginningTotalTransactions` uses `creditDebitSummation` (a `SUM`/`GROUP BY` modifier with no `date` column selected). The resulting `Ledger` entries have `entry.date === undefined`. Inside `Ledger#whereToDate`:

```ts
toDateParsed.isAfter(entry.date) || toDateParsed.isSame(entry.date)
// moment#isAfter(undefined) → false
// moment#isSame(undefined)  → false
```

Every beginning-cash entry is filtered out → closing balance is always 0.

## Fix

Remove the redundant `.whereToDate()` call. The SQL boundary is sufficient.

```diff
-    const cashToDate = this.beginningCashFrom(this.query.fromDate);
-
     const closingBalance = this.cashLedger
-      .whereToDate(cashToDate)
       .whereAccountId(account.id)
       .getClosingBalance();
```

`beginningCashFrom` is still used in `CashFlowDatePeriods.ts` so it is not removed.
