### PR TITLE
properly support DB_PORT environment variable

### DIFF
--- a/packages/server/src/common/config/system-database.ts
+++ b/packages/server/src/common/config/system-database.ts
@@ -3,7 +3,7 @@ import { registerAs } from '@nestjs/config';
 export default registerAs('systemDatabase', () => ({
   client: 'mysql',
   host: process.env.SYSTEM_DB_HOST || process.env.DB_HOST,
-  port: process.env.SYSTEM_DB_PORT || process.env.DB_PORT || 5432,
+  port: process.env.SYSTEM_DB_PORT || process.env.DB_PORT || 3306,
   user: process.env.SYSTEM_DB_USER || process.env.DB_USER,
   password: process.env.SYSTEM_DB_PASSWORD || process.env.DB_PASSWORD,
   databaseName: process.env.SYSTEM_DB_NAME || process.env.DB_NAME,

--- a/packages/server/src/common/config/tenant-database.ts
+++ b/packages/server/src/common/config/tenant-database.ts
@@ -4,7 +4,7 @@ import { registerAs } from '@nestjs/config';
 export default registerAs('tenantDatabase', () => ({
   client: 'mysql',
   host: process.env.TENANT_DB_HOST || process.env.DB_HOST,
-  port: process.env.TENANT_DB_PORT || process.env.DB_PORT || 5432,
+  port: process.env.TENANT_DB_PORT || process.env.DB_PORT || 3306,
   user: process.env.TENANT_DB_USER || process.env.DB_USER,
   password: process.env.TENANT_DB_PASSWORD || process.env.DB_PASSWORD,
   dbNamePrefix: process.env.TENANT_DB_NAME_PERFIX || 'bigcapital_tenant_',

--- a/packages/server/src/modules/CLI/commands/BaseCommand.ts
+++ b/packages/server/src/modules/CLI/commands/BaseCommand.ts
@@ -15,6 +15,7 @@ export abstract class BaseCommand extends CommandRunner {
       client: this.configService.get('systemDatabase.client'),
       connection: {
         host: this.configService.get('systemDatabase.host'),
+        port: this.configService.get('systemDatabase.port'),
         user: this.configService.get('systemDatabase.user'),
         password: this.configService.get('systemDatabase.password'),
         database: this.configService.get('systemDatabase.databaseName'),
@@ -37,6 +38,7 @@ export abstract class BaseCommand extends CommandRunner {
       client: this.configService.get('tenantDatabase.client'),
       connection: {
         host: this.configService.get('tenantDatabase.host'),
+        port: this.configService.get('tenantDatabase.port'),
         user: this.configService.get('tenantDatabase.user'),
         password: this.configService.get('tenantDatabase.password'),
         database: `${this.configService.get('tenantDatabase.dbNamePrefix')}${organizationId}`,

--- a/packages/server/src/modules/System/SystemDB/SystemDB.module.ts
+++ b/packages/server/src/modules/System/SystemDB/SystemDB.module.ts
@@ -16,6 +16,7 @@ const providers = [
       client: configService.get('systemDatabase.client'),
       connection: {
         host: configService.get('systemDatabase.host'),
+        port: configService.get('systemDatabase.port'),
         user: configService.get('systemDatabase.user'),
         password: configService.get('systemDatabase.password'),
         database: configService.get('systemDatabase.databaseName'),

--- a/packages/server/src/modules/Tenancy/TenancyDB/TenancyDB.module.ts
+++ b/packages/server/src/modules/Tenancy/TenancyDB/TenancyDB.module.ts
@@ -26,6 +26,7 @@ export const TenancyDatabaseProxyProvider = ClsModule.forFeatureAsync({
       client: configService.get('tenantDatabase.client'),
       connection: {
         host: configService.get('tenantDatabase.host'),
+        port: configService.get('tenantDatabase.port'),
         user: configService.get('tenantDatabase.user'),
         password: configService.get('tenantDatabase.password'),
         database,


### PR DESCRIPTION
Modify following files to support `DB_PORT` variables from `system-database.ts` and `tenant-database.ts` config files:

- `BaseCommand.ts`
- `TenancyDB.module.ts`
- `SystemDB.module.ts`

Change default port in `system-database.ts` and `tenant-database.ts` from `5432` (postgres default) to the `3306` (mariadb/mysql default). Originally, this did not cause any issues because it was unused.