### PR TITLE
security/Add RBAC guards to WarehouseTransfersController

### DIFF
--- a/packages/server/src/modules/Roles/AbilitySchema.ts
+++ b/packages/server/src/modules/Roles/AbilitySchema.ts
@@ -25,6 +25,7 @@ import { PaymentReceiveAction } from '../PaymentReceived/types/PaymentReceived.t
 import { PreferencesAction } from '../Settings/Settings.types';
 import { AuditLogAction } from '../EE/AuditLogs/types/AuditLogs.types';
 import { AttachmentAction } from '../Attachments/Attachments.types';
+import { WarehouseTransferAction } from '../Warehouses/Warehouse.types';
 
 export const AbilitySchema: ISubjectAbilitiesSchema[] = [
   {
@@ -325,6 +326,32 @@ export const AbilitySchema: ISubjectAbilitiesSchema[] = [
     abilities: [
       { key: AttachmentAction.View, label: 'ability.view', default: true },
       { key: AttachmentAction.Delete, label: 'ability.delete', default: true },
+    ],
+  },
+  {
+    subject: AbilitySubject.Warehouse,
+    subjectLabel: 'ability.warehouse_transfers',
+    abilities: [
+      {
+        key: WarehouseTransferAction.VIEW,
+        label: 'ability.view',
+        default: true,
+      },
+      {
+        key: WarehouseTransferAction.CREATE,
+        label: 'ability.create',
+        default: true,
+      },
+      {
+        key: WarehouseTransferAction.EDIT,
+        label: 'ability.edit',
+        default: true,
+      },
+      {
+        key: WarehouseTransferAction.DELETE,
+        label: 'ability.delete',
+        default: true,
+      },
     ],
   },
 ];

--- a/packages/server/src/modules/Warehouses/Warehouse.types.ts
+++ b/packages/server/src/modules/Warehouses/Warehouse.types.ts
@@ -7,6 +7,13 @@ export interface IWarehouse {
   id?: number;
 }
 
+export enum WarehouseTransferAction {
+  CREATE = 'Create',
+  EDIT = 'Edit',
+  DELETE = 'Delete',
+  VIEW = 'View',
+}
+
 export interface IWarehouseTransferEntry {
   id?: number;
   index?: number;

--- a/packages/server/src/modules/WarehousesTransfers/WarehouseTransfers.controller.ts
+++ b/packages/server/src/modules/WarehousesTransfers/WarehouseTransfers.controller.ts
@@ -8,6 +8,7 @@ import {
   Param,
   Query,
   Inject,
+  UseGuards,
 } from '@nestjs/common';
 import {
   ApiExtraModels,
@@ -25,11 +26,17 @@ import { GetWarehouseTransfersQueryDto } from '../Warehouses/dtos/GetWarehouseTr
 import { WarehouseTransferResponseDto } from './dtos/WarehouseTransferResponse.dto';
 import { PaginatedResponseDto } from '@/common/dtos/PaginatedResults.dto';
 import { ApiCommonHeaders } from '@/common/decorators/ApiCommonHeaders';
+import { RequirePermission } from '@/modules/Roles/RequirePermission.decorator';
+import { PermissionGuard } from '@/modules/Roles/Permission.guard';
+import { AuthorizationGuard } from '@/modules/Roles/Authorization.guard';
+import { AbilitySubject } from '@/modules/Roles/Roles.types';
+import { WarehouseTransferAction } from '../Warehouses/Warehouse.types';
 
 @Controller('warehouse-transfers')
 @ApiTags('Warehouse Transfers')
 @ApiExtraModels(WarehouseTransferResponseDto, PaginatedResponseDto)
 @ApiCommonHeaders()
+@UseGuards(AuthorizationGuard, PermissionGuard)
 export class WarehouseTransfersController {
   /**
    * @param {WarehouseTransferApplication} warehouseTransferApplication - Warehouse transfer application.
@@ -43,6 +50,10 @@ export class WarehouseTransfersController {
    * Creates a new warehouse transfer transaction.
    */
   @Post()
+  @RequirePermission(
+    WarehouseTransferAction.CREATE,
+    AbilitySubject.Warehouse,
+  )
   @ApiOperation({ summary: 'Create a new warehouse transfer transaction.' })
   @ApiResponse({
     status: 200,
@@ -68,6 +79,7 @@ export class WarehouseTransfersController {
    * Edits warehouse transfer transaction.
    */
   @Post(':id')
+  @RequirePermission(WarehouseTransferAction.EDIT, AbilitySubject.Warehouse)
   @ApiOperation({ summary: 'Edit the given warehouse transfer transaction.' })
   @ApiResponse({
     status: 200,
@@ -94,6 +106,7 @@ export class WarehouseTransfersController {
    * Initiates the warehouse transfer.
    */
   @Put(':id/initiate')
+  @RequirePermission(WarehouseTransferAction.EDIT, AbilitySubject.Warehouse)
   @ApiOperation({ summary: 'Initiate the given warehouse transfer.' })
   @ApiResponse({
     status: 200,
@@ -112,6 +125,7 @@ export class WarehouseTransfersController {
    * Marks the given warehouse transfer as transferred.
    */
   @Put(':id/transferred')
+  @RequirePermission(WarehouseTransferAction.EDIT, AbilitySubject.Warehouse)
   @ApiOperation({
     summary: 'Mark the given warehouse transfer as transferred.',
   })
@@ -133,6 +147,7 @@ export class WarehouseTransfersController {
    * Retrieves warehouse transfer transactions with pagination.
    */
   @Get()
+  @RequirePermission(WarehouseTransferAction.VIEW, AbilitySubject.Warehouse)
   @ApiOperation({
     summary: 'Retrieve warehouse transfer transactions with pagination.',
   })
@@ -169,6 +184,7 @@ export class WarehouseTransfersController {
    * Retrieves warehouse transfer transaction details.
    */
   @Get(':id')
+  @RequirePermission(WarehouseTransferAction.VIEW, AbilitySubject.Warehouse)
   @ApiOperation({ summary: 'Retrieve warehouse transfer transaction details.' })
   @ApiResponse({
     status: 200,
@@ -189,6 +205,10 @@ export class WarehouseTransfersController {
    * Deletes the given warehouse transfer transaction.
    */
   @Delete(':id')
+  @RequirePermission(
+    WarehouseTransferAction.DELETE,
+    AbilitySubject.Warehouse,
+  )
   @ApiOperation({ summary: 'Delete the given warehouse transfer transaction.' })
   @ApiResponse({
     status: 200,


### PR DESCRIPTION
None of the 7 endpoints in WarehouseTransfersController enforced authorization — any authenticated user, regardless of role or permissions, could create/edit/initiate/deliver/view/delete warehouse transfer transactions. AccountsController and other controllers already follow the AuthorizationGuard + PermissionGuard + RequirePermission pattern; this applies the same pattern here.

AbilitySubject.Warehouse already existed in the permission enum but was never enforced on any controller and was missing from AbilitySchema.ts (the schema that drives which permissions are configurable in the Roles UI). Added the missing schema entry so admins can actually grant this permission to custom roles — without it, this fix would make warehouse-transfers permanently inaccessible to non-admin roles rather than correctly gated. New roles get View/Create/Edit/Delete checked by default, consistent with how other transactional subjects (Item, Customer, Bill, etc.) are defaulted in this schema.

Relates to #1002 (one of the ~53 affected controllers named in that issue; scoped to this one controller for a focused, reviewable change rather than attempting all of them at once).

I have read and agree to the standard terms for contributing to this project.

Signed: Abhinav Reddy