### PR TITLE
fix(tax-engine) + feat: balanced GL for taxed invoices, per-customer withholding tax, ANZ bank import preset, webapp fixes

### DIFF
--- a/docker-compose.taxfix.yml
+++ b/docker-compose.taxfix.yml
@@ -1,0 +1,5 @@
+# Override: run the locally-built patched server image (branch fix/invoice-tax-gl-balance).
+# Usage: docker compose -f docker-compose.prod.yml -f docker-compose.taxfix.yml up -d server
+services:
+  server:
+    image: bigcapital-server:taxfix

--- a/docker-compose.taxfix.yml
+++ b/docker-compose.taxfix.yml
@@ -3,3 +3,5 @@
 services:
   server:
     image: bigcapital-server:taxfix
+  webapp:
+    image: bigcapital-webapp:whtui

--- a/e2e/anz-import.spec.ts
+++ b/e2e/anz-import.spec.ts
@@ -1,0 +1,149 @@
+import { test, expect, APIRequestContext } from '@playwright/test';
+import crypto from 'crypto';
+import path from 'path';
+import fs from 'fs';
+import os from 'os';
+
+/**
+ * UI e2e for the ANZ (NZ) bank statement import.
+ *
+ * 1. The stock import wizard accepts a raw ANZ CSV upload and advances to
+ *    the mapping step listing the ANZ columns (the server auto-detects and
+ *    normalizes the format at parse time, so no special UI is needed).
+ * 2. After an import (driven through the real import API), the banking
+ *    screen renders the type-conditionally resolved payees.
+ */
+const SECRET = process.env.E2E_JWT_SECRET || '123123';
+const EMAIL = process.env.E2E_USER_EMAIL || 'ravi.kaniyawala@gmail.com';
+const ORG = process.env.E2E_ORGANIZATION_ID || '4yqtr1mr7c5gg4';
+const BASE = process.env.PLAYWRIGHT_TEST_BASE_URL || 'http://localhost';
+const ACCOUNT_ID = 1000;
+
+// Unique per-run reference so the dedup logic doesn't skip repeated runs.
+const RUN_REF = `e2e${Date.now()}`;
+const ANZ_CSV = [
+  'Type,Details,Particulars,Code,Reference,Amount,Date,ForeignCurrencyAmount,ConversionCharge',
+  `Visa Purchase,4037-****-****-4028  Df,,E2E Anz Cafe,${RUN_REF}a,-42.42,04/07/2026,,`,
+  `Eft-Pos,E2E Anz Grocer,4037********,4028   C,${RUN_REF}b,-13.37,04/07/2026,,`,
+].join('\n');
+
+function mintToken(): string {
+  const b64u = (b: Buffer) => b.toString('base64url');
+  const header = b64u(Buffer.from(JSON.stringify({ alg: 'HS384', typ: 'JWT' })));
+  const now = Math.floor(Date.now() / 1000);
+  const payload = b64u(
+    Buffer.from(JSON.stringify({ sub: EMAIL, iat: now, exp: now + 3600 })),
+  );
+  const sig = crypto
+    .createHmac('sha384', SECRET)
+    .update(`${header}.${payload}`)
+    .digest('base64url');
+  return `${header}.${payload}.${sig}`;
+}
+
+const apiHeaders = (token: string) => ({
+  Authorization: `Bearer ${token}`,
+  'organization-id': ORG,
+});
+
+const sessionCookies = (token: string) =>
+  [
+    { name: 'token', value: token },
+    { name: 'authenticated_user_id', value: '1' },
+    { name: 'organization_id', value: ORG },
+    { name: 'tenant_id', value: '1' },
+  ].map((c) => ({ ...c, url: BASE }));
+
+/** Runs the full import through the real import API. */
+async function importAnzCsv(request: APIRequestContext, token: string) {
+  const upload = await request.post(`${BASE}/api/import/file`, {
+    headers: apiHeaders(token),
+    multipart: {
+      file: {
+        name: 'anz-e2e.csv',
+        mimeType: 'text/csv',
+        buffer: Buffer.from(ANZ_CSV),
+      },
+      resource: 'uncategorized_bank_transaction',
+      params: JSON.stringify({ accountId: ACCOUNT_ID }),
+    },
+  });
+  expect(upload.status(), await upload.text()).toBe(200);
+  const importId = (await upload.json()).import.import_id;
+
+  const mapping = await request.post(`${BASE}/api/import/${importId}/mapping`, {
+    headers: { ...apiHeaders(token), 'Content-Type': 'application/json' },
+    data: {
+      mapping: [
+        { from: 'Date', to: 'date' },
+        { from: 'Details', to: 'payee' },
+        { from: 'Particulars', to: 'description' },
+        { from: 'Reference', to: 'referenceNo' },
+        { from: 'Amount', to: 'amount' },
+      ],
+    },
+  });
+  expect(mapping.status(), await mapping.text()).toBe(200);
+
+  const commit = await request.post(`${BASE}/api/import/${importId}/import`, {
+    headers: { ...apiHeaders(token), 'Content-Type': 'application/json' },
+    data: {},
+  });
+  expect(commit.status(), await commit.text()).toBe(201);
+  const meta = await commit.json();
+  expect(meta.created_count).toBe(2);
+}
+
+test.describe('ANZ bank statement import', () => {
+  let token: string;
+
+  test.beforeAll(() => {
+    token = mintToken();
+  });
+
+  test('import wizard accepts a raw ANZ CSV upload', async ({
+    browser,
+  }) => {
+    const context = await browser.newContext({ baseURL: BASE });
+    await context.addCookies(sessionCookies(token));
+    const page = await context.newPage();
+
+    await page.goto(`/cashflow-accounts/${ACCOUNT_ID}/import`);
+
+    const csvPath = path.join(os.tmpdir(), 'anz-e2e-wizard.csv');
+    fs.writeFileSync(csvPath, ANZ_CSV);
+
+    await page.setInputFiles('input[type="file"]', csvPath, {
+      timeout: 30_000,
+    });
+    // The dropzone accepts the raw ANZ CSV (no reshaping needed by the
+    // user). The upload/mapping/commit round-trip is covered end-to-end
+    // against the real endpoints in the sibling test below.
+    await expect(page.locator('body')).toContainText('anz-e2e-wizard.csv', {
+      timeout: 30_000,
+    });
+    await expect(page.locator('body')).toContainText('Mapping');
+    await context.close();
+  });
+
+  test('imported ANZ rows render with resolved payees in the banking screen', async ({
+    browser,
+    request,
+  }) => {
+    await importAnzCsv(request, token);
+
+    const context = await browser.newContext({ baseURL: BASE });
+    await context.addCookies(sessionCookies(token));
+    const page = await context.newPage();
+
+    await page.goto(
+      `/cashflow-accounts/${ACCOUNT_ID}/transactions?filter=uncategorized`,
+    );
+    // Card row payee resolved from the Code column; Eft-Pos from Details.
+    await expect(page.locator('body')).toContainText('E2E Anz Cafe', {
+      timeout: 30_000,
+    });
+    await expect(page.locator('body')).toContainText('E2E Anz Grocer');
+    await context.close();
+  });
+});

--- a/e2e/customer-withholding-field.spec.ts
+++ b/e2e/customer-withholding-field.spec.ts
@@ -1,0 +1,149 @@
+import { test, expect, APIRequestContext } from '@playwright/test';
+import crypto from 'crypto';
+
+/**
+ * UI e2e for the customer withholding-tax-rate field.
+ *
+ * Opens the real customer edit screen, verifies the "Withholding tax rate"
+ * field renders with the persisted value, edits it through the form, saves,
+ * and verifies persistence via the API and on reload.
+ */
+const SECRET = process.env.E2E_JWT_SECRET || '123123';
+const EMAIL = process.env.E2E_USER_EMAIL || 'ravi.kaniyawala@gmail.com';
+const ORG = process.env.E2E_ORGANIZATION_ID || '4yqtr1mr7c5gg4';
+const BASE = process.env.PLAYWRIGHT_TEST_BASE_URL || 'http://localhost';
+const CUSTOMER_ID = 1; // Datacom - carries a 20% withholding rate.
+
+function mintToken(): string {
+  const b64u = (b: Buffer) => b.toString('base64url');
+  const header = b64u(Buffer.from(JSON.stringify({ alg: 'HS384', typ: 'JWT' })));
+  const now = Math.floor(Date.now() / 1000);
+  const payload = b64u(
+    Buffer.from(JSON.stringify({ sub: EMAIL, iat: now, exp: now + 3600 })),
+  );
+  const sig = crypto
+    .createHmac('sha384', SECRET)
+    .update(`${header}.${payload}`)
+    .digest('base64url');
+  return `${header}.${payload}.${sig}`;
+}
+
+const apiHeaders = (token: string) => ({
+  Authorization: `Bearer ${token}`,
+  'organization-id': ORG,
+  'Content-Type': 'application/json',
+});
+
+const sessionCookies = (token: string) =>
+  [
+    { name: 'token', value: token },
+    { name: 'authenticated_user_id', value: '1' },
+    { name: 'organization_id', value: ORG },
+    { name: 'tenant_id', value: '1' },
+  ].map((c) => ({ ...c, url: BASE }));
+
+async function setRate(
+  request: APIRequestContext,
+  token: string,
+  rate: number | null,
+) {
+  const res = await request.put(`${BASE}/api/customers/${CUSTOMER_ID}`, {
+    headers: apiHeaders(token),
+    data: {
+      customerType: 'business',
+      currencyCode: 'NZD',
+      displayName: 'Datacom Systems Limited',
+      companyName: 'Datacom Systems Limited',
+      withholdingTaxRate: rate,
+    },
+  });
+  expect(res.status(), await res.text()).toBe(200);
+}
+
+async function getRate(
+  request: APIRequestContext,
+  token: string,
+): Promise<number | null> {
+  const res = await request.get(`${BASE}/api/customers/${CUSTOMER_ID}`, {
+    headers: apiHeaders(token),
+  });
+  const body = await res.json();
+  const customer = body?.data ?? body?.customer ?? body;
+  const rate = customer.withholding_tax_rate;
+  return rate === null || rate === undefined ? null : Number(rate);
+}
+
+test.describe('customer withholding tax rate field', () => {
+  let token: string;
+
+  test.beforeAll(async ({ request }) => {
+    token = mintToken();
+    await setRate(request, token, 20);
+  });
+
+  test.afterAll(async ({ request }) => {
+    // Restore the real configuration.
+    await setRate(request, token, 20);
+  });
+
+  test('renders, edits and persists through the customer edit screen', async ({
+    browser,
+    request,
+  }) => {
+    const context = await browser.newContext({ baseURL: BASE });
+    await context.addCookies(sessionCookies(token));
+    const page = await context.newPage();
+
+    await page.goto(`/customers/${CUSTOMER_ID}/edit`);
+
+    const field = page.locator('input[name="withholding_tax_rate"]');
+    await expect(field).toBeVisible({ timeout: 30_000 });
+    await expect(field).toHaveValue('20');
+    // The label renders from the locale string.
+    await expect(page.locator('body')).toContainText('Withholding tax rate');
+
+    // Edit through the form and save.
+    await field.fill('25');
+    // The primary floating action is labeled "Edit" in edit mode.
+    await page.getByRole('button', { name: /^edit$/i }).first().click();
+    await expect(page.locator('body')).toContainText(/edited successfully/i, {
+      timeout: 30_000,
+    });
+
+    // Persisted via the API...
+    await expect
+      .poll(async () => getRate(request, token), { timeout: 15_000 })
+      .toBe(25);
+
+    // ...and round-trips on reload.
+    await page.goto(`/customers/${CUSTOMER_ID}/edit`);
+    await expect(page.locator('input[name="withholding_tax_rate"]')).toHaveValue(
+      '25',
+      { timeout: 30_000 },
+    );
+    await context.close();
+  });
+
+  test('saves with the field cleared (no withholding)', async ({
+    browser,
+    request,
+  }) => {
+    const context = await browser.newContext({ baseURL: BASE });
+    await context.addCookies(sessionCookies(token));
+    const page = await context.newPage();
+
+    await page.goto(`/customers/${CUSTOMER_ID}/edit`);
+    const field = page.locator('input[name="withholding_tax_rate"]');
+    await expect(field).toBeVisible({ timeout: 30_000 });
+
+    await field.fill('');
+    await page.getByRole('button', { name: /^edit$/i }).first().click();
+    await expect(page.locator('body')).toContainText(/edited successfully/i, {
+      timeout: 30_000,
+    });
+    await expect
+      .poll(async () => getRate(request, token), { timeout: 15_000 })
+      .toBe(null);
+    await context.close();
+  });
+});

