### PR TITLE
fix(auth): reject requests for inactive tenants (GHSA-cq48-8wj2-3pqx)

### DIFF
--- a/packages/server/src/modules/Auth/commands/AuthApiKeyAuthorization.service.spec.ts
+++ b/packages/server/src/modules/Auth/commands/AuthApiKeyAuthorization.service.spec.ts
@@ -1,0 +1,44 @@
+import { AuthApiKeyAuthorizeService } from './AuthApiKeyAuthorization.service';
+
+describe('AuthApiKeyAuthorizeService', () => {
+  let service: AuthApiKeyAuthorizeService;
+  let apiKeyFindOne: jest.Mock;
+  let tenantFindById: jest.Mock;
+  let clsSet: jest.Mock;
+
+  beforeEach(() => {
+    apiKeyFindOne = jest.fn();
+    tenantFindById = jest.fn();
+    clsSet = jest.fn();
+
+    service = new AuthApiKeyAuthorizeService(
+      { set: clsSet } as any,
+      { query: () => ({ findOne: apiKeyFindOne }) } as any,
+      { query: () => ({ findById: tenantFindById }) } as any,
+    );
+  });
+
+  const validKey = {
+    key: 'k_123',
+    revoked: false,
+    expiresAt: null,
+    tenantId: 7,
+    userId: 2,
+  };
+
+  it('rejects when the tenant is inactive', async () => {
+    apiKeyFindOne.mockResolvedValue(validKey);
+    tenantFindById.mockResolvedValue({ isActive: false });
+
+    await expect(service.authorize('k_123')).resolves.toBe(false);
+    expect(clsSet).not.toHaveBeenCalled();
+  });
+
+  it('authorizes when the tenant is active', async () => {
+    apiKeyFindOne.mockResolvedValue(validKey);
+    tenantFindById.mockResolvedValue({ isActive: true, organizationId: 'org-1' });
+
+    await expect(service.authorize('k_123')).resolves.toBe(true);
+    expect(clsSet).toHaveBeenCalledWith('organizationId', 'org-1');
+  });
+});

