### PR TITLE
fix(webapp): import useEffect in SetupInitializingForm

### DIFF
--- a/packages/webapp/src/containers/Setup/SetupInitializingForm.tsx
+++ b/packages/webapp/src/containers/Setup/SetupInitializingForm.tsx
@@ -2,7 +2,7 @@
 import { ProgressBar, Intent } from '@blueprintjs/core';
 import { css } from '@emotion/css';
 import { x } from '@xstyled/emotion';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { FormattedMessage as T } from '@/components';
 import { withOrganizationActions } from '@/containers/Organization/withOrganizationActions';
 import { useJob, useCurrentOrganization } from '@/hooks/query';


### PR DESCRIPTION
## Summary

`SetupInitializingForm.tsx` calls `useEffect` (lines 36 and 43) but only imports the default `React` export, not the named `useEffect` hook:

```tsx
import React from 'react';
```

This builds fine in dev, but in the production bundle it crashes immediately with:

```
Uncaught ReferenceError: useEffect is not defined
    at SetupInitializingForm (WizardSetupPage-*.js)
```

Since `EnsureOrganizationIsNotReady` renders `SetupInitializingForm` as part of the wizard flow, this breaks the entire setup wizard for any fresh self-hosted install as soon as it reaches the "initializing" step — the app just hard-crashes with a blank page.

I ran into this self-hosting via Docker Compose on the published `bigcapitalhq/webapp:v0.25.23` (also `:latest`) image, and confirmed by diffing the minified `WizardSetupPage` chunk between `v0.25.22` and `v0.25.23`: the older build correctly namespaces every `useEffect` call (`v.useEffect`), the newer one calls it bare with no import — matching this file exactly. Still present on current `develop` as of this PR.

## Fix

```diff
-import React from 'react';
+import React, { useEffect } from 'react';
```

Matches the existing convention elsewhere in the same directory (e.g. `SetupSubscription.tsx` imports `useEffect` explicitly).

## Test plan
- [x] Confirmed the exact same bare `useEffect` call pattern in the shipped `v0.25.23`/`:latest` production bundle, absent in `v0.25.22`
- [ ] Maintainers to confirm via a dev/prod build that the wizard's initializing step no longer throws