--- a/e2e/invoice-tax-gl.spec.ts
+++ b/e2e/invoice-tax-gl.spec.ts
@@ -1,0 +1,150 @@
+import { test, expect, APIRequestContext } from '@playwright/test';
+import crypto from 'crypto';
+
+/**
+ * UI e2e for the invoice tax-engine GL fix.
+ *
+ * Creates a tax-EXCLUSIVE invoice (1,000.00 + 15% GST) through the API and
+ * asserts the webapp renders the tax-included total (1,150.00). Before the
+ * fix the total omitted the tax amount for exclusive-tax invoices, so the
+ * UI displayed 1,000.00 and the posted GL entries were unbalanced.
+ *
+ * Auth: mints the same HS384 JWT the server issues (dev fallback secret)
+ * and injects the session cookies the webapp reads - no new user accounts.
+ */
+// NOTE: deliberately NOT process.env.APP_JWT_SECRET - the root .env (loaded
+// by playwright.config.ts via dotenv) may define it while the server container
+// still runs on the built-in dev fallback secret.
+const SECRET = process.env.E2E_JWT_SECRET || '123123';
+const EMAIL = process.env.E2E_USER_EMAIL || 'ravi.kaniyawala@gmail.com';
+const ORG = process.env.E2E_ORGANIZATION_ID || '4yqtr1mr7c5gg4';
+const BASE = process.env.PLAYWRIGHT_TEST_BASE_URL || 'http://localhost';
+
+const INVOICE_NO = 'E2E-GST-1';
+
+function mintToken(): string {
+  const b64u = (b: Buffer) => b.toString('base64url');
+  const header = b64u(Buffer.from(JSON.stringify({ alg: 'HS384', typ: 'JWT' })));
+  const now = Math.floor(Date.now() / 1000);
+  const payload = b64u(
+    Buffer.from(JSON.stringify({ sub: EMAIL, iat: now, exp: now + 3600 })),
+  );
+  const sig = crypto
+    .createHmac('sha384', SECRET)
+    .update(`${header}.${payload}`)
+    .digest('base64url');
+  return `${header}.${payload}.${sig}`;
+}
+
+const apiHeaders = (token: string) => ({
+  Authorization: `Bearer ${token}`,
+  'organization-id': ORG,
+  'Content-Type': 'application/json',
+});
+
+async function deleteInvoiceByNo(
+  request: APIRequestContext,
+  token: string,
+  invoiceNo: string,
+) {
+  const res = await request.get(
+    `${BASE}/api/sale-invoices?search_keyword=${invoiceNo}`,
+    { headers: apiHeaders(token) },
+  );
+  if (!res.ok()) return;
+  const body = await res.json();
+  const invoices = body?.data ?? body?.sales_invoices ?? [];
+  for (const invoice of invoices) {
+    if (invoice.invoice_no === invoiceNo) {
+      await request.delete(`${BASE}/api/sale-invoices/${invoice.id}`, {
+        headers: apiHeaders(token),
+      });
+    }
+  }
+}
+
+test.describe('invoice tax GL fix', () => {
+  let token: string;
+  let invoiceId: number;
+
+  test.beforeAll(async ({ request }) => {
+    token = mintToken();
+    // Clean up leftovers from previous runs, then create the fixture invoice.
+    await deleteInvoiceByNo(request, token, INVOICE_NO);
+
+    const res = await request.post(`${BASE}/api/sale-invoices`, {
+      headers: apiHeaders(token),
+      data: {
+        customerId: 1,
+        invoiceDate: '2026-06-30',
+        dueDate: '2026-07-31',
+        delivered: true,
+        isInclusiveTax: false,
+        invoiceNo: INVOICE_NO,
+        entries: [
+          {
+            index: 1,
+            itemId: 1000,
+            quantity: 1,
+            rate: 1000,
+            description: 'E2E exclusive GST line',
+            taxRateId: 5,
+          },
+        ],
+      },
+    });
+    expect(res.status(), await res.text()).toBe(201);
+    invoiceId = (await res.json()).id;
+  });
+
+  test.afterAll(async ({ request }) => {
+    if (invoiceId) {
+      await request.delete(`${BASE}/api/sale-invoices/${invoiceId}`, {
+        headers: apiHeaders(token),
+      });
+    }
+  });
+
+  test('invoice list renders the tax-included total', async ({ browser }) => {
+    const context = await browser.newContext({ baseURL: BASE });
+    await context.addCookies(
+      [
+        { name: 'token', value: token },
+        { name: 'authenticated_user_id', value: '1' },
+        { name: 'organization_id', value: ORG },
+        { name: 'tenant_id', value: '1' },
+      ].map((c) => ({ ...c, url: BASE })),
+    );
+    const page = await context.newPage();
+
+    await page.goto('/invoices');
+    await expect(page.locator('body')).toContainText(INVOICE_NO, {
+      timeout: 30_000,
+    });
+    // 1,000.00 + 15% GST - the buggy total rendered 1,000.00.
+    await expect(page.locator('body')).toContainText('1,150.00');
+    await context.close();
+  });
+
+  test('sales tax liability report renders the GST rate row', async ({
+    browser,
+  }) => {
+    const context = await browser.newContext({ baseURL: BASE });
+    await context.addCookies(
+      [
+        { name: 'token', value: token },
+        { name: 'authenticated_user_id', value: '1' },
+        { name: 'organization_id', value: ORG },
+        { name: 'tenant_id', value: '1' },
+      ].map((c) => ({ ...c, url: BASE })),
+    );
+    const page = await context.newPage();
+
+    await page.goto('/financial-reports/sales-tax-liability-summary');
+    // The report is populated natively from tax_rate_id-tagged GL rows.
+    await expect(page.locator('body')).toContainText('GST', {
+      timeout: 30_000,
+    });
+    await context.close();
+  });
+});

--- a/e2e/invoice-withholding-tax.spec.ts
+++ b/e2e/invoice-withholding-tax.spec.ts
@@ -1,0 +1,157 @@
+import { test, expect, APIRequestContext } from '@playwright/test';
+import crypto from 'crypto';
+
+/**
+ * UI e2e for per-customer withholding tax.
+ *
+ * The customer (id 1) carries withholdingTaxRate=20. An invoice of
+ * 1,000.00 + 15% GST (total 1,150.00) is paid with the NET bank amount
+ * only (950.00). The withheld 200.00 must be booked automatically into
+ * the Withholding Tax Receivable account, so the webapp renders the
+ * invoice as fully Paid - impossible without the companion booking.
+ */
+const SECRET = process.env.E2E_JWT_SECRET || '123123';
+const EMAIL = process.env.E2E_USER_EMAIL || 'ravi.kaniyawala@gmail.com';
+const ORG = process.env.E2E_ORGANIZATION_ID || '4yqtr1mr7c5gg4';
+const BASE = process.env.PLAYWRIGHT_TEST_BASE_URL || 'http://localhost';
+
+const INVOICE_NO = 'E2E-WHT-1';
+
+function mintToken(): string {
+  const b64u = (b: Buffer) => b.toString('base64url');
+  const header = b64u(Buffer.from(JSON.stringify({ alg: 'HS384', typ: 'JWT' })));
+  const now = Math.floor(Date.now() / 1000);
+  const payload = b64u(
+    Buffer.from(JSON.stringify({ sub: EMAIL, iat: now, exp: now + 3600 })),
+  );
+  const sig = crypto
+    .createHmac('sha384', SECRET)
+    .update(`${header}.${payload}`)
+    .digest('base64url');
+  return `${header}.${payload}.${sig}`;
+}
+
+const apiHeaders = (token: string) => ({
+  Authorization: `Bearer ${token}`,
+  'organization-id': ORG,
+  'Content-Type': 'application/json',
+});
+
+async function deleteInvoiceByNo(
+  request: APIRequestContext,
+  token: string,
+  invoiceNo: string,
+) {
+  const res = await request.get(
+    `${BASE}/api/sale-invoices?search_keyword=${invoiceNo}`,
+    { headers: apiHeaders(token) },
+  );
+  if (!res.ok()) return;
+  const body = await res.json();
+  const invoices = body?.data ?? body?.sales_invoices ?? [];
+  for (const invoice of invoices) {
+    if (invoice.invoice_no === invoiceNo) {
+      await request.delete(`${BASE}/api/sale-invoices/${invoice.id}`, {
+        headers: apiHeaders(token),
+      });
+    }
+  }
+}
+
+test.describe('per-customer withholding tax', () => {
+  let token: string;
+  let invoiceId: number;
+  let paymentId: number;
+
+  test.beforeAll(async ({ request }) => {
+    token = mintToken();
+    await deleteInvoiceByNo(request, token, INVOICE_NO);
+
+    // The customer must carry the withholding rate.
+    const cust = await request.put(`${BASE}/api/customers/1`, {
+      headers: apiHeaders(token),
+      data: {
+        customerType: 'business',
+        currencyCode: 'NZD',
+        displayName: 'Datacom Systems Limited',
+        companyName: 'Datacom Systems Limited',
+        withholdingTaxRate: 20,
+      },
+    });
+    expect(cust.status(), await cust.text()).toBe(200);
+
+    const res = await request.post(`${BASE}/api/sale-invoices`, {
+      headers: apiHeaders(token),
+      data: {
+        customerId: 1,
+        invoiceDate: '2026-06-30',
+        dueDate: '2026-07-31',
+        delivered: true,
+        isInclusiveTax: false,
+        invoiceNo: INVOICE_NO,
+        entries: [
+          {
+            index: 1,
+            itemId: 1000,
+            quantity: 1,
+            rate: 1000,
+            description: 'E2E WHT line',
+            taxRateId: 5,
+          },
+        ],
+      },
+    });
+    expect(res.status(), await res.text()).toBe(201);
+    invoiceId = (await res.json()).id;
+
+    // Pay the NET bank amount only: 1,150 - 20% x 1,000 = 950.
+    const pay = await request.post(`${BASE}/api/payments-received`, {
+      headers: apiHeaders(token),
+      data: {
+        customerId: 1,
+        paymentDate: '2026-07-01',
+        depositAccountId: 1000,
+        referenceNo: 'E2E WHT net payment',
+        entries: [{ index: 1, invoiceId, paymentAmount: 950 }],
+      },
+    });
+    expect(pay.status(), await pay.text()).toBe(201);
+    paymentId = (await pay.json()).id;
+  });
+
+  test.afterAll(async ({ request }) => {
+    if (paymentId) {
+      await request.delete(`${BASE}/api/payments-received/${paymentId}`, {
+        headers: apiHeaders(token),
+      });
+    }
+    if (invoiceId) {
+      await request.delete(`${BASE}/api/sale-invoices/${invoiceId}`, {
+        headers: apiHeaders(token),
+      });
+    }
+  });
+
+  test('net-of-withholding payment renders the invoice as fully paid', async ({
+    browser,
+  }) => {
+    const context = await browser.newContext({ baseURL: BASE });
+    await context.addCookies(
+      [
+        { name: 'token', value: token },
+        { name: 'authenticated_user_id', value: '1' },
+        { name: 'organization_id', value: ORG },
+        { name: 'tenant_id', value: '1' },
+      ].map((c) => ({ ...c, url: BASE })),
+    );
+    const page = await context.newPage();
+
+    await page.goto('/invoices');
+    const row = page.getByRole('row', { name: new RegExp(INVOICE_NO) });
+    await expect(row).toContainText('1,150.00', { timeout: 30_000 });
+    await expect(row).toContainText(/paid/i);
+    // Fully paid - nothing left due on the row.
+    await expect(row).not.toContainText(/partially/i);
+    await context.close();
+  });
+});

--- a/e2e/webapp-sweep.spec.ts
+++ b/e2e/webapp-sweep.spec.ts
@@ -1,0 +1,186 @@
+import { test, expect } from '@playwright/test';
+import crypto from 'crypto';
+
+/**
+ * Full-webapp smoke sweep: visits every reachable dashboard route and
+ * records, per route: uncaught page errors, console errors, failed API
+ * responses (>=500), and React error-boundary fallbacks. The single test
+ * fails with the aggregated findings so one run reports everything.
+ */
+const SECRET = process.env.E2E_JWT_SECRET || '123123';
+const EMAIL = process.env.E2E_USER_EMAIL || 'ravi.kaniyawala@gmail.com';
+const ORG = process.env.E2E_ORGANIZATION_ID || '4yqtr1mr7c5gg4';
+const BASE = process.env.PLAYWRIGHT_TEST_BASE_URL || 'http://localhost';
+
+// Real entities in the local tenant (edit routes need existing ids).
+const IDS = {
+  account: 1000,
+  customer: 1,
+  invoice: 2,
+  item: 1000,
+  journal: 1001,
+  paymentReceived: 2,
+};
+
+const ROUTES: string[] = [
+  '/',
+  '/homepage',
+  '/accounts',
+  '/items',
+  `/items/${IDS.item}/edit`,
+  '/items/new',
+  '/items/categories',
+  '/inventory-adjustments',
+  '/customers',
+  `/customers/${IDS.customer}/edit`,
+  '/customers/new',
+  '/vendors',
+  '/vendors/new',
+  '/estimates',
+  '/estimates/new',
+  '/invoices',
+  `/invoices/${IDS.invoice}/edit`,
+  '/invoices/new',
+  '/receipts',
+  '/receipts/new',
+  '/credit-notes',
+  '/payments-received',
+  `/payments-received/${IDS.paymentReceived}/edit`,
+  '/payments-received/new',
+  '/bills',
+  '/bills/new',
+  '/payments-made',
+  '/payments-made/new',
+  '/vendor-credits',
+  '/expenses',
+  '/expenses/new',
+  '/manual-journals',
+  `/manual-journals/${IDS.journal}/edit`,
+  '/make-journal-entry',
+  '/cashflow-accounts',
+  `/cashflow-accounts/${IDS.account}/transactions`,
+  `/cashflow-accounts/${IDS.account}/transactions?filter=uncategorized`,
+  `/cashflow-accounts/${IDS.account}/import`,
+  '/banking/rules',
+  '/warehouses-transfers',
+  '/transactions-locking',
+  '/financial-reports/balance-sheet',
+  '/financial-reports/profit-loss-sheet',
+  '/financial-reports/trial-balance-sheet',
+  '/financial-reports/general-ledger',
+  '/financial-reports/journal-sheet',
+  '/financial-reports/cash-flow',
+  '/financial-reports/sales-tax-liability-summary',
+  '/financial-reports/receivable-aging-summary',
+  '/financial-reports/payable-aging-summary',
+  '/financial-reports/customers-balance-summary',
+  '/financial-reports/vendors-balance-summary',
+  '/financial-reports/transactions-by-customers',
+  '/financial-reports/transactions-by-vendors',
+  '/financial-reports/sales-by-items',
+  '/financial-reports/purchases-by-items',
+  '/financial-reports/inventory-valuation',
+  '/financial-reports/inventory-item-details',
+  '/financial-reports/realized-gain-loss',
+  '/financial-reports/unrealized-gain-loss',
+  '/financial-reports/audit-log',
+  '/preferences/general',
+  '/preferences/users',
+  '/preferences/currencies',
+  '/preferences/branches',
+  '/preferences/warehouses',
+];
+
+// Benign noise we deliberately ignore (3rd-party, favicons, websockets).
+const IGNORED_CONSOLE = [
+  /Download the React DevTools/i,
+  /React Router Future Flag/i,
+  /Warning: /, // React dev warnings - not user-facing failures
+  /favicon/i,
+  /posthog/i,
+  /\[mobx\]/i,
+];
+
+function mintToken(): string {
+  const b64u = (b: Buffer) => b.toString('base64url');
+  const header = b64u(Buffer.from(JSON.stringify({ alg: 'HS384', typ: 'JWT' })));
+  const now = Math.floor(Date.now() / 1000);
+  const payload = b64u(
+    Buffer.from(JSON.stringify({ sub: EMAIL, iat: now, exp: now + 7200 })),
+  );
+  const sig = crypto
+    .createHmac('sha384', SECRET)
+    .update(`${header}.${payload}`)
+    .digest('base64url');
+  return `${header}.${payload}.${sig}`;
+}
+
+test.describe('webapp route sweep', () => {
+  test('every dashboard route renders without errors', async ({ browser }) => {
+    test.setTimeout(15 * 60 * 1000);
+
+    const token = mintToken();
+    const context = await browser.newContext({ baseURL: BASE });
+    await context.addCookies(
+      [
+        { name: 'token', value: token },
+        { name: 'authenticated_user_id', value: '1' },
+        { name: 'organization_id', value: ORG },
+        { name: 'tenant_id', value: '1' },
+      ].map((c) => ({ ...c, url: BASE })),
+    );
+    const page = await context.newPage();
+
+    const findings: string[] = [];
+    let currentRoute = '';
+
+    page.on('pageerror', (err) => {
+      findings.push(`[pageerror] ${currentRoute}: ${err.message.slice(0, 200)}`);
+    });
+    page.on('console', (msg) => {
+      if (msg.type() !== 'error') return;
+      const text = msg.text();
+      if (IGNORED_CONSOLE.some((re) => re.test(text))) return;
+      findings.push(`[console] ${currentRoute}: ${text.slice(0, 200)}`);
+    });
+    page.on('response', (res) => {
+      if (res.status() >= 500 && res.url().includes('/api/')) {
+        findings.push(
+          `[api ${res.status()}] ${currentRoute}: ${res
+            .url()
+            .replace(BASE, '')
+            .slice(0, 150)}`,
+        );
+      }
+    });
+
+    for (const route of ROUTES) {
+      currentRoute = route;
+      try {
+        await page.goto(route, { waitUntil: 'networkidle', timeout: 45_000 });
+      } catch (err) {
+        findings.push(`[nav] ${route}: ${(err as Error).message.slice(0, 120)}`);
+        continue;
+      }
+      // Small settle for late queries + pacing to stay under the API
+      // throttle (sweep fires many requests; 429s would cascade into
+      // false findings).
+      await page.waitForTimeout(1500);
+
+      const body = (await page.locator('body').innerText()).trim();
+      if (body.includes('Something went wrong')) {
+        findings.push(`[error-boundary] ${route}`);
+      }
+      if (body.length < 40) {
+        findings.push(`[blank] ${route}: body="${body.slice(0, 40)}"`);
+      }
+    }
+    await context.close();
+
+    const deduped = Array.from(new Set(findings));
+    expect(
+      deduped,
+      `Route sweep findings (${deduped.length}):\n` + deduped.join('\n'),
+    ).toEqual([]);
+  });
+});

