### PR TITLE
fix(webapp): fix "Something went wrong" when connecting a bank via Plaid

### DIFF
--- a/packages/webapp/src/hooks/utils/useOpenPlaidConnect.ts
+++ b/packages/webapp/src/hooks/utils/useOpenPlaidConnect.ts
@@ -12,7 +12,7 @@ export const useOpenPlaidConnect = () => {
   const openPlaidAsync = useCallback(() => {
     return getPlaidLinkToken()
       .then((res) => {
-        setPlaidId((res as { data: { link_token: string } }).data.link_token);
+        setPlaidId((res as { link_token: string }).link_token);
       })
       .catch(() => {
         AppToaster.show({


### PR DESCRIPTION
## Problem

Clicking **Connect Bank/Credit Card** on the Cash Flow accounts page always shows a `Something went wrong.` toast, even when the backend successfully returns a valid Plaid link token.

## Root cause

`fetchPlaidLinkToken` already returns the response body **unwrapped**:

```ts
// shared/sdk-ts/src/plaid.ts
const { data } = await post({});
return (data ?? {}) as PlaidLinkTokenResponse; // -> { link_token, expiration, request_id }
```

But `useOpenPlaidConnect` reads one level too deep:

```ts
// packages/webapp/src/hooks/utils/useOpenPlaidConnect.ts
setPlaidId((res as { data: { link_token: string } }).data.link_token);
//                                                   ^^^^ res.data is undefined
```

`res.data` is `undefined`, so `res.data.link_token` throws a `TypeError`. That rejection is caught by the `.catch()` in the same hook, which surfaces the generic `Something went wrong.` toast — so a **successful** request fails in its own success handler and the Plaid Link popup never opens.

Verified against a real response from the endpoint:

```json
{ "expiration": "...", "link_token": "link-sandbox-...", "request_id": "..." }
```

There is no `data` wrapper.

## Fix

Read `link_token` directly off the unwrapped response.

```diff
- setPlaidId((res as { data: { link_token: string } }).data.link_token);
+ setPlaidId((res as { link_token: string }).link_token);
```

## Testing

- With valid `PLAID_CLIENT_ID` / `PLAID_SECRET`, clicking **Connect Bank/Credit Card** now opens the Plaid Link popup instead of showing the error toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)