--- a/packages/server/src/modules/Auth/commands/AuthApiKeyAuthorization.service.ts
+++ b/packages/server/src/modules/Auth/commands/AuthApiKeyAuthorization.service.ts
@@ -40,6 +40,7 @@ export class AuthApiKeyAuthorizeService {
       .findById(apiKeyRecord.tenantId);
 
     if (!tenant) return false;
+    if (!tenant.isActive) return false;
 
     this.clsService.set('organizationId', tenant.organizationId);
     this.clsService.set('userId', apiKeyRecord.userId);

--- a/packages/server/src/modules/Tenancy/TenancyGlobal.guard.spec.ts
+++ b/packages/server/src/modules/Tenancy/TenancyGlobal.guard.spec.ts
@@ -1,0 +1,97 @@
+import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import { TenancyGlobalGuard } from './TenancyGlobal.guard';
+
+const mockQuery = (resolvedValue: any) => ({
+  findOne: jest.fn().mockResolvedValue(resolvedValue),
+});
+
+describe('TenancyGlobalGuard', () => {
+  let guard: TenancyGlobalGuard;
+  let tenantQuery: { findOne: jest.Mock };
+  let membershipQuery: { findOne: jest.Mock };
+  let metadata: Record<string, any>;
+  let reflector: { getAllAndOverride: jest.Mock };
+
+  const buildContext = (headers: any = {}): ExecutionContext =>
+    ({
+      switchToHttp: () => ({ getRequest: () => ({ headers }) }),
+      getHandler: () => () => undefined,
+      getClass: () => class Handler {},
+    } as any);
+
+  beforeEach(() => {
+    tenantQuery = mockQuery(undefined);
+    membershipQuery = mockQuery(undefined);
+    metadata = {};
+    reflector = {
+      getAllAndOverride: jest.fn((key: string) => metadata[key]),
+    } as any;
+
+    guard = new TenancyGlobalGuard(
+      { query: () => tenantQuery } as any,
+      { query: () => tenantQuery } as any,
+      reflector as any,
+      { get: jest.fn().mockReturnValue(1) } as any,
+    );
+    // Re-bind the tenant model mock to return tenantQuery and the userTenant
+    // model mock to return membershipQuery.
+    (guard as any).tenantModel = { query: () => tenantQuery };
+    (guard as any).userTenantModel = { query: () => membershipQuery };
+  });
+
+  it('rejects requests targeting an inactive tenant', async () => {
+    tenantQuery.findOne.mockResolvedValue({ isActive: false });
+
+    await expect(
+      guard.canActivate(
+        buildContext({
+          'organization-id': 'org-1',
+          authorization: 'Bearer jwt-token',
+        }),
+      ),
+    ).rejects.toThrow(UnauthorizedException);
+  });
+
+  it('allows requests targeting an active tenant with a valid membership', async () => {
+    tenantQuery.findOne.mockResolvedValue({ isActive: true });
+    membershipQuery.findOne.mockResolvedValue({ id: 9 });
+
+    await expect(
+      guard.canActivate(
+        buildContext({
+          'organization-id': 'org-1',
+          authorization: 'Bearer jwt-token',
+        }),
+      ),
+    ).resolves.toBe(true);
+  });
+
+  it('still rejects inactive tenants even with a valid membership', async () => {
+    tenantQuery.findOne.mockResolvedValue({ isActive: false });
+    membershipQuery.findOne.mockResolvedValue({ id: 9 });
+
+    await expect(
+      guard.canActivate(
+        buildContext({
+          'organization-id': 'org-1',
+          authorization: 'Bearer jwt-token',
+        }),
+      ),
+    ).rejects.toThrow(UnauthorizedException);
+  });
+
+  it('allows an inactive tenant when @AllowInactiveTenant() is set', async () => {
+    metadata['ALLOW_INACTIVE_TENANT'] = true;
+    tenantQuery.findOne.mockResolvedValue({ isActive: false });
+    membershipQuery.findOne.mockResolvedValue({ id: 9 });
+
+    await expect(
+      guard.canActivate(
+        buildContext({
+          'organization-id': 'org-1',
+          authorization: 'Bearer jwt-token',
+        }),
+      ),
+    ).resolves.toBe(true);
+  });
+});

--- a/packages/server/src/modules/Tenancy/TenancyGlobal.guard.ts
+++ b/packages/server/src/modules/Tenancy/TenancyGlobal.guard.ts
@@ -17,6 +17,11 @@ export const IS_TENANT_AGNOSTIC = 'IS_TENANT_AGNOSTIC';
 
 export const TenantAgnosticRoute = () => SetMetadata(IS_TENANT_AGNOSTIC, true);
 
+export const ALLOW_INACTIVE_TENANT = 'ALLOW_INACTIVE_TENANT';
+
+export const AllowInactiveTenant = () =>
+  SetMetadata(ALLOW_INACTIVE_TENANT, true);
+
 @Injectable()
 export class TenancyGlobalGuard implements CanActivate {
   constructor(
@@ -48,6 +53,10 @@ export class TenancyGlobalGuard implements CanActivate {
       IS_TENANT_AGNOSTIC,
       [context.getHandler(), context.getClass()],
     );
+    const allowInactiveTenant = this.reflector.getAllAndOverride<boolean>(
+      ALLOW_INACTIVE_TENANT,
+      [context.getHandler(), context.getClass()],
+    );
 
     if (isPublic || isTenantAgnostic || isAuthApiKey) {
       return true;
@@ -61,6 +70,13 @@ export class TenancyGlobalGuard implements CanActivate {
     const tenant = await this.tenantModel.query().findOne({ organizationId });
     if (!tenant) {
       throw new UnauthorizedException('Organization not found.');
+    }
+
+    // Reject requests targeting a deactivated/deleting workspace, even with a
+    // still-valid JWT. Owner-only workspace mutation routes opt out via
+    // @AllowInactiveTenant() so deactivation stays reversible.
+    if (!tenant.isActive && !allowInactiveTenant) {
+      throw new UnauthorizedException('This workspace is inactive.');
     }
 
     const membership = await this.userTenantModel

--- a/packages/server/src/modules/ee/Workspaces/Workspaces.controller.ts
+++ b/packages/server/src/modules/ee/Workspaces/Workspaces.controller.ts
@@ -17,7 +17,10 @@ import {
   getSchemaPath,
 } from '@nestjs/swagger';
 import { ClsService } from 'nestjs-cls';
-import { TenantAgnosticRoute } from '@/modules/Tenancy/TenancyGlobal.guard';
+import {
+  AllowInactiveTenant,
+  TenantAgnosticRoute,
+} from '@/modules/Tenancy/TenancyGlobal.guard';
 import { IgnoreUserVerifiedRoute } from '@/modules/Auth/guards/EnsureUserVerified.guard';
 import { IgnoreTenantInitializedRoute } from '@/modules/Tenancy/EnsureTenantIsInitialized.guard';
 import { IgnoreTenantSeededRoute } from '@/modules/Tenancy/EnsureTenantIsSeeded.guards';
@@ -121,6 +124,7 @@ export class WorkspacesController {
   @IgnoreTenantInitializedRoute()
   @IgnoreTenantSeededRoute()
   @IgnoreTenantModelsInitialize()
+  @AllowInactiveTenant()
   @HttpCode(200)
   @ApiOperation({ summary: 'Delete a workspace (owner only)' })
   @ApiResponse({
@@ -160,6 +164,7 @@ export class WorkspacesController {
   @IgnoreTenantInitializedRoute()
   @IgnoreTenantSeededRoute()
   @IgnoreTenantModelsInitialize()
+  @AllowInactiveTenant()
   @HttpCode(200)
   @ApiOperation({ summary: 'Inactivate a workspace (owner only)' })
   @ApiResponse({
@@ -185,6 +190,7 @@ export class WorkspacesController {
   @IgnoreTenantInitializedRoute()
   @IgnoreTenantSeededRoute()
   @IgnoreTenantModelsInitialize()
+  @AllowInactiveTenant()
   @HttpCode(200)
   @ApiOperation({ summary: 'Reactivate a workspace (owner only)' })
   @ApiResponse({


### PR DESCRIPTION
## Summary
Fixes https://github.com/bigcapitalhq/bigcapital/security/advisories/GHSA-cq48-8wj2-3pqx

Deactivating a workspace did not invalidate already-issued JWTs, so a user holding a token from before deactivation could keep making authenticated requests to the inactive workspace until the token expired (CVSS 8.8, CWE-613).

The reporter pointed at `AuthSigninService.verifyPayload`, but that path has no organization context (the org arrives later via the `organization-id` header). The real per-request chokepoint that resolves the tenant is `TenancyGlobalGuard`.

- **`TenancyGlobalGuard`**: reject when the resolved tenant is inactive (`isInactive` / `isDeleting`). Owner-only workspace mutation routes opt out via a new `@AllowInactiveTenant()` decorator so deactivation stays reversible.
- **`AuthApiKeyAuthorizeService`**: API-key requests bypass the guard, so reject inactive tenants in the API-key authorize path too.
- **`WorkspacesController`**: mark `delete` / `inactivate` / `activate` owner-only routes with `@AllowInactiveTenant()` (`InactivateWorkspaceService` already enforces owner-only).

Note: a full session-version / token-rotation mechanism is the longer-term hardening (the advisory's second suggestion); this closes the hole immediately with no migration.

## Test plan
- [x] `TenancyGlobal.guard.spec.ts` — inactive tenant → 401; active tenant + membership → 200; inactive + `@AllowInactiveTenant()` → 200
- [x] `AuthApiKeyAuthorization.service.spec.ts` — inactive tenant → `authorize` returns false; active → true
- [x] `pnpm typecheck` clean (only pre-existing `sanitize-html` errors remain)
- [ ] Manual: sign in → set `tenants.isInactive = 1` → bearer request returns 401 → reactivate → 200

Credit: @phamkhanhhung1998 (reporter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)