--- a/packages/server/Dockerfile
+++ b/packages/server/Dockerfile
@@ -23,14 +23,17 @@ RUN pnpm install --frozen-lockfile
 # Copy source code
 COPY --chown=node:node ./packages/server ./packages/server
 
-# The repo tracks both src/modules/ee and src/modules/EE; on case-insensitive
-# filesystems (macOS checkouts) they collapse into a single directory, which
-# breaks the case-sensitive build here. Mirror whichever casing exists so both
-# import spellings resolve. No-op on case-sensitive checkouts.
-RUN if [ -d packages/server/src/modules/EE ] && [ ! -d packages/server/src/modules/ee ]; then \
-      cp -r packages/server/src/modules/EE packages/server/src/modules/ee; \
-    elif [ -d packages/server/src/modules/ee ] && [ ! -d packages/server/src/modules/EE ]; then \
-      cp -r packages/server/src/modules/ee packages/server/src/modules/EE; \
+# The repo tracks both src/modules/ee and src/modules/EE; case-insensitive
+# filesystems (macOS checkouts) collapse them into a single "EE" directory,
+# which breaks this case-sensitive build stage (lowercase imports no longer
+# resolve). When only one casing survived the checkout, rewrite the lowercase
+# import specifiers to the surviving casing. No-op on case-sensitive checkouts
+# where both directories exist.
+RUN set -e; MODS=packages/server/src/modules; \
+    if [ -d "$MODS/EE" ] && [ ! -d "$MODS/ee" ]; then \
+      find packages/server/src -name "*.ts" -exec grep -l "/ee/" {} + | xargs -r sed -i "s|/ee/|/EE/|g"; \
+    elif [ -d "$MODS/ee" ] && [ ! -d "$MODS/EE" ]; then \
+      find packages/server/src -name "*.ts" -exec grep -l "/EE/" {} + | xargs -r sed -i "s|/EE/|/ee/|g"; \
     fi
 
 # Build NestJS application

--- a/packages/server/Dockerfile
+++ b/packages/server/Dockerfile
@@ -23,6 +23,16 @@ RUN pnpm install --frozen-lockfile
 # Copy source code
 COPY --chown=node:node ./packages/server ./packages/server
 
+# The repo tracks both src/modules/ee and src/modules/EE; on case-insensitive
+# filesystems (macOS checkouts) they collapse into a single directory, which
+# breaks the case-sensitive build here. Mirror whichever casing exists so both
+# import spellings resolve. No-op on case-sensitive checkouts.
+RUN if [ -d packages/server/src/modules/EE ] && [ ! -d packages/server/src/modules/ee ]; then \
+      cp -r packages/server/src/modules/EE packages/server/src/modules/ee; \
+    elif [ -d packages/server/src/modules/ee ] && [ ! -d packages/server/src/modules/EE ]; then \
+      cp -r packages/server/src/modules/ee packages/server/src/modules/EE; \
+    fi
+
 # Build NestJS application
 RUN pnpm run build:server --skip-nx-cache
 

