### PR TITLE
fix(auth): password reset 500s — moment default-import broken under esModuleInterop:false (#1058)

### DIFF
--- a/packages/server/src/modules/Auth/commands/AuthResetPassword.service.ts
+++ b/packages/server/src/modules/Auth/commands/AuthResetPassword.service.ts
@@ -1,4 +1,4 @@
-import moment from 'moment';
+import * as moment from 'moment';
 import { ConfigService } from '@nestjs/config';
 import { Inject, Injectable } from '@nestjs/common';
 import { SystemUser } from '@/modules/System/models/SystemUser';


### PR DESCRIPTION
## Problem

Password reset is broken in the latest release (v0.25.23): every `POST /api/auth/reset_password/{token}` returns 500 with:

```
TypeError: (0 , moment_1.default) is not a function
    at AuthResetPasswordService.resetPassword (dist/modules/Auth/commands/AuthResetPassword.service.js:41)
```

This is issue #1058 ("Cannot Reset Password"), and it also blocks the invited-user flow (related to #811).

## Root cause

`packages/server/tsconfig` compiles with `module: commonjs` and **`esModuleInterop` off** (only `allowSyntheticDefaultImports` is set). `AuthResetPassword.service.ts` is the one file in the server that imports moment as a **default** import:

```ts
import moment from 'moment';
// ...
if (moment().diff(tokenModel.createdAt, 'seconds') > resetPasswordSeconds) { ... }
```

Without `esModuleInterop`, that emits an **unwrapped** require and a `.default` access:

```js
const moment_1 = require("moment");        // no __importDefault wrapper
(0, moment_1.default)().diff(...)           // moment_1.default is undefined
```

moment's CommonJS export **is** the callable (`module.exports = moment`), so `.default` doesn't exist. Every other file in the server imports moment as a namespace (`import * as moment from 'moment'`), which emits the correct `moment_1()` — verified: this is the only file server-wide with the broken `moment_1.default` pattern.

## Fix

Use the namespace import already used everywhere else, so the emitted call is `moment_1()`:

```diff
-import moment from 'moment';
+import * as moment from 'moment';
```

One line, one file. Behavior is unchanged everywhere except that the reset-token expiry check now runs instead of throwing.

Closes #1058.