### PR TITLE
fix(auth): invited users can't log in (ORGANIZATION.INACTIVE) despite valid password (#811 / BIG-302)

### DIFF
--- a/packages/server/src/modules/Auth/commands/AuthSignin.service.ts
+++ b/packages/server/src/modules/Auth/commands/AuthSignin.service.ts
@@ -94,6 +94,15 @@ export class AuthSigninService {
         user.tenantId,
       );
       if (tenant) return tenant;
+      // Fix (#811): `users.tenant_id` is an authoritative workspace assignment.
+      // Invited users get `tenant_id` set on accept but never receive an explicit
+      // `USER_TENANTS` membership row, so the membership-only checks above resolve
+      // to null and login fails with ORGANIZATION.INACTIVE despite a valid password.
+      // Trust the direct assignment when the tenant itself is active.
+      const assignedTenant = await this.tenantModel
+        .query()
+        .findById(user.tenantId);
+      if (assignedTenant?.isActive) return assignedTenant;
     }
     const memberships = await this.userTenantModel
       .query()


### PR DESCRIPTION
## Problem

Reproduced #811 ("Login fails after successful password reset on new user account", BIG-302) on a clean v0.25.23 deploy. After an invited user accepts and sets a password, **login fails** — and it also fails after a password reset.

## Root cause (it is NOT the password hash)

The reporter suspected a hash mismatch, but that's a red herror — I verified `bcrypt.compare(plaintext, storedHash)` returns **true** for the invited user. The 401 body is actually:

```json
{"message":"No active workspace available. Please contact the administrator.","errors":[{"type":"ORGANIZATION.INACTIVE"}]}
```

`AuthSigninService.resolveSigninTenant()` resolves the workspace **only** through a `USER_TENANTS` membership row (via `tryGetActiveTenantForUser`). But an invited user gets `users.tenant_id` set on accept and **never receives a `USER_TENANTS` membership row** (only the org owner gets one at signup). So every membership check returns null and login is rejected with `ORGANIZATION.INACTIVE`, even though the tenant is active and the password is valid.

Confirmed against the DB: the invited user has `users.tenant_id = 1` but zero rows in `USER_TENANTS`; the owner has both. Manually inserting the missing membership row makes login succeed (201).

## Fix

`users.tenant_id` is itself an authoritative workspace assignment. When the membership-based lookups find nothing, fall back to the user's assigned tenant if it is active:

```ts
if (user.tenantId) {
  const tenant = await this.tryGetActiveTenantForUser(user.id, user.tenantId);
  if (tenant) return tenant;
  // Fix (#811): invited users have tenant_id set but no USER_TENANTS row.
  const assignedTenant = await this.tenantModel.query().findById(user.tenantId);
  if (assignedTenant?.isActive) return assignedTenant;
}
```

This unblocks **already-invited** accounts with no data migration. A complementary change (having invite-accept create the `USER_TENANTS` membership) would also be reasonable and I'm happy to add it if you prefer, but the fallback fixes existing broken installs.

Closes #811.