### PR TITLE
security/Add RBAC guard to Trial Balance report controller

### DIFF
--- a/packages/server/src/modules/FinancialStatements/modules/TrialBalanceSheet/TrialBalanceSheet.controller.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/TrialBalanceSheet/TrialBalanceSheet.controller.ts
@@ -1,4 +1,11 @@
-import { Controller, Get, Headers, Query, Res } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Headers,
+  Query,
+  Res,
+  UseGuards,
+} from '@nestjs/common';
 import {
   ApiExtraModels,
   ApiOperation,
@@ -20,6 +27,11 @@ import {
   TrialBalanceSheetTableResponseDto,
 } from './TrialBalanceSheetResponse.dto';
 import { ApiCommonHeaders } from '@/common/decorators/ApiCommonHeaders';
+import { RequirePermission } from '@/modules/Roles/RequirePermission.decorator';
+import { PermissionGuard } from '@/modules/Roles/Permission.guard';
+import { AuthorizationGuard } from '@/modules/Roles/Authorization.guard';
+import { AbilitySubject } from '@/modules/Roles/Roles.types';
+import { ReportsAction } from '../../types/Report.types';
 
 @Controller('reports/trial-balance-sheet')
 @ApiTags('Reports')
@@ -29,12 +41,18 @@ import { ApiCommonHeaders } from '@/common/decorators/ApiCommonHeaders';
   TrialBalanceSheetTableResponseDto,
   NumberFormatQueryDto,
 )
+// Restrict this financial report to authenticated users granted the trial-balance read permission.
+@UseGuards(AuthorizationGuard, PermissionGuard)
 export class TrialBalanceSheetController {
   constructor(
     private readonly trialBalanceSheetApp: TrialBalanceSheetApplication,
   ) {}
 
   @Get()
+  @RequirePermission(
+    ReportsAction.READ_TRIAL_BALANCE_SHEET,
+    AbilitySubject.Report,
+  )
   @ApiOperation({ summary: 'Get trial balance sheet' })
   @ApiQuery({
     name: 'numberFormat',


### PR DESCRIPTION
Part of #1002.

- **The gap:** the Trial Balance report can be opened by **any logged-in user, whatever their role.** The other financial reports (Balance Sheet, P&L, etc.) already block this — this one was missed.
- **The fix:** add the same check the other reports use, tied to the "view trial balance" permission that already exists. One file, no new settings or database changes.
- **Risk:** none for allowed users; only unauthorized access is blocked. Type-check and lint pass.

Prepared with Ghost, an AI maintenance agent — reviewed by me before opening.
