### PR TITLE
security/Add RBAC guard to Inventory Valuation report controller

### DIFF
--- a/packages/server/src/modules/FinancialStatements/modules/InventoryValuationSheet/InventoryValuation.controller.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/InventoryValuationSheet/InventoryValuation.controller.ts
@@ -8,7 +8,14 @@ import {
   ApiTags,
   getSchemaPath,
 } from '@nestjs/swagger';
-import { Controller, Get, Headers, Query, Res } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Headers,
+  Query,
+  Res,
+  UseGuards,
+} from '@nestjs/common';
 import { InventoryValuationSheetApplication } from './InventoryValuationSheetApplication';
 import { NumberFormatQueryDto } from '@/modules/BankingTransactions/dtos/NumberFormatQuery.dto';
 import { InventoryValuationQueryDto } from './InventoryValuationQuery.dto';
@@ -18,6 +25,11 @@ import {
   InventoryValuationTableResponseDto,
 } from './InventoryValuationResponse.dto';
 import { ApiCommonHeaders } from '@/common/decorators/ApiCommonHeaders';
+import { RequirePermission } from '@/modules/Roles/RequirePermission.decorator';
+import { PermissionGuard } from '@/modules/Roles/Permission.guard';
+import { AuthorizationGuard } from '@/modules/Roles/Authorization.guard';
+import { AbilitySubject } from '@/modules/Roles/Roles.types';
+import { ReportsAction } from '../../types/Report.types';
 
 @Controller('reports/inventory-valuation')
 @ApiTags('Reports')
@@ -27,12 +39,18 @@ import { ApiCommonHeaders } from '@/common/decorators/ApiCommonHeaders';
   InventoryValuationTableResponseDto,
   NumberFormatQueryDto,
 )
+// Restrict this financial report to authenticated users granted the inventory-valuation read permission.
+@UseGuards(AuthorizationGuard, PermissionGuard)
 export class InventoryValuationController {
   constructor(
     private readonly inventoryValuationApp: InventoryValuationSheetApplication,
   ) {}
 
   @Get()
+  @RequirePermission(
+    ReportsAction.READ_INVENTORY_VALUATION_SUMMARY,
+    AbilitySubject.Report,
+  )
   @ApiOperation({ summary: 'Retrieves the inventory valuation sheet' })
   @ApiQuery({
     name: 'numberFormat',


### PR DESCRIPTION
Part of #1002.

- **The gap:** the Inventory Valuation report can be opened by **any logged-in user, whatever their role.** The other financial reports (Balance Sheet, P&L, etc.) already block this — this one was missed.
- **The fix:** add the same check the other reports use, tied to the "view inventory valuation" permission that already exists. One file, no new settings or database changes.
- **Risk:** none for allowed users; only unauthorized access is blocked. Type-check and lint pass.

Prepared with Ghost, an AI maintenance agent — reviewed by me before opening.
