### PR TITLE
fix(attachments): guard attachment upload/link/unlink (GHSA-xhq3-pp9m-vpmr)

### DIFF
--- a/packages/server/src/modules/Attachments/Attachments.controller.spec.ts
+++ b/packages/server/src/modules/Attachments/Attachments.controller.spec.ts
@@ -1,0 +1,59 @@
+import { ForbiddenException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Ability } from '@casl/ability';
+import { PermissionGuard } from '@/modules/Roles/Permission.guard';
+import { AttachmentsController } from './Attachments.controller';
+import { AbilitySubject } from '@/modules/Roles/Roles.types';
+import { AttachmentAction } from './Attachments.types';
+
+describe('AttachmentsController authorization', () => {
+  const reflector = new Reflector();
+  const guard = new PermissionGuard(reflector);
+
+  const ctx = (handler: any, ability: Ability) =>
+    ({
+      switchToHttp: () => ({ getRequest: () => ({ ability }) }),
+      getHandler: () => handler,
+      getClass: () => AttachmentsController,
+    } as any);
+
+  const cases: Array<[string, string]> = [
+    ['uploadAttachment', AttachmentAction.Create],
+    ['linkDocument', AttachmentAction.Create],
+    ['unlinkDocument', AttachmentAction.Delete],
+    ['getAttachment', AttachmentAction.View],
+    ['deleteAttachment', AttachmentAction.Delete],
+    ['getAttachmentPresignedUrl', AttachmentAction.View],
+  ];
+
+  it.each(cases)(
+    '%s is denied (403) for a role with no Attachment permission',
+    (method) => {
+      const deny = new Ability([]);
+      expect(() =>
+        guard.canActivate(ctx(AttachmentsController.prototype[method], deny)),
+      ).toThrow(ForbiddenException);
+    },
+  );
+
+  it.each(cases)(
+    '%s is allowed for a role that grants the matching Attachment permission',
+    (method, action) => {
+      const allow = new Ability([
+        { action, subject: AbilitySubject.Attachment },
+      ] as any);
+      expect(
+        guard.canActivate(ctx(AttachmentsController.prototype[method], allow)),
+      ).toBe(true);
+    },
+  );
+
+  it('grants all attachment operations to a manage-all (admin) ability', () => {
+    const admin = new Ability([{ action: 'manage', subject: 'all' }] as any);
+    for (const [method] of cases) {
+      expect(
+        guard.canActivate(ctx(AttachmentsController.prototype[method], admin)),
+      ).toBe(true);
+    }
+  });
+});

--- a/packages/server/src/modules/Attachments/Attachments.controller.ts
+++ b/packages/server/src/modules/Attachments/Attachments.controller.ts
@@ -19,6 +19,7 @@ import {
   Res,
   UnauthorizedException,
   UploadedFile,
+  UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
 import {
@@ -32,12 +33,15 @@ import { FileInterceptor } from '@/common/interceptors/file.interceptor';
 import { ConfigService } from '@nestjs/config';
 import { ApiCommonHeaders } from '@/common/decorators/ApiCommonHeaders';
 import { RequirePermission } from '@/modules/Roles/RequirePermission.decorator';
+import { PermissionGuard } from '@/modules/Roles/Permission.guard';
+import { AuthorizationGuard } from '@/modules/Roles/Authorization.guard';
 import { AbilitySubject } from '@/modules/Roles/Roles.types';
 import { AttachmentAction } from './Attachments.types';
 
 @ApiTags('Attachments')
 @Controller('/attachments')
 @ApiCommonHeaders()
+@UseGuards(AuthorizationGuard, PermissionGuard)
 export class AttachmentsController {
   /**
    * @param {AttachmentsApplication} attachmentsApplication - Attachments application.
@@ -56,6 +60,7 @@ export class AttachmentsController {
   @HttpCode(200)
   @UseInterceptors(FileInterceptor('file'))
   @ApiConsumes('multipart/form-data')
+  @RequirePermission(AttachmentAction.Create, AbilitySubject.Attachment)
   @ApiOperation({ summary: 'Upload attachment to S3' })
   @ApiBody({ description: 'Upload attachment', type: UploadAttachmentDto })
   @ApiResponse({
@@ -133,6 +138,7 @@ export class AttachmentsController {
   @ApiOperation({ summary: 'Link attachment to a model' })
   @ApiParam({ name: 'id', description: 'Attachment ID' })
   @ApiBody({ type: LinkAttachmentDto })
+  @RequirePermission(AttachmentAction.Create, AbilitySubject.Attachment)
   @ApiResponse({
     status: 200,
     description: 'The document has been linked successfully',
@@ -160,6 +166,7 @@ export class AttachmentsController {
   @ApiOperation({ summary: 'Unlink attachment from a model' })
   @ApiParam({ name: 'id', description: 'Attachment ID' })
   @ApiBody({ type: UnlinkAttachmentDto })
+  @RequirePermission(AttachmentAction.Delete, AbilitySubject.Attachment)
   @ApiResponse({
     status: 200,
     description: 'The document has been unlinked successfully',

--- a/packages/server/src/modules/Attachments/Attachments.types.ts
+++ b/packages/server/src/modules/Attachments/Attachments.types.ts
@@ -4,5 +4,6 @@ export interface AttachmentLinkDTO {
 
 export enum AttachmentAction {
   View = 'View',
+  Create = 'Create',
   Delete = 'Delete',
 }

--- a/packages/server/src/modules/Roles/AbilitySchema.ts
+++ b/packages/server/src/modules/Roles/AbilitySchema.ts
@@ -325,6 +325,7 @@ export const AbilitySchema: ISubjectAbilitiesSchema[] = [
     subjectLabel: 'ability.attachments',
     abilities: [
       { key: AttachmentAction.View, label: 'ability.view', default: true },
+      { key: AttachmentAction.Create, label: 'ability.create', default: true },
       { key: AttachmentAction.Delete, label: 'ability.delete', default: true },
     ],
   },


### PR DESCRIPTION
## Summary
Fixes https://github.com/bigcapitalhq/bigcapital/security/advisories/GHSA-xhq3-pp9m-vpmr

`POST /attachments` (upload) and the link/unlink handlers ran without any authorization guard (CVSS 5.4, CWE-862). Any authenticated workspace member could upload files and consume object storage even with a role that had no Attachment permission. The other handlers (`get` / `delete` / `presigned-url`) already declared `@RequirePermission`, but it was dead metadata because the controller never applied the guards.

- Add `AttachmentAction.Create` and register it on the `Attachment` subject (`default: true` so existing/new custom roles keep upload capability; a role with **no** Attachment permission is now denied).
- Guard `AttachmentsController` with `AuthorizationGuard` + `PermissionGuard`.
- `upload` / `link` require `Attachment.Create`; `unlink` requires `Attachment.Delete`.

Out of scope (not fixed here, flagged separately): `unlinkDocument` still calls `.link()` in its body — a pre-existing copy-paste bug unrelated to this advisory.

## Test plan
- [x] `Attachments.controller.spec.ts` — every handler (upload/link/unlink/get/delete/presigned) is denied (403) with no Attachment permission; allowed with the matching permission; admin `manage all` passes
- [x] `pnpm typecheck` clean
- [ ] Manual: role without Attachment permission gets 403 on `POST /attachments`

Credit: @phamkhanhhung1998 (reporter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)