### PR TITLE
fix(roles): guard role management endpoints (GHSA-jgqg-324p-322h)

### DIFF
--- a/packages/server/src/modules/Roles/AbilitySchema.ts
+++ b/packages/server/src/modules/Roles/AbilitySchema.ts
@@ -20,6 +20,7 @@ import {
   AbilitySubject,
   ISubjectAbilitiesSchema,
   ISubjectAbilitySchema,
+  RoleAction,
 } from './Roles.types';
 import { PaymentReceiveAction } from '../PaymentReceived/types/PaymentReceived.types';
 import { PreferencesAction } from '../Settings/Settings.types';
@@ -326,6 +327,16 @@ export const AbilitySchema: ISubjectAbilitiesSchema[] = [
     abilities: [
       { key: AttachmentAction.View, label: 'ability.view', default: true },
       { key: AttachmentAction.Delete, label: 'ability.delete', default: true },
+    ],
+  },
+  {
+    subject: AbilitySubject.Role,
+    subjectLabel: 'ability.roles',
+    abilities: [
+      { key: RoleAction.View, label: 'ability.view', default: false },
+      { key: RoleAction.Create, label: 'ability.create', default: false },
+      { key: RoleAction.Edit, label: 'ability.edit', default: false },
+      { key: RoleAction.Delete, label: 'ability.delete', default: false },
     ],
   },
   {

--- a/packages/server/src/modules/Roles/Roles.controller.spec.ts
+++ b/packages/server/src/modules/Roles/Roles.controller.spec.ts
@@ -1,0 +1,58 @@
+import { ForbiddenException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Ability } from '@casl/ability';
+import { PermissionGuard } from './Permission.guard';
+import { RolesController } from './Roles.controller';
+import { AbilitySubject, RoleAction } from './Roles.types';
+
+describe('RolesController authorization', () => {
+  const reflector = new Reflector();
+  const guard = new PermissionGuard(reflector);
+
+  const ctx = (handler: any, ability: Ability) =>
+    ({
+      switchToHttp: () => ({ getRequest: () => ({ ability }) }),
+      getHandler: () => handler,
+      getClass: () => RolesController,
+    } as any);
+
+  const cases: Array<[string, string]> = [
+    ['createRole', RoleAction.Create],
+    ['editRole', RoleAction.Edit],
+    ['deleteRole', RoleAction.Delete],
+    ['getRoles', RoleAction.View],
+    ['getRole', RoleAction.View],
+    ['getRolePermissionsSchema', RoleAction.View],
+  ];
+
+  it.each(cases)(
+    '%s is denied (403) for a role without the Role permission',
+    (method) => {
+      const deny = new Ability([]);
+      expect(() =>
+        guard.canActivate(ctx(RolesController.prototype[method], deny)),
+      ).toThrow(ForbiddenException);
+    },
+  );
+
+  it.each(cases)(
+    '%s is allowed for a role that grants the matching Role permission',
+    (method, action) => {
+      const allow = new Ability([
+        { action, subject: AbilitySubject.Role },
+      ] as any);
+      expect(
+        guard.canActivate(ctx(RolesController.prototype[method], allow)),
+      ).toBe(true);
+    },
+  );
+
+  it('grants all Role operations to a manage-all (admin) ability', () => {
+    const admin = new Ability([{ action: 'manage', subject: 'all' }] as any);
+    for (const [method] of cases) {
+      expect(
+        guard.canActivate(ctx(RolesController.prototype[method], admin)),
+      ).toBe(true);
+    }
+  });
+});

--- a/packages/server/src/modules/Roles/Roles.controller.ts
+++ b/packages/server/src/modules/Roles/Roles.controller.ts
@@ -8,6 +8,7 @@ import {
   Body,
   HttpStatus,
   ParseIntPipe,
+  UseGuards,
 } from '@nestjs/common';
 import { CreateRoleDto, EditRoleDto } from './dtos/Role.dto';
 import { RolesApplication } from './Roles.application';
@@ -22,15 +23,21 @@ import {
 } from '@nestjs/swagger';
 import { RoleResponseDto } from './dtos/RoleResponse.dto';
 import { ApiCommonHeaders } from '@/common/decorators/ApiCommonHeaders';
+import { RequirePermission } from './RequirePermission.decorator';
+import { PermissionGuard } from './Permission.guard';
+import { AuthorizationGuard } from './Authorization.guard';
+import { AbilitySubject, RoleAction } from './Roles.types';
 
 @ApiTags('Roles')
 @Controller('roles')
 @ApiExtraModels(RoleResponseDto)
 @ApiCommonHeaders()
+@UseGuards(AuthorizationGuard, PermissionGuard)
 export class RolesController {
   constructor(private readonly rolesApp: RolesApplication) {}
 
   @Post()
+  @RequirePermission(RoleAction.Create, AbilitySubject.Role)
   @ApiOperation({ summary: 'Create a new role' })
   @ApiBody({ type: CreateRoleDto })
   @ApiResponse({
@@ -47,6 +54,7 @@ export class RolesController {
   }
 
   @Put(':id')
+  @RequirePermission(RoleAction.Edit, AbilitySubject.Role)
   @ApiOperation({ summary: 'Edit an existing role' })
   @ApiParam({ name: 'id', description: 'Role ID' })
   @ApiBody({ type: EditRoleDto })
@@ -67,6 +75,7 @@ export class RolesController {
   }
 
   @Delete(':id')
+  @RequirePermission(RoleAction.Delete, AbilitySubject.Role)
   @ApiOperation({ summary: 'Delete a role' })
   @ApiParam({ name: 'id', description: 'Role ID' })
   @ApiResponse({
@@ -83,6 +92,7 @@ export class RolesController {
   }
 
   @Get('permissions/schema')
+  @RequirePermission(RoleAction.View, AbilitySubject.Role)
   @ApiOperation({ summary: 'Get role permissions schema' })
   @ApiResponse({
     status: HttpStatus.OK,
@@ -95,6 +105,7 @@ export class RolesController {
   }
 
   @Get()
+  @RequirePermission(RoleAction.View, AbilitySubject.Role)
   @ApiOperation({ summary: 'Get all roles' })
   @ApiResponse({
     status: HttpStatus.OK,
@@ -111,6 +122,7 @@ export class RolesController {
   }
 
   @Get(':id')
+  @RequirePermission(RoleAction.View, AbilitySubject.Role)
   @ApiOperation({ summary: 'Get a specific role by ID' })
   @ApiParam({ name: 'id', description: 'Role ID' })
   @ApiResponse({

--- a/packages/server/src/modules/Roles/Roles.types.ts
+++ b/packages/server/src/modules/Roles/Roles.types.ts
@@ -25,6 +25,13 @@ export type AppAbility = Ability<Abilities>;
 export const createAbility = (rules: RawRuleOf<AppAbility>[]) =>
   new Ability<Abilities>(rules);
 
+export enum RoleAction {
+  View = 'View',
+  Create = 'Create',
+  Edit = 'Edit',
+  Delete = 'Delete',
+}
+
 export interface ISubjectAbilitySchema {
   key: string;
   label: string;


### PR DESCRIPTION
## Summary
Fixes https://github.com/bigcapitalhq/bigcapital/security/advisories/GHSA-jgqg-324p-322h

Every `Roles` CRUD endpoint ran without an authorization guard (CVSS 8.8, CWE-862). Any authenticated workspace member could list roles, edit any role's permissions (including their own), grant themselves arbitrary permissions, and escalate to admin-equivalent capabilities inside the tenant.

Applies the existing CASL guard pattern already used by `Customers` / `Vendors`:

- Add `RoleAction` (`View`/`Create`/`Edit`/`Delete`) and a `Role` subject in `AbilitySchema`, all `default: false` so custom roles never self-grant role management.
- Guard `RolesController` with `AuthorizationGuard` + `PermissionGuard` and `@RequirePermission(...)` on every handler (create/edit/delete/view/view-list/permissions-schema).
- Admin keeps full access via the `admin` slug (`manage` all).

No migration/seed needed — matches the `security/Add RBAC guards to WarehouseTransfersController` precedent.

## Test plan
- [x] `Roles.controller.spec.ts` — each handler is denied (403) for a role without the `Role` permission; allowed for a role granting the matching permission; admin `manage all` passes all
- [x] `pnpm typecheck` clean
- [ ] Manual: low-priv role cannot `GET/POST/PUT/DELETE /roles`

Credit: @phamkhanhhung1998 (reporter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)