--- a/packages/server/src/database/tenant/migrations/20260705000001_add_withholding_tax_rate_to_contacts.ts
+++ b/packages/server/src/database/tenant/migrations/20260705000001_add_withholding_tax_rate_to_contacts.ts
@@ -1,0 +1,21 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema.alterTable('contacts', (table) => {
+    // Percentage (0-100) withheld by the payer from the tax-exclusive
+    // amount (e.g. NZ schedular payments). Null means no withholding.
+    table.decimal('withholding_tax_rate', 5, 2).nullable().after('code');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.alterTable('contacts', (table) => {
+    table.dropColumn('withholding_tax_rate');
+  });
+};

--- a/packages/server/src/modules/Accounts/Accounts.constants.ts
+++ b/packages/server/src/modules/Accounts/Accounts.constants.ts
@@ -20,6 +20,17 @@ export const TaxPayableAccount = {
   predefined: true,
 };
 
+export const WithholdingTaxReceivableAccount = {
+  name: 'Withholding Tax Receivable',
+  slug: 'withholding-tax-receivable',
+  accountType: 'other-current-asset',
+  code: '100011',
+  description: 'Income tax withheld by payers, claimable against tax owed.',
+  active: true,
+  index: 1,
+  predefined: true,
+};
+
 export const UnearnedRevenueAccount = {
   name: 'Unearned Revenue',
   slug: 'unearned-revenue',

--- a/packages/server/src/modules/Accounts/repositories/Account.repository.ts
+++ b/packages/server/src/modules/Accounts/repositories/Account.repository.ts
@@ -14,6 +14,7 @@ import {
   StripeClearingAccount,
   TaxPayableAccount,
   UnearnedRevenueAccount,
+  WithholdingTaxReceivableAccount,
 } from '../Accounts.constants';
 
 @Injectable({ scope: Scope.REQUEST })
@@ -171,6 +172,29 @@ export class AccountRepository extends TenantRepository {
     if (!result) {
       result = await this.model.query(trx).insertAndFetch({
         ...TaxPayableAccount,
+        ...extraAttrs,
+      });
+    }
+    return result;
+  }
+
+  /**
+   * Finds or creates the withholding tax receivable account.
+   * @param {Record<string, string>} extraAttrs
+   * @param {Knex.Transaction} trx
+   * @returns
+   */
+  async findOrCreateWithholdingTaxReceivable(
+    extraAttrs: Record<string, string> = {},
+    trx?: Knex.Transaction,
+  ) {
+    let result = await this.model
+      .query(trx)
+      .findOne({ slug: WithholdingTaxReceivableAccount.slug, ...extraAttrs });
+
+    if (!result) {
+      result = await this.model.query(trx).insertAndFetch({
+        ...WithholdingTaxReceivableAccount,
         ...extraAttrs,
       });
     }

--- a/packages/server/src/modules/BankingCategorize/commands/AnzBankStatementFormat.ts
+++ b/packages/server/src/modules/BankingCategorize/commands/AnzBankStatementFormat.ts
@@ -1,0 +1,124 @@
+import { createHash } from 'crypto';
+import * as moment from 'moment';
+
+/**
+ * ANZ (NZ) bank statement export support.
+ *
+ * ANZ CSV exports use the columns:
+ *   Type, Details, Particulars, Code, Reference, Amount, Date,
+ *   ForeignCurrencyAmount, ConversionCharge
+ *
+ * The merchant/counterparty lives in a DIFFERENT column depending on the
+ * transaction type: card transactions (Visa Purchase/Refund) carry the
+ * masked card number in `Details` and the merchant in `Code`, while all
+ * other types carry the counterparty in `Details`. Dates are dd/MM/yyyy.
+ *
+ * `transformAnzStatementRows` normalizes rows in place of the original
+ * columns so the standard import mapping works naturally:
+ *   Date -> date (ISO), Details -> payee (resolved), Particulars ->
+ *   description (type + FX note), Reference -> referenceNo (occurrence
+ *   suffixed for exact duplicates within the same file, keeping re-imports
+ *   deterministic).
+ */
+export const ANZ_BANK_FORMAT = 'anz-nz';
+
+const ANZ_SIGNATURE_COLUMNS = [
+  'Type',
+  'Details',
+  'Particulars',
+  'Code',
+  'Reference',
+  'Amount',
+  'Date',
+];
+
+const ANZ_CARD_TYPES = /^visa\s+(purchase|refund)$/i;
+
+const str = (value: unknown): string =>
+  value === null || value === undefined ? '' : String(value).trim();
+
+/**
+ * Detects whether the parsed sheet is an ANZ (NZ) statement export.
+ */
+export const isAnzBankStatementSheet = (
+  rows: Record<string, unknown>[],
+): boolean => {
+  const first = rows?.[0];
+  if (!first) return false;
+
+  const columns = Object.keys(first);
+  return ANZ_SIGNATURE_COLUMNS.every((column) => columns.includes(column));
+};
+
+/**
+ * Normalizes ANZ statement rows onto the standard bank import columns.
+ */
+export const transformAnzStatementRows = (
+  rows: Record<string, unknown>[],
+): Record<string, unknown>[] => {
+  const occurrences = new Map<string, number>();
+
+  return rows.map((row) => {
+    const type = str(row['Type']);
+    const isCard = ANZ_CARD_TYPES.test(type);
+
+    const details = str(row['Details']);
+    const code = str(row['Code']);
+    const payee = isCard ? code || details : details || code;
+
+    const foreignAmount = str(row['ForeignCurrencyAmount']);
+    const description = foreignAmount ? `${type} - ${foreignAmount}` : type;
+
+    const date = moment(str(row['Date']), 'DD/MM/YYYY', true);
+    const isoDate = date.isValid() ? date.format('YYYY-MM-DD') : str(row['Date']);
+
+    let reference = str(row['Reference']) || str(row['Particulars']);
+
+    // Suffix exact duplicates within the file so the dedup id stays unique
+    // and deterministic across re-imports of overlapping exports.
+    const occurrenceKey = [isoDate, str(row['Amount']), payee, reference].join(
+      '|',
+    );
+    const occurrence = (occurrences.get(occurrenceKey) || 0) + 1;
+    occurrences.set(occurrenceKey, occurrence);
+
+    if (occurrence > 1) {
+      reference = reference ? `${reference} #${occurrence}` : `#${occurrence}`;
+    }
+    return {
+      ...row,
+      Date: isoDate,
+      Details: payee,
+      Particulars: description,
+      Reference: reference,
+    };
+  });
+};
+
+/**
+ * Builds a deterministic unique id for an imported bank transaction, used
+ * to skip already-imported rows on re-import.
+ */
+export const buildBankTransactionUniqueId = (
+  accountId: number | string,
+  dto: {
+    date: unknown;
+    amount: unknown;
+    payee?: unknown;
+    referenceNo?: unknown;
+  },
+): string => {
+  const date = moment(dto.date as moment.MomentInput).isValid()
+    ? moment(dto.date as moment.MomentInput).format('YYYY-MM-DD')
+    : str(dto.date);
+  const key = [
+    ANZ_BANK_FORMAT,
+    str(accountId),
+    date,
+    String(Number(dto.amount)),
+    str(dto.payee),
+    str(dto.referenceNo),
+  ].join('|');
+
+  return `imp-${createHash('sha1').update(key).digest('hex').slice(0, 32)}`;
+};

--- a/packages/server/src/modules/BankingCategorize/commands/AnzBankStatementFormat.ts
+++ b/packages/server/src/modules/BankingCategorize/commands/AnzBankStatementFormat.ts
@@ -39,14 +39,23 @@ const str = (value: unknown): string =>
 
 /**
  * Detects whether the parsed sheet is an ANZ (NZ) statement export.
+ *
+ * Prefers the explicit sheet columns (from the upload step) since the
+ * sheet parser omits empty cells, so individual rows may miss columns.
+ * @param {Record<string, unknown>[]} rows - Parsed sheet rows.
+ * @param {string[]} sheetColumns - Sheet header columns, when known.
  */
 export const isAnzBankStatementSheet = (
   rows: Record<string, unknown>[],
+  sheetColumns?: string[],
 ): boolean => {
-  const first = rows?.[0];
-  if (!first) return false;
+  if (!rows?.length && !sheetColumns?.length) return false;
 
-  const columns = Object.keys(first);
+  const columns = sheetColumns?.length
+    ? sheetColumns
+    : Array.from(
+        new Set(rows.slice(0, 25).flatMap((row) => Object.keys(row))),
+      );
   return ANZ_SIGNATURE_COLUMNS.every((column) => columns.includes(column));
 };
 

--- a/packages/server/src/modules/BankingCategorize/commands/UncategorizedTransactionsImportable.ts
+++ b/packages/server/src/modules/BankingCategorize/commands/UncategorizedTransactionsImportable.ts
@@ -78,7 +78,7 @@ export class UncategorizedTransactionsImportable extends Importable {
 
     const isAnz =
       params.bankFormat === ANZ_BANK_FORMAT ||
-      isAnzBankStatementSheet(sheetData);
+      isAnzBankStatementSheet(sheetData, importFile?.columnsParsed);
 
     if (!isAnz) return sheetData;
 

--- a/packages/server/src/modules/BankingCategorize/commands/UncategorizedTransactionsImportable.ts
+++ b/packages/server/src/modules/BankingCategorize/commands/UncategorizedTransactionsImportable.ts
@@ -11,6 +11,14 @@ import { CreateUncategorizedTransactionDTO } from '../types/BankingCategorize.ty
 import { TenantModelProxy } from '@/modules/System/models/TenantBaseModel';
 import { ImportableService } from '../../Import/decorators/Import.decorator';
 import { UncategorizedBankTransaction } from '../../BankingTransactions/models/UncategorizedBankTransaction';
+import { ServiceError } from '../../Items/ServiceError';
+import {
+  ANZ_BANK_FORMAT,
+  buildBankTransactionUniqueId,
+  isAnzBankStatementSheet,
+  transformAnzStatementRows,
+} from './AnzBankStatementFormat';
+
 @Injectable()
 @ImportableService({ name: UncategorizedBankTransaction.name })
 export class UncategorizedTransactionsImportable extends Importable {
@@ -19,6 +27,11 @@ export class UncategorizedTransactionsImportable extends Importable {
 
     @Inject(Account.name)
     private readonly accountModel: TenantModelProxy<typeof Account>,
+
+    @Inject(UncategorizedBankTransaction.name)
+    private readonly uncategorizedBankTransactionModel: TenantModelProxy<
+      typeof UncategorizedBankTransaction
+    >,
   ) {
     super();
   }
@@ -32,7 +45,52 @@ export class UncategorizedTransactionsImportable extends Importable {
     createDTO: CreateUncategorizedTransactionDTO,
     trx?: Knex.Transaction,
   ) {
+    // Skip rows that were already imported (deterministic unique id set
+    // by the bank-format pre-transform).
+    if (createDTO.plaidTransactionId) {
+      const existing = await this.uncategorizedBankTransactionModel()
+        .query(trx)
+        .findOne({ plaidTransactionId: createDTO.plaidTransactionId });
+
+      if (existing) {
+        throw new ServiceError(
+          'DUPLICATE_BANK_TRANSACTION',
+          'The bank transaction has already been imported.',
+        );
+      }
+    }
     return this.createUncategorizedTransaction.create(createDTO, trx);
+  }
+
+  /**
+   * Pre-transforms the raw sheet rows: detects ANZ (NZ) statement exports
+   * and normalizes them (type-conditional payee column, dd/MM/yyyy dates,
+   * FX descriptions, occurrence-suffixed references) so the standard
+   * column mapping applies.
+   */
+  public preParseSheet(
+    sheetData: Record<string, unknown>[],
+    importFile?: any,
+  ): Record<string, unknown>[] {
+    const params = importFile?.paramsParsed || {};
+    // Explicit opt-out.
+    if (params.bankFormat === 'none') return sheetData;
+
+    const isAnz =
+      params.bankFormat === ANZ_BANK_FORMAT ||
+      isAnzBankStatementSheet(sheetData);
+
+    if (!isAnz) return sheetData;
+
+    // Annotate the import params (in-memory) so transform() computes the
+    // dedup unique id for the normalized rows.
+    if (importFile) {
+      importFile.params = JSON.stringify({
+        ...params,
+        detectedBankFormat: ANZ_BANK_FORMAT,
+      });
+    }
+    return transformAnzStatementRows(sheetData);
   }
 
   /**
@@ -45,11 +103,20 @@ export class UncategorizedTransactionsImportable extends Importable {
     createDTO: CreateUncategorizedTransactionDTO,
     context?: ImportableContext,
   ): CreateUncategorizedTransactionDTO {
-    return {
+    const params = context.import.paramsParsed;
+    const transformed = {
       ...createDTO,
-      accountId: context.import.paramsParsed.accountId,
-      batch: context.import.paramsParsed.batch,
+      accountId: params.accountId,
+      batch: params.batch,
     };
+    // Deterministic unique id so overlapping exports dedupe on re-import.
+    if (params.detectedBankFormat === ANZ_BANK_FORMAT) {
+      transformed.plaidTransactionId = buildBankTransactionUniqueId(
+        params.accountId,
+        transformed,
+      );
+    }
+    return transformed;
   }
 
   /**
@@ -70,6 +137,12 @@ export class UncategorizedTransactionsImportable extends Importable {
   public paramsValidationSchema() {
     return yup.object().shape({
       accountId: yup.number().required(),
+      // Bank export format: auto-detected when omitted; 'none' opts out.
+      bankFormat: yup
+        .string()
+        .oneOf([ANZ_BANK_FORMAT, 'none'])
+        .nullable()
+        .notRequired(),
     });
   }
 

--- a/packages/server/src/modules/BankingCategorize/commands/__tests__/AnzBankStatementFormat.spec.ts
+++ b/packages/server/src/modules/BankingCategorize/commands/__tests__/AnzBankStatementFormat.spec.ts
@@ -1,0 +1,152 @@
+import {
+  buildBankTransactionUniqueId,
+  isAnzBankStatementSheet,
+  transformAnzStatementRows,
+} from '../AnzBankStatementFormat';
+
+// Rows shaped like a real ANZ (NZ) CSV export.
+const anzRows = () => [
+  {
+    Type: 'Visa Purchase',
+    Details: '4037-****-****-4028  Df',
+    Particulars: '',
+    Code: 'Dd *Doordash',
+    Reference: '',
+    Amount: '-95.78',
+    Date: '03/07/2026',
+    ForeignCurrencyAmount: '',
+    ConversionCharge: '',
+  },
+  {
+    Type: 'Eft-Pos',
+    Details: 'Sushi Zen',
+    Particulars: '4037********',
+    Code: '4028   C',
+    Reference: '260703133957',
+    Amount: '-14.40',
+    Date: '03/07/2026',
+    ForeignCurrencyAmount: '',
+    ConversionCharge: '',
+  },
+  {
+    Type: 'Direct Credit',
+    Details: 'Akqa Ltd',
+    Particulars: '',
+    Code: '',
+    Reference: '19236',
+    Amount: '25116.00',
+    Date: '11/06/2026',
+    ForeignCurrencyAmount: '',
+    ConversionCharge: '',
+  },
+  {
+    Type: 'Visa Purchase',
+    Details: '4037-****-****-4028  If',
+    Particulars: '      0.56',
+    Code: 'Engenious  I',
+    Reference: '        6.88',
+    Amount: '-536.81',
+    Date: '26/06/2026',
+    ForeignCurrencyAmount: 'USD 299.99 converted at 0.56',
+    ConversionCharge: 'This includes a currency conversion charge of $6.88',
+  },
+];
+
+describe('isAnzBankStatementSheet', () => {
+  it('detects the ANZ export signature', () => {
+    expect(isAnzBankStatementSheet(anzRows())).toBe(true);
+  });
+
+  it('rejects a generic bank sheet', () => {
+    expect(
+      isAnzBankStatementSheet([
+        { Date: '2026-01-01', Amount: '-10', Payee: 'X' },
+      ]),
+    ).toBe(false);
+    expect(isAnzBankStatementSheet([])).toBe(false);
+  });
+});
+
+describe('transformAnzStatementRows', () => {
+  it('resolves the payee from Code for card transactions', () => {
+    const [visa] = transformAnzStatementRows(anzRows());
+    expect(visa.Details).toBe('Dd *Doordash');
+  });
+
+  it('resolves the payee from Details for non-card transactions', () => {
+    const rows = transformAnzStatementRows(anzRows());
+    expect(rows[1].Details).toBe('Sushi Zen'); // Eft-Pos
+    expect(rows[2].Details).toBe('Akqa Ltd'); // Direct Credit
+  });
+
+  it('converts dd/MM/yyyy dates to ISO', () => {
+    const rows = transformAnzStatementRows(anzRows());
+    expect(rows[0].Date).toBe('2026-07-03');
+    expect(rows[2].Date).toBe('2026-06-11');
+  });
+
+  it('describes the transaction type with FX details', () => {
+    const rows = transformAnzStatementRows(anzRows());
+    expect(rows[0].Particulars).toBe('Visa Purchase');
+    expect(rows[3].Particulars).toBe(
+      'Visa Purchase - USD 299.99 converted at 0.56',
+    );
+  });
+
+  it('suffixes exact duplicate rows so each keeps a unique reference', () => {
+    const duplicate = {
+      Type: 'Visa Purchase',
+      Details: '4037-****-****-4028  Df',
+      Particulars: '',
+      Code: 'Smz*Salt Caf',
+      Reference: '',
+      Amount: '-6.20',
+      Date: '02/07/2026',
+      ForeignCurrencyAmount: '',
+      ConversionCharge: '',
+    };
+    const rows = transformAnzStatementRows([
+      { ...duplicate },
+      { ...duplicate },
+      { ...duplicate },
+    ]);
+    expect(rows[0].Reference).toBe('');
+    expect(rows[1].Reference).toBe('#2');
+    expect(rows[2].Reference).toBe('#3');
+  });
+});
+
+describe('buildBankTransactionUniqueId', () => {
+  const dto = {
+    date: '2026-07-03',
+    amount: -95.78,
+    payee: 'Dd *Doordash',
+    referenceNo: '',
+  };
+
+  it('is deterministic for the same transaction', () => {
+    expect(buildBankTransactionUniqueId(1000, dto)).toBe(
+      buildBankTransactionUniqueId(1000, { ...dto }),
+    );
+  });
+
+  it('differs across accounts, amounts and references', () => {
+    const base = buildBankTransactionUniqueId(1000, dto);
+    expect(buildBankTransactionUniqueId(1001, dto)).not.toBe(base);
+    expect(
+      buildBankTransactionUniqueId(1000, { ...dto, amount: -95.79 }),
+    ).not.toBe(base);
+    expect(
+      buildBankTransactionUniqueId(1000, { ...dto, referenceNo: '#2' }),
+    ).not.toBe(base);
+  });
+
+  it('normalizes date objects and strings to the same id', () => {
+    expect(
+      buildBankTransactionUniqueId(1000, {
+        ...dto,
+        date: new Date('2026-07-03T00:00:00Z'),
+      }),
+    ).toBe(buildBankTransactionUniqueId(1000, dto));
+  });
+});

--- a/packages/server/src/modules/BankingCategorize/commands/__tests__/AnzBankStatementFormat.spec.ts
+++ b/packages/server/src/modules/BankingCategorize/commands/__tests__/AnzBankStatementFormat.spec.ts
@@ -57,6 +57,24 @@ describe('isAnzBankStatementSheet', () => {
     expect(isAnzBankStatementSheet(anzRows())).toBe(true);
   });
 
+
+  it('detects via explicit sheet columns when rows omit empty cells', () => {
+    const sparseRow = {
+      Type: 'Visa Purchase',
+      Details: '4037-****-****-4028  Df',
+      Code: 'Dd *Doordash',
+      Amount: '-95.78',
+      Date: '03/07/2026',
+    };
+    const columns = [
+      'Type','Details','Particulars','Code','Reference','Amount','Date',
+      'ForeignCurrencyAmount','ConversionCharge',
+    ];
+    expect(isAnzBankStatementSheet([sparseRow], columns)).toBe(true);
+    // union-of-keys fallback fails for a single sparse row (by design).
+    expect(isAnzBankStatementSheet([sparseRow])).toBe(false);
+  });
+
   it('rejects a generic bank sheet', () => {
     expect(
       isAnzBankStatementSheet([

--- a/packages/server/src/modules/BankingMatching/BankingMatching.controller.ts
+++ b/packages/server/src/modules/BankingMatching/BankingMatching.controller.ts
@@ -15,6 +15,7 @@ import {
   Post,
   Query,
 } from '@nestjs/common';
+import { castArray } from 'lodash';
 import { BankingMatchingApplication } from './BankingMatchingApplication';
 import { MatchBankTransactionDto } from './dtos/MatchBankTransaction.dto';
 import { GetMatchedTransactionsQueryDto } from './dtos/GetMatchedTransactionsQuery.dto';
@@ -45,11 +46,15 @@ export class BankingMatchingController {
     schema: { $ref: getSchemaPath(GetMatchedTransactionsResponseDto) },
   })
   async getMatchedTransactions(
-    @Query('uncategorizedTransactionIds') uncategorizedTransactionIds: number[],
+    @Query('uncategorizedTransactionIds')
+    uncategorizedTransactionIds: number[] | number,
     @Query() filter: GetMatchedTransactionsQueryDto,
   ) {
+    // A single query param arrives as a scalar - normalize to numbers.
+    const ids = castArray(uncategorizedTransactionIds ?? []).map(Number);
+
     return this.bankingMatchingApplication.getMatchedTransactions(
-      uncategorizedTransactionIds ?? [],
+      ids,
       filter as any,
     );
   }

--- a/packages/server/src/modules/BankingMatching/queries/GetMatchedTransactionInvoicesTransformer.ts
+++ b/packages/server/src/modules/BankingMatching/queries/GetMatchedTransactionInvoicesTransformer.ts
@@ -1,4 +1,5 @@
 import { Transformer } from '@/modules/Transformer/Transformer';
+import { computeNetOfWithholding } from '@/modules/PaymentReceived/withholding.utils';
 
 export class GetMatchedTransactionInvoicesTransformer extends Transformer {
   /**
@@ -41,11 +42,18 @@ export class GetMatchedTransactionInvoicesTransformer extends Transformer {
 
   /**
    * Retrieve the invoice amount.
+   *
+   * When the customer has a withholding tax rate the bank deposit arrives
+   * net of the withheld amount, so surface the net amount for matching.
    * @param invoice
    * @returns {number}
    */
   protected amount(invoice) {
-    return invoice.dueAmount;
+    return computeNetOfWithholding(
+      invoice.dueAmount,
+      invoice.subtotalExludingTax,
+      Number(invoice.customer?.withholdingTaxRate) || 0,
+    );
   }
   /**
    * Format the amount of the invoice.
@@ -53,7 +61,7 @@ export class GetMatchedTransactionInvoicesTransformer extends Transformer {
    * @returns {string}
    */
   protected amountFormatted(invoice) {
-    return this.formatNumber(invoice.dueAmount, {
+    return this.formatNumber(this.amount(invoice), {
       currencyCode: invoice.currencyCode,
       money: true,
     });

--- a/packages/server/src/modules/BankingMatching/queries/GetMatchedTransactionsByInvoices.service.ts
+++ b/packages/server/src/modules/BankingMatching/queries/GetMatchedTransactionsByInvoices.service.ts
@@ -14,6 +14,7 @@ import { SaleInvoice } from '@/modules/SaleInvoices/models/SaleInvoice';
 import { TransformerInjectable } from '@/modules/Transformer/TransformerInjectable.service';
 import { UncategorizedBankTransaction } from '@/modules/BankingTransactions/models/UncategorizedBankTransaction';
 import { IPaymentReceivedCreateDTO } from '@/modules/PaymentReceived/types/PaymentReceived.types';
+import { computeNetOfWithholding } from '@/modules/PaymentReceived/withholding.utils';
 import { TenantModelProxy } from '@/modules/System/models/TenantBaseModel';
 
 @Injectable()
@@ -49,6 +50,8 @@ export class GetMatchedTransactionsByInvoices extends GetMatchedTransactionsByTy
         q.whereNull('matchedBankTransaction.id');
         q.modify('unpaid');
         q.modify('published');
+        // The customer withholding tax rate nets the matchable amount.
+        q.withGraphFetched('customer');
 
         if (filter.fromDate) {
           q.where('invoiceDate', '>=', filter.fromDate);
@@ -76,7 +79,8 @@ export class GetMatchedTransactionsByInvoices extends GetMatchedTransactionsByTy
   ): Promise<MatchedTransactionPOJO> {
     const invoice = await this.saleInvoiceModel()
       .query()
-      .findById(transactionId);
+      .findById(transactionId)
+      .withGraphFetched('customer');
 
     return this.transformer.transform(
       invoice,
@@ -107,20 +111,29 @@ export class GetMatchedTransactionsByInvoices extends GetMatchedTransactionsByTy
         .findById(uncategorizedTransactionId)
         .throwIfNotFound();
 
-    const invoice = await SaleInvoice.query(trx)
+    const invoice = await this.saleInvoiceModel()
+      .query(trx)
       .findById(matchTransactionDTO.referenceId)
+      .withGraphFetched('customer')
       .throwIfNotFound();
 
+    // The bank deposit arrives net of the customer's withholding tax; the
+    // withheld remainder is booked automatically on payment creation.
+    const paymentAmount = computeNetOfWithholding(
+      invoice.dueAmount,
+      invoice.subtotalExludingTax,
+      Number(invoice.customer?.withholdingTaxRate) || 0,
+    );
     const createPaymentReceivedDTO: IPaymentReceivedCreateDTO = {
       customerId: invoice.customerId,
       paymentDate: uncategorizedTransaction.date,
-      amount: invoice.dueAmount,
+      amount: paymentAmount,
       depositAccountId: uncategorizedTransaction.accountId,
       entries: [
         {
           index: 1,
           invoiceId: invoice.id,
-          paymentAmount: invoice.dueAmount,
+          paymentAmount,
         },
       ],
       branchId: invoice.branchId,

--- a/packages/server/src/modules/BankingMatching/queries/GetMatchedTransactionsByInvoices.service.ts
+++ b/packages/server/src/modules/BankingMatching/queries/GetMatchedTransactionsByInvoices.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { Knex } from 'knex';
-import { first } from 'lodash';
+import { first, keyBy, uniq } from 'lodash';
 import { GetMatchedTransactionInvoicesTransformer } from './GetMatchedTransactionInvoicesTransformer';
 import {
   GetMatchedTransactionsFilter,
@@ -10,6 +10,7 @@ import {
 } from '../types';
 import { GetMatchedTransactionsByType } from './GetMatchedTransactionsByType';
 import { CreatePaymentReceivedService } from '@/modules/PaymentReceived/commands/CreatePaymentReceived.serivce';
+import { Customer } from '@/modules/Customers/models/Customer';
 import { SaleInvoice } from '@/modules/SaleInvoices/models/SaleInvoice';
 import { TransformerInjectable } from '@/modules/Transformer/TransformerInjectable.service';
 import { UncategorizedBankTransaction } from '@/modules/BankingTransactions/models/UncategorizedBankTransaction';
@@ -25,6 +26,9 @@ export class GetMatchedTransactionsByInvoices extends GetMatchedTransactionsByTy
 
     @Inject(SaleInvoice.name)
     private readonly saleInvoiceModel: TenantModelProxy<typeof SaleInvoice>,
+
+    @Inject(Customer.name)
+    private readonly customerModel: TenantModelProxy<typeof Customer>,
 
     @Inject(UncategorizedBankTransaction.name)
     private readonly uncategorizedBankTransactionModel: TenantModelProxy<
@@ -50,8 +54,6 @@ export class GetMatchedTransactionsByInvoices extends GetMatchedTransactionsByTy
         q.whereNull('matchedBankTransaction.id');
         q.modify('unpaid');
         q.modify('published');
-        // The customer withholding tax rate nets the matchable amount.
-        q.withGraphFetched('customer');
 
         if (filter.fromDate) {
           q.where('invoiceDate', '>=', filter.fromDate);
@@ -61,7 +63,17 @@ export class GetMatchedTransactionsByInvoices extends GetMatchedTransactionsByTy
         }
         q.orderBy('invoiceDate', 'DESC');
       });
+    // Attach customers separately (the withholding tax rate nets the
+    // matchable amount) - graph algorithms cannot be mixed on the query.
+    const customerIds = uniq(invoices.map((invoice) => invoice.customerId));
+    const customers = await this.customerModel()
+      .query()
+      .whereIn('id', customerIds);
+    const customersById = keyBy(customers, 'id');
 
+    invoices.forEach((invoice) => {
+      invoice.customer = customersById[invoice.customerId];
+    });
     return this.transformer.transform(
       invoices,
       new GetMatchedTransactionInvoicesTransformer(),

--- a/packages/server/src/modules/BankingPlaid/command/PlaidSyncDB.ts
+++ b/packages/server/src/modules/BankingPlaid/command/PlaidSyncDB.ts
@@ -24,6 +24,7 @@ import { IPlaidTransactionsSyncedEventPayload } from '../types/BankingPlaid.type
 import { UncategorizedBankTransaction } from '../../BankingTransactions/models/UncategorizedBankTransaction';
 import { Inject, Injectable } from '@nestjs/common';
 import { CreateUncategorizedTransactionService } from '@/modules/BankingCategorize/commands/CreateUncategorizedTransaction.service';
+import { UncategorizedBankTransactionDto } from '@/modules/BankingCategorize/dtos/CreateUncategorizedBankTransaction.dto';
 import { TenantModelProxy } from '../../System/models/TenantBaseModel';
 
 const CONCURRENCY_ASYNC = 10;
@@ -111,11 +112,18 @@ export class PlaidSyncDb {
       .throwIfNotFound();
 
     // Transformes the Plaid transactions to cashflow create DTOs.
-    const transformTransaction = R.curry(transformPlaidTrxsToCashflowCreate)(
-      cashflowAccount.id,
-    );
-    const uncategorizedTransDTOs =
-      R.map(transformTransaction)(plaidTranasctions);
+    // NOTE: plaid's `Transaction` narrows `transaction_type` differently than
+    // `TransactionBase`; the transform only reads shared fields, so the cast
+    // is safe (previously hidden by ramda's curried-map type erasure).
+    const uncategorizedTransDTOs: UncategorizedBankTransactionDto[] =
+      plaidTranasctions.map((plaidTransaction) =>
+        transformPlaidTrxsToCashflowCreate(
+          cashflowAccount.id,
+          plaidTransaction as unknown as Parameters<
+            typeof transformPlaidTrxsToCashflowCreate
+          >[1],
+        ),
+      );
 
     // Creating account transaction queue.
     await bluebird.map(

--- a/packages/server/src/modules/BankingTranasctionsRegonize/BankingTransactionsRegonize.module.ts
+++ b/packages/server/src/modules/BankingTranasctionsRegonize/BankingTransactionsRegonize.module.ts
@@ -1,5 +1,7 @@
 import { forwardRef, Module } from '@nestjs/common';
 import { RegisterTenancyModel } from '../Tenancy/TenancyModels/Tenancy.module';
+import { InjectSystemModel } from '../System/SystemModels/SystemModels.module';
+import { ImportModel } from '../Import/models/Import';
 import { RecognizedBankTransaction } from './models/RecognizedBankTransaction';
 import { RevertRecognizedTransactionsService } from './commands/RevertRecognizedTransactions.service';
 import { RecognizeTranasctionsService } from './commands/RecognizeTranasctions.service';
@@ -18,6 +20,7 @@ import { RegonizeTransactionsPrcessor } from './jobs/RecognizeTransactionsJob';
 import { TenancyModule } from '../Tenancy/Tenancy.module';
 
 const models = [RegisterTenancyModel(RecognizedBankTransaction)];
+const systemModels = [InjectSystemModel(ImportModel)];
 
 @Module({
   imports: [
@@ -34,6 +37,7 @@ const models = [RegisterTenancyModel(RecognizedBankTransaction)];
     ...models,
   ],
   providers: [
+    ...systemModels,
     RecognizedTransactionsApplication,
     GetRecognizedTransactionsService,
     RevertRecognizedTransactionsService,

--- a/packages/server/src/modules/BankingTranasctionsRegonize/commands/RecognizeTranasctions.service.ts
+++ b/packages/server/src/modules/BankingTranasctionsRegonize/commands/RecognizeTranasctions.service.ts
@@ -111,9 +111,14 @@ export class RecognizeTranasctionsService {
       const accountBankRules = bankRulesByAccountId.get(
         `${transaction.accountId}`,
       );
+      // Account-scoped rules take priority, then the all-accounts rules.
+      const applicableBankRules = [
+        ...(accountBankRules || []),
+        ...(allAccountsBankRules || []),
+      ];
       const recognizedBankRule = bankRulesMatchTransaction(
         transaction,
-        accountBankRules,
+        applicableBankRules,
       );
       if (recognizedBankRule) {
         await this.markBankRuleAsRecognized(

--- a/packages/server/src/modules/BankingTranasctionsRegonize/events/TriggerRecognizedTransactions.ts
+++ b/packages/server/src/modules/BankingTranasctionsRegonize/events/TriggerRecognizedTransactions.ts
@@ -1,5 +1,5 @@
 import { isEqual, omit } from 'lodash';
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { OnEvent } from '@nestjs/event-emitter';
 import { events } from '@/common/events/events';
 import {
@@ -15,6 +15,9 @@ import {
   RecognizeUncategorizedTransactionsQueue,
 } from '../_types';
 import { TenancyContext } from '@/modules/Tenancy/TenancyContext.service';
+import { IImportFileCommitedEventPayload } from '@/modules/Import/interfaces';
+import { ImportModel } from '@/modules/Import/models/Import';
+import { UncategorizedBankTransaction } from '@/modules/BankingTransactions/models/UncategorizedBankTransaction';
 
 @Injectable()
 export class TriggerRecognizedTransactionsSubscriber {
@@ -23,6 +26,9 @@ export class TriggerRecognizedTransactionsSubscriber {
 
     @InjectQueue(RecognizeUncategorizedTransactionsQueue)
     private readonly recognizeTransactionsQueue: Queue,
+
+    @Inject(ImportModel.name)
+    private readonly importModel: typeof ImportModel,
   ) {}
 
   /**
@@ -109,14 +115,24 @@ export class TriggerRecognizedTransactionsSubscriber {
   @OnEvent(events.import.onImportCommitted)
   async triggerRecognizeTransactionsOnImportCommitted({
     importId,
-
-    // @ts-ignore
   }: IImportFileCommitedEventPayload) {
-    // const importFile = await Import.query().findOne({ importId });
-    // const batch = importFile.paramsParsed.batch;
-    // const payload = { transactionsCriteria: { batch } };
-    // // Cannot continue if the imported resource is not bank account transactions.
-    // if (importFile.resource !== 'UncategorizedCashflowTransaction') return;
-    // await this.agenda.now('recognize-uncategorized-transactions-job', payload);
+    const importFile = await this.importModel.query().findOne({ importId });
+
+    // Cannot continue if the imported resource is not bank transactions.
+    if (importFile?.resource !== UncategorizedBankTransaction.name) return;
+
+    const batch = importFile.paramsParsed?.batch;
+    if (!batch) return;
+
+    const tenantPayload = await this.tenancyContect.getTenantJobPayload();
+    const payload = {
+      transactionsCriteria: { batch },
+      ...tenantPayload,
+    } as RecognizeUncategorizedTransactionsJobPayload;
+
+    await this.recognizeTransactionsQueue.add(
+      RecognizeUncategorizedTransactionsJob,
+      payload,
+    );
   }
 }

--- a/packages/server/src/modules/Bills/models/Bill.ts
+++ b/packages/server/src/modules/Bills/models/Bill.ts
@@ -185,10 +185,12 @@ export class Bill extends TenantBaseModel {
   get total(): number {
     const adjustmentAmount = defaultTo(this.adjustment, 0);
 
+    // Subtotal already includes tax when inclusive tax is enabled, so the
+    // withheld tax amount should be added only when the tax is exclusive.
     return R.compose(
       R.add(adjustmentAmount),
       R.subtract(R.__, this.discountAmount),
-      R.when(R.always(this.isInclusiveTax), R.add(this.taxAmountWithheld)),
+      R.unless(R.always(this.isInclusiveTax), R.add(this.taxAmountWithheld)),
     )(this.subtotal);
   }
 
@@ -369,7 +371,8 @@ export class Bill extends TenantBaseModel {
        */
       dueBills(query) {
         query.where(
-          raw(`COALESCE(AMOUNT, 0) -
+          raw(`COALESCE(AMOUNT, 0) +
+            IF(IS_INCLUSIVE_TAX, 0, COALESCE(TAX_AMOUNT_WITHHELD, 0)) -
             COALESCE(PAYMENT_AMOUNT, 0) -
             COALESCE(CREDITED_AMOUNT, 0) > 0
           `),
@@ -392,13 +395,21 @@ export class Bill extends TenantBaseModel {
        */
       partiallyPaid(query) {
         query.whereNot('payment_amount', 0);
-        query.whereNot(raw('`PAYMENT_AMOUNT` = `AMOUNT`'));
+        query.whereNot(
+          raw(
+            'PAYMENT_AMOUNT = AMOUNT + IF(IS_INCLUSIVE_TAX, 0, COALESCE(TAX_AMOUNT_WITHHELD, 0))',
+          ),
+        );
       },
       /**
        * Filters the paid bills.
        */
       paid(query) {
-        query.where(raw('`PAYMENT_AMOUNT` = `AMOUNT`'));
+        query.where(
+          raw(
+            'PAYMENT_AMOUNT = AMOUNT + IF(IS_INCLUSIVE_TAX, 0, COALESCE(TAX_AMOUNT_WITHHELD, 0))',
+          ),
+        );
       },
       /**
        * Filters the bills from the given date.
@@ -412,7 +423,9 @@ export class Bill extends TenantBaseModel {
        */
       sortByStatus(query, order) {
         const dir = sanitizeSortDirection(order);
-        query.orderByRaw(`PAYMENT_AMOUNT = AMOUNT ${dir}`);
+        query.orderByRaw(
+          `PAYMENT_AMOUNT = AMOUNT + IF(IS_INCLUSIVE_TAX, 0, COALESCE(TAX_AMOUNT_WITHHELD, 0)) ${dir}`,
+        );
       },
 
       /**

--- a/packages/server/src/modules/Bills/models/__tests__/Bill.total.spec.ts
+++ b/packages/server/src/modules/Bills/models/__tests__/Bill.total.spec.ts
@@ -1,0 +1,41 @@
+import { Bill } from '../Bill';
+
+const makeBill = (attrs: Partial<Bill>): Bill => {
+  return Object.assign(new Bill(), {
+    exchangeRate: 1,
+    currencyCode: 'NZD',
+    paymentAmount: 0,
+    creditedAmount: 0,
+    taxAmountWithheld: 0,
+    discount: 0,
+    adjustment: 0,
+    ...attrs,
+  });
+};
+
+describe('Bill total (tax handling)', () => {
+  it('adds withheld tax to total when tax is EXCLUSIVE', () => {
+    const bill = makeBill({
+      amount: 1000, // subtotal excluding tax
+      taxAmountWithheld: 150,
+      isInclusiveTax: false,
+    });
+    expect(bill.total).toBeCloseTo(1150, 2);
+    expect(bill.totalLocal).toBeCloseTo(1150, 2);
+  });
+
+  it('does NOT add withheld tax again when tax is INCLUSIVE', () => {
+    const bill = makeBill({
+      amount: 1150, // subtotal already including tax
+      taxAmountWithheld: 150,
+      isInclusiveTax: true,
+    });
+    expect(bill.total).toBeCloseTo(1150, 2);
+    expect(bill.subtotalExcludingTax).toBeCloseTo(1000, 2);
+  });
+
+  it('keeps total = subtotal when there is no tax', () => {
+    const bill = makeBill({ amount: 500, isInclusiveTax: false });
+    expect(bill.total).toBeCloseTo(500, 2);
+  });
+});

--- a/packages/server/src/modules/Customers/dtos/CreateCustomer.dto.ts
+++ b/packages/server/src/modules/Customers/dtos/CreateCustomer.dto.ts
@@ -4,6 +4,8 @@ import {
   IsNotEmpty,
   IsNumber,
   IsString,
+  Max,
+  Min,
   ValidateIf,
 } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
@@ -167,4 +169,17 @@ export class CreateCustomerDto extends ContactAddressDto {
   @IsOptional()
   @IsString()
   code?: string;
+
+  @ApiProperty({
+    required: false,
+    description:
+      'Withholding tax rate (0-100) the payer deducts from the tax-exclusive amount, e.g. NZ schedular payments',
+    example: 20,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  @Max(100)
+  withholdingTaxRate?: number;
+
 }

--- a/packages/server/src/modules/Customers/dtos/EditCustomer.dto.ts
+++ b/packages/server/src/modules/Customers/dtos/EditCustomer.dto.ts
@@ -1,4 +1,12 @@
-import { IsBoolean, IsEmail, IsNotEmpty, IsString } from 'class-validator';
+import {
+  IsBoolean,
+  IsEmail,
+  IsNotEmpty,
+  IsNumber,
+  IsString,
+  Max,
+  Min,
+} from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 import { ContactAddressDto } from './ContactAddress.dto';
 import { IsOptional } from '@/common/decorators/Validators';
@@ -68,4 +76,17 @@ export class EditCustomerDto extends ContactAddressDto {
   @IsOptional()
   @IsString()
   code?: string;
+
+  @ApiProperty({
+    required: false,
+    description:
+      'Withholding tax rate (0-100) the payer deducts from the tax-exclusive amount, e.g. NZ schedular payments',
+    example: 20,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  @Max(100)
+  withholdingTaxRate?: number;
+
 }

--- a/packages/server/src/modules/Customers/models/Customer.ts
+++ b/packages/server/src/modules/Customers/models/Customer.ts
@@ -73,6 +73,12 @@ export class Customer extends TenantBaseModel {
   code?: string;
 
   /**
+   * Percentage (0-100) the payer withholds from the tax-exclusive amount
+   * (e.g. NZ schedular payments). Null means no withholding.
+   */
+  withholdingTaxRate?: number;
+
+  /**
    * Query builder.
    */
   static QueryBuilder = CustomerQueryBuilder;

--- a/packages/server/src/modules/Import/ImportFileDataTransformer.ts
+++ b/packages/server/src/modules/Import/ImportFileDataTransformer.ts
@@ -12,11 +12,15 @@ import {
   getMapToPath,
 } from './_utils';
 import { ResourceService } from '../Resource/ResourceService';
+import { ImportableRegistry } from './ImportableRegistry';
 import { CurrencyParsingDTOs } from './_constants';
 
 @Injectable()
 export class ImportFileDataTransformer {
-  constructor(private readonly resource: ResourceService) {}
+  constructor(
+    private readonly resource: ResourceService,
+    private readonly importableRegistry: ImportableRegistry,
+  ) {}
 
   /**
    * Parses the given sheet data before passing to the service layer.
@@ -30,8 +34,15 @@ export class ImportFileDataTransformer {
     data: Record<string, unknown>[],
     trx?: Knex.Transaction,
   ): Promise<Record<string, any>[]> {
+    // Let the importable service pre-transform the raw rows (all columns)
+    // before mapping, e.g. to normalize bank-specific export formats.
+    const importable = await this.importableRegistry.getImportable(
+      importFile.resource,
+    );
+    const preParsedData = importable.preParseSheet(data, importFile);
+
     // Sanitize the sheet data.
-    const sanitizedData = sanitizeSheetData(data);
+    const sanitizedData = sanitizeSheetData(preParsedData);
 
     // Map the sheet columns key with the given map.
     const mappedDTOs = this.mapSheetColumns(

--- a/packages/server/src/modules/Import/Importable.ts
+++ b/packages/server/src/modules/Import/Importable.ts
@@ -26,6 +26,23 @@ export abstract class Importable {
   }
 
   /**
+   * Pre-transforms the raw parsed sheet rows before column mapping and
+   * validation. Receives ALL sheet columns (not only the mapped ones), so
+   * importable services can normalize bank/provider-specific export formats.
+   * Implementations may annotate `importFile.params` (in-memory) to signal
+   * the downstream `transform()` hook.
+   * @param {Record<string, unknown>[]} sheetData - Raw parsed sheet rows.
+   * @param {any} importFile - The import file model.
+   * @returns {Record<string, unknown>[]}
+   */
+  public preParseSheet(
+    sheetData: Record<string, unknown>[],
+    importFile?: any,
+  ): Record<string, unknown>[] {
+    return sheetData;
+  }
+
+  /**
    * Concurrency controlling of the importing process.
    * @returns {number}
    */

--- a/packages/server/src/modules/PaymentReceived/PaymentsReceived.module.ts
+++ b/packages/server/src/modules/PaymentReceived/PaymentsReceived.module.ts
@@ -43,6 +43,8 @@ import { GetPaymentReceivedMailTemplate } from './queries/GetPaymentReceivedMail
 import { GetPaymentReceivedMailState } from './queries/GetPaymentReceivedMailState.service';
 import { BulkDeletePaymentReceivedService } from './BulkDeletePaymentReceived.service';
 import { ValidateBulkDeletePaymentReceivedService } from './ValidateBulkDeletePaymentReceived.service';
+import { PaymentReceivedWithholdingTax } from './commands/PaymentReceivedWithholdingTax.service';
+import { PaymentReceivedWithholdingTaxSubscriber } from './subscribers/PaymentReceivedWithholdingTaxSubscriber';
 
 @Module({
   controllers: [PaymentReceivesController],
@@ -74,6 +76,8 @@ import { ValidateBulkDeletePaymentReceivedService } from './ValidateBulkDeletePa
     GetPaymentReceivedMailState,
     BulkDeletePaymentReceivedService,
     ValidateBulkDeletePaymentReceivedService,
+    PaymentReceivedWithholdingTax,
+    PaymentReceivedWithholdingTaxSubscriber,
   ],
   exports: [
     PaymentReceivesApplication,

--- a/packages/server/src/modules/PaymentReceived/__tests__/withholding.utils.spec.ts
+++ b/packages/server/src/modules/PaymentReceived/__tests__/withholding.utils.spec.ts
@@ -1,0 +1,71 @@
+import {
+  computeWithholdingSettlement,
+  computeNetOfWithholding,
+} from '../withholding.utils';
+
+describe('computeWithholdingSettlement', () => {
+  // Datacom May 2026: 18,112.50 + 15% GST = 20,829.38; 20% WHT on labour
+  // = 3,622.50; net banked = 17,206.88.
+  const datacomMay = {
+    total: 20829.38,
+    subtotalExcludingTax: 18112.5,
+    withholdingTaxRate: 20,
+  };
+
+  it('applies for a net-of-withholding settlement', () => {
+    const result = computeWithholdingSettlement({
+      ...datacomMay,
+      paymentAmount: 17206.88,
+    });
+    expect(result.applies).toBe(true);
+    expect(result.withheldAmount).toBeCloseTo(3622.5, 2);
+  });
+
+  it('books the exact residual so the invoice settles to zero', () => {
+    const result = computeWithholdingSettlement({
+      ...datacomMay,
+      paymentAmount: 17206.9, // 2c rounding drift from the bank
+    });
+    expect(result.applies).toBe(true);
+    expect(result.withheldAmount).toBeCloseTo(20829.38 - 17206.9, 2);
+  });
+
+  it('does not apply for a gross (full total) payment', () => {
+    const result = computeWithholdingSettlement({
+      ...datacomMay,
+      paymentAmount: 20829.38,
+    });
+    expect(result.applies).toBe(false);
+    expect(result.withheldAmount).toBe(0);
+  });
+
+  it('does not apply for an arbitrary partial payment', () => {
+    const result = computeWithholdingSettlement({
+      ...datacomMay,
+      paymentAmount: 10000,
+    });
+    expect(result.applies).toBe(false);
+  });
+
+  it('does not apply when the customer has no withholding rate', () => {
+    const result = computeWithholdingSettlement({
+      ...datacomMay,
+      withholdingTaxRate: 0,
+      paymentAmount: 17206.88,
+    });
+    expect(result.applies).toBe(false);
+  });
+});
+
+describe('computeNetOfWithholding', () => {
+  it('returns total minus withholding on the tax-exclusive base', () => {
+    expect(computeNetOfWithholding(20829.38, 18112.5, 20)).toBeCloseTo(
+      17206.88,
+      2,
+    );
+  });
+
+  it('returns the total unchanged without a rate', () => {
+    expect(computeNetOfWithholding(20829.38, 18112.5, 0)).toBe(20829.38);
+  });
+});

--- a/packages/server/src/modules/PaymentReceived/commands/PaymentReceivedWithholdingTax.service.ts
+++ b/packages/server/src/modules/PaymentReceived/commands/PaymentReceivedWithholdingTax.service.ts
@@ -1,0 +1,133 @@
+import { Knex } from 'knex';
+import { Inject, Injectable } from '@nestjs/common';
+import { CreatePaymentReceivedService } from './CreatePaymentReceived.serivce';
+import { DeletePaymentReceivedService } from './DeletePaymentReceived.service';
+import { AccountRepository } from '@/modules/Accounts/repositories/Account.repository';
+import { Customer } from '@/modules/Customers/models/Customer';
+import { SaleInvoice } from '@/modules/SaleInvoices/models/SaleInvoice';
+import { PaymentReceived } from '../models/PaymentReceived';
+import { TenantModelProxy } from '@/modules/System/models/TenantBaseModel';
+import { CreatePaymentReceivedDto } from '../dtos/PaymentReceived.dto';
+import { computeWithholdingSettlement } from '../withholding.utils';
+
+/** Reference prefix linking a companion withholding payment to its origin. */
+export const WITHHOLDING_PAYMENT_REF_PREFIX = 'WHT-';
+
+/**
+ * Books withholding tax withheld by payers (e.g. NZ schedular payments).
+ *
+ * When a customer has a withholding tax rate and a received payment settles
+ * an invoice net of that withholding, a companion payment is created into
+ * the "Withholding Tax Receivable" asset account for the withheld portion,
+ * so the invoice settles in full and the withheld tax is tracked as a
+ * claimable asset (Dr Withholding Tax Receivable / Cr Accounts Receivable).
+ */
+@Injectable()
+export class PaymentReceivedWithholdingTax {
+  constructor(
+    private readonly createPaymentReceivedService: CreatePaymentReceivedService,
+    private readonly deletePaymentReceivedService: DeletePaymentReceivedService,
+    private readonly accountRepository: AccountRepository,
+
+    @Inject(Customer.name)
+    private readonly customerModel: TenantModelProxy<typeof Customer>,
+
+    @Inject(SaleInvoice.name)
+    private readonly saleInvoiceModel: TenantModelProxy<typeof SaleInvoice>,
+
+    @Inject(PaymentReceived.name)
+    private readonly paymentReceivedModel: TenantModelProxy<
+      typeof PaymentReceived
+    >,
+  ) {}
+
+  /**
+   * Creates the companion withholding payment when the given payment
+   * settles its invoices net of the customer's withholding tax.
+   * @param {number} paymentReceiveId - The origin payment id.
+   * @param {CreatePaymentReceivedDto} paymentReceiveDTO - The origin payment DTO.
+   * @param {Knex.Transaction} trx
+   */
+  public async createWithheldPaymentIfApplies(
+    paymentReceiveId: number,
+    paymentReceiveDTO: CreatePaymentReceivedDto,
+    trx?: Knex.Transaction,
+  ): Promise<void> {
+    const customer = await this.customerModel()
+      .query(trx)
+      .findById(paymentReceiveDTO.customerId);
+
+    const withholdingTaxRate = Number(customer?.withholdingTaxRate) || 0;
+    if (withholdingTaxRate <= 0) return;
+
+    const withholdingAccount =
+      await this.accountRepository.findOrCreateWithholdingTaxReceivable(
+        {},
+        trx,
+      );
+    // Guards against recursion once the companion payment is created.
+    if (paymentReceiveDTO.depositAccountId === withholdingAccount.id) return;
+
+    const withheldEntries = [];
+
+    for (const entry of paymentReceiveDTO.entries || []) {
+      const invoice = await this.saleInvoiceModel()
+        .query(trx)
+        .findById(entry.invoiceId);
+      if (!invoice) continue;
+
+      const settlement = computeWithholdingSettlement({
+        total: invoice.total,
+        subtotalExcludingTax: invoice.subtotalExludingTax,
+        paymentAmount: Number(entry.paymentAmount),
+        withholdingTaxRate,
+      });
+      if (settlement.applies) {
+        withheldEntries.push({
+          index: withheldEntries.length + 1,
+          invoiceId: entry.invoiceId,
+          paymentAmount: settlement.withheldAmount,
+        });
+      }
+    }
+    if (withheldEntries.length === 0) return;
+
+    await this.createPaymentReceivedService.createPaymentReceived(
+      {
+        customerId: paymentReceiveDTO.customerId,
+        paymentDate: paymentReceiveDTO.paymentDate,
+        depositAccountId: withholdingAccount.id,
+        referenceNo: `${WITHHOLDING_PAYMENT_REF_PREFIX}${paymentReceiveId}`,
+        statement: 'Withholding tax withheld by payer (auto)',
+        branchId: paymentReceiveDTO.branchId,
+        entries: withheldEntries,
+      } as CreatePaymentReceivedDto,
+      trx,
+    );
+  }
+
+  /**
+   * Deletes the companion withholding payment(s) of the given origin
+   * payment, if any.
+   * @param {number} paymentReceiveId - The origin payment id.
+   * @param {Knex.Transaction} trx
+   */
+  public async deleteWithheldPaymentIfExists(
+    paymentReceiveId: number,
+    trx?: Knex.Transaction,
+  ): Promise<void> {
+    const companions = await this.paymentReceivedModel()
+      .query(trx)
+      .where(
+        'reference_no',
+        `${WITHHOLDING_PAYMENT_REF_PREFIX}${paymentReceiveId}`,
+      );
+
+    for (const companion of companions) {
+      await this.deletePaymentReceivedService.deletePaymentReceive(
+        companion.id,
+        trx,
+      );
+    }
+  }
+}

--- a/packages/server/src/modules/PaymentReceived/subscribers/PaymentReceivedWithholdingTaxSubscriber.ts
+++ b/packages/server/src/modules/PaymentReceived/subscribers/PaymentReceivedWithholdingTaxSubscriber.ts
@@ -1,0 +1,47 @@
+import { Injectable } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { events } from '@/common/events/events';
+import { PaymentReceivedWithholdingTax } from '../commands/PaymentReceivedWithholdingTax.service';
+import {
+  IPaymentReceivedCreatedPayload,
+  IPaymentReceivedDeletedPayload,
+} from '../types/PaymentReceived.types';
+
+@Injectable()
+export class PaymentReceivedWithholdingTaxSubscriber {
+  constructor(
+    private readonly withholdingTaxService: PaymentReceivedWithholdingTax,
+  ) {}
+
+  /**
+   * Books the withheld tax portion once a net-of-withholding payment is
+   * created for a customer with a withholding tax rate.
+   */
+  @OnEvent(events.paymentReceive.onCreated)
+  public async handleWithholdingTaxOnPaymentCreated({
+    paymentReceiveId,
+    paymentReceiveDTO,
+    trx,
+  }: IPaymentReceivedCreatedPayload) {
+    await this.withholdingTaxService.createWithheldPaymentIfApplies(
+      paymentReceiveId,
+      paymentReceiveDTO,
+      trx,
+    );
+  }
+
+  /**
+   * Removes the companion withholding payment when the origin payment is
+   * deleted.
+   */
+  @OnEvent(events.paymentReceive.onDeleted)
+  public async handleWithholdingTaxOnPaymentDeleted({
+    paymentReceiveId,
+    trx,
+  }: IPaymentReceivedDeletedPayload) {
+    await this.withholdingTaxService.deleteWithheldPaymentIfExists(
+      paymentReceiveId,
+      trx,
+    );
+  }
+}

--- a/packages/server/src/modules/PaymentReceived/withholding.utils.ts
+++ b/packages/server/src/modules/PaymentReceived/withholding.utils.ts
@@ -1,0 +1,71 @@
+interface WithholdingSettlementInput {
+  /** Invoice total including tax. */
+  total: number;
+  /** Invoice subtotal excluding tax (the withholding base). */
+  subtotalExcludingTax: number;
+  /** The payment amount applied to the invoice. */
+  paymentAmount: number;
+  /** Customer withholding tax rate (percentage, 0-100). */
+  withholdingTaxRate: number;
+}
+
+interface WithholdingSettlementResult {
+  /** Whether the payment matches a net-of-withholding settlement. */
+  applies: boolean;
+  /** The withheld amount to book (residual so the invoice settles to zero). */
+  withheldAmount: number;
+}
+
+const AMOUNT_TOLERANCE = 0.05;
+
+const round2 = (value: number) => Math.round(value * 100) / 100;
+
+/**
+ * Detects whether a customer payment settles an invoice net of withholding
+ * tax, and computes the withheld amount to book.
+ *
+ * Withholding (e.g. NZ schedular tax) is deducted by the payer from the
+ * tax-exclusive amount: net = total - rate% * subtotalExcludingTax. When the
+ * payment matches that net amount (within tolerance), the residual
+ * (total - payment) should be booked against the withholding receivable
+ * account so the invoice is fully settled.
+ */
+export const computeWithholdingSettlement = (
+  input: WithholdingSettlementInput,
+): WithholdingSettlementResult => {
+  const { total, subtotalExcludingTax, paymentAmount, withholdingTaxRate } =
+    input;
+
+  if (!withholdingTaxRate || withholdingTaxRate <= 0) {
+    return { applies: false, withheldAmount: 0 };
+  }
+  const expectedWithheld = round2(
+    (withholdingTaxRate / 100) * subtotalExcludingTax,
+  );
+  const expectedNet = round2(total - expectedWithheld);
+
+  if (Math.abs(paymentAmount - expectedNet) > AMOUNT_TOLERANCE) {
+    return { applies: false, withheldAmount: 0 };
+  }
+  // Book the exact residual so rounding never leaves the invoice open.
+  const withheldAmount = round2(total - paymentAmount);
+
+  return { applies: withheldAmount > 0, withheldAmount };
+};
+
+/**
+ * Computes the expected net-of-withholding amount for an invoice.
+ * Used to surface net amounts as bank-match candidates.
+ */
+export const computeNetOfWithholding = (
+  total: number,
+  subtotalExcludingTax: number,
+  withholdingTaxRate: number,
+): number => {
+  if (!withholdingTaxRate || withholdingTaxRate <= 0) return total;
+
+  const expectedWithheld = round2(
+    (withholdingTaxRate / 100) * subtotalExcludingTax,
+  );
+  return round2(total - expectedWithheld);
+};

--- a/packages/server/src/modules/SaleInvoices/models/SaleInvoice.ts
+++ b/packages/server/src/modules/SaleInvoices/models/SaleInvoice.ts
@@ -17,6 +17,8 @@ import { InjectAttachable } from '@/modules/Attachments/decorators/InjectAttacha
 import { ExportableModel } from '@/modules/Export/decorators/ExportableModel.decorator';
 import { InjectModelMeta } from '@/modules/Tenancy/TenancyModels/decorators/InjectModelMeta.decorator';
 import { SaleInvoiceMeta } from './SaleInvoice.meta';
+// Type-only: the runtime relation uses a lazy require to avoid module cycles.
+import type { Customer } from '../../Customers/models/Customer';
 import { InjectModelDefaultViews } from '@/modules/Views/decorators/InjectModelDefaultViews.decorator';
 import { SaleInvoiceDefaultViews } from '../constants';
 
@@ -64,6 +66,7 @@ export class SaleInvoice extends TenantBaseModel {
   public attachments!: Document[];
   public writtenoffExpenseAccount!: Account;
   public paymentMethods!: TransactionPaymentServiceEntry[];
+  public customer!: Customer;
   /**
    * Table name
    */

--- a/packages/server/src/modules/SaleInvoices/models/SaleInvoice.ts
+++ b/packages/server/src/modules/SaleInvoices/models/SaleInvoice.ts
@@ -209,12 +209,15 @@ export class SaleInvoice extends TenantBaseModel {
    * @returns {number}
    */
   get total() {
-    const adjustmentAmount = defaultTo(this.adjustment, 0);
+    // Ramda's defaultTo(default, value) - the default comes first.
+    const adjustmentAmount = defaultTo(0, this.adjustment);
 
+    // Subtotal already includes tax when inclusive tax is enabled, so the
+    // withheld tax amount should be added only when the tax is exclusive.
     return R.compose(
       R.add(adjustmentAmount),
       R.subtract(R.__, this.discountAmount),
-      R.when(R.always(this.isInclusiveTax), R.add(this.taxAmountWithheld)),
+      R.unless(R.always(this.isInclusiveTax), R.add(this.taxAmountWithheld)),
     )(this.subtotal);
   }
 
@@ -332,7 +335,8 @@ export class SaleInvoice extends TenantBaseModel {
       dueInvoices(query) {
         query.where(
           raw(`
-            COALESCE(BALANCE, 0) -
+            COALESCE(BALANCE, 0) +
+            IF(IS_INCLUSIVE_TAX, 0, COALESCE(TAX_AMOUNT_WITHHELD, 0)) -
             COALESCE(PAYMENT_AMOUNT, 0) -
             COALESCE(WRITTENOFF_AMOUNT, 0) -
             COALESCE(CREDITED_AMOUNT, 0) > 0
@@ -400,13 +404,21 @@ export class SaleInvoice extends TenantBaseModel {
        */
       partiallyPaid(query) {
         query.whereNot('payment_amount', 0);
-        query.whereNot(raw('`PAYMENT_AMOUNT` = `BALANCE`'));
+        query.whereNot(
+          raw(
+            'PAYMENT_AMOUNT = BALANCE + IF(IS_INCLUSIVE_TAX, 0, COALESCE(TAX_AMOUNT_WITHHELD, 0))',
+          ),
+        );
       },
       /**
        * Filters the paid invoices.
        */
       paid(query) {
-        query.where(raw('PAYMENT_AMOUNT = BALANCE'));
+        query.where(
+          raw(
+            'PAYMENT_AMOUNT = BALANCE + IF(IS_INCLUSIVE_TAX, 0, COALESCE(TAX_AMOUNT_WITHHELD, 0))',
+          ),
+        );
       },
       /**
        * Filters the sale invoices from the given date.
@@ -419,7 +431,9 @@ export class SaleInvoice extends TenantBaseModel {
        */
       sortByStatus(query, order) {
         const dir = sanitizeSortDirection(order);
-        query.orderByRaw(`PAYMENT_AMOUNT = BALANCE ${dir}`);
+        query.orderByRaw(
+          `PAYMENT_AMOUNT = BALANCE + IF(IS_INCLUSIVE_TAX, 0, COALESCE(TAX_AMOUNT_WITHHELD, 0)) ${dir}`,
+        );
       },
 
       /**
@@ -427,7 +441,9 @@ export class SaleInvoice extends TenantBaseModel {
        */
       sortByDueAmount(query, order) {
         const dir = sanitizeSortDirection(order);
-        query.orderByRaw(`BALANCE - PAYMENT_AMOUNT ${dir}`);
+        query.orderByRaw(
+          `BALANCE + IF(IS_INCLUSIVE_TAX, 0, COALESCE(TAX_AMOUNT_WITHHELD, 0)) - PAYMENT_AMOUNT ${dir}`,
+        );
       },
 
       /**

--- a/packages/server/src/modules/SaleInvoices/models/__tests__/SaleInvoice.total.spec.ts
+++ b/packages/server/src/modules/SaleInvoices/models/__tests__/SaleInvoice.total.spec.ts
@@ -1,0 +1,159 @@
+import { SaleInvoice } from '../SaleInvoice';
+import { ItemEntry } from '@/modules/TransactionItemEntry/models/ItemEntry';
+import { InvoiceGL } from '../../ledger/InvoiceGL';
+import { DiscountType } from '@/common/types/Discount';
+
+const makeInvoice = (attrs: Partial<SaleInvoice>): SaleInvoice => {
+  return Object.assign(new SaleInvoice(), {
+    exchangeRate: 1,
+    currencyCode: 'NZD',
+    paymentAmount: 0,
+    writtenoffAmount: 0,
+    creditedAmount: 0,
+    taxAmountWithheld: 0,
+    discount: 0,
+    adjustment: 0,
+    ...attrs,
+  });
+};
+
+const makeEntry = (attrs: Partial<ItemEntry>): ItemEntry => {
+  return Object.assign(new ItemEntry(), {
+    discount: 0,
+    ...attrs,
+  });
+};
+
+describe('SaleInvoice total (tax handling)', () => {
+  it('adds withheld tax to total when tax is EXCLUSIVE', () => {
+    const invoice = makeInvoice({
+      balance: 18975, // subtotal excluding tax (stored in the `balance` column)
+      taxAmountWithheld: 2846.25,
+      isInclusiveTax: false,
+    });
+    expect(invoice.total).toBeCloseTo(21821.25, 2);
+    expect(invoice.totalLocal).toBeCloseTo(21821.25, 2);
+    expect(invoice.subtotalExludingTax).toBeCloseTo(18975, 2);
+  });
+
+  it('does NOT add withheld tax again when tax is INCLUSIVE', () => {
+    const invoice = makeInvoice({
+      balance: 21821.25, // subtotal already including tax
+      taxAmountWithheld: 2846.25,
+      isInclusiveTax: true,
+    });
+    expect(invoice.total).toBeCloseTo(21821.25, 2);
+    expect(invoice.subtotalExludingTax).toBeCloseTo(18975, 2);
+  });
+
+  it('keeps total = subtotal when there is no tax', () => {
+    const invoice = makeInvoice({ balance: 1000, isInclusiveTax: false });
+    expect(invoice.total).toBeCloseTo(1000, 2);
+  });
+
+  it('applies discount and adjustment on top of the tax-included total', () => {
+    const invoice = makeInvoice({
+      balance: 1000,
+      taxAmountWithheld: 150,
+      isInclusiveTax: false,
+      discount: 100,
+      discountType: DiscountType.Amount,
+      adjustment: 50,
+    });
+    // (1000 + 150) - 100 + 50
+    expect(invoice.total).toBeCloseTo(1100, 2);
+  });
+
+  it('due amount derives from the tax-included total', () => {
+    const invoice = makeInvoice({
+      balance: 18975,
+      taxAmountWithheld: 2846.25,
+      isInclusiveTax: false,
+      paymentAmount: 18026.25, // net bank payment
+    });
+    // Remaining due should be the withheld portion (3,795.00).
+    expect(invoice.dueAmount).toBeCloseTo(3795.0, 2);
+  });
+});
+
+describe('InvoiceGL balanced entries', () => {
+  const sumDebits = (entries: any[]) =>
+    entries.reduce((s, e) => s + (e.debit || 0), 0);
+  const sumCredits = (entries: any[]) =>
+    entries.reduce((s, e) => s + (e.credit || 0), 0);
+
+  const buildGL = (invoice: SaleInvoice) => {
+    const gl = new InvoiceGL(invoice);
+    gl.setARAccountId(1006);
+    gl.setTaxPayableAccountId(1013);
+    gl.setDiscountAccountId(1031);
+    gl.setOtherChargesAccountId(1033);
+    return gl.getInvoiceGLEntries();
+  };
+
+  it('debits equal credits for an EXCLUSIVE-tax invoice', () => {
+    const entry = makeEntry({
+      quantity: 165,
+      rate: 115,
+      taxRate: 15,
+      taxRateId: 5,
+      isInclusiveTax: 0,
+      sellAccountId: 1026,
+    });
+    const invoice = makeInvoice({
+      balance: entry.amount, // 18,975
+      taxAmountWithheld: entry.taxAmount, // 2,846.25
+      isInclusiveTax: false,
+      entries: [entry],
+    });
+    const entries = buildGL(invoice);
+
+    expect(sumDebits(entries)).toBeCloseTo(sumCredits(entries), 2);
+    expect(sumDebits(entries)).toBeCloseTo(21821.25, 2);
+  });
+
+  it('debits equal credits for an INCLUSIVE-tax invoice', () => {
+    const entry = makeEntry({
+      quantity: 1,
+      rate: 21821.25,
+      taxRate: 15,
+      taxRateId: 5,
+      isInclusiveTax: 1,
+      sellAccountId: 1026,
+    });
+    const invoice = makeInvoice({
+      balance: entry.amount, // 21,821.25 tax-inclusive
+      taxAmountWithheld: entry.taxAmount, // 2,846.25
+      isInclusiveTax: true,
+      entries: [entry],
+    });
+    const entries = buildGL(invoice);
+
+    expect(sumDebits(entries)).toBeCloseTo(sumCredits(entries), 2);
+    expect(sumDebits(entries)).toBeCloseTo(21821.25, 2);
+  });
+
+  it('tax and income GL rows carry the tax rate id', () => {
+    const entry = makeEntry({
+      quantity: 165,
+      rate: 115,
+      taxRate: 15,
+      taxRateId: 5,
+      isInclusiveTax: 0,
+      sellAccountId: 1026,
+    });
+    const invoice = makeInvoice({
+      balance: entry.amount,
+      taxAmountWithheld: entry.taxAmount,
+      isInclusiveTax: false,
+      entries: [entry],
+    });
+    const entries = buildGL(invoice);
+    const taxEntry = entries.find((e) => e.accountId === 1013);
+    const incomeEntry = entries.find((e) => e.accountId === 1026);
+
+    expect(taxEntry.taxRateId).toBe(5);
+    expect(incomeEntry.taxRateId).toBe(5);
+    expect(taxEntry.credit).toBeCloseTo(2846.25, 2);
+  });
+});

--- a/packages/webapp/index.html
+++ b/packages/webapp/index.html
@@ -9,7 +9,7 @@
       name="description"
       content="Bigcapital Financial Managment Software"
     />
-    <link rel="modulepreload" href="/manifest.json" />
+    <link rel="manifest" href="/manifest.json" />
     <script type="module" src="/public/preload-theme.js"></script>
     <title>Bigcapital</title>
   </head>

--- a/packages/webapp/src/containers/CashFlow/AccountTransactions/AccountTransactionsFilterTabs.tsx
+++ b/packages/webapp/src/containers/CashFlow/AccountTransactions/AccountTransactionsFilterTabs.tsx
@@ -38,7 +38,10 @@ export function AccountTransactionsFilterTabs() {
           title={
             <>
               <span style={{ color: 'var(--color-danger)' }}>
-                {currentAccount.uncategorized_transactions}
+                {/* The account query may still be resolving when the meta
+                    summary (which gates this tab) has already loaded. */}
+                {currentAccount?.uncategorized_transactions ??
+                  bankAccountMetaSummary?.totalUncategorizedTransactions}
               </span>{' '}
               Uncategorized Transactions
             </>

--- a/packages/webapp/src/containers/Customers/CustomerForm/CustomerForm.schema.tsx
+++ b/packages/webapp/src/containers/Customers/CustomerForm/CustomerForm.schema.tsx
@@ -38,6 +38,11 @@ const Schema = Yup.object().shape({
   shipping_address_phone: Yup.string().nullable(),
 
   opening_balance: Yup.number().nullable(),
+  withholding_tax_rate: Yup.number()
+    .min(0)
+    .max(100)
+    .nullable()
+    .label(intl.get('customer.label.withholding_tax_rate')),
   currency_code: Yup.string(),
   opening_balance_at: Yup.date(),
   opening_balance_branch_id: Yup.string(),

--- a/packages/webapp/src/containers/Customers/CustomerForm/CustomerFormFinancialSection.tsx
+++ b/packages/webapp/src/containers/Customers/CustomerForm/CustomerFormFinancialSection.tsx
@@ -11,6 +11,7 @@ import {
   BranchSelect,
   FeatureCan,
   FMoneyInputGroup,
+  FInputGroup,
   ExchangeRateInputGroup,
   FDateInput,
   Icon,
@@ -55,6 +56,7 @@ export function CustomerFormFinancialSection() {
       <CustomerOpeningBalanceField />
       <CustomerOpeningBalanceExchangeRateField />
       <CustomerOpeningBalanceAtField />
+      <CustomerWithholdingTaxRateField />
 
       <FeatureCan feature={Features.Branches}>
         <FFormGroup
@@ -71,6 +73,34 @@ export function CustomerFormFinancialSection() {
         </FFormGroup>
       </FeatureCan>
     </Box>
+  );
+}
+
+/**
+ * Percentage the payer withholds from the tax-exclusive amount (e.g. NZ
+ * schedular payments). When set, net-of-withholding payments book the
+ * withheld portion automatically.
+ */
+function CustomerWithholdingTaxRateField() {
+  return (
+    <FFormGroup
+      name={'withholding_tax_rate'}
+      label={intl.get('customer.label.withholding_tax_rate')}
+      inline
+      fill
+      helperText={<ErrorMessage name="withholding_tax_rate" />}
+    >
+      <ControlGroup>
+        <FInputGroup
+          name={'withholding_tax_rate'}
+          type="number"
+          min={0}
+          max={100}
+          fill={true}
+        />
+        <InputPrependText text={'%'} />
+      </ControlGroup>
+    </FFormGroup>
   );
 }
 

--- a/packages/webapp/src/containers/Customers/CustomerForm/CustomerFormFormik.tsx
+++ b/packages/webapp/src/containers/Customers/CustomerForm/CustomerFormFormik.tsx
@@ -118,6 +118,11 @@ function CustomerFormFormikRoot({
     const formValues = {
       ...values,
       active: parseBoolean(values.active, true),
+      // Empty input means no withholding - the API expects null, not ''.
+      withholding_tax_rate:
+        values.withholding_tax_rate === '' || values.withholding_tax_rate == null
+          ? null
+          : Number(values.withholding_tax_rate),
     };
 
     const onSuccess = (res: { data?: unknown }) => {

--- a/packages/webapp/src/containers/Customers/CustomerForm/CustomerFormPage.tsx
+++ b/packages/webapp/src/containers/Customers/CustomerForm/CustomerFormPage.tsx
@@ -15,7 +15,7 @@ import {
  */
 export function CustomerFormPage() {
   const { id } = useParams();
-  const customerId = parseInt(id, 10);
+  const customerId = id ? parseInt(id, 10) : undefined;
 
   return (
     <CustomerFormProvider customerId={customerId}>

--- a/packages/webapp/src/containers/Customers/CustomerForm/utils.tsx
+++ b/packages/webapp/src/containers/Customers/CustomerForm/utils.tsx
@@ -42,6 +42,7 @@ export const defaultInitialValues = {
   currency_code: '',
 
   opening_balance: '',
+  withholding_tax_rate: '',
   opening_balance_at: moment(new Date()).format('YYYY-MM-DD'),
   opening_balance_exchange_rate: '',
   opening_balance_branch_id: '',

--- a/packages/webapp/src/containers/FinancialStatements/AgingSummary/dynamicColumns.ts
+++ b/packages/webapp/src/containers/FinancialStatements/AgingSummary/dynamicColumns.ts
@@ -67,6 +67,24 @@ const agingPeriodAccessor = R.curry(
   },
 );
 
+/** Matches the column key against both server (snake_case) and legacy
+ * (camelCase) spellings. */
+const keyIn = (keys: string[]) => (column: AgingSummaryColumn) =>
+  keys.includes(column.key);
+
+/**
+ * Fallback for unmapped dynamic columns: react-table requires an id or a
+ * string accessor - without one the whole report crashes to the error
+ * boundary. Renders the cell by index like the aging-period columns.
+ */
+const unmappedColumnFallback = R.curry(
+  (data: unknown[], column: AgingSummaryColumn | Record<string, unknown>) => {
+    if ((column as any).accessor || (column as any).id) return column;
+
+    return agingPeriodAccessor(data, column as AgingSummaryColumn);
+  },
+);
+
 const dynamicColumnMapper = R.curry(
   (data: unknown[], column: AgingSummaryColumn) => {
     const totalAccessorColumn = totalAccessor(data);
@@ -75,11 +93,14 @@ const dynamicColumnMapper = R.curry(
     const agingPeriodAccessorColumn = agingPeriodAccessor(data);
 
     return R.compose(
-      R.when(R.pathEq(['key'], 'total'), totalAccessorColumn),
-      R.when(R.pathEq(['key'], 'current'), currentAccessorColumn),
-      R.when(R.pathEq(['key'], 'customerName'), customerNameAccessorColumn),
-      R.when(R.pathEq(['key'], 'vendorName'), customerNameAccessorColumn),
-      R.when(R.pathEq(['key'], 'agingPeriod'), agingPeriodAccessorColumn),
+      unmappedColumnFallback(data),
+      R.when(keyIn(['total']), totalAccessorColumn),
+      R.when(keyIn(['current']), currentAccessorColumn),
+      R.when(
+        keyIn(['customer_name', 'customerName', 'vendor_name', 'vendorName']),
+        customerNameAccessorColumn,
+      ),
+      R.when(keyIn(['aging_period', 'agingPeriod']), agingPeriodAccessorColumn),
     )(column);
   },
 );

--- a/packages/webapp/src/hooks/query/customers/queries.ts
+++ b/packages/webapp/src/hooks/query/customers/queries.ts
@@ -141,7 +141,10 @@ export function useCustomer(
     ...props,
     queryKey: customersKeys.detail(id),
     queryFn: () => fetchCustomer(fetcher, id!),
-    enabled: id != null,
+    // NaN guards against routes without an id (e.g. /customers/new) and
+    // the caller's `enabled` must not be silently discarded.
+    enabled:
+      id != null && !Number.isNaN(id as number) && (props?.enabled ?? true),
   });
 }
 

--- a/packages/webapp/src/lang/en/index.json
+++ b/packages/webapp/src/lang/en/index.json
@@ -1169,11 +1169,9 @@
   "refresh": "Refresh",
   "total_name": "Total {name}",
   "income": "Income",
-  "total_income": "Total Income",
   "cost_of_sales": "Cost of sales",
   "total_cost_of_sales": "Total cost of sales",
   "gross_profit": "Gross profit",
-  "total_expenses": "Total Expenses",
   "net_operating_income": "Net Operating income",
   "other_income": "Other Income",
   "total_other_income": "Total other income",
@@ -2381,5 +2379,6 @@
   "api_key.display_warning": "This API key will only be shown once. Please copy and save it securely.",
   "api_key.label": "API Key",
   "api_key.copy_to_clipboard": "Copy to clipboard",
-  "the_expenses_has_been_deleted_successfully": "The expenses have been deleted successfully."
+  "the_expenses_has_been_deleted_successfully": "The expenses have been deleted successfully.",
+  "customer.label.withholding_tax_rate": "Withholding tax rate (%)"
 }

--- a/playwright.sweep.config.ts
+++ b/playwright.sweep.config.ts
@@ -1,0 +1,2 @@
+import base from './playwright.config';
+export default { ...base, testMatch: 'webapp-sweep.spec.ts', timeout: 15 * 60 * 1000 };

--- a/playwright.taxfix.config.ts
+++ b/playwright.taxfix.config.ts
@@ -1,2 +1,2 @@
 import base from './playwright.config';
-export default { ...base, testMatch: ['invoice-tax-gl.spec.ts', 'invoice-withholding-tax.spec.ts', 'anz-import.spec.ts'] };
+export default { ...base, testMatch: ['invoice-tax-gl.spec.ts', 'invoice-withholding-tax.spec.ts', 'anz-import.spec.ts', 'customer-withholding-field.spec.ts'] };

--- a/playwright.taxfix.config.ts
+++ b/playwright.taxfix.config.ts
@@ -1,2 +1,2 @@
 import base from './playwright.config';
-export default { ...base, testMatch: ['invoice-tax-gl.spec.ts', 'invoice-withholding-tax.spec.ts'] };
+export default { ...base, testMatch: ['invoice-tax-gl.spec.ts', 'invoice-withholding-tax.spec.ts', 'anz-import.spec.ts'] };

--- a/playwright.taxfix.config.ts
+++ b/playwright.taxfix.config.ts
@@ -1,2 +1,2 @@
 import base from './playwright.config';
-export default { ...base, testMatch: 'invoice-tax-gl.spec.ts' };
+export default { ...base, testMatch: ['invoice-tax-gl.spec.ts', 'invoice-withholding-tax.spec.ts'] };

--- a/playwright.taxfix.config.ts
+++ b/playwright.taxfix.config.ts
@@ -1,0 +1,2 @@
+import base from './playwright.config';
+export default { ...base, testMatch: 'invoice-tax-gl.spec.ts' };


### PR DESCRIPTION
## Summary

This PR fixes several correctness bugs in the invoice tax engine and adds three features that make Bigcapital practical for contractor accounting in withholding-tax jurisdictions (e.g. NZ schedular payments, GST 15%). Everything was developed and verified against a live deployment with real bank/invoice data: 51 unit tests, ~53 API assertions, and 8 Playwright e2e specs (including a 66-route full-webapp sweep) are included.

### 1. Invoice tax engine posted unbalanced GL entries (bug fix)
The `total` getter on `SaleInvoice`/`Bill` added `taxAmountWithheld` when `isInclusiveTax` was **enabled** (subtotal already includes tax) and skipped it when tax was exclusive — inverted logic. Every taxed invoice/bill posted unbalanced GL (AR/AP off by the tax amount). Also fixed en route: a ramda `defaultTo(default, value)` arg-order bug that silently dropped invoice-level adjustments from totals, and the raw-SQL paid/unpaid filters that were only consistent *because of* the bug. GL rows carry `tax_rate_id`, so the Sales Tax Liability Summary now populates natively.

### 2. Per-customer withholding tax (feature)
`withholding_tax_rate` (0–100) on customers + a predefined *Withholding Tax Receivable* asset account. When a received payment settles an invoice **net of withholding** (tolerance-based detection), a companion payment is booked automatically (Dr WHT Receivable / Cr AR) so the invoice settles in full and the withheld tax is tracked as a claimable asset; deleting the origin cascades. Bank matching surfaces and pays **net** amounts, so matching the actual bank deposit completes settlement. Webapp: rate field on the customer form (empty = null).

### 3. Bank-format presets for the transactions import + recognition on import (feature)
New `preParseSheet` hook on `Importable` (pre-transform raw sheet rows before mapping). First preset: **ANZ (NZ)** statement exports, auto-detected by header signature — type-conditional payee (card rows carry the merchant in `Code`), dd/MM/yyyy dates, FX descriptions, occurrence-suffixed refs, and deterministic per-row ids so re-importing overlapping exports skips already-imported rows. Also implements the dead `onImportCommitted` recognition trigger (imports never ran bank rules since the framework migration) and fixes all-accounts bank rules never being applied (and a crash on rule-less accounts).

### 4. Webapp fixes from a full route sweep
A new 66-route Playwright sweep (`e2e/webapp-sweep.spec.ts`) surfaced and this PR fixes: the PWA manifest declared with `rel="modulepreload"` (module-script MIME error on every page); **AR/AP aging reports crashing to the error boundary** (column mapper matched camelCase keys, server emits snake_case — now matches both + crash-proof fallback); `GET /api/customers/NaN` from `/customers/new` (hook clobbered the caller's `enabled`; `NaN != null`); a race crash on the banking transactions page.

### Build unblockers
`develop` currently fails to build from clean checkouts in two ways this PR addresses: the `modules/ee`/`modules/EE` casing collision breaks case-sensitive Docker builds of macOS checkouts (import-rewrite guard in the Dockerfile), and `PlaidSyncDB` has a type error previously hidden by ramda's curried-map type erasure.

## Review notes
- The work is also available as four independent stacked branches on the fork (`fix/invoice-tax-gl-balance` → `feat/customer-withholding-tax` → `feat/anz-import-bank-rules` → `feat/customer-withholding-ui`) — happy to split this PR if preferred.
- Known limitation (documented in code): editing an origin payment does not re-sync its withholding companion; delete/recreate instead.
- `taxAmountWithheld` on invoices is the summed line tax — the withholding feature deliberately does not overload it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
