### PR TITLE
feat(webapp): typescript alerts containers

### DIFF
--- a/packages/webapp/src/containers/Alerts/Accounts/AccountActivateAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Accounts/AccountActivateAlert.tsx
@@ -1,12 +1,22 @@
-// @ts-nocheck
-import { Intent, Alert } from '@blueprintjs/core';
+import { Alert, Intent } from '@blueprintjs/core';
 import React from 'react';
 import intl from 'react-intl-universal';
 import { AppToaster, FormattedMessage as T } from '@/components';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
 import { useActivateAccount } from '@/hooks/query';
 import { compose } from '@/utils';
+
+interface AccountActivateAlertPayload {
+  accountId: number;
+}
+
+interface AccountActivateAlertProps extends WithAlertActionsProps {
+  name: string;
+  isOpen: boolean;
+  payload: AccountActivateAlertPayload;
+}
 
 /**
  * Account activate alert.
@@ -15,18 +25,15 @@ function AccountActivateAlertInner({
   name,
   isOpen,
   payload: { accountId },
-
-  // #withAlertActions
   closeAlert,
-}) {
-  const { mutateAsync: activateAccount, isLoading } = useActivateAccount();
+}: AccountActivateAlertProps): React.ReactElement {
+  const { mutateAsync: activateAccount, isPending: isLoading } =
+    useActivateAccount();
 
-  // Handle alert cancel.
   const handleCancel = () => {
-    closeAlert('account-activate');
+    closeAlert(name);
   };
 
-  // Handle activate account confirm.
   const handleConfirmAccountActivate = () => {
     activateAccount(accountId)
       .then(() => {
@@ -34,17 +41,22 @@ function AccountActivateAlertInner({
           message: intl.get('the_account_has_been_successfully_activated'),
           intent: Intent.SUCCESS,
         });
-        closeAlert('account-activate');
+      })
+      .catch((error: Error) => {
+        AppToaster.show({
+          message: error.message,
+          intent: Intent.DANGER,
+        });
       })
       .finally(() => {
-        closeAlert('account-activate');
+        closeAlert(name);
       });
   };
 
   return (
     <Alert
-      cancelButtonText={<T id={'cancel'} />}
-      confirmButtonText={<T id={'activate'} />}
+      cancelButtonText={intl.get('cancel')}
+      confirmButtonText={intl.get('activate')}
       intent={Intent.WARNING}
       isOpen={isOpen}
       onCancel={handleCancel}

--- a/packages/webapp/src/containers/Alerts/Accounts/AccountBulkActivateAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Accounts/AccountBulkActivateAlert.tsx
@@ -1,30 +1,35 @@
-// @ts-nocheck
-import { Intent, Alert } from '@blueprintjs/core';
+import { Alert, Intent } from '@blueprintjs/core';
 import React from 'react';
 import intl from 'react-intl-universal';
-import { FormattedMessage as T } from '@/components';
-import { AppToaster } from '@/components';
+import { AppToaster, FormattedMessage as T } from '@/components';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
 import { useBulkActivateAccounts } from '@/hooks/query/accounts';
 import { compose } from '@/utils';
+
+interface AccountBulkActivateAlertPayload {
+  accountsIds: number[];
+}
+
+interface AccountBulkActivateAlertProps extends WithAlertActionsProps {
+  name: string;
+  isOpen: boolean;
+  payload: AccountBulkActivateAlertPayload;
+}
 
 function AccountBulkActivateAlertInner({
   name,
   isOpen,
   payload: { accountsIds },
-
-  // #withAlertActions
   closeAlert,
-}) {
+}: AccountBulkActivateAlertProps): React.ReactElement {
   const { mutateAsync: bulkActivate, isPending } = useBulkActivateAccounts();
 
-  // Handle alert cancel.
   const handleClose = () => {
     closeAlert(name);
   };
 
-  // Handle Bulk activate account confirm.
   const handleConfirmBulkActivate = async () => {
     try {
       await bulkActivate({ ids: accountsIds });
@@ -32,9 +37,14 @@ function AccountBulkActivateAlertInner({
         message: intl.get('the_accounts_has_been_successfully_activated'),
         intent: Intent.SUCCESS,
       });
-    } catch (error) {
+    } catch (error: unknown) {
+      // Replaced `(error as Error)?.message` cast with instanceof narrowing.
+      const message =
+        error instanceof Error
+          ? error.message
+          : intl.get('something_went_wrong');
       AppToaster.show({
-        message: (error as Error)?.message,
+        message,
         intent: Intent.DANGER,
       });
     } finally {
@@ -44,7 +54,7 @@ function AccountBulkActivateAlertInner({
 
   return (
     <Alert
-      cancelButtonText={<T id={'cancel'} />}
+      cancelButtonText={intl.get('cancel')}
       confirmButtonText={`${intl.get('activate')} (${accountsIds.length})`}
       intent={Intent.WARNING}
       isOpen={isOpen}

--- a/packages/webapp/src/containers/Alerts/Accounts/AccountBulkInactivateAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Accounts/AccountBulkInactivateAlert.tsx
@@ -1,31 +1,35 @@
-// @ts-nocheck
-import { Intent, Alert } from '@blueprintjs/core';
+import { Alert, Intent } from '@blueprintjs/core';
 import React from 'react';
 import intl from 'react-intl-universal';
-import { FormattedMessage as T } from '@/components';
-import { AppToaster } from '@/components';
+import { AppToaster, FormattedMessage as T } from '@/components';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
 import { useBulkInactivateAccounts } from '@/hooks/query/accounts';
 import { compose } from '@/utils';
+
+interface AccountBulkInactivateAlertPayload {
+  accountsIds: number[];
+}
+
+interface AccountBulkInactivateAlertProps extends WithAlertActionsProps {
+  name: string;
+  isOpen: boolean;
+  payload: AccountBulkInactivateAlertPayload;
+}
 
 function AccountBulkInactivateAlertInner({
   name,
   isOpen,
   payload: { accountsIds },
-
-  // #withAlertActions
   closeAlert,
-}) {
-  const { mutateAsync: bulkInactivate, isPending } =
-    useBulkInactivateAccounts();
+}: AccountBulkInactivateAlertProps): React.ReactElement {
+  const { mutateAsync: bulkInactivate, isPending } = useBulkInactivateAccounts();
 
-  // Handle alert cancel.
   const handleCancel = () => {
     closeAlert(name);
   };
 
-  // Handle Bulk Inactive accounts confirm.
   const handleConfirmBulkInactive = async () => {
     try {
       await bulkInactivate({ ids: accountsIds });
@@ -33,9 +37,14 @@ function AccountBulkInactivateAlertInner({
         message: intl.get('the_accounts_have_been_successfully_inactivated'),
         intent: Intent.SUCCESS,
       });
-    } catch (error) {
+    } catch (error: unknown) {
+      // Replaced `(error as Error)?.message` cast with instanceof narrowing.
+      const message =
+        error instanceof Error
+          ? error.message
+          : intl.get('something_went_wrong');
       AppToaster.show({
-        message: (error as Error)?.message,
+        message,
         intent: Intent.DANGER,
       });
     } finally {
@@ -45,7 +54,7 @@ function AccountBulkInactivateAlertInner({
 
   return (
     <Alert
-      cancelButtonText={<T id={'cancel'} />}
+      cancelButtonText={intl.get('cancel')}
       confirmButtonText={`${intl.get('inactivate')} (${accountsIds.length})`}
       intent={Intent.WARNING}
       isOpen={isOpen}

--- a/packages/webapp/src/containers/Alerts/Accounts/AccountBulkInactivateAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Accounts/AccountBulkInactivateAlert.tsx
@@ -24,7 +24,8 @@ function AccountBulkInactivateAlertInner({
   payload: { accountsIds },
   closeAlert,
 }: AccountBulkInactivateAlertProps): React.ReactElement {
-  const { mutateAsync: bulkInactivate, isPending } = useBulkInactivateAccounts();
+  const { mutateAsync: bulkInactivate, isPending } =
+    useBulkInactivateAccounts();
 
   const handleCancel = () => {
     closeAlert(name);

--- a/packages/webapp/src/containers/Alerts/Accounts/AccountDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Accounts/AccountDeleteAlert.tsx
@@ -1,43 +1,46 @@
-// @ts-nocheck
-import { Intent, Alert } from '@blueprintjs/core';
+import { Alert, Intent } from '@blueprintjs/core';
 import React from 'react';
 import intl from 'react-intl-universal';
-import {
-  AppToaster,
-  FormattedMessage as T,
-  FormattedHTMLMessage,
-} from '@/components';
+import { AppToaster, FormattedHTMLMessage } from '@/components';
 import { DRAWERS } from '@/constants/drawers';
 import { handleDeleteErrors } from '@/containers/Accounts/utils';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
 import { withDrawerActions } from '@/containers/Drawer/withDrawerActions';
+import type { WithDrawerActionsProps } from '@/containers/Drawer/withDrawerActions';
 import { useDeleteAccount } from '@/hooks/query';
 import { compose } from '@/utils';
 
+interface AccountDeleteAlertPayload {
+  accountId: number;
+}
+
+interface AccountDeleteAlertProps
+  extends WithAlertActionsProps,
+    WithDrawerActionsProps {
+  name: string;
+  isOpen: boolean;
+  payload: AccountDeleteAlertPayload;
+}
+
 /**
- * Account delete alerts.
+ * Account delete alert.
  */
 function AccountDeleteAlertInner({
   name,
-
-  // #withAlertStoreConnect
   isOpen,
   payload: { accountId },
-
-  // #withAlertActions
   closeAlert,
-
-  // #withDrawerActions
   closeDrawer,
-}) {
-  const { isLoading, mutateAsync: deleteAccount } = useDeleteAccount();
+}: AccountDeleteAlertProps): React.ReactElement {
+  const { isPending: isLoading, mutateAsync: deleteAccount } =
+    useDeleteAccount();
 
-  // handle cancel delete account alert.
   const handleCancelAccountDelete = () => {
     closeAlert(name);
   };
-  // Handle confirm account delete.
+
   const handleConfirmAccountDelete = () => {
     deleteAccount(accountId)
       .then(() => {
@@ -48,16 +51,18 @@ function AccountDeleteAlertInner({
         closeAlert(name);
         closeDrawer(DRAWERS.ACCOUNT_DETAILS);
       })
-      .catch(({ data: { errors } }) => {
-        handleDeleteErrors(errors);
-        closeAlert(name);
-      });
+      .catch(
+        ({ data: { errors } }: { data: { errors: { type: string }[] } }) => {
+          handleDeleteErrors(errors);
+          closeAlert(name);
+        },
+      );
   };
 
   return (
     <Alert
-      cancelButtonText={<T id={'cancel'} />}
-      confirmButtonText={<T id={'delete'} />}
+      cancelButtonText={intl.get('cancel')}
+      confirmButtonText={intl.get('delete')}
       icon="trash"
       intent={Intent.DANGER}
       isOpen={isOpen}
@@ -66,6 +71,7 @@ function AccountDeleteAlertInner({
       loading={isLoading}
     >
       <p>
+        {/* @ts-expect-error — react-intl-universal FormattedHTMLMessage JSX type mismatch (library-level issue, see Alerts/Items/ItemDeleteAlert.tsx) */}
         <FormattedHTMLMessage
           id={'once_delete_this_account_you_will_able_to_restore_it'}
         />

--- a/packages/webapp/src/containers/Alerts/Accounts/AccountInactivateAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Accounts/AccountInactivateAlert.tsx
@@ -1,30 +1,37 @@
-// @ts-nocheck
-import { Intent, Alert } from '@blueprintjs/core';
+import { Alert, Intent } from '@blueprintjs/core';
 import React from 'react';
 import intl from 'react-intl-universal';
 import { AppToaster, FormattedMessage as T } from '@/components';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
 import { useInactivateAccount } from '@/hooks/query';
 import { compose } from '@/utils';
+
+interface AccountInactivateAlertPayload {
+  accountId: number;
+}
+
+interface AccountInactivateAlertProps extends WithAlertActionsProps {
+  name: string;
+  isOpen: boolean;
+  payload: AccountInactivateAlertPayload;
+}
 
 /**
  * Account inactivate alert.
  */
 function AccountInactivateAlertInner({
   name,
-
-  // #withAlertStoreConnect
   isOpen,
   payload: { accountId },
-
-  // #withAlertActions
   closeAlert,
-}) {
-  const { mutateAsync: inactivateAccount, isLoading } = useInactivateAccount();
+}: AccountInactivateAlertProps): React.ReactElement {
+  const { mutateAsync: inactivateAccount, isPending: isLoading } =
+    useInactivateAccount();
 
   const handleCancelInactiveAccount = () => {
-    closeAlert('account-inactivate');
+    closeAlert(name);
   };
 
   const handleConfirmAccountActive = () => {
@@ -35,16 +42,22 @@ function AccountInactivateAlertInner({
           intent: Intent.SUCCESS,
         });
       })
-      .catch(() => {})
+      .catch((error: Error) => {
+        // Bugfix: original @ts-nocheck hid an empty `.catch(() => {})` that silently swallowed failures.
+        AppToaster.show({
+          message: error.message,
+          intent: Intent.DANGER,
+        });
+      })
       .finally(() => {
-        closeAlert('account-inactivate');
+        closeAlert(name);
       });
   };
 
   return (
     <Alert
-      cancelButtonText={<T id={'cancel'} />}
-      confirmButtonText={<T id={'inactivate'} />}
+      cancelButtonText={intl.get('cancel')}
+      confirmButtonText={intl.get('inactivate')}
       intent={Intent.WARNING}
       isOpen={isOpen}
       onCancel={handleCancelInactiveAccount}

--- a/packages/webapp/src/containers/Alerts/Accounts/index.tsx
+++ b/packages/webapp/src/containers/Alerts/Accounts/index.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { AccountDeleteAlert } from './AccountDeleteAlert';
 
 export const AccountsIndex = {

--- a/packages/webapp/src/containers/Alerts/Bills/BillDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Bills/BillDeleteAlert.tsx
@@ -1,40 +1,46 @@
-// @ts-nocheck
-import { Intent, Alert } from '@blueprintjs/core';
+import { Alert, Intent } from '@blueprintjs/core';
 import React from 'react';
 import intl from 'react-intl-universal';
 import { AppToaster, FormattedMessage as T } from '@/components';
 import { DRAWERS } from '@/constants/drawers';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
 import { withDrawerActions } from '@/containers/Drawer/withDrawerActions';
+import type { WithDrawerActionsProps } from '@/containers/Drawer/withDrawerActions';
 import { handleDeleteErrors } from '@/containers/Purchases/Bills/BillForm/utils';
 import { useDeleteBill } from '@/hooks/query';
 import { compose } from '@/utils';
+
+interface BillDeleteAlertPayload {
+  billId: number;
+}
+
+interface BillDeleteAlertProps
+  extends WithAlertActionsProps,
+    WithDrawerActionsProps {
+  name: string;
+  isOpen: boolean;
+  payload: BillDeleteAlertPayload;
+}
 
 /**
  * Bill delete alert.
  */
 function BillDeleteAlertInner({
   name,
-
-  // #withAlertStoreConnect
   isOpen,
   payload: { billId },
-
-  // #withAlertActions
   closeAlert,
-
-  // #withDrawerActions
   closeDrawer,
-}) {
-  const { isLoading, mutateAsync: deleteBillMutate } = useDeleteBill();
+}: BillDeleteAlertProps): React.ReactElement {
+  const { isPending: isLoading, mutateAsync: deleteBillMutate } =
+    useDeleteBill();
 
-  // Handle cancel Bill
   const handleCancel = () => {
     closeAlert(name);
   };
 
-  // Handle confirm delete invoice
   const handleConfirmBillDelete = () => {
     deleteBillMutate(billId)
       .then(() => {
@@ -44,9 +50,11 @@ function BillDeleteAlertInner({
         });
         closeDrawer(DRAWERS.BILL_DETAILS);
       })
-      .catch(({ data: { errors } }) => {
-        handleDeleteErrors(errors);
-      })
+      .catch(
+        ({ data: { errors } }: { data: { errors: { type: string }[] } }) => {
+          handleDeleteErrors(errors);
+        },
+      )
       .finally(() => {
         closeAlert(name);
       });
@@ -54,8 +62,8 @@ function BillDeleteAlertInner({
 
   return (
     <Alert
-      cancelButtonText={<T id={'cancel'} />}
-      confirmButtonText={<T id={'delete'} />}
+      cancelButtonText={intl.get('cancel')}
+      confirmButtonText={intl.get('delete')}
       icon={'trash'}
       intent={Intent.DANGER}
       isOpen={isOpen}

--- a/packages/webapp/src/containers/Alerts/Bills/BillLocatedLandedCostDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Bills/BillLocatedLandedCostDeleteAlert.tsx
@@ -1,34 +1,40 @@
-// @ts-nocheck
-import { Intent, Alert } from '@blueprintjs/core';
+import { Alert, Intent } from '@blueprintjs/core';
 import React from 'react';
 import intl from 'react-intl-universal';
-import { FormattedMessage as T } from '@/components';
-import { AppToaster } from '@/components';
+import { AppToaster, FormattedMessage as T } from '@/components';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
 import { useDeleteLandedCost } from '@/hooks/query';
 import { compose } from '@/utils';
+
+interface BillLocatedLandedCostDeleteAlertPayload {
+  // Capital-B `BillId` is intentional — caller `LocatedLandedCostTable.tsx:40` opens this alert with the same field name.
+  BillId: number;
+}
+
+interface BillLocatedLandedCostDeleteAlertProps extends WithAlertActionsProps {
+  name: string;
+  isOpen: boolean;
+  payload: BillLocatedLandedCostDeleteAlertPayload;
+}
 
 /**
  *  Bill transaction delete alert.
  */
 function BillTransactionDeleteAlert({
   name,
-  // #withAlertStoreConnect
   isOpen,
   payload: { BillId },
-  // #withAlertActions
   closeAlert,
-}) {
-  const { mutateAsync: deleteLandedCostMutate, isLoading } =
+}: BillLocatedLandedCostDeleteAlertProps): React.ReactElement {
+  const { mutateAsync: deleteLandedCostMutate, isPending: isLoading } =
     useDeleteLandedCost();
 
-  // Handle cancel delete.
   const handleCancelAlert = () => {
     closeAlert(name);
   };
 
-  // Handle confirm delete .
   const handleConfirmLandedCostDelete = () => {
     deleteLandedCostMutate(BillId)
       .then(() => {
@@ -36,17 +42,23 @@ function BillTransactionDeleteAlert({
           message: intl.get('landed_cost.action.delete.success_message'),
           intent: Intent.SUCCESS,
         });
-        closeAlert(name);
       })
-      .catch(() => {
+      .catch((error: Error) => {
+        // Bugfix: original @ts-nocheck had an empty `.catch(() => closeAlert(name))` that silently swallowed failures.
+        AppToaster.show({
+          message: error.message,
+          intent: Intent.DANGER,
+        });
+      })
+      .finally(() => {
         closeAlert(name);
       });
   };
 
   return (
     <Alert
-      cancelButtonText={<T id={'cancel'} />}
-      confirmButtonText={<T id={'delete'} />}
+      cancelButtonText={intl.get('cancel')}
+      confirmButtonText={intl.get('delete')}
       icon="trash"
       intent={Intent.DANGER}
       isOpen={isOpen}

--- a/packages/webapp/src/containers/Alerts/Bills/BillOpenAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Bills/BillOpenAlert.tsx
@@ -1,34 +1,38 @@
-// @ts-nocheck
-import { Intent, Alert } from '@blueprintjs/core';
+import { Alert, Intent } from '@blueprintjs/core';
 import React from 'react';
 import intl from 'react-intl-universal';
 import { AppToaster, FormattedMessage as T } from '@/components';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
 import { useOpenBill } from '@/hooks/query';
 import { compose } from '@/utils';
+
+interface BillOpenAlertPayload {
+  billId: number;
+}
+
+interface BillOpenAlertProps extends WithAlertActionsProps {
+  name: string;
+  isOpen: boolean;
+  payload: BillOpenAlertPayload;
+}
 
 /**
  * Bill open alert.
  */
 function BillOpenAlertInner({
   name,
-
-  // #withAlertStoreConnect
   isOpen,
   payload: { billId },
-
-  // #withAlertActions
   closeAlert,
-}) {
-  const { isLoading, mutateAsync: openBillMutate } = useOpenBill();
+}: BillOpenAlertProps): React.ReactElement {
+  const { isPending: isLoading, mutateAsync: openBillMutate } = useOpenBill();
 
-  // Handle cancel open bill alert.
   const handleCancelOpenBill = () => {
     closeAlert(name);
   };
 
-  // Handle confirm bill open.
   const handleConfirmBillOpen = () => {
     openBillMutate(billId)
       .then(() => {
@@ -36,17 +40,23 @@ function BillOpenAlertInner({
           message: intl.get('the_bill_has_been_opened_successfully'),
           intent: Intent.SUCCESS,
         });
-        closeAlert(name);
       })
-      .catch((error) => {
+      .catch((error: Error) => {
+        // Bugfix: original @ts-nocheck silently closed the alert on error without surfacing the failure.
+        AppToaster.show({
+          message: error.message,
+          intent: Intent.DANGER,
+        });
+      })
+      .finally(() => {
         closeAlert(name);
       });
   };
 
   return (
     <Alert
-      cancelButtonText={<T id={'cancel'} />}
-      confirmButtonText={<T id={'open'} />}
+      cancelButtonText={intl.get('cancel')}
+      confirmButtonText={intl.get('open')}
       intent={Intent.WARNING}
       isOpen={isOpen}
       onCancel={handleCancelOpenBill}

--- a/packages/webapp/src/containers/Alerts/Branches/BranchDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Branches/BranchDeleteAlert.tsx
@@ -1,39 +1,39 @@
-// @ts-nocheck
-import { Intent, Alert } from '@blueprintjs/core';
+import { Alert, Intent } from '@blueprintjs/core';
 import React from 'react';
 import intl from 'react-intl-universal';
-import {
-  AppToaster,
-  FormattedMessage as T,
-  FormattedHTMLMessage,
-} from '@/components';
+import { AppToaster, FormattedHTMLMessage } from '@/components';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
 import { handleDeleteErrors } from '@/containers/Preferences/Branches/utils';
 import { useDeleteBranch } from '@/hooks/query';
 import { compose } from '@/utils';
+
+interface BranchDeleteAlertPayload {
+  branchId: number | string;
+}
+
+interface BranchDeleteAlertProps extends WithAlertActionsProps {
+  name: string;
+  isOpen: boolean;
+  payload: BranchDeleteAlertPayload;
+}
 
 /**
  * Branch delete alert.
  */
 function BranchDeleteAlertInner({
   name,
-
-  // #withAlertStoreConnect
   isOpen,
   payload: { branchId },
-
-  // #withAlertActions
   closeAlert,
-}) {
-  const { mutateAsync: deleteBranch, isLoading } = useDeleteBranch();
+}: BranchDeleteAlertProps): React.ReactElement {
+  const { mutateAsync: deleteBranch, isPending: isLoading } = useDeleteBranch();
 
-  // Handle cancel delete alert.
   const handleCancelDelete = () => {
     closeAlert(name);
   };
 
-  // Handle confirm delete branch.
   const handleConfirmDeleteBranch = () => {
     deleteBranch(branchId)
       .then(() => {
@@ -42,9 +42,11 @@ function BranchDeleteAlertInner({
           intent: Intent.SUCCESS,
         });
       })
-      .catch(({ data: { errors } }) => {
-        handleDeleteErrors(errors);
-      })
+      .catch(
+        ({ data: { errors } }: { data: { errors: { type: string }[] } }) => {
+          handleDeleteErrors(errors);
+        },
+      )
       .finally(() => {
         closeAlert(name);
       });
@@ -52,8 +54,8 @@ function BranchDeleteAlertInner({
 
   return (
     <Alert
-      cancelButtonText={<T id={'cancel'} />}
-      confirmButtonText={<T id={'delete'} />}
+      cancelButtonText={intl.get('cancel')}
+      confirmButtonText={intl.get('delete')}
       icon="trash"
       intent={Intent.DANGER}
       isOpen={isOpen}
@@ -62,6 +64,7 @@ function BranchDeleteAlertInner({
       loading={isLoading}
     >
       <p>
+        {/* @ts-expect-error — react-intl-universal FormattedHTMLMessage JSX type mismatch (library-level issue, see Alerts/Items/ItemDeleteAlert.tsx) */}
         <FormattedHTMLMessage id={'branch.once_delete_this_branch'} />
       </p>
     </Alert>

--- a/packages/webapp/src/containers/Alerts/Branches/BranchMarkPrimaryAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Branches/BranchMarkPrimaryAlert.tsx
@@ -1,35 +1,39 @@
-// @ts-nocheck
-import { Intent, Alert } from '@blueprintjs/core';
+import { Alert, Intent } from '@blueprintjs/core';
 import React from 'react';
 import intl from 'react-intl-universal';
 import { AppToaster, FormattedMessage as T } from '@/components';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
 import { useMarkBranchAsPrimary } from '@/hooks/query';
 import { compose } from '@/utils';
+
+interface BranchMarkPrimaryAlertPayload {
+  branchId: number | string;
+}
+
+interface BranchMarkPrimaryAlertProps extends WithAlertActionsProps {
+  name: string;
+  isOpen: boolean;
+  payload: BranchMarkPrimaryAlertPayload;
+}
 
 /**
  * branch mark primary alert.
  */
 function BranchMarkPrimaryAlertInner({
   name,
-
-  // #withAlertStoreConnect
   isOpen,
   payload: { branchId },
-
-  // #withAlertActions
   closeAlert,
-}) {
-  const { mutateAsync: markPrimaryBranchMutate, isLoading } =
+}: BranchMarkPrimaryAlertProps): React.ReactElement {
+  const { mutateAsync: markPrimaryBranchMutate, isPending: isLoading } =
     useMarkBranchAsPrimary();
 
-  // Handle cancel mark primary alert.
   const handleCancelMarkPrimaryAlert = () => {
     closeAlert(name);
   };
 
-  // andle cancel mark primary confirm.
   const handleConfirmMarkPrimaryBranch = () => {
     markPrimaryBranchMutate(branchId)
       .then(() => {
@@ -37,17 +41,21 @@ function BranchMarkPrimaryAlertInner({
           message: intl.get('branch.alert.mark_primary_message'),
           intent: Intent.SUCCESS,
         });
-        closeAlert(name);
       })
-      .catch((error) => {
+      .catch((error: Error) => {
+        // Bugfix: original @ts-nocheck silently closed the alert on error without surfacing the failure.
+        AppToaster.show({
+          message: error.message,
+          intent: Intent.DANGER,
+        });
+      })
+      .finally(() => {
         closeAlert(name);
       });
   };
 
   return (
     <Alert
-      // cancelButtonText={<T id={'cancel'} />}
-      // confirmButtonText={<T id={'make_primary'} />}
       intent={Intent.WARNING}
       isOpen={isOpen}
       onCancel={handleCancelMarkPrimaryAlert}

--- a/packages/webapp/src/containers/Alerts/CashFlow/AccountDeleteTransactionAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/CashFlow/AccountDeleteTransactionAlert.tsx
@@ -1,44 +1,49 @@
-// @ts-nocheck
-import { Intent, Alert } from '@blueprintjs/core';
+import { Alert, Intent } from '@blueprintjs/core';
 import React from 'react';
 import intl from 'react-intl-universal';
-import {
-  AppToaster,
-  FormattedMessage as T,
-  FormattedHTMLMessage,
-} from '@/components';
+import { AppToaster, FormattedHTMLMessage } from '@/components';
 import { DRAWERS } from '@/constants/drawers';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
 import { withDrawerActions } from '@/containers/Drawer/withDrawerActions';
+import type { WithDrawerActionsProps } from '@/containers/Drawer/withDrawerActions';
 import { useDeleteCashflowTransaction } from '@/hooks/query';
 import { compose } from '@/utils';
+
+interface AccountDeleteTransactionAlertPayload {
+  referenceId: number;
+}
+
+interface AccountDeleteTransactionAlertProps
+  extends WithAlertActionsProps,
+    WithDrawerActionsProps {
+  name: string;
+  isOpen: boolean;
+  payload: AccountDeleteTransactionAlertPayload;
+}
+
+interface CashflowTransactionError {
+  type: string;
+}
 
 /**
  * Account delete transaction alert.
  */
 function AccountDeleteTransactionAlertInner({
   name,
-
-  // #withAlertStoreConnect
   isOpen,
   payload: { referenceId },
-
-  // #withAlertActions
   closeAlert,
-
-  // #withDrawerActions
   closeDrawer,
-}) {
-  const { mutateAsync: deleteTransactionMutate, isLoading } =
+}: AccountDeleteTransactionAlertProps): React.ReactElement {
+  const { mutateAsync: deleteTransactionMutate, isPending: isLoading } =
     useDeleteCashflowTransaction();
 
-  // handle cancel delete alert
   const handleCancelDeleteAlert = () => {
     closeAlert(name);
   };
 
-  // handleConfirm delete transaction.
   const handleConfirmTransactioneDelete = () => {
     deleteTransactionMutate(referenceId)
       .then(() => {
@@ -48,29 +53,35 @@ function AccountDeleteTransactionAlertInner({
         });
         closeDrawer(DRAWERS.CASHFLOW_TRNASACTION_DETAILS);
       })
-      .catch(({ data: { errors } }) => {
-        if (
-          errors.find(
-            (e) =>
-              e.type ===
-              'CANNOT_DELETE_TRANSACTION_CONVERTED_FROM_UNCATEGORIZED',
-          )
-        ) {
-          AppToaster.show({
-            message:
-              'Cannot delete transaction converted from uncategorized transaction but you uncategorize it.',
-            intent: Intent.DANGER,
-          });
-        } else if (
-          errors.find((e) => e.type === 'CANNOT_DELETE_TRANSACTION_MATCHED')
-        ) {
-          AppToaster.show({
-            message:
-              'Cannot delete a transaction matched to the bank transaction',
-            intent: Intent.DANGER,
-          });
-        }
-      })
+      .catch(
+        ({
+          data: { errors },
+        }: {
+          data: { errors: CashflowTransactionError[] };
+        }) => {
+          if (
+            errors.find(
+              (e) =>
+                e.type ===
+                'CANNOT_DELETE_TRANSACTION_CONVERTED_FROM_UNCATEGORIZED',
+            )
+          ) {
+            AppToaster.show({
+              message:
+                'Cannot delete transaction converted from uncategorized transaction but you uncategorize it.',
+              intent: Intent.DANGER,
+            });
+          } else if (
+            errors.find((e) => e.type === 'CANNOT_DELETE_TRANSACTION_MATCHED')
+          ) {
+            AppToaster.show({
+              message:
+                'Cannot delete a transaction matched to the bank transaction',
+              intent: Intent.DANGER,
+            });
+          }
+        },
+      )
       .finally(() => {
         closeAlert(name);
       });
@@ -78,8 +89,8 @@ function AccountDeleteTransactionAlertInner({
 
   return (
     <Alert
-      cancelButtonText={<T id={'cancel'} />}
-      confirmButtonText={<T id={'delete'} />}
+      cancelButtonText={intl.get('cancel')}
+      confirmButtonText={intl.get('delete')}
       icon="trash"
       intent={Intent.DANGER}
       isOpen={isOpen}
@@ -88,6 +99,7 @@ function AccountDeleteTransactionAlertInner({
       loading={isLoading}
     >
       <p>
+        {/* @ts-expect-error — react-intl-universal FormattedHTMLMessage JSX type mismatch (library-level issue, see Alerts/Items/ItemDeleteAlert.tsx) */}
         <FormattedHTMLMessage
           id={
             'cash_flow_transaction_once_delete_this_transaction_you_will_able_to_restore_it'

--- a/packages/webapp/src/containers/Alerts/Contacts/ContactActivateAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Contacts/ContactActivateAlert.tsx
@@ -1,34 +1,39 @@
-// @ts-nocheck
-import { Intent, Alert } from '@blueprintjs/core';
+import { Alert, Intent } from '@blueprintjs/core';
 import React from 'react';
 import intl from 'react-intl-universal';
 import { AppToaster, FormattedMessage as T } from '@/components';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
 import { useActivateContact } from '@/hooks/query';
 import { compose } from '@/utils';
+
+interface ContactActivateAlertPayload {
+  contactId: number;
+}
+
+interface ContactActivateAlertProps extends WithAlertActionsProps {
+  name: string;
+  isOpen: boolean;
+  payload: ContactActivateAlertPayload;
+}
 
 /**
  *  Contact activate alert.
  */
 function ContactActivateAlertInner({
   name,
-
-  // #withAlertStoreConnect
   isOpen,
-  payload: { contactId, service },
-
-  // #withAlertActions
+  payload: { contactId },
   closeAlert,
-}) {
-  const { mutateAsync: activateContact, isLoading } = useActivateContact();
+}: ContactActivateAlertProps): React.ReactElement {
+  const { mutateAsync: activateContact, isPending: isLoading } =
+    useActivateContact();
 
-  // Handle activate contact alert cancel.
   const handleCancelActivateContact = () => {
     closeAlert(name);
   };
 
-  // Handle confirm contact activated.
   const handleConfirmContactActivate = () => {
     activateContact(contactId)
       .then(() => {
@@ -37,7 +42,13 @@ function ContactActivateAlertInner({
           intent: Intent.SUCCESS,
         });
       })
-      .catch((error) => {})
+      .catch((error: Error) => {
+        // Bugfix: original @ts-nocheck had an empty `.catch((error) => {})` that silently swallowed failures.
+        AppToaster.show({
+          message: error.message,
+          intent: Intent.DANGER,
+        });
+      })
       .finally(() => {
         closeAlert(name);
       });
@@ -45,8 +56,8 @@ function ContactActivateAlertInner({
 
   return (
     <Alert
-      cancelButtonText={<T id={'cancel'} />}
-      confirmButtonText={<T id={'activate'} />}
+      cancelButtonText={intl.get('cancel')}
+      confirmButtonText={intl.get('activate')}
       intent={Intent.WARNING}
       isOpen={isOpen}
       onCancel={handleCancelActivateContact}

--- a/packages/webapp/src/containers/Alerts/Contacts/ContactInactivateAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Contacts/ContactInactivateAlert.tsx
@@ -1,33 +1,40 @@
-// @ts-nocheck
-import { Intent, Alert } from '@blueprintjs/core';
+import { Alert, Intent } from '@blueprintjs/core';
 import React from 'react';
 import intl from 'react-intl-universal';
 import { AppToaster, FormattedMessage as T } from '@/components';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
 import { useInactivateContact } from '@/hooks/query';
 import { compose } from '@/utils';
+
+interface ContactInactivateAlertPayload {
+  contactId: number;
+  service: string;
+}
+
+interface ContactInactivateAlertProps extends WithAlertActionsProps {
+  name: string;
+  isOpen: boolean;
+  payload: ContactInactivateAlertPayload;
+}
 
 /**
  * Contact inactivate alert.
  */
 function ContactInactivateAlertInner({
   name,
-  // #withAlertStoreConnect
   isOpen,
   payload: { contactId, service },
-
-  // #withAlertActions
   closeAlert,
-}) {
-  const { mutateAsync: inactivateContact, isLoading } = useInactivateContact();
+}: ContactInactivateAlertProps): React.ReactElement {
+  const { mutateAsync: inactivateContact, isPending: isLoading } =
+    useInactivateContact();
 
-  // Handle cancel inactivate alert.
   const handleCancelInactivateContact = () => {
     closeAlert(name);
   };
 
-  // Handle confirm contact Inactive.
   const handleConfirmContactInactive = () => {
     inactivateContact(contactId)
       .then(() => {
@@ -36,7 +43,13 @@ function ContactInactivateAlertInner({
           intent: Intent.SUCCESS,
         });
       })
-      .catch((error) => {})
+      .catch((error: Error) => {
+        // Bugfix: original @ts-nocheck had an empty `.catch((error) => {})` that silently swallowed failures.
+        AppToaster.show({
+          message: error.message,
+          intent: Intent.DANGER,
+        });
+      })
       .finally(() => {
         closeAlert(name);
       });
@@ -44,8 +57,8 @@ function ContactInactivateAlertInner({
 
   return (
     <Alert
-      cancelButtonText={<T id={'cancel'} />}
-      confirmButtonText={<T id={'inactivate'} />}
+      cancelButtonText={intl.get('cancel')}
+      confirmButtonText={intl.get('inactivate')}
       intent={Intent.WARNING}
       isOpen={isOpen}
       onCancel={handleCancelInactivateContact}

--- a/packages/webapp/src/containers/Alerts/CreditNotes/CreditNoteDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/CreditNotes/CreditNoteDeleteAlert.tsx
@@ -1,43 +1,46 @@
-// @ts-nocheck
-import { Intent, Alert } from '@blueprintjs/core';
+import { Alert, Intent } from '@blueprintjs/core';
 import React from 'react';
 import intl from 'react-intl-universal';
-import {
-  AppToaster,
-  FormattedMessage as T,
-  FormattedHTMLMessage,
-} from '@/components';
+import { AppToaster, FormattedHTMLMessage } from '@/components';
 import { DRAWERS } from '@/constants/drawers';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
 import { withDrawerActions } from '@/containers/Drawer/withDrawerActions';
+import type { WithDrawerActionsProps } from '@/containers/Drawer/withDrawerActions';
 import { handleDeleteErrors } from '@/containers/Sales/CreditNotes/CreditNotesLanding/utils';
 import { useDeleteCreditNote } from '@/hooks/query';
 import { compose } from '@/utils';
+
+interface CreditNoteDeleteAlertPayload {
+  creditNoteId: number;
+}
+
+interface CreditNoteDeleteAlertProps
+  extends WithAlertActionsProps,
+    WithDrawerActionsProps {
+  name: string;
+  isOpen: boolean;
+  payload: CreditNoteDeleteAlertPayload;
+}
 
 /**
  * Credit note delete alert.
  */
 function CreditNoteDeleteAlertInner({
   name,
-
-  // #withAlertStoreConnect
   isOpen,
   payload: { creditNoteId },
-
-  // #withAlertActions
   closeAlert,
-
-  // #withDrawerActions
   closeDrawer,
-}) {
-  const { isLoading, mutateAsync: deleteCreditNoteMutate } =
+}: CreditNoteDeleteAlertProps): React.ReactElement {
+  const { isPending: isLoading, mutateAsync: deleteCreditNoteMutate } =
     useDeleteCreditNote();
 
-  // handle cancel delete credit note alert.
   const handleCancelDeleteAlert = () => {
     closeAlert(name);
   };
+
   const handleConfirmCreditNoteDelete = () => {
     deleteCreditNoteMutate(creditNoteId)
       .then(() => {
@@ -47,9 +50,11 @@ function CreditNoteDeleteAlertInner({
         });
         closeDrawer(DRAWERS.CREDIT_NOTE_DETAILS);
       })
-      .catch(({ data: { errors } }) => {
-        handleDeleteErrors(errors);
-      })
+      .catch(
+        ({ data: { errors } }: { data: { errors: { type: string }[] } }) => {
+          handleDeleteErrors(errors);
+        },
+      )
       .finally(() => {
         closeAlert(name);
       });
@@ -57,8 +62,8 @@ function CreditNoteDeleteAlertInner({
 
   return (
     <Alert
-      cancelButtonText={<T id={'cancel'} />}
-      confirmButtonText={<T id={'delete'} />}
+      cancelButtonText={intl.get('cancel')}
+      confirmButtonText={intl.get('delete')}
       icon="trash"
       intent={Intent.DANGER}
       isOpen={isOpen}
@@ -67,6 +72,7 @@ function CreditNoteDeleteAlertInner({
       loading={isLoading}
     >
       <p>
+        {/* @ts-expect-error — react-intl-universal FormattedHTMLMessage JSX type mismatch (library-level issue, see Alerts/Items/ItemDeleteAlert.tsx) */}
         <FormattedHTMLMessage id={'credit_note.once_delete_this_credit_note'} />
       </p>
     </Alert>

--- a/packages/webapp/src/containers/Alerts/CreditNotes/CreditNoteOpenedAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/CreditNotes/CreditNoteOpenedAlert.tsx
@@ -1,34 +1,39 @@
-// @ts-nocheck
-import { Intent, Alert } from '@blueprintjs/core';
+import { Alert, Intent } from '@blueprintjs/core';
 import React from 'react';
 import intl from 'react-intl-universal';
 import { AppToaster, FormattedMessage as T } from '@/components';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
 import { useOpenCreditNote } from '@/hooks/query';
 import { compose } from '@/utils';
+
+interface CreditNoteOpenedAlertPayload {
+  creditNoteId: number;
+}
+
+interface CreditNoteOpenedAlertProps extends WithAlertActionsProps {
+  name: string;
+  isOpen: boolean;
+  payload: CreditNoteOpenedAlertPayload;
+}
 
 /**
  * Credit note opened alert.
  */
 function CreditNoteOpenedAlertInner({
   name,
-
-  // #withAlertStoreConnect
   isOpen,
   payload: { creditNoteId },
-
-  // #withAlertActions
   closeAlert,
-}) {
-  const { mutateAsync: openCreditNoteMutate, isLoading } = useOpenCreditNote();
+}: CreditNoteOpenedAlertProps): React.ReactElement {
+  const { mutateAsync: openCreditNoteMutate, isPending: isLoading } =
+    useOpenCreditNote();
 
-  // Handle cancel opened credit note alert.
   const handleAlertCancel = () => {
     closeAlert(name);
   };
 
-  // Handle confirm credit note opened.
   const handleAlertConfirm = () => {
     openCreditNoteMutate(creditNoteId)
       .then(() => {
@@ -37,7 +42,13 @@ function CreditNoteOpenedAlertInner({
           intent: Intent.SUCCESS,
         });
       })
-      .catch((error) => {})
+      .catch((error: Error) => {
+        // Bugfix: original @ts-nocheck had an empty `.catch((error) => {})` that silently swallowed failures.
+        AppToaster.show({
+          message: error.message,
+          intent: Intent.DANGER,
+        });
+      })
       .finally(() => {
         closeAlert(name);
       });
@@ -45,8 +56,8 @@ function CreditNoteOpenedAlertInner({
 
   return (
     <Alert
-      cancelButtonText={<T id={'cancel'} />}
-      confirmButtonText={<T id={'open'} />}
+      cancelButtonText={intl.get('cancel')}
+      confirmButtonText={intl.get('open')}
       intent={Intent.WARNING}
       isOpen={isOpen}
       onCancel={handleAlertCancel}
@@ -59,6 +70,7 @@ function CreditNoteOpenedAlertInner({
     </Alert>
   );
 }
+
 export const CreditNoteOpenedAlert = compose(
   withAlertStoreConnect(),
   withAlertActions,

--- a/packages/webapp/src/containers/Alerts/CreditNotes/ReconcileCreditNoteDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/CreditNotes/ReconcileCreditNoteDeleteAlert.tsx
@@ -1,38 +1,40 @@
-// @ts-nocheck
-import { Intent, Alert } from '@blueprintjs/core';
+import { Alert, Intent } from '@blueprintjs/core';
 import React from 'react';
 import intl from 'react-intl-universal';
-import {
-  AppToaster,
-  FormattedMessage as T,
-  FormattedHTMLMessage,
-} from '@/components';
+import { AppToaster, FormattedHTMLMessage } from '@/components';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
 import { withDrawerActions } from '@/containers/Drawer/withDrawerActions';
+import type { WithDrawerActionsProps } from '@/containers/Drawer/withDrawerActions';
 import { useDeleteReconcileCredit } from '@/hooks/query';
 import { compose } from '@/utils';
+
+interface ReconcileCreditNoteDeleteAlertPayload {
+  creditNoteId: number;
+}
+
+interface ReconcileCreditNoteDeleteAlertProps
+  extends WithAlertActionsProps,
+    WithDrawerActionsProps {
+  name: string;
+  isOpen: boolean;
+  payload: ReconcileCreditNoteDeleteAlertPayload;
+}
 
 /**
  * Reconcile credit note delete alert.
  */
 function ReconcileCreditNoteDeleteAlertInner({
   name,
-
-  // #withAlertStoreConnect
   isOpen,
   payload: { creditNoteId },
-
-  // #withAlertActions
   closeAlert,
-
-  // #withDrawerActions
   closeDrawer,
-}) {
-  const { isLoading, mutateAsync: deleteReconcileCreditMutate } =
+}: ReconcileCreditNoteDeleteAlertProps): React.ReactElement {
+  const { isPending: isLoading, mutateAsync: deleteReconcileCreditMutate } =
     useDeleteReconcileCredit();
 
-  // handle cancel delete credit note alert.
   const handleCancelDeleteAlert = () => {
     closeAlert(name);
   };
@@ -45,8 +47,12 @@ function ReconcileCreditNoteDeleteAlertInner({
           intent: Intent.SUCCESS,
         });
       })
-      .catch(({ data: { errors } }) => {
-        // handleDeleteErrors(errors);
+      .catch((error: Error) => {
+        // Bugfix: original @ts-nocheck had a commented-out `handleDeleteErrors(errors)` and empty catch — failures were silently swallowed.
+        AppToaster.show({
+          message: error.message,
+          intent: Intent.DANGER,
+        });
       })
       .finally(() => {
         closeAlert(name);
@@ -55,8 +61,8 @@ function ReconcileCreditNoteDeleteAlertInner({
 
   return (
     <Alert
-      cancelButtonText={<T id={'cancel'} />}
-      confirmButtonText={<T id={'delete'} />}
+      cancelButtonText={intl.get('cancel')}
+      confirmButtonText={intl.get('delete')}
       icon="trash"
       intent={Intent.DANGER}
       isOpen={isOpen}
@@ -65,6 +71,7 @@ function ReconcileCreditNoteDeleteAlertInner({
       loading={isLoading}
     >
       <p>
+        {/* @ts-expect-error — react-intl-universal FormattedHTMLMessage JSX type mismatch (library-level issue, see Alerts/Items/ItemDeleteAlert.tsx) */}
         <FormattedHTMLMessage
           id={
             'reconcile_credit_note.once_you_delete_this_reconcile_credit_note'

--- a/packages/webapp/src/containers/Alerts/CreditNotes/RefundCreditNoteDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/CreditNotes/RefundCreditNoteDeleteAlert.tsx
@@ -1,38 +1,45 @@
-// @ts-nocheck
-import { Intent, Alert } from '@blueprintjs/core';
+import { Alert, Intent } from '@blueprintjs/core';
 import React from 'react';
 import intl from 'react-intl-universal';
-import { FormattedMessage as T, AppToaster } from '@/components';
+import { AppToaster, FormattedMessage as T } from '@/components';
 import { DRAWERS } from '@/constants/drawers';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
 import { withDrawerActions } from '@/containers/Drawer/withDrawerActions';
+import type { WithDrawerActionsProps } from '@/containers/Drawer/withDrawerActions';
 import { useDeleteRefundCreditNote } from '@/hooks/query';
 import { compose } from '@/utils';
+
+interface RefundCreditNoteDeleteAlertPayload {
+  creditNoteId: number;
+}
+
+interface RefundCreditNoteDeleteAlertProps
+  extends WithAlertActionsProps,
+    WithDrawerActionsProps {
+  name: string;
+  isOpen: boolean;
+  payload: RefundCreditNoteDeleteAlertPayload;
+}
 
 /**
  * Refund credit transactions delete alert
  */
 function RefundCreditNoteDeleteAlertInner({
   name,
-  // #withAlertStoreConnect
   isOpen,
   payload: { creditNoteId },
-  // #withAlertActions
   closeAlert,
-
-  // #withDrawerActions
   closeDrawer,
-}) {
-  const { mutateAsync: deleteRefundCreditMutate, isLoading } =
+}: RefundCreditNoteDeleteAlertProps): React.ReactElement {
+  const { mutateAsync: deleteRefundCreditMutate, isPending: isLoading } =
     useDeleteRefundCreditNote();
 
-  // Handle cancel delete.
   const handleCancelAlert = () => {
     closeAlert(name);
   };
 
-  // Handle confirm delete .
   const handleConfirmRefundCreditDelete = () => {
     deleteRefundCreditMutate(creditNoteId)
       .then(() => {
@@ -42,7 +49,13 @@ function RefundCreditNoteDeleteAlertInner({
         });
         closeDrawer(DRAWERS.REFUND_CREDIT_NOTE_DETAILS);
       })
-      .catch(() => {})
+      .catch((error: Error) => {
+        // Bugfix: original @ts-nocheck had an empty `.catch(() => {})` that silently swallowed failures.
+        AppToaster.show({
+          message: error.message,
+          intent: Intent.DANGER,
+        });
+      })
       .finally(() => {
         closeAlert(name);
       });
@@ -50,8 +63,8 @@ function RefundCreditNoteDeleteAlertInner({
 
   return (
     <Alert
-      cancelButtonText={<T id={'cancel'} />}
-      confirmButtonText={<T id={'delete'} />}
+      cancelButtonText={intl.get('cancel')}
+      confirmButtonText={intl.get('delete')}
       icon="trash"
       intent={Intent.DANGER}
       isOpen={isOpen}

--- a/packages/webapp/src/containers/Alerts/Currencies/CurrencyDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Currencies/CurrencyDeleteAlert.tsx
@@ -45,14 +45,8 @@ function CurrencyDeleteAlertInner({
         });
       })
       .catch(
-        ({
-          data: { errors },
-        }: {
-          data: { errors: CurrencyDeleteError[] };
-        }) => {
-          if (
-            errors.find((e) => e.type === 'CANNOT_DELETE_BASE_CURRENCY')
-          ) {
+        ({ data: { errors } }: { data: { errors: CurrencyDeleteError[] } }) => {
+          if (errors.find((e) => e.type === 'CANNOT_DELETE_BASE_CURRENCY')) {
             AppToaster.show({
               intent: Intent.DANGER,
               message: 'Cannot delete the base currency.',

--- a/packages/webapp/src/containers/Alerts/Currencies/CurrencyDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Currencies/CurrencyDeleteAlert.tsx
@@ -1,60 +1,74 @@
-// @ts-nocheck
-import { Intent, Alert } from '@blueprintjs/core';
+import { Alert, Intent } from '@blueprintjs/core';
 import React from 'react';
 import intl from 'react-intl-universal';
-import {
-  AppToaster,
-  FormattedMessage as T,
-  FormattedHTMLMessage,
-} from '@/components';
+import { AppToaster, FormattedHTMLMessage } from '@/components';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
 import { useDeleteCurrency } from '@/hooks/query';
 import { compose } from '@/utils';
+
+interface CurrencyDeleteAlertPayload {
+  currency_code: string;
+}
+
+interface CurrencyDeleteAlertProps extends WithAlertActionsProps {
+  name: string;
+  isOpen: boolean;
+  payload: CurrencyDeleteAlertPayload;
+}
+
+interface CurrencyDeleteError {
+  type: string;
+}
 
 /**
  * Currency delete alerts.
  */
 function CurrencyDeleteAlertInner({
   name,
-
-  // #withAlertStoreConnect
   isOpen,
   payload: { currency_code },
-
-  // #withAlertActions
   closeAlert,
-}) {
-  const { mutateAsync: deleteCurrency, isLoading } = useDeleteCurrency();
+}: CurrencyDeleteAlertProps): React.ReactElement {
+  const { mutateAsync: deleteCurrency, isPending: isLoading } =
+    useDeleteCurrency();
 
-  // handle cancel delete currency alert.
   const handleCancelCurrencyDelete = () => closeAlert(name);
 
-  // handle alert confirm delete currency.
   const handleConfirmCurrencyDelete = () => {
     deleteCurrency(currency_code)
-      .then((response) => {
+      .then(() => {
         AppToaster.show({
           message: intl.get('the_currency_has_been_deleted_successfully'),
           intent: Intent.SUCCESS,
         });
-        closeAlert(name);
       })
-      .catch(({ data: { errors } }) => {
-        if (errors.find((e) => e.type === 'CANNOT_DELETE_BASE_CURRENCY')) {
-          AppToaster.show({
-            intent: Intent.DANGER,
-            message: 'Cannot delete the base currency.',
-          });
-        }
+      .catch(
+        ({
+          data: { errors },
+        }: {
+          data: { errors: CurrencyDeleteError[] };
+        }) => {
+          if (
+            errors.find((e) => e.type === 'CANNOT_DELETE_BASE_CURRENCY')
+          ) {
+            AppToaster.show({
+              intent: Intent.DANGER,
+              message: 'Cannot delete the base currency.',
+            });
+          }
+        },
+      )
+      .finally(() => {
         closeAlert(name);
       });
   };
 
   return (
     <Alert
-      cancelButtonText={<T id={'cancel'} />}
-      confirmButtonText={<T id={'delete'} />}
+      cancelButtonText={intl.get('cancel')}
+      confirmButtonText={intl.get('delete')}
       intent={Intent.DANGER}
       isOpen={isOpen}
       onCancel={handleCancelCurrencyDelete}
@@ -62,6 +76,7 @@ function CurrencyDeleteAlertInner({
       loading={isLoading}
     >
       <p>
+        {/* @ts-expect-error — react-intl-universal FormattedHTMLMessage JSX type mismatch (library-level issue, see Alerts/Items/ItemDeleteAlert.tsx) */}
         <FormattedHTMLMessage
           id={'once_delete_this_currency_you_will_able_to_restore_it'}
         />

--- a/packages/webapp/src/containers/Alerts/Estimates/EstimateApproveAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Estimates/EstimateApproveAlert.tsx
@@ -1,36 +1,41 @@
-// @ts-nocheck
-import { Intent, Alert } from '@blueprintjs/core';
+import { Alert, Intent } from '@blueprintjs/core';
 import { useQueryClient } from '@tanstack/react-query';
 import React, { useCallback } from 'react';
 import intl from 'react-intl-universal';
 import { AppToaster, FormattedMessage as T } from '@/components';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
 import { useApproveEstimate } from '@/hooks/query';
 import { compose } from '@/utils';
+
+interface EstimateApproveAlertPayload {
+  estimateId: number;
+}
+
+interface EstimateApproveAlertProps extends WithAlertActionsProps {
+  name: string;
+  isOpen: boolean;
+  payload: EstimateApproveAlertPayload;
+}
 
 /**
  * Estimate approve alert.
  */
 function EstimateApproveAlertInner({
   name,
-
-  // #withAlertStoreConnect
   isOpen,
   payload: { estimateId },
-
-  // #withAlertActions
   closeAlert,
-}) {
+}: EstimateApproveAlertProps): React.ReactElement {
   const queryClient = useQueryClient();
-  const { mutateAsync: deliverEstimateMutate, isLoading } =
+  const { mutateAsync: deliverEstimateMutate, isPending: isLoading } =
     useApproveEstimate();
 
-  // handle cancel approve alert.
   const handleCancelApproveEstimate = () => {
     closeAlert(name);
   };
-  // Handle confirm estimate approve.
+
   const handleConfirmEstimateApprove = useCallback(() => {
     deliverEstimateMutate(estimateId)
       .then(() => {
@@ -40,16 +45,22 @@ function EstimateApproveAlertInner({
         });
         queryClient.invalidateQueries({ queryKey: ['estimates-table'] });
       })
-      .catch((error) => {})
+      .catch((error: Error) => {
+        // Bugfix: original @ts-nocheck had an empty `.catch((error) => {})` that silently swallowed failures.
+        AppToaster.show({
+          message: error.message,
+          intent: Intent.DANGER,
+        });
+      })
       .finally(() => {
         closeAlert(name);
       });
-  }, [estimateId, deliverEstimateMutate, closeAlert, name]);
+  }, [estimateId, deliverEstimateMutate, closeAlert, name, queryClient]);
 
   return (
     <Alert
-      cancelButtonText={<T id={'cancel'} />}
-      confirmButtonText={<T id={'approve'} />}
+      cancelButtonText={intl.get('cancel')}
+      confirmButtonText={intl.get('approve')}
       intent={Intent.WARNING}
       isOpen={isOpen}
       loading={isLoading}

--- a/packages/webapp/src/containers/Alerts/Estimates/EstimateDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Estimates/EstimateDeleteAlert.tsx
@@ -1,44 +1,50 @@
-// @ts-nocheck
-import { Intent, Alert } from '@blueprintjs/core';
+import { Alert, Intent } from '@blueprintjs/core';
 import React, { useCallback } from 'react';
 import intl from 'react-intl-universal';
-import {
-  AppToaster,
-  FormattedMessage as T,
-  FormattedHTMLMessage,
-} from '@/components';
+import { AppToaster, FormattedHTMLMessage } from '@/components';
 import { DRAWERS } from '@/constants/drawers';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
 import { withDrawerActions } from '@/containers/Drawer/withDrawerActions';
+import type { WithDrawerActionsProps } from '@/containers/Drawer/withDrawerActions';
 import { useDeleteEstimate } from '@/hooks/query';
 import { compose } from '@/utils';
+
+interface EstimateDeleteAlertPayload {
+  estimateId: number;
+}
+
+interface EstimateDeleteAlertProps
+  extends WithAlertActionsProps,
+    WithDrawerActionsProps {
+  name: string;
+  isOpen: boolean;
+  payload: EstimateDeleteAlertPayload;
+}
+
+interface EstimateDeleteError {
+  type: string;
+}
 
 /**
  * Estimate delete alert.
  */
 function EstimateDeleteAlertInner({
   name,
-
-  // #withAlertStoreConnect
   isOpen,
   payload: { estimateId },
-
-  // #withAlertActions
   closeAlert,
-
-  // #withDrawerActions
   closeDrawer,
-}) {
-  const { mutateAsync: deleteEstimateMutate, isLoading } = useDeleteEstimate();
+}: EstimateDeleteAlertProps): React.ReactElement {
+  const { mutateAsync: deleteEstimateMutate, isPending: isLoading } =
+    useDeleteEstimate();
 
-  // handle cancel delete  alert.
-  const handleAlertCancel = () => {
+  const handleAlertCancel = useCallback(() => {
     closeAlert(name);
-  };
+  }, [closeAlert, name]);
 
-  // handle confirm delete estimate
-  const handleAlertConfirm = () => {
+  const handleAlertConfirm = useCallback(() => {
     deleteEstimateMutate(estimateId)
       .then(() => {
         AppToaster.show({
@@ -47,27 +53,33 @@ function EstimateDeleteAlertInner({
         });
         closeDrawer(DRAWERS.ESTIMATE_DETAILS);
       })
-      .catch(({ data: { errors } }) => {
-        if (
-          errors.find((e) => e.type === 'SALE_ESTIMATE_CONVERTED_TO_INVOICE')
-        ) {
-          AppToaster.show({
-            intent: Intent.DANGER,
-            message: intl.get(
-              'estimate.delete.error.estimate_converted_to_invoice',
-            ),
-          });
-        }
-      })
+      .catch(
+        ({
+          data: { errors },
+        }: {
+          data: { errors: EstimateDeleteError[] };
+        }) => {
+          if (
+            errors.find((e) => e.type === 'SALE_ESTIMATE_CONVERTED_TO_INVOICE')
+          ) {
+            AppToaster.show({
+              intent: Intent.DANGER,
+              message: intl.get(
+                'estimate.delete.error.estimate_converted_to_invoice',
+              ),
+            });
+          }
+        },
+      )
       .finally(() => {
         closeAlert(name);
       });
-  };
+  }, [estimateId, deleteEstimateMutate, closeDrawer, closeAlert, name]);
 
   return (
     <Alert
-      cancelButtonText={<T id={'cancel'} />}
-      confirmButtonText={<T id={'delete'} />}
+      cancelButtonText={intl.get('cancel')}
+      confirmButtonText={intl.get('delete')}
       icon="trash"
       intent={Intent.DANGER}
       isOpen={isOpen}
@@ -76,6 +88,7 @@ function EstimateDeleteAlertInner({
       onConfirm={handleAlertConfirm}
     >
       <p>
+        {/* @ts-expect-error — react-intl-universal FormattedHTMLMessage JSX type mismatch (library-level issue, see Alerts/Items/ItemDeleteAlert.tsx) */}
         <FormattedHTMLMessage
           id={'once_delete_this_estimate_you_will_able_to_restore_it'}
         />

--- a/packages/webapp/src/containers/Alerts/Estimates/EstimateDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Estimates/EstimateDeleteAlert.tsx
@@ -54,11 +54,7 @@ function EstimateDeleteAlertInner({
         closeDrawer(DRAWERS.ESTIMATE_DETAILS);
       })
       .catch(
-        ({
-          data: { errors },
-        }: {
-          data: { errors: EstimateDeleteError[] };
-        }) => {
+        ({ data: { errors } }: { data: { errors: EstimateDeleteError[] } }) => {
           if (
             errors.find((e) => e.type === 'SALE_ESTIMATE_CONVERTED_TO_INVOICE')
           ) {

--- a/packages/webapp/src/containers/Alerts/Estimates/EstimateDeliveredAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Estimates/EstimateDeliveredAlert.tsx
@@ -1,35 +1,39 @@
-// @ts-nocheck
-import { Intent, Alert } from '@blueprintjs/core';
+import { Alert, Intent } from '@blueprintjs/core';
 import React from 'react';
 import intl from 'react-intl-universal';
 import { AppToaster, FormattedMessage as T } from '@/components';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
 import { useDeliverEstimate } from '@/hooks/query';
 import { compose } from '@/utils';
+
+interface EstimateDeliveredAlertPayload {
+  estimateId: number;
+}
+
+interface EstimateDeliveredAlertProps extends WithAlertActionsProps {
+  name: string;
+  isOpen: boolean;
+  payload: EstimateDeliveredAlertPayload;
+}
 
 /**
  * Estimate delivered alert.
  */
 function EstimateDeliveredAlertInner({
   name,
-
-  // #withAlertStoreConnect
   isOpen,
   payload: { estimateId },
-
-  // #withAlertActions
   closeAlert,
-}) {
-  const { mutateAsync: deliverEstimateMutate, isLoading } =
+}: EstimateDeliveredAlertProps): React.ReactElement {
+  const { mutateAsync: deliverEstimateMutate, isPending: isLoading } =
     useDeliverEstimate();
 
-  // Handle cancel delivered estimate alert.
   const handleAlertCancel = () => {
     closeAlert(name);
   };
 
-  // Handle confirm estimate delivered.
   const handleAlertConfirm = () => {
     deliverEstimateMutate(estimateId)
       .then(() => {
@@ -38,7 +42,13 @@ function EstimateDeliveredAlertInner({
           intent: Intent.SUCCESS,
         });
       })
-      .catch((error) => {})
+      .catch((error: Error) => {
+        // Bugfix: original @ts-nocheck had an empty `.catch((error) => {})` that silently swallowed failures.
+        AppToaster.show({
+          message: error.message,
+          intent: Intent.DANGER,
+        });
+      })
       .finally(() => {
         closeAlert(name);
       });
@@ -46,8 +56,8 @@ function EstimateDeliveredAlertInner({
 
   return (
     <Alert
-      cancelButtonText={<T id={'cancel'} />}
-      confirmButtonText={<T id={'deliver'} />}
+      cancelButtonText={intl.get('cancel')}
+      confirmButtonText={intl.get('deliver')}
       intent={Intent.WARNING}
       isOpen={isOpen}
       onCancel={handleAlertCancel}

--- a/packages/webapp/src/containers/Alerts/Estimates/EstimateRejectAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Estimates/EstimateRejectAlert.tsx
@@ -1,34 +1,39 @@
-// @ts-nocheck
-import { Intent, Alert } from '@blueprintjs/core';
+import { Alert, Intent } from '@blueprintjs/core';
 import React from 'react';
 import intl from 'react-intl-universal';
 import { AppToaster, FormattedMessage as T } from '@/components';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
 import { useRejectEstimate } from '@/hooks/query';
 import { compose } from '@/utils';
+
+interface EstimateRejectAlertPayload {
+  estimateId: number;
+}
+
+interface EstimateRejectAlertProps extends WithAlertActionsProps {
+  name: string;
+  isOpen: boolean;
+  payload: EstimateRejectAlertPayload;
+}
 
 /**
  *  Estimate reject delete alerts.
  */
 function EstimateRejectAlertInner({
   name,
-
-  // #withAlertStoreConnect
   isOpen,
   payload: { estimateId },
-
-  // #withAlertActions
   closeAlert,
-}) {
-  const { mutateAsync: rejectEstimateMutate, isLoading } = useRejectEstimate();
+}: EstimateRejectAlertProps): React.ReactElement {
+  const { mutateAsync: rejectEstimateMutate, isPending: isLoading } =
+    useRejectEstimate();
 
-  // Handle cancel reject estimate alert.
   const handleCancelRejectEstimate = () => {
     closeAlert(name);
   };
 
-  // Handle confirm estimate reject.
   const handleConfirmEstimateReject = () => {
     rejectEstimateMutate(estimateId)
       .then(() => {
@@ -37,7 +42,13 @@ function EstimateRejectAlertInner({
           intent: Intent.SUCCESS,
         });
       })
-      .catch((error) => {})
+      .catch((error: Error) => {
+        // Bugfix: original @ts-nocheck had an empty `.catch((error) => {})` that silently swallowed failures.
+        AppToaster.show({
+          message: error.message,
+          intent: Intent.DANGER,
+        });
+      })
       .finally(() => {
         closeAlert(name);
       });
@@ -45,8 +56,8 @@ function EstimateRejectAlertInner({
 
   return (
     <Alert
-      cancelButtonText={<T id={'cancel'} />}
-      confirmButtonText={<T id={'reject'} />}
+      cancelButtonText={intl.get('cancel')}
+      confirmButtonText={intl.get('reject')}
       intent={Intent.WARNING}
       isOpen={isOpen}
       onCancel={handleCancelRejectEstimate}

--- a/packages/webapp/src/containers/Alerts/Expenses/ExpenseDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Expenses/ExpenseDeleteAlert.tsx
@@ -1,38 +1,46 @@
-// @ts-nocheck
-import { Intent, Alert } from '@blueprintjs/core';
+import { Alert, Intent } from '@blueprintjs/core';
 import React from 'react';
 import intl from 'react-intl-universal';
 import { handleDeleteErrors } from './_utils';
 import { AppToaster, FormattedMessage as T } from '@/components';
 import { DRAWERS } from '@/constants/drawers';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
 import { withDrawerActions } from '@/containers/Drawer/withDrawerActions';
+import type { WithDrawerActionsProps } from '@/containers/Drawer/withDrawerActions';
 import { useDeleteExpense } from '@/hooks/query';
 import { compose } from '@/utils';
+
+interface ExpenseDeleteAlertPayload {
+  expenseId: number;
+}
+
+interface ExpenseDeleteAlertProps
+  extends WithAlertActionsProps,
+    WithDrawerActionsProps {
+  name: string;
+  isOpen: boolean;
+  payload: ExpenseDeleteAlertPayload;
+}
 
 /**
  * Expense delete alert.
  */
 function ExpenseDeleteAlertInner({
-  // #withAlertActions
+  name,
   closeAlert,
-
-  // #withAlertStoreConnect
   isOpen,
   payload: { expenseId },
-
-  // #withDrawerActions
   closeDrawer,
-}) {
-  const { mutateAsync: deleteExpenseMutate, isLoading } = useDeleteExpense();
+}: ExpenseDeleteAlertProps): React.ReactElement {
+  const { mutateAsync: deleteExpenseMutate, isPending: isLoading } =
+    useDeleteExpense();
 
-  // Handle cancel expense journal.
   const handleCancelExpenseDelete = () => {
-    closeAlert('expense-delete');
+    closeAlert(name);
   };
 
-  // Handle confirm delete expense.
   const handleConfirmExpenseDelete = () => {
     deleteExpenseMutate(expenseId)
       .then(() => {
@@ -44,18 +52,20 @@ function ExpenseDeleteAlertInner({
         });
         closeDrawer(DRAWERS.EXPENSE_DETAILS);
       })
-      .catch(({ data: { errors } }) => {
-        handleDeleteErrors(errors);
-      })
+      .catch(
+        ({ data: { errors } }: { data: { errors: { type: string }[] } }) => {
+          handleDeleteErrors(errors);
+        },
+      )
       .finally(() => {
-        closeAlert('expense-delete');
+        closeAlert(name);
       });
   };
 
   return (
     <Alert
-      cancelButtonText={<T id={'cancel'} />}
-      confirmButtonText={<T id={'delete'} />}
+      cancelButtonText={intl.get('cancel')}
+      confirmButtonText={intl.get('delete')}
       icon="trash"
       intent={Intent.DANGER}
       isOpen={isOpen}

--- a/packages/webapp/src/containers/Alerts/Expenses/ExpenseDeleteEntriesAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Expenses/ExpenseDeleteEntriesAlert.tsx
@@ -1,10 +1,22 @@
-// @ts-nocheck
-import { Intent, Alert } from '@blueprintjs/core';
+import { Alert, Intent } from '@blueprintjs/core';
 import React from 'react';
-import { FormattedMessage as T } from '@/components';
+import intl from 'react-intl-universal';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
 import { compose, saveInvoke } from '@/utils';
+
+interface ExpenseDeleteEntriesAlertPayload {
+  // The original `payload: {}` shape — this alert is a generic clear-lines confirmation that doesn't read any payload field.
+  [key: string]: unknown;
+}
+
+interface ExpenseDeleteEntriesAlertProps extends WithAlertActionsProps {
+  name: string;
+  isOpen: boolean;
+  payload: ExpenseDeleteEntriesAlertPayload;
+  onConfirm?: (event: React.SyntheticEvent<HTMLElement>) => void;
+}
 
 /**
  * Alert description.
@@ -12,29 +24,23 @@ import { compose, saveInvoke } from '@/utils';
 function ExpenseDeleteEntriesAlertInner({
   name,
   onConfirm,
-
-  // #withAlertStoreConnect
   isOpen,
-  payload: {},
-
-  // #withAlertActions
+  payload,
   closeAlert,
-}) {
-  // Handle the alert cancel.
+}: ExpenseDeleteEntriesAlertProps): React.ReactElement {
   const handleCancel = () => {
     closeAlert(name);
   };
 
-  // Handle confirm the alert.
-  const handleConfirm = (event) => {
+  const handleConfirm = (event: React.SyntheticEvent<HTMLElement>) => {
     closeAlert(name);
     saveInvoke(onConfirm, event);
   };
 
   return (
     <Alert
-      cancelButtonText={<T id={'cancel'} />}
-      confirmButtonText={<T id={'clear_all_lines'} />}
+      cancelButtonText={intl.get('cancel')}
+      confirmButtonText={intl.get('clear_all_lines')}
       intent={Intent.DANGER}
       isOpen={isOpen}
       onCancel={handleCancel}

--- a/packages/webapp/src/containers/Alerts/Expenses/ExpensePublishAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Expenses/ExpensePublishAlert.tsx
@@ -1,31 +1,39 @@
-// @ts-nocheck
-import { Intent, Alert } from '@blueprintjs/core';
+import { Alert, Intent } from '@blueprintjs/core';
 import React from 'react';
 import intl from 'react-intl-universal';
 import { AppToaster, FormattedMessage as T } from '@/components';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
 import { usePublishExpense } from '@/hooks/query';
 import { compose } from '@/utils';
+
+interface ExpensePublishAlertPayload {
+  expenseId: number;
+}
+
+interface ExpensePublishAlertProps extends WithAlertActionsProps {
+  name: string;
+  isOpen: boolean;
+  payload: ExpensePublishAlertPayload;
+}
 
 /**
  * Expense publish alert.
  */
 function ExpensePublishAlertInner({
   closeAlert,
-
-  // #withAlertStoreConnect
   name,
   payload: { expenseId },
   isOpen,
-}) {
-  const { mutateAsync: publishExpenseMutate, isLoading } = usePublishExpense();
+}: ExpensePublishAlertProps): React.ReactElement {
+  const { mutateAsync: publishExpenseMutate, isPending: isLoading } =
+    usePublishExpense();
 
   const handleCancelPublishExpense = () => {
-    closeAlert('expense-publish');
+    closeAlert(name);
   };
 
-  // Handle publish expense confirm.
   const handleConfirmPublishExpense = () => {
     publishExpenseMutate(expenseId)
       .then(() => {
@@ -33,17 +41,23 @@ function ExpensePublishAlertInner({
           message: intl.get('the_expense_has_been_published'),
           intent: Intent.SUCCESS,
         });
-        closeAlert(name);
       })
-      .catch((error) => {
+      .catch((error: Error) => {
+        // Bugfix: original @ts-nocheck silently closed the alert on error without surfacing the failure.
+        AppToaster.show({
+          message: error.message,
+          intent: Intent.DANGER,
+        });
+      })
+      .finally(() => {
         closeAlert(name);
       });
   };
 
   return (
     <Alert
-      cancelButtonText={<T id={'cancel'} />}
-      confirmButtonText={<T id={'publish'} />}
+      cancelButtonText={intl.get('cancel')}
+      confirmButtonText={intl.get('publish')}
       intent={Intent.WARNING}
       isOpen={isOpen}
       onCancel={handleCancelPublishExpense}

--- a/packages/webapp/src/containers/Alerts/Expenses/_utils.ts
+++ b/packages/webapp/src/containers/Alerts/Expenses/_utils.ts
@@ -2,9 +2,13 @@ import { Intent } from '@blueprintjs/core';
 import intl from 'react-intl-universal';
 import { AppToaster } from '@/components';
 
-export const handleDeleteErrors = (errors: any) => {
+interface DeleteError {
+  type: string;
+}
+
+export const handleDeleteErrors = (errors: DeleteError[]): void => {
   if (
-    errors.find((e: any) => e.type === 'EXPENSE_HAS_ASSOCIATED_LANDED_COST')
+    errors.find((e) => e.type === 'EXPENSE_HAS_ASSOCIATED_LANDED_COST')
   ) {
     AppToaster.show({
       intent: Intent.DANGER,
@@ -13,7 +17,7 @@ export const handleDeleteErrors = (errors: any) => {
       ),
     });
   }
-  if (errors.find((e: any) => e.type === 'CANNOT_DELETE_TRANSACTION_MATCHED')) {
+  if (errors.find((e) => e.type === 'CANNOT_DELETE_TRANSACTION_MATCHED')) {
     AppToaster.show({
       intent: Intent.DANGER,
       message: 'Cannot delete a transaction matched with a bank transaction.',

--- a/packages/webapp/src/containers/Alerts/Expenses/_utils.ts
+++ b/packages/webapp/src/containers/Alerts/Expenses/_utils.ts
@@ -7,9 +7,7 @@ interface DeleteError {
 }
 
 export const handleDeleteErrors = (errors: DeleteError[]): void => {
-  if (
-    errors.find((e) => e.type === 'EXPENSE_HAS_ASSOCIATED_LANDED_COST')
-  ) {
+  if (errors.find((e) => e.type === 'EXPENSE_HAS_ASSOCIATED_LANDED_COST')) {
     AppToaster.show({
       intent: Intent.DANGER,
       message: intl.get(

--- a/packages/webapp/src/containers/Alerts/Invoices/CancelBadDebtAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Invoices/CancelBadDebtAlert.tsx
@@ -1,34 +1,39 @@
-// @ts-nocheck
-import { Intent, Alert } from '@blueprintjs/core';
+import { Alert, Intent } from '@blueprintjs/core';
 import React from 'react';
 import intl from 'react-intl-universal';
 import { AppToaster, FormattedMessage as T } from '@/components';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
 import { useCancelBadDebt } from '@/hooks/query';
 import { compose } from '@/utils';
+
+interface CancelBadDebtAlertPayload {
+  invoiceId: number;
+}
+
+interface CancelBadDebtAlertProps extends WithAlertActionsProps {
+  name: string;
+  isOpen: boolean;
+  payload: CancelBadDebtAlertPayload;
+}
 
 /**
  * Cancel bad debt alert.
  */
 function CancelBadDebtAlertInner({
   name,
-
-  // #withAlertStoreConnect
   isOpen,
   payload: { invoiceId },
-
-  // #withAlertActions
   closeAlert,
-}) {
-  // handle cancel  alert.
+}: CancelBadDebtAlertProps): React.ReactElement {
+  const { mutateAsync: cancelBadDebtMutate, isPending: isLoading } =
+    useCancelBadDebt();
+
   const handleCancel = () => {
     closeAlert(name);
   };
 
-  const { mutateAsync: cancelBadDebtMutate, isLoading } = useCancelBadDebt();
-
-  // handleConfirm alert.
   const handleConfirm = () => {
     cancelBadDebtMutate(invoiceId)
       .then(() => {
@@ -37,7 +42,13 @@ function CancelBadDebtAlertInner({
           intent: Intent.SUCCESS,
         });
       })
-      .catch(() => {})
+      .catch((error: Error) => {
+        // Bugfix: original @ts-nocheck had an empty `.catch(() => {})` that silently swallowed failures.
+        AppToaster.show({
+          message: error.message,
+          intent: Intent.DANGER,
+        });
+      })
       .finally(() => {
         closeAlert(name);
       });
@@ -45,8 +56,8 @@ function CancelBadDebtAlertInner({
 
   return (
     <Alert
-      cancelButtonText={<T id={'cancel'} />}
-      confirmButtonText={<T id={'save'} />}
+      cancelButtonText={intl.get('cancel')}
+      confirmButtonText={intl.get('save')}
       intent={Intent.WARNING}
       isOpen={isOpen}
       onCancel={handleCancel}

--- a/packages/webapp/src/containers/Alerts/Invoices/InvoiceDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Invoices/InvoiceDeleteAlert.tsx
@@ -1,44 +1,46 @@
-// @ts-nocheck
-import { Intent, Alert } from '@blueprintjs/core';
+import { Alert, Intent } from '@blueprintjs/core';
 import React from 'react';
 import intl from 'react-intl-universal';
-import {
-  AppToaster,
-  FormattedMessage as T,
-  FormattedHTMLMessage,
-} from '@/components';
+import { AppToaster, FormattedHTMLMessage } from '@/components';
 import { DRAWERS } from '@/constants/drawers';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
 import { withDrawerActions } from '@/containers/Drawer/withDrawerActions';
+import type { WithDrawerActionsProps } from '@/containers/Drawer/withDrawerActions';
 import { handleDeleteErrors } from '@/containers/Sales/Invoices/InvoicesLanding/components';
 import { useDeleteInvoice } from '@/hooks/query';
 import { compose } from '@/utils';
+
+interface InvoiceDeleteAlertPayload {
+  invoiceId: number;
+}
+
+interface InvoiceDeleteAlertProps
+  extends WithAlertActionsProps,
+    WithDrawerActionsProps {
+  name: string;
+  isOpen: boolean;
+  payload: InvoiceDeleteAlertPayload;
+}
 
 /**
  * Invoice delete alert.
  */
 function InvoiceDeleteAlertInner({
   name,
-
-  // #withAlertStoreConnect
   isOpen,
   payload: { invoiceId },
-
-  // #withAlertActions
   closeAlert,
-
-  // #withDrawerActions
   closeDrawer,
-}) {
-  const { mutateAsync: deleteInvoiceMutate, isLoading } = useDeleteInvoice();
+}: InvoiceDeleteAlertProps): React.ReactElement {
+  const { mutateAsync: deleteInvoiceMutate, isPending: isLoading } =
+    useDeleteInvoice();
 
-  // handle cancel delete invoice alert.
   const handleCancelDeleteAlert = () => {
     closeAlert(name);
   };
 
-  // handleConfirm delete invoice
   const handleConfirmInvoiceDelete = () => {
     deleteInvoiceMutate(invoiceId)
       .then(() => {
@@ -48,9 +50,11 @@ function InvoiceDeleteAlertInner({
         });
         closeDrawer(DRAWERS.INVOICE_DETAILS);
       })
-      .catch(({ data: { errors } }) => {
-        handleDeleteErrors(errors);
-      })
+      .catch(
+        ({ data: { errors } }: { data: { errors: { type: string }[] } }) => {
+          handleDeleteErrors(errors);
+        },
+      )
       .finally(() => {
         closeAlert(name);
       });
@@ -58,8 +62,8 @@ function InvoiceDeleteAlertInner({
 
   return (
     <Alert
-      cancelButtonText={<T id={'cancel'} />}
-      confirmButtonText={<T id={'delete'} />}
+      cancelButtonText={intl.get('cancel')}
+      confirmButtonText={intl.get('delete')}
       icon="trash"
       intent={Intent.DANGER}
       isOpen={isOpen}
@@ -68,6 +72,7 @@ function InvoiceDeleteAlertInner({
       loading={isLoading}
     >
       <p>
+        {/* @ts-expect-error — react-intl-universal FormattedHTMLMessage JSX type mismatch (library-level issue, see Alerts/Items/ItemDeleteAlert.tsx) */}
         <FormattedHTMLMessage
           id={'once_delete_this_invoice_you_will_able_to_restore_it'}
         />

--- a/packages/webapp/src/containers/Alerts/Invoices/InvoiceDeliverAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Invoices/InvoiceDeliverAlert.tsx
@@ -1,34 +1,39 @@
-// @ts-nocheck
-import { Intent, Alert } from '@blueprintjs/core';
+import { Alert, Intent } from '@blueprintjs/core';
 import React from 'react';
 import intl from 'react-intl-universal';
 import { AppToaster, FormattedMessage as T } from '@/components';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
 import { useDeliverInvoice } from '@/hooks/query';
 import { compose } from '@/utils';
+
+interface InvoiceDeliverAlertPayload {
+  invoiceId: number;
+}
+
+interface InvoiceDeliverAlertProps extends WithAlertActionsProps {
+  name: string;
+  isOpen: boolean;
+  payload: InvoiceDeliverAlertPayload;
+}
 
 /**
  * Sale invoice alert.
  */
 function InvoiceDeliverAlertInner({
   name,
-
-  // #withAlertStoreConnect
   isOpen,
   payload: { invoiceId },
-
-  // #withAlertActions
   closeAlert,
-}) {
-  const { mutateAsync: deliverInvoiceMutate, isLoading } = useDeliverInvoice();
+}: InvoiceDeliverAlertProps): React.ReactElement {
+  const { mutateAsync: deliverInvoiceMutate, isPending: isLoading } =
+    useDeliverInvoice();
 
-  // handle cancel delete deliver alert.
   const handleCancelDeleteAlert = () => {
     closeAlert(name);
   };
 
-  // Handle confirm invoice deliver.
   const handleConfirmInvoiceDeliver = () => {
     deliverInvoiceMutate(invoiceId)
       .then(() => {
@@ -37,7 +42,13 @@ function InvoiceDeliverAlertInner({
           intent: Intent.SUCCESS,
         });
       })
-      .catch((error) => {})
+      .catch((error: Error) => {
+        // Bugfix: original @ts-nocheck had an empty `.catch((error) => {})` that silently swallowed failures.
+        AppToaster.show({
+          message: error.message,
+          intent: Intent.DANGER,
+        });
+      })
       .finally(() => {
         closeAlert(name);
       });
@@ -45,8 +56,8 @@ function InvoiceDeliverAlertInner({
 
   return (
     <Alert
-      cancelButtonText={<T id={'cancel'} />}
-      confirmButtonText={<T id={'deliver'} />}
+      cancelButtonText={intl.get('cancel')}
+      confirmButtonText={intl.get('deliver')}
       intent={Intent.WARNING}
       isOpen={isOpen}
       onCancel={handleCancelDeleteAlert}

--- a/packages/webapp/src/containers/Alerts/ManualJournals/JournalDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/ManualJournals/JournalDeleteAlert.tsx
@@ -1,40 +1,47 @@
-// @ts-nocheck
-import { Intent, Alert } from '@blueprintjs/core';
+import { Alert, Intent } from '@blueprintjs/core';
 import React from 'react';
 import intl from 'react-intl-universal';
 import { handleDeleteErrors } from './_utils';
 import { AppToaster, FormattedMessage as T } from '@/components';
 import { DRAWERS } from '@/constants/drawers';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
 import { withDrawerActions } from '@/containers/Drawer/withDrawerActions';
+import type { WithDrawerActionsProps } from '@/containers/Drawer/withDrawerActions';
 import { useDeleteJournal } from '@/hooks/query';
 import { compose } from '@/utils';
+
+interface JournalDeleteAlertPayload {
+  manualJournalId: number;
+  journalNumber: string;
+}
+
+interface JournalDeleteAlertProps
+  extends WithAlertActionsProps,
+    WithDrawerActionsProps {
+  name: string;
+  isOpen: boolean;
+  payload: JournalDeleteAlertPayload;
+}
 
 /**
  * Journal delete alert.
  */
 function JournalDeleteAlertInner({
   name,
-
-  // #withAlertStoreConnect
   isOpen,
   payload: { manualJournalId, journalNumber },
-
-  // #withAlertActions
   closeAlert,
-
-  // #withDrawerActions
   closeDrawer,
-}) {
-  const { mutateAsync: deleteJournalMutate, isLoading } = useDeleteJournal();
+}: JournalDeleteAlertProps): React.ReactElement {
+  const { mutateAsync: deleteJournalMutate, isPending: isLoading } =
+    useDeleteJournal();
 
-  // Handle cancel delete manual journal.
   const handleCancelAlert = () => {
     closeAlert(name);
   };
 
-  // Handle confirm delete manual journal.
   const handleConfirmManualJournalDelete = () => {
     deleteJournalMutate(manualJournalId)
       .then(() => {
@@ -44,19 +51,22 @@ function JournalDeleteAlertInner({
           }),
           intent: Intent.SUCCESS,
         });
-        closeAlert(name);
         closeDrawer(DRAWERS.JOURNAL_DETAILS);
       })
-      .catch(({ data: { errors } }) => {
-        handleDeleteErrors(errors);
+      .catch(
+        ({ data: { errors } }: { data: { errors: { type: string }[] } }) => {
+          handleDeleteErrors(errors);
+        },
+      )
+      .finally(() => {
         closeAlert(name);
       });
   };
 
   return (
     <Alert
-      cancelButtonText={<T id={'cancel'} />}
-      confirmButtonText={<T id={'delete'} />}
+      cancelButtonText={intl.get('cancel')}
+      confirmButtonText={intl.get('delete')}
       icon="trash"
       intent={Intent.DANGER}
       isOpen={isOpen}

--- a/packages/webapp/src/containers/Alerts/ManualJournals/JournalDeleteEntriesAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/ManualJournals/JournalDeleteEntriesAlert.tsx
@@ -1,41 +1,46 @@
-// @ts-nocheck
-import { Intent, Alert } from '@blueprintjs/core';
+import { Alert, Intent } from '@blueprintjs/core';
 import React from 'react';
-import { FormattedMessage as T } from '@/components';
+import intl from 'react-intl-universal';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
 import { compose, saveInvoke } from '@/utils';
+
+interface JournalDeleteEntriesAlertPayload {
+  // Empty payload — this alert is a generic clear-lines confirmation that doesn't read any payload field.
+  [key: string]: unknown;
+}
+
+interface JournalDeleteEntriesAlertProps extends WithAlertActionsProps {
+  name: string;
+  isOpen: boolean;
+  payload: JournalDeleteEntriesAlertPayload;
+  onConfirm?: (event: React.SyntheticEvent<HTMLElement>) => void;
+}
 
 /**
  * Make journal delete entries alert.
  */
 function JournalDeleteEntriesAlertInner({
-  // #ownProps
   name,
   onConfirm,
-
-  // #withAlertStoreConnect
   isOpen,
-  payload: {},
-
-  // #withAlertActions
+  payload,
   closeAlert,
-}) {
-  // Handle the alert cancel.
+}: JournalDeleteEntriesAlertProps): React.ReactElement {
   const handleCancel = () => {
     closeAlert(name);
   };
 
-  // Handle confirm delete manual journal.
-  const handleConfirm = (event) => {
+  const handleConfirm = (event: React.SyntheticEvent<HTMLElement>) => {
     closeAlert(name);
     saveInvoke(onConfirm, event);
   };
 
   return (
     <Alert
-      cancelButtonText={<T id={'cancel'} />}
-      confirmButtonText={<T id={'clear_all_lines'} />}
+      cancelButtonText={intl.get('cancel')}
+      confirmButtonText={intl.get('clear_all_lines')}
       intent={Intent.DANGER}
       isOpen={isOpen}
       onCancel={handleCancel}

--- a/packages/webapp/src/containers/Alerts/ManualJournals/JournalPublishAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/ManualJournals/JournalPublishAlert.tsx
@@ -1,34 +1,40 @@
-// @ts-nocheck
-import { Intent, Alert } from '@blueprintjs/core';
+import { Alert, Intent } from '@blueprintjs/core';
 import React from 'react';
 import intl from 'react-intl-universal';
 import { AppToaster, FormattedMessage as T } from '@/components';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
 import { usePublishJournal } from '@/hooks/query';
 import { compose } from '@/utils';
+
+interface JournalPublishAlertPayload {
+  manualJournalId: number;
+  journalNumber: string;
+}
+
+interface JournalPublishAlertProps extends WithAlertActionsProps {
+  name: string;
+  isOpen: boolean;
+  payload: JournalPublishAlertPayload;
+}
 
 /**
  * Journal publish alert.
  */
 function JournalPublishAlertInner({
   name,
-
-  // #withAlertStoreConnect
   isOpen,
-  payload: { manualJournalId, journalNumber },
-
-  // #withAlertActions
+  payload: { manualJournalId },
   closeAlert,
-}) {
-  const { mutateAsync: publishJournalMutate, isLoading } = usePublishJournal();
+}: JournalPublishAlertProps): React.ReactElement {
+  const { mutateAsync: publishJournalMutate, isPending: isLoading } =
+    usePublishJournal();
 
-  // Handle cancel manual journal alert.
   const handleCancel = () => {
     closeAlert(name);
   };
 
-  // Handle publish manual journal confirm.
   const handleConfirm = () => {
     publishJournalMutate(manualJournalId)
       .then(() => {
@@ -37,7 +43,13 @@ function JournalPublishAlertInner({
           intent: Intent.SUCCESS,
         });
       })
-      .catch((error) => {})
+      .catch((error: Error) => {
+        // Bugfix: original @ts-nocheck had an empty `.catch((error) => {})` that silently swallowed failures.
+        AppToaster.show({
+          message: error.message,
+          intent: Intent.DANGER,
+        });
+      })
       .finally(() => {
         closeAlert(name);
       });
@@ -45,8 +57,8 @@ function JournalPublishAlertInner({
 
   return (
     <Alert
-      cancelButtonText={<T id={'cancel'} />}
-      confirmButtonText={<T id={'publish'} />}
+      cancelButtonText={intl.get('cancel')}
+      confirmButtonText={intl.get('publish')}
       intent={Intent.WARNING}
       isOpen={isOpen}
       onCancel={handleCancel}

--- a/packages/webapp/src/containers/Alerts/ManualJournals/_utils.ts
+++ b/packages/webapp/src/containers/Alerts/ManualJournals/_utils.ts
@@ -1,8 +1,12 @@
 import { Intent } from '@blueprintjs/core';
 import { AppToaster } from '@/components';
 
-export const handleDeleteErrors = (errors: any) => {
-  if (errors.find((e: any) => e.type === 'CANNOT_DELETE_TRANSACTION_MATCHED')) {
+interface DeleteError {
+  type: string;
+}
+
+export const handleDeleteErrors = (errors: DeleteError[]): void => {
+  if (errors.find((e) => e.type === 'CANNOT_DELETE_TRANSACTION_MATCHED')) {
     AppToaster.show({
       intent: Intent.DANGER,
       message: 'Cannot delete a transaction matched with a bank transaction.',

--- a/packages/webapp/src/containers/Alerts/PaymentMades/ChangingFullAmountAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/PaymentMades/ChangingFullAmountAlert.tsx
@@ -1,9 +1,22 @@
-// @ts-nocheck
-import { Intent, Alert } from '@blueprintjs/core';
+import { Alert, Intent } from '@blueprintjs/core';
 import React from 'react';
+import intl from 'react-intl-universal';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
 import { compose, saveInvoke } from '@/utils';
+
+interface ChangingFullAmountAlertPayload {
+  // Empty payload — alert reads no payload field.
+  [key: string]: unknown;
+}
+
+interface ChangingFullAmountAlertProps extends WithAlertActionsProps {
+  name: string;
+  isOpen: boolean;
+  payload: ChangingFullAmountAlertPayload;
+  onConfirm?: (event: React.SyntheticEvent<HTMLElement>) => void;
+}
 
 /**
  * Changing full-amount alert in payment made form.
@@ -11,29 +24,23 @@ import { compose, saveInvoke } from '@/utils';
 function ChangingFullAmountAlertInner({
   name,
   onConfirm,
-
-  // #withAlertStoreConnect
   isOpen,
-  payload: {},
-
-  // #withAlertActions
+  payload,
   closeAlert,
-}) {
-  // Handle the alert cancel.
+}: ChangingFullAmountAlertProps): React.ReactElement {
   const handleCancel = () => {
     closeAlert(name);
   };
 
-  // Handle confirm delete manual journal.
-  const handleConfirm = (event) => {
+  const handleConfirm = (event: React.SyntheticEvent<HTMLElement>) => {
     closeAlert(name);
     saveInvoke(onConfirm, event);
   };
 
   return (
     <Alert
-      cancelButtonText={<T id={'cancel'} />}
-      confirmButtonText={<T id={'ok'} />}
+      cancelButtonText={intl.get('cancel')}
+      confirmButtonText={intl.get('ok')}
       intent={Intent.DANGER}
       isOpen={isOpen}
       onCancel={handleCancel}

--- a/packages/webapp/src/containers/Alerts/PaymentMades/ClearTransactionAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/PaymentMades/ClearTransactionAlert.tsx
@@ -1,36 +1,45 @@
-// @ts-nocheck
-import { Intent, Alert } from '@blueprintjs/core';
+import { Alert, Intent } from '@blueprintjs/core';
 import React from 'react';
+import intl from 'react-intl-universal';
 import { FormattedMessage as T } from '@/components';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
 import { compose } from '@/utils';
 
+interface ClearTransactionAlertPayload {
+  // Empty payload — alert reads no payload field.
+  [key: string]: unknown;
+}
+
+interface ClearTransactionAlertProps extends WithAlertActionsProps {
+  name: string;
+  isOpen: boolean;
+  payload: ClearTransactionAlertPayload;
+}
+
 /**
- * Alert description.
+ * Clear payment transaction alert.
  */
 function ClearPaymentTransactionAlert({
   name,
-
-  // #withAlertStoreConnect
   isOpen,
-  payload: {},
-
-  // #withAlertActions
+  payload,
   closeAlert,
-}) {
-  // Handle the alert cancel.
+}: ClearTransactionAlertProps): React.ReactElement {
   const handleCancel = () => {
     closeAlert(name);
   };
 
-  // Handle confirm delete manual journal.
-  const handleConfirm = () => {};
+  // Bugfix: original @ts-nocheck had an empty `() => {}` body — clicking confirm did nothing. Now closes the alert.
+  const handleConfirm = () => {
+    closeAlert(name);
+  };
 
   return (
     <Alert
-      cancelButtonText={<T id={'cancel'} />}
-      confirmButtonText={<T id={'action'} />}
+      cancelButtonText={intl.get('cancel')}
+      confirmButtonText={intl.get('action')}
       icon="trash"
       intent={Intent.DANGER}
       isOpen={isOpen}

--- a/packages/webapp/src/containers/Alerts/PaymentMades/ClearningAllLinesAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/PaymentMades/ClearningAllLinesAlert.tsx
@@ -1,36 +1,45 @@
-// @ts-nocheck
-import { Intent, Alert } from '@blueprintjs/core';
+import { Alert, Intent } from '@blueprintjs/core';
 import React from 'react';
+import intl from 'react-intl-universal';
 import { FormattedMessage as T } from '@/components';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
 import { compose } from '@/utils';
+
+interface ClearingAllLinesAlertPayload {
+  // Empty payload — alert reads no payload field.
+  [key: string]: unknown;
+}
+
+interface ClearingAllLinesAlertProps extends WithAlertActionsProps {
+  name: string;
+  isOpen: boolean;
+  payload: ClearingAllLinesAlertPayload;
+}
 
 /**
  * Clearning all lines alert.
  */
 function ClearAllLinesAlert({
   name,
-
-  // #withAlertStoreConnect
   isOpen,
-  payload: {},
-
-  // #withAlertActions
+  payload,
   closeAlert,
-}) {
-  // Handle the alert cancel.
+}: ClearingAllLinesAlertProps): React.ReactElement {
   const handleCancel = () => {
     closeAlert(name);
   };
 
-  // Handle confirm delete manual journal.
-  const handleConfirm = () => {};
+  // Bugfix: original @ts-nocheck had an empty `() => {}` body — clicking confirm did nothing. Now closes the alert.
+  const handleConfirm = () => {
+    closeAlert(name);
+  };
 
   return (
     <Alert
-      cancelButtonText={<T id={'cancel'} />}
-      confirmButtonText={<T id={'action'} />}
+      cancelButtonText={intl.get('cancel')}
+      confirmButtonText={intl.get('action')}
       icon="trash"
       intent={Intent.DANGER}
       isOpen={isOpen}

--- a/packages/webapp/src/containers/Alerts/PaymentMades/PaymentMadeDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/PaymentMades/PaymentMadeDeleteAlert.tsx
@@ -1,41 +1,46 @@
-// @ts-nocheck
-import { Intent, Alert } from '@blueprintjs/core';
+import { Alert, Intent } from '@blueprintjs/core';
 import React from 'react';
 import intl from 'react-intl-universal';
 import { handleDeleteErrors } from './_utils';
 import { AppToaster, FormattedMessage as T } from '@/components';
 import { DRAWERS } from '@/constants/drawers';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
 import { withDrawerActions } from '@/containers/Drawer/withDrawerActions';
+import type { WithDrawerActionsProps } from '@/containers/Drawer/withDrawerActions';
 import { useDeletePaymentMade } from '@/hooks/query';
 import { compose } from '@/utils';
+
+interface PaymentMadeDeleteAlertPayload {
+  paymentMadeId: number;
+}
+
+interface PaymentMadeDeleteAlertProps
+  extends WithAlertActionsProps,
+    WithDrawerActionsProps {
+  name: string;
+  isOpen: boolean;
+  payload: PaymentMadeDeleteAlertPayload;
+}
 
 /**
  * Payment made delete alert.
  */
 function PaymentMadeDeleteAlertInner({
   name,
-
-  // #withAlertStoreConnect
   isOpen,
   payload: { paymentMadeId },
-
-  // #withAlertActions
   closeAlert,
-
-  // #withDrawerActions
   closeDrawer,
-}) {
-  const { mutateAsync: deletePaymentMadeMutate, isLoading } =
+}: PaymentMadeDeleteAlertProps): React.ReactElement {
+  const { mutateAsync: deletePaymentMadeMutate, isPending: isLoading } =
     useDeletePaymentMade();
 
-  // Handle cancel payment made.
   const handleCancelPaymentMadeDelete = () => {
     closeAlert(name);
   };
 
-  // Handle confirm delete payment made
   const handleConfirmPaymentMadeDelete = () => {
     deletePaymentMadeMutate(paymentMadeId)
       .then(() => {
@@ -45,9 +50,11 @@ function PaymentMadeDeleteAlertInner({
         });
         closeDrawer(DRAWERS.PAYMENT_MADE_DETAILS);
       })
-      .catch(({ data: { errors } }) => {
-        handleDeleteErrors(errors);
-      })
+      .catch(
+        ({ data: { errors } }: { data: { errors: { type: string }[] } }) => {
+          handleDeleteErrors(errors);
+        },
+      )
       .finally(() => {
         closeAlert(name);
       });
@@ -55,8 +62,8 @@ function PaymentMadeDeleteAlertInner({
 
   return (
     <Alert
-      cancelButtonText={<T id={'cancel'} />}
-      confirmButtonText={<T id={'delete'} />}
+      cancelButtonText={intl.get('cancel')}
+      confirmButtonText={intl.get('delete')}
       icon={'trash'}
       intent={Intent.DANGER}
       isOpen={isOpen}

--- a/packages/webapp/src/containers/Alerts/PaymentMades/_utils.ts
+++ b/packages/webapp/src/containers/Alerts/PaymentMades/_utils.ts
@@ -1,8 +1,12 @@
 import { Intent } from '@blueprintjs/core';
 import { AppToaster } from '@/components';
 
-export const handleDeleteErrors = (errors: any) => {
-  if (errors.find((e: any) => e.type === 'CANNOT_DELETE_TRANSACTION_MATCHED')) {
+interface DeleteError {
+  type: string;
+}
+
+export const handleDeleteErrors = (errors: DeleteError[]): void => {
+  if (errors.find((e) => e.type === 'CANNOT_DELETE_TRANSACTION_MATCHED')) {
     AppToaster.show({
       intent: Intent.DANGER,
       message: 'Cannot delete a transaction matched with a bank transaction.',

--- a/packages/webapp/src/containers/Alerts/PaymentReceived/ClearingAllLinesAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/PaymentReceived/ClearingAllLinesAlert.tsx
@@ -1,10 +1,23 @@
-// @ts-nocheck
-import { Intent, Alert } from '@blueprintjs/core';
+import { Alert, Intent } from '@blueprintjs/core';
 import React from 'react';
+import intl from 'react-intl-universal';
 import { FormattedMessage as T } from '@/components';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
 import { saveInvoke, compose } from '@/utils';
+
+interface ClearingAllLinesAlertPayload {
+  // Empty payload — alert reads no payload field.
+  [key: string]: unknown;
+}
+
+interface ClearingAllLinesAlertProps extends WithAlertActionsProps {
+  name: string;
+  isOpen: boolean;
+  payload: ClearingAllLinesAlertPayload;
+  onConfirm?: (event: React.SyntheticEvent<HTMLElement>) => void;
+}
 
 /**
  * Clearning all lines alert.
@@ -12,29 +25,23 @@ import { saveInvoke, compose } from '@/utils';
 function ClearningAllLinesAlert({
   name,
   onConfirm,
-
-  // #withAlertStoreConnect
   isOpen,
-  payload: {},
-
-  // #withAlertActions
+  payload,
   closeAlert,
-}) {
-  // Handle the alert cancel.
+}: ClearingAllLinesAlertProps): React.ReactElement {
   const handleCancel = () => {
     closeAlert(name);
   };
 
-  // Handle confirm delete manual journal.
-  const handleConfirm = (event) => {
+  const handleConfirm = (event: React.SyntheticEvent<HTMLElement>) => {
     closeAlert(name);
     saveInvoke(onConfirm, event);
   };
 
   return (
     <Alert
-      cancelButtonText={<T id={'cancel'} />}
-      confirmButtonText={<T id={'action'} />}
+      cancelButtonText={intl.get('cancel')}
+      confirmButtonText={intl.get('action')}
       intent={Intent.DANGER}
       isOpen={isOpen}
       onCancel={handleCancel}

--- a/packages/webapp/src/containers/Alerts/PaymentReceived/PaymentReceivedDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/PaymentReceived/PaymentReceivedDeleteAlert.tsx
@@ -1,45 +1,46 @@
-// @ts-nocheck
-import { Intent, Alert } from '@blueprintjs/core';
+import { Alert, Intent } from '@blueprintjs/core';
 import React from 'react';
 import intl from 'react-intl-universal';
 import { handleDeleteErrors } from './_utils';
-import {
-  AppToaster,
-  FormattedMessage as T,
-  FormattedHTMLMessage,
-} from '@/components';
+import { AppToaster, FormattedHTMLMessage } from '@/components';
 import { DRAWERS } from '@/constants/drawers';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
 import { withDrawerActions } from '@/containers/Drawer/withDrawerActions';
+import type { WithDrawerActionsProps } from '@/containers/Drawer/withDrawerActions';
 import { useDeletePaymentReceive } from '@/hooks/query';
 import { compose } from '@/utils';
+
+interface PaymentReceivedDeleteAlertPayload {
+  paymentReceiveId: number;
+}
+
+interface PaymentReceivedDeleteAlertProps
+  extends WithAlertActionsProps,
+    WithDrawerActionsProps {
+  name: string;
+  isOpen: boolean;
+  payload: PaymentReceivedDeleteAlertPayload;
+}
 
 /**
  * Payment receive delete alert.
  */
 function PaymentReceivedDeleteAlertInner({
   name,
-
-  // #withAlertStoreConnect
   isOpen,
   payload: { paymentReceiveId },
-
-  // #withAlertActions
   closeAlert,
-
-  // #withDrawerActions
   closeDrawer,
-}) {
-  const { mutateAsync: deletePaymentReceiveMutate, isLoading } =
+}: PaymentReceivedDeleteAlertProps): React.ReactElement {
+  const { mutateAsync: deletePaymentReceiveMutate, isPending: isLoading } =
     useDeletePaymentReceive();
 
-  // Handle cancel payment Receive.
   const handleCancelDeleteAlert = () => {
     closeAlert(name);
   };
 
-  // Handle confirm delete payment receive.
   const handleConfirmPaymentReceiveDelete = () => {
     deletePaymentReceiveMutate(paymentReceiveId)
       .then(() => {
@@ -51,9 +52,11 @@ function PaymentReceivedDeleteAlertInner({
         });
         closeDrawer(DRAWERS.PAYMENT_RECEIVED_DETAILS);
       })
-      .catch(({ data: { errors } }) => {
-        handleDeleteErrors(errors);
-      })
+      .catch(
+        ({ data: { errors } }: { data: { errors: { type: string }[] } }) => {
+          handleDeleteErrors(errors);
+        },
+      )
       .finally(() => {
         closeAlert(name);
       });
@@ -61,8 +64,8 @@ function PaymentReceivedDeleteAlertInner({
 
   return (
     <Alert
-      cancelButtonText={<T id={'cancel'} />}
-      confirmButtonText={<T id={'delete'} />}
+      cancelButtonText={intl.get('cancel')}
+      confirmButtonText={intl.get('delete')}
       icon="trash"
       intent={Intent.DANGER}
       isOpen={isOpen}
@@ -71,6 +74,7 @@ function PaymentReceivedDeleteAlertInner({
       loading={isLoading}
     >
       <p>
+        {/* @ts-expect-error — react-intl-universal FormattedHTMLMessage JSX type mismatch (library-level issue, see Alerts/Items/ItemDeleteAlert.tsx) */}
         <FormattedHTMLMessage
           id={'once_delete_this_payment_received_you_will_able_to_restore_it'}
         />

--- a/packages/webapp/src/containers/Alerts/PaymentReceived/_utils.ts
+++ b/packages/webapp/src/containers/Alerts/PaymentReceived/_utils.ts
@@ -1,8 +1,12 @@
 import { Intent } from '@blueprintjs/core';
 import { AppToaster } from '@/components';
 
-export const handleDeleteErrors = (errors: any) => {
-  if (errors.find((e: any) => e.type === 'CANNOT_DELETE_TRANSACTION_MATCHED')) {
+interface DeleteError {
+  type: string;
+}
+
+export const handleDeleteErrors = (errors: DeleteError[]): void => {
+  if (errors.find((e) => e.type === 'CANNOT_DELETE_TRANSACTION_MATCHED')) {
     AppToaster.show({
       intent: Intent.DANGER,
       message: 'Cannot delete a transaction matched with a bank transaction.',

--- a/packages/webapp/src/containers/Alerts/Receipts/ReceiptCloseAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Receipts/ReceiptCloseAlert.tsx
@@ -1,34 +1,39 @@
-// @ts-nocheck
-import { Intent, Alert } from '@blueprintjs/core';
+import { Alert, Intent } from '@blueprintjs/core';
 import React from 'react';
 import intl from 'react-intl-universal';
 import { AppToaster, FormattedMessage as T } from '@/components';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
 import { useCloseReceipt } from '@/hooks/query';
 import { compose } from '@/utils';
+
+interface ReceiptCloseAlertPayload {
+  receiptId: number;
+}
+
+interface ReceiptCloseAlertProps extends WithAlertActionsProps {
+  name: string;
+  isOpen: boolean;
+  payload: ReceiptCloseAlertPayload;
+}
 
 /**
  * Receipt close alert.
  */
 function ReceiptCloseAlertInner({
   name,
-
-  // #withAlertStoreConnect
   isOpen,
   payload: { receiptId },
-
-  // #withAlertActions
   closeAlert,
-}) {
-  const { mutateAsync: closeReceiptMutate, isLoading } = useCloseReceipt();
+}: ReceiptCloseAlertProps): React.ReactElement {
+  const { mutateAsync: closeReceiptMutate, isPending: isLoading } =
+    useCloseReceipt();
 
-  // handle cancel delete alert.
   const handleCancelDeleteAlert = () => {
     closeAlert(name);
   };
 
-  // Handle confirm receipt close.
   const handleConfirmReceiptClose = () => {
     closeReceiptMutate(receiptId)
       .then(() => {
@@ -37,7 +42,13 @@ function ReceiptCloseAlertInner({
           intent: Intent.SUCCESS,
         });
       })
-      .catch((error) => {})
+      .catch((error: Error) => {
+        // Bugfix: original @ts-nocheck had an empty `.catch((error) => {})` that silently swallowed failures.
+        AppToaster.show({
+          message: error.message,
+          intent: Intent.DANGER,
+        });
+      })
       .finally(() => {
         closeAlert(name);
       });
@@ -45,8 +56,8 @@ function ReceiptCloseAlertInner({
 
   return (
     <Alert
-      cancelButtonText={<T id={'cancel'} />}
-      confirmButtonText={<T id={'close'} />}
+      cancelButtonText={intl.get('cancel')}
+      confirmButtonText={intl.get('close')}
       intent={Intent.WARNING}
       isOpen={isOpen}
       onCancel={handleCancelDeleteAlert}

--- a/packages/webapp/src/containers/Alerts/Receipts/ReceiptDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Receipts/ReceiptDeleteAlert.tsx
@@ -1,43 +1,45 @@
-// @ts-nocheck
-import { Intent, Alert } from '@blueprintjs/core';
+import { Alert, Intent } from '@blueprintjs/core';
 import React from 'react';
 import intl from 'react-intl-universal';
-import {
-  AppToaster,
-  FormattedMessage as T,
-  FormattedHTMLMessage,
-} from '@/components';
+import { AppToaster, FormattedHTMLMessage } from '@/components';
 import { DRAWERS } from '@/constants/drawers';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
 import { withDrawerActions } from '@/containers/Drawer/withDrawerActions';
+import type { WithDrawerActionsProps } from '@/containers/Drawer/withDrawerActions';
 import { useDeleteReceipt } from '@/hooks/query';
 import { compose } from '@/utils';
 
+interface ReceiptDeleteAlertPayload {
+  receiptId: number;
+}
+
+interface ReceiptDeleteAlertProps
+  extends WithAlertActionsProps,
+    WithDrawerActionsProps {
+  name: string;
+  isOpen: boolean;
+  payload: ReceiptDeleteAlertPayload;
+}
+
 /**
- * Invoice  alert.
+ * Receipt delete alert.
  */
 function NameDeleteAlert({
   name,
-
-  // #withAlertStoreConnect
   isOpen,
   payload: { receiptId },
-
-  // #withAlertActions
   closeAlert,
-
-  // #withDrawerActions
   closeDrawer,
-}) {
-  const { mutateAsync: deleteReceiptMutate, isLoading } = useDeleteReceipt();
+}: ReceiptDeleteAlertProps): React.ReactElement {
+  const { mutateAsync: deleteReceiptMutate, isPending: isLoading } =
+    useDeleteReceipt();
 
-  // Handle cancel delete  alert.
   const handleCancelDeleteAlert = () => {
     closeAlert(name);
   };
 
-  // Handle confirm delete receipt
   const handleConfirmReceiptDelete = () => {
     deleteReceiptMutate(receiptId)
       .then(() => {
@@ -47,7 +49,13 @@ function NameDeleteAlert({
         });
         closeDrawer(DRAWERS.RECEIPT_DETAILS);
       })
-      .catch(() => {})
+      .catch((error: Error) => {
+        // Bugfix: original @ts-nocheck had an empty `.catch(() => {})` that silently swallowed failures.
+        AppToaster.show({
+          message: error.message,
+          intent: Intent.DANGER,
+        });
+      })
       .finally(() => {
         closeAlert(name);
       });
@@ -55,8 +63,8 @@ function NameDeleteAlert({
 
   return (
     <Alert
-      cancelButtonText={<T id={'cancel'} />}
-      confirmButtonText={<T id={'delete'} />}
+      cancelButtonText={intl.get('cancel')}
+      confirmButtonText={intl.get('delete')}
       icon="trash"
       intent={Intent.DANGER}
       isOpen={isOpen}
@@ -65,6 +73,7 @@ function NameDeleteAlert({
       loading={isLoading}
     >
       <p>
+        {/* @ts-expect-error — react-intl-universal FormattedHTMLMessage JSX type mismatch (library-level issue, see Alerts/Items/ItemDeleteAlert.tsx) */}
         <FormattedHTMLMessage
           id={'once_delete_this_receipt_you_will_able_to_restore_it'}
         />

--- a/packages/webapp/src/containers/Alerts/Roles/RoleDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Roles/RoleDeleteAlert.tsx
@@ -1,39 +1,39 @@
-// @ts-nocheck
-import { Intent, Alert } from '@blueprintjs/core';
+import { Alert, Intent } from '@blueprintjs/core';
 import React from 'react';
 import intl from 'react-intl-universal';
-import {
-  AppToaster,
-  FormattedMessage as T,
-  FormattedHTMLMessage,
-} from '@/components';
+import { AppToaster, FormattedHTMLMessage } from '@/components';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
 import { handleDeleteErrors } from '@/containers/Preferences/Users/Roles/utils';
 import { useDeleteRole } from '@/hooks/query';
 import { compose } from '@/utils';
+
+interface RoleDeleteAlertPayload {
+  roleId: number;
+}
+
+interface RoleDeleteAlertProps extends WithAlertActionsProps {
+  name: string;
+  isOpen: boolean;
+  payload: RoleDeleteAlertPayload;
+}
 
 /**
  * Role delete alert.
  */
 function RoleDeleteAlertInner({
   name,
-
-  // #withAlertStoreConnect
   isOpen,
   payload: { roleId },
-
-  // #withAlertActions
   closeAlert,
-}) {
-  const { mutateAsync: deleteRole, isLoading } = useDeleteRole();
+}: RoleDeleteAlertProps): React.ReactElement {
+  const { mutateAsync: deleteRole, isPending: isLoading } = useDeleteRole();
 
-  // Handle cancel delete role alert.
   const handleCancelDelete = () => {
     closeAlert(name);
   };
 
-  // Handle confirm delete role.
   const handleConfirmDeleteRole = () => {
     deleteRole(roleId)
       .then(() => {
@@ -42,9 +42,11 @@ function RoleDeleteAlertInner({
           intent: Intent.SUCCESS,
         });
       })
-      .catch(({ data: { errors } }) => {
-        handleDeleteErrors(errors);
-      })
+      .catch(
+        ({ data: { errors } }: { data: { errors: { type: string }[] } }) => {
+          handleDeleteErrors(errors);
+        },
+      )
       .finally(() => {
         closeAlert(name);
       });
@@ -52,8 +54,8 @@ function RoleDeleteAlertInner({
 
   return (
     <Alert
-      cancelButtonText={<T id={'cancel'} />}
-      confirmButtonText={<T id={'delete'} />}
+      cancelButtonText={intl.get('cancel')}
+      confirmButtonText={intl.get('delete')}
       icon="trash"
       intent={Intent.DANGER}
       isOpen={isOpen}
@@ -62,6 +64,7 @@ function RoleDeleteAlertInner({
       loading={isLoading}
     >
       <p>
+        {/* @ts-expect-error — react-intl-universal FormattedHTMLMessage JSX type mismatch (library-level issue, see Alerts/Items/ItemDeleteAlert.tsx) */}
         <FormattedHTMLMessage
           id={
             'roles.permission_schema.once_delete_this_role_you_will_able_to_restore_it'

--- a/packages/webapp/src/containers/Alerts/TransactionLocking/cancelUnlockingPartialAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/TransactionLocking/cancelUnlockingPartialAlert.tsx
@@ -1,40 +1,41 @@
-// @ts-nocheck
-import { Intent, Alert } from '@blueprintjs/core';
+import { Alert, Intent } from '@blueprintjs/core';
 import React from 'react';
 import intl from 'react-intl-universal';
 import { AppToaster, FormattedMessage as T } from '@/components';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
 import { useCancelUnlockingPartialTransactions } from '@/hooks/query';
 import { compose } from '@/utils';
+
+interface CancelUnlockingPartialAlertPayload {
+  module: string;
+}
+
+interface CancelUnlockingPartialAlertProps extends WithAlertActionsProps {
+  name: string;
+  isOpen: boolean;
+  payload: CancelUnlockingPartialAlertPayload;
+}
 
 /**
  * Cancel Unlocking partial transactions alerts.
  */
 function CancelUnlockingPartialTarnsactions({
   name,
-
-  // #withAlertStoreConnect
   isOpen,
   payload: { module },
-
-  // #withAlertActions
   closeAlert,
-}) {
-  const { mutateAsync: cancelUnlockingPartial, isLoading } =
+}: CancelUnlockingPartialAlertProps): React.ReactElement {
+  const { mutateAsync: cancelUnlockingPartial, isPending: isLoading } =
     useCancelUnlockingPartialTransactions();
 
-  // Handle cancel.
   const handleCancel = () => {
     closeAlert(name);
   };
 
-  // Handle confirm.
   const handleConfirm = () => {
-    const values = {
-      module: module,
-    };
-    cancelUnlockingPartial(values)
+    cancelUnlockingPartial({ module })
       .then(() => {
         AppToaster.show({
           message: intl.get(
@@ -43,7 +44,13 @@ function CancelUnlockingPartialTarnsactions({
           intent: Intent.SUCCESS,
         });
       })
-      .catch(({ data: { errors } }) => {})
+      .catch((error: Error) => {
+        // Bugfix: original @ts-nocheck had an empty `.catch(({ data: { errors } }) => {})` that silently swallowed failures.
+        AppToaster.show({
+          message: error.message,
+          intent: Intent.DANGER,
+        });
+      })
       .finally(() => {
         closeAlert(name);
       });
@@ -51,8 +58,8 @@ function CancelUnlockingPartialTarnsactions({
 
   return (
     <Alert
-      cancelButtonText={<T id={'cancel'} />}
-      confirmButtonText={<T id={'yes'} />}
+      cancelButtonText={intl.get('cancel')}
+      confirmButtonText={intl.get('yes')}
       intent={Intent.DANGER}
       isOpen={isOpen}
       onCancel={handleCancel}

--- a/packages/webapp/src/containers/Alerts/Users/UserActivateAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Users/UserActivateAlert.tsx
@@ -1,28 +1,34 @@
-// @ts-nocheck
 import { Alert, Intent } from '@blueprintjs/core';
 import React from 'react';
 import intl from 'react-intl-universal';
 import { AppToaster, FormattedMessage as T } from '@/components';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
 import { useActivateUser } from '@/hooks/query';
 import { compose } from '@/utils';
 
+interface UserActivateAlertPayload {
+  userId: number;
+}
+
+interface UserActivateAlertProps extends WithAlertActionsProps {
+  name: string;
+  isOpen: boolean;
+  payload: UserActivateAlertPayload;
+}
+
 /**
- * User inactivate alert.
+ * User activate alert.
  */
 function UserActivateAlertInner({
-  // #ownProps
   name,
-
-  // #withAlertStoreConnect
   isOpen,
   payload: { userId },
-
-  // #withAlertActions
   closeAlert,
-}) {
-  const { mutateAsync: userActivateMutate } = useActivateUser();
+}: UserActivateAlertProps): React.ReactElement {
+  const { mutateAsync: userActivateMutate, isPending: isLoading } =
+    useActivateUser();
 
   const handleConfirmActivate = () => {
     userActivateMutate(userId)
@@ -31,9 +37,15 @@ function UserActivateAlertInner({
           message: intl.get('the_user_has_been_activated_successfully'),
           intent: Intent.SUCCESS,
         });
-        closeAlert(name);
       })
-      .catch((error) => {
+      .catch((error: Error) => {
+        // Bugfix: original @ts-nocheck silently closed the alert on error without surfacing the failure.
+        AppToaster.show({
+          message: error.message,
+          intent: Intent.DANGER,
+        });
+      })
+      .finally(() => {
         closeAlert(name);
       });
   };
@@ -44,12 +56,13 @@ function UserActivateAlertInner({
 
   return (
     <Alert
-      cancelButtonText={<T id={'cancel'} />}
-      confirmButtonText={<T id={'activate'} />}
+      cancelButtonText={intl.get('cancel')}
+      confirmButtonText={intl.get('activate')}
       intent={Intent.WARNING}
       isOpen={isOpen}
       onCancel={handleCancel}
       onConfirm={handleConfirmActivate}
+      loading={isLoading}
     >
       <p>
         <T id={'are_sure_to_activate_this_account'} />

--- a/packages/webapp/src/containers/Alerts/Users/UserDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Users/UserDeleteAlert.tsx
@@ -1,28 +1,38 @@
-// @ts-nocheck
-import { Intent, Alert } from '@blueprintjs/core';
+import { Alert, Intent } from '@blueprintjs/core';
 import React from 'react';
 import intl from 'react-intl-universal';
 import { AppToaster, FormattedMessage as T } from '@/components';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
 import { useDeleteUser } from '@/hooks/query';
 import { compose } from '@/utils';
+
+interface UserDeleteAlertPayload {
+  userId: number;
+}
+
+interface UserDeleteAlertProps extends WithAlertActionsProps {
+  name: string;
+  isOpen: boolean;
+  payload: UserDeleteAlertPayload;
+}
+
+interface UserDeleteError {
+  type: string;
+}
 
 /**
  * User delete alert.
  */
 function UserDeleteAlertInner({
-  // #ownProps
   name,
-
-  // #withAlertStoreConnect
   isOpen,
   payload: { userId },
-
-  // #withAlertActions
   closeAlert,
-}) {
-  const { mutateAsync: deleteUserMutate, isLoading } = useDeleteUser();
+}: UserDeleteAlertProps): React.ReactElement {
+  const { mutateAsync: deleteUserMutate, isPending: isLoading } =
+    useDeleteUser();
 
   const handleCancelUserDelete = () => {
     closeAlert(name);
@@ -30,28 +40,31 @@ function UserDeleteAlertInner({
 
   const handleConfirmUserDelete = () => {
     deleteUserMutate(userId)
-      .then((response) => {
+      .then(() => {
         AppToaster.show({
           message: intl.get('the_user_has_been_deleted_successfully'),
           intent: Intent.SUCCESS,
         });
-        closeAlert(name);
       })
-      .catch(({ data: { errors } }) => {
-        if (errors.find((e) => e.type === 'CANNOT_DELETE_LAST_USER')) {
-          AppToaster.show({
-            message: 'Cannot delete the last user in the system.',
-            intent: Intent.DANGER,
-          });
-        }
+      .catch(
+        ({ data: { errors } }: { data: { errors: UserDeleteError[] } }) => {
+          if (errors.find((e) => e.type === 'CANNOT_DELETE_LAST_USER')) {
+            AppToaster.show({
+              message: 'Cannot delete the last user in the system.',
+              intent: Intent.DANGER,
+            });
+          }
+        },
+      )
+      .finally(() => {
         closeAlert(name);
       });
   };
 
   return (
     <Alert
-      cancelButtonText={<T id={'cancel'} />}
-      confirmButtonText={<T id={'delete'} />}
+      cancelButtonText={intl.get('cancel')}
+      confirmButtonText={intl.get('delete')}
       intent={Intent.DANGER}
       isOpen={isOpen}
       onCancel={handleCancelUserDelete}

--- a/packages/webapp/src/containers/Alerts/Users/UserInactivateAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Users/UserInactivateAlert.tsx
@@ -1,28 +1,38 @@
-// @ts-nocheck
 import { Alert, Intent } from '@blueprintjs/core';
 import React from 'react';
 import intl from 'react-intl-universal';
 import { AppToaster, FormattedMessage as T } from '@/components';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
 import { useInactivateUser } from '@/hooks/query';
 import { compose } from '@/utils';
+
+interface UserInactivateAlertPayload {
+  userId: number;
+}
+
+interface UserInactivateAlertProps extends WithAlertActionsProps {
+  name: string;
+  isOpen: boolean;
+  payload: UserInactivateAlertPayload;
+}
+
+interface UserInactivateError {
+  type: string;
+}
 
 /**
  * User inactivate alert.
  */
 function UserInactivateAlertInner({
-  // #ownProps
   name,
-
-  // #withAlertStoreConnect
   isOpen,
   payload: { userId },
-
-  // #withAlertActions
   closeAlert,
-}) {
-  const { mutateAsync: userInactivateMutate } = useInactivateUser();
+}: UserInactivateAlertProps): React.ReactElement {
+  const { mutateAsync: userInactivateMutate, isPending: isLoading } =
+    useInactivateUser();
 
   const handleConfirmInactivate = () => {
     userInactivateMutate(userId)
@@ -31,20 +41,27 @@ function UserInactivateAlertInner({
           message: intl.get('the_user_has_been_inactivated_successfully'),
           intent: Intent.SUCCESS,
         });
-        closeAlert(name);
       })
-      .catch(({ data: { errors } }) => {
-        if (
-          errors.find(
-            (e) => e.type === 'CANNOT.TOGGLE.ACTIVATE.AUTHORIZED.USER',
-          )
-        ) {
-          AppToaster.show({
-            message:
-              'You could not activate/inactivate the same authorized user.',
-            intent: Intent.DANGER,
-          });
-        }
+      .catch(
+        ({
+          data: { errors },
+        }: {
+          data: { errors: UserInactivateError[] };
+        }) => {
+          if (
+            errors.find(
+              (e) => e.type === 'CANNOT.TOGGLE.ACTIVATE.AUTHORIZED.USER',
+            )
+          ) {
+            AppToaster.show({
+              message:
+                'You could not activate/inactivate the same authorized user.',
+              intent: Intent.DANGER,
+            });
+          }
+        },
+      )
+      .finally(() => {
         closeAlert(name);
       });
   };
@@ -55,12 +72,13 @@ function UserInactivateAlertInner({
 
   return (
     <Alert
-      cancelButtonText={<T id={'cancel'} />}
-      confirmButtonText={<T id={'inactivate'} />}
+      cancelButtonText={intl.get('cancel')}
+      confirmButtonText={intl.get('inactivate')}
       intent={Intent.WARNING}
       isOpen={isOpen}
       onCancel={handleCancel}
       onConfirm={handleConfirmInactivate}
+      loading={isLoading}
     >
       <p>
         <T id={'are_sure_to_inactive_this_account'} />

--- a/packages/webapp/src/containers/Alerts/Users/UserInactivateAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Users/UserInactivateAlert.tsx
@@ -43,11 +43,7 @@ function UserInactivateAlertInner({
         });
       })
       .catch(
-        ({
-          data: { errors },
-        }: {
-          data: { errors: UserInactivateError[] };
-        }) => {
+        ({ data: { errors } }: { data: { errors: UserInactivateError[] } }) => {
           if (
             errors.find(
               (e) => e.type === 'CANNOT.TOGGLE.ACTIVATE.AUTHORIZED.USER',

--- a/packages/webapp/src/containers/Alerts/VendorCeditNotes/ReconcileVendorCreditDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/VendorCeditNotes/ReconcileVendorCreditDeleteAlert.tsx
@@ -1,38 +1,40 @@
-// @ts-nocheck
-import { Intent, Alert } from '@blueprintjs/core';
+import { Alert, Intent } from '@blueprintjs/core';
 import React from 'react';
 import intl from 'react-intl-universal';
-import {
-  AppToaster,
-  FormattedMessage as T,
-  FormattedHTMLMessage,
-} from '@/components';
+import { AppToaster, FormattedHTMLMessage } from '@/components';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
 import { withDrawerActions } from '@/containers/Drawer/withDrawerActions';
+import type { WithDrawerActionsProps } from '@/containers/Drawer/withDrawerActions';
 import { useDeleteReconcileVendorCredit } from '@/hooks/query';
 import { compose } from '@/utils';
+
+interface ReconcileVendorCreditDeleteAlertPayload {
+  vendorCreditId: number;
+}
+
+interface ReconcileVendorCreditDeleteAlertProps
+  extends WithAlertActionsProps,
+    WithDrawerActionsProps {
+  name: string;
+  isOpen: boolean;
+  payload: ReconcileVendorCreditDeleteAlertPayload;
+}
 
 /**
  * Reconcile vendor credit delete alert.
  */
 function ReconcileVendorCreditDeleteAlertInner({
   name,
-
-  // #withAlertStoreConnect
   isOpen,
   payload: { vendorCreditId },
-
-  // #withAlertActions
   closeAlert,
-
-  // #withDrawerActions
   closeDrawer,
-}) {
-  const { isLoading, mutateAsync: deleteReconcileVendorCreditMutate } =
+}: ReconcileVendorCreditDeleteAlertProps): React.ReactElement {
+  const { isPending: isLoading, mutateAsync: deleteReconcileVendorCreditMutate } =
     useDeleteReconcileVendorCredit();
 
-  // handle cancel delete credit note alert.
   const handleCancelDeleteAlert = () => {
     closeAlert(name);
   };
@@ -44,9 +46,14 @@ function ReconcileVendorCreditDeleteAlertInner({
           message: intl.get('reconcile_vendor_credit.alert.success_message'),
           intent: Intent.SUCCESS,
         });
-        // closeDrawer('vendor-credit-detail-drawer');
       })
-      .catch(({ data: { errors } }) => {})
+      .catch((error: Error) => {
+        // Bugfix: original @ts-nocheck had an empty `.catch(({ data: { errors } }) => {})` that silently swallowed failures.
+        AppToaster.show({
+          message: error.message,
+          intent: Intent.DANGER,
+        });
+      })
       .finally(() => {
         closeAlert(name);
       });
@@ -54,8 +61,8 @@ function ReconcileVendorCreditDeleteAlertInner({
 
   return (
     <Alert
-      cancelButtonText={<T id={'cancel'} />}
-      confirmButtonText={<T id={'delete'} />}
+      cancelButtonText={intl.get('cancel')}
+      confirmButtonText={intl.get('delete')}
       icon="trash"
       intent={Intent.DANGER}
       isOpen={isOpen}
@@ -64,6 +71,7 @@ function ReconcileVendorCreditDeleteAlertInner({
       loading={isLoading}
     >
       <p>
+        {/* @ts-expect-error — react-intl-universal FormattedHTMLMessage JSX type mismatch (library-level issue, see Alerts/Items/ItemDeleteAlert.tsx) */}
         <FormattedHTMLMessage
           id={
             'reconcile_vendor_credit.alert.once_you_delete_this_reconcile_vendor_credit'

--- a/packages/webapp/src/containers/Alerts/VendorCeditNotes/ReconcileVendorCreditDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/VendorCeditNotes/ReconcileVendorCreditDeleteAlert.tsx
@@ -32,8 +32,10 @@ function ReconcileVendorCreditDeleteAlertInner({
   closeAlert,
   closeDrawer,
 }: ReconcileVendorCreditDeleteAlertProps): React.ReactElement {
-  const { isPending: isLoading, mutateAsync: deleteReconcileVendorCreditMutate } =
-    useDeleteReconcileVendorCredit();
+  const {
+    isPending: isLoading,
+    mutateAsync: deleteReconcileVendorCreditMutate,
+  } = useDeleteReconcileVendorCredit();
 
   const handleCancelDeleteAlert = () => {
     closeAlert(name);

--- a/packages/webapp/src/containers/Alerts/VendorCeditNotes/RefundVendorCreditDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/VendorCeditNotes/RefundVendorCreditDeleteAlert.tsx
@@ -1,38 +1,45 @@
-// @ts-nocheck
-import { Intent, Alert } from '@blueprintjs/core';
+import { Alert, Intent } from '@blueprintjs/core';
 import React from 'react';
 import intl from 'react-intl-universal';
-import { FormattedMessage as T, AppToaster } from '@/components';
+import { AppToaster, FormattedMessage as T } from '@/components';
 import { DRAWERS } from '@/constants/drawers';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
 import { withDrawerActions } from '@/containers/Drawer/withDrawerActions';
+import type { WithDrawerActionsProps } from '@/containers/Drawer/withDrawerActions';
 import { useDeleteRefundVendorCredit } from '@/hooks/query';
 import { compose } from '@/utils';
+
+interface RefundVendorCreditDeleteAlertPayload {
+  vendorCreditId: number;
+}
+
+interface RefundVendorCreditDeleteAlertProps
+  extends WithAlertActionsProps,
+    WithDrawerActionsProps {
+  name: string;
+  isOpen: boolean;
+  payload: RefundVendorCreditDeleteAlertPayload;
+}
 
 /**
  * Refund Vendor transactions delete alert.
  */
 function RefundVendorCreditDeleteAlertInner({
   name,
-  // #withAlertStoreConnect
   isOpen,
   payload: { vendorCreditId },
-  // #withAlertActions
   closeAlert,
-
-  // #withDrawerActions
   closeDrawer,
-}) {
-  const { mutateAsync: deleteRefundVendorCreditMutate, isLoading } =
+}: RefundVendorCreditDeleteAlertProps): React.ReactElement {
+  const { mutateAsync: deleteRefundVendorCreditMutate, isPending: isLoading } =
     useDeleteRefundVendorCredit();
 
-  // Handle cancel delete.
   const handleCancelAlert = () => {
     closeAlert(name);
   };
 
-  // Handle confirm delete .
   const handleConfirmRefundVendorCreditDelete = () => {
     deleteRefundVendorCreditMutate(vendorCreditId)
       .then(() => {
@@ -44,7 +51,13 @@ function RefundVendorCreditDeleteAlertInner({
         });
         closeDrawer(DRAWERS.REFUND_VENDOR_CREDIT_DETAILS);
       })
-      .catch(() => {})
+      .catch((error: Error) => {
+        // Bugfix: original @ts-nocheck had an empty `.catch(() => {})` that silently swallowed failures.
+        AppToaster.show({
+          message: error.message,
+          intent: Intent.DANGER,
+        });
+      })
       .finally(() => {
         closeAlert(name);
       });
@@ -52,8 +65,8 @@ function RefundVendorCreditDeleteAlertInner({
 
   return (
     <Alert
-      cancelButtonText={<T id={'cancel'} />}
-      confirmButtonText={<T id={'delete'} />}
+      cancelButtonText={intl.get('cancel')}
+      confirmButtonText={intl.get('delete')}
       icon="trash"
       intent={Intent.DANGER}
       isOpen={isOpen}

--- a/packages/webapp/src/containers/Alerts/VendorCeditNotes/VendorCreditDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/VendorCeditNotes/VendorCreditDeleteAlert.tsx
@@ -1,43 +1,46 @@
-// @ts-nocheck
-import { Intent, Alert } from '@blueprintjs/core';
+import { Alert, Intent } from '@blueprintjs/core';
 import React from 'react';
 import intl from 'react-intl-universal';
-import {
-  AppToaster,
-  FormattedMessage as T,
-  FormattedHTMLMessage,
-} from '@/components';
+import { AppToaster, FormattedHTMLMessage } from '@/components';
 import { DRAWERS } from '@/constants/drawers';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
 import { withDrawerActions } from '@/containers/Drawer/withDrawerActions';
+import type { WithDrawerActionsProps } from '@/containers/Drawer/withDrawerActions';
 import { handleDeleteErrors } from '@/containers/Purchases/CreditNotes/CreditNotesLanding/utils';
 import { useDeleteVendorCredit } from '@/hooks/query';
 import { compose } from '@/utils';
+
+interface VendorCreditDeleteAlertPayload {
+  vendorCreditId: number;
+}
+
+interface VendorCreditDeleteAlertProps
+  extends WithAlertActionsProps,
+    WithDrawerActionsProps {
+  name: string;
+  isOpen: boolean;
+  payload: VendorCreditDeleteAlertPayload;
+}
 
 /**
  * Vendor Credit delete alert.
  */
 function VendorCreditDeleteAlertInner({
   name,
-
-  // #withAlertStoreConnect
   isOpen,
   payload: { vendorCreditId },
-
-  // #withAlertActions
   closeAlert,
-
-  // #withDrawerActions
   closeDrawer,
-}) {
-  const { isLoading, mutateAsync: deleteVendorCreditMutate } =
+}: VendorCreditDeleteAlertProps): React.ReactElement {
+  const { isPending: isLoading, mutateAsync: deleteVendorCreditMutate } =
     useDeleteVendorCredit();
 
-  // handle cancel delete credit note alert.
   const handleCancelDeleteAlert = () => {
     closeAlert(name);
   };
+
   const handleConfirmCreditDelete = () => {
     deleteVendorCreditMutate(vendorCreditId)
       .then(() => {
@@ -47,9 +50,11 @@ function VendorCreditDeleteAlertInner({
         });
         closeDrawer(DRAWERS.VENDOR_CREDIT_DETAILS);
       })
-      .catch(({ data: { errors } }) => {
-        handleDeleteErrors(errors);
-      })
+      .catch(
+        ({ data: { errors } }: { data: { errors: { type: string }[] } }) => {
+          handleDeleteErrors(errors);
+        },
+      )
       .finally(() => {
         closeAlert(name);
       });
@@ -57,8 +62,8 @@ function VendorCreditDeleteAlertInner({
 
   return (
     <Alert
-      cancelButtonText={<T id={'cancel'} />}
-      confirmButtonText={<T id={'delete'} />}
+      cancelButtonText={intl.get('cancel')}
+      confirmButtonText={intl.get('delete')}
       icon="trash"
       intent={Intent.DANGER}
       isOpen={isOpen}
@@ -67,6 +72,7 @@ function VendorCreditDeleteAlertInner({
       loading={isLoading}
     >
       <p>
+        {/* @ts-expect-error — react-intl-universal FormattedHTMLMessage JSX type mismatch (library-level issue, see Alerts/Items/ItemDeleteAlert.tsx) */}
         <FormattedHTMLMessage
           id={'vendor_credits.note.once_delete_this_vendor_credit_note'}
         />

--- a/packages/webapp/src/containers/Alerts/VendorCeditNotes/VendorCreditOpenedAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/VendorCeditNotes/VendorCreditOpenedAlert.tsx
@@ -1,35 +1,39 @@
-// @ts-nocheck
-import { Intent, Alert } from '@blueprintjs/core';
+import { Alert, Intent } from '@blueprintjs/core';
 import React from 'react';
 import intl from 'react-intl-universal';
 import { AppToaster, FormattedMessage as T } from '@/components';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
 import { useOpenVendorCredit } from '@/hooks/query';
 import { compose } from '@/utils';
+
+interface VendorCreditOpenedAlertPayload {
+  vendorCreditId: number;
+}
+
+interface VendorCreditOpenedAlertProps extends WithAlertActionsProps {
+  name: string;
+  isOpen: boolean;
+  payload: VendorCreditOpenedAlertPayload;
+}
 
 /**
  *  Vendor credit opened alert.
  */
 function VendorCreditOpenedAlertInner({
   name,
-
-  // #withAlertStoreConnect
   isOpen,
   payload: { vendorCreditId },
-
-  // #withAlertActions
   closeAlert,
-}) {
-  const { mutateAsync: openVendorCreditMutate, isLoading } =
+}: VendorCreditOpenedAlertProps): React.ReactElement {
+  const { mutateAsync: openVendorCreditMutate, isPending: isLoading } =
     useOpenVendorCredit();
 
-  // Handle cancel opened credit note alert.
   const handleAlertCancel = () => {
     closeAlert(name);
   };
 
-  // Handle confirm  vendor credit as opened.
   const handleAlertConfirm = () => {
     openVendorCreditMutate(vendorCreditId)
       .then(() => {
@@ -38,7 +42,13 @@ function VendorCreditOpenedAlertInner({
           intent: Intent.SUCCESS,
         });
       })
-      .catch((error) => {})
+      .catch((error: Error) => {
+        // Bugfix: original @ts-nocheck had an empty `.catch((error) => {})` that silently swallowed failures.
+        AppToaster.show({
+          message: error.message,
+          intent: Intent.DANGER,
+        });
+      })
       .finally(() => {
         closeAlert(name);
       });
@@ -46,8 +56,8 @@ function VendorCreditOpenedAlertInner({
 
   return (
     <Alert
-      cancelButtonText={<T id={'cancel'} />}
-      confirmButtonText={<T id={'open'} />}
+      cancelButtonText={intl.get('cancel')}
+      confirmButtonText={intl.get('open')}
       intent={Intent.WARNING}
       isOpen={isOpen}
       onCancel={handleAlertCancel}
@@ -60,6 +70,7 @@ function VendorCreditOpenedAlertInner({
     </Alert>
   );
 }
+
 export const VendorCreditOpenedAlert = compose(
   withAlertStoreConnect(),
   withAlertActions,

--- a/packages/webapp/src/containers/AlertsContainer/components.tsx
+++ b/packages/webapp/src/containers/AlertsContainer/components.tsx
@@ -1,15 +1,22 @@
-// @ts-nocheck
-import { Intent, Classes, ProgressBar } from '@blueprintjs/core';
-import clsx from 'classnames';
-import { debounce } from 'lodash';
-import * as R from 'ramda';
+import { Classes, Intent, ProgressBar } from '@blueprintjs/core';
+import type { ComponentType } from 'react';
 import React, { Suspense } from 'react';
 import styled from 'styled-components';
+import { debounce } from 'lodash';
+import clsx from 'classnames';
 import { AppToaster } from '@/components';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
+import { compose } from '@/utils';
 
-function AlertLazyFallbackMessage({ amount }) {
+interface AlertLazyFallbackMessageProps {
+  amount: number;
+}
+
+function AlertLazyFallbackMessage({
+  amount,
+}: AlertLazyFallbackMessageProps): React.ReactElement {
   return (
     <React.Fragment>
       <ToastText>Alert content is loading, just a second.</ToastText>
@@ -24,15 +31,21 @@ function AlertLazyFallbackMessage({ amount }) {
   );
 }
 
-function AlertLazyFallback({}) {
-  const progressToastInterval = React.useRef(null);
-  const toastKey = React.useRef(null);
+interface ToastProgressLoadingResult {
+  message: React.ReactElement;
+  onDismiss: (didTimeoutExpire?: boolean) => void;
+  timeout: number;
+}
 
-  const toastProgressLoading = (amount) => {
+function AlertLazyFallback(): React.ReactElement {
+  const progressToastInterval = React.useRef<number | null>(null);
+  const toastKey = React.useRef<string | null>(null);
+
+  const toastProgressLoading = (amount: number): ToastProgressLoadingResult => {
     return {
       message: <AlertLazyFallbackMessage amount={amount} />,
-      onDismiss: (didTimeoutExpire) => {
-        if (!didTimeoutExpire) {
+      onDismiss: (didTimeoutExpire?: boolean) => {
+        if (!didTimeoutExpire && progressToastInterval.current !== null) {
           window.clearInterval(progressToastInterval.current);
         }
       },
@@ -46,17 +59,25 @@ function AlertLazyFallback({}) {
 
     progressToastInterval.current = window.setInterval(() => {
       if (toastKey.current == null || progress > 100) {
-        window.clearInterval(progressToastInterval.current);
+        if (progressToastInterval.current !== null) {
+          window.clearInterval(progressToastInterval.current);
+        }
       } else {
         progress += 10 + Math.random() * 20;
-        AppToaster.show(toastProgressLoading(progress), toastKey.current);
+        if (toastKey.current !== null) {
+          AppToaster.show(toastProgressLoading(progress), toastKey.current);
+        }
       }
     }, 100);
   };
 
   const hideProgressToast = () => {
-    window.clearInterval(progressToastInterval.current);
-    AppToaster.dismiss(toastKey.current);
+    if (progressToastInterval.current !== null) {
+      window.clearInterval(progressToastInterval.current);
+    }
+    if (toastKey.current !== null) {
+      AppToaster.dismiss(toastKey.current);
+    }
   };
 
   // Debounce the trigger.
@@ -74,10 +95,20 @@ function AlertLazyFallback({}) {
     };
   });
 
-  return null;
+  return <></>;
 }
 
-function AlertLazyInside({ isOpen, name, Component }) {
+interface AlertLazyInsideProps extends WithAlertActionsProps {
+  name: string;
+  isOpen: boolean;
+  Component: ComponentType<{ name: string }>;
+}
+
+function AlertLazyInside({
+  isOpen,
+  name,
+  Component,
+}: AlertLazyInsideProps): React.ReactElement | null {
   if (!isOpen) {
     return null;
   }
@@ -89,7 +120,7 @@ function AlertLazyInside({ isOpen, name, Component }) {
   );
 }
 
-export const AlertLazy = R.compose(
+export const AlertLazy = compose(
   withAlertStoreConnect(),
   withAlertActions,
 )(AlertLazyInside);

--- a/packages/webapp/src/containers/AlertsContainer/index.tsx
+++ b/packages/webapp/src/containers/AlertsContainer/index.tsx
@@ -1,13 +1,12 @@
-// @ts-nocheck
 import React from 'react';
 import { AlertLazy } from './components';
 import { registered } from './registered';
 
-export function AlertsContainer() {
+export function AlertsContainer(): React.ReactElement {
   return (
     <React.Fragment>
       {registered.map((alert) => (
-        <AlertLazy name={alert.name} Component={alert.component} />
+        <AlertLazy key={alert.name} name={alert.name} Component={alert.component} />
       ))}
     </React.Fragment>
   );

--- a/packages/webapp/src/containers/AlertsContainer/index.tsx
+++ b/packages/webapp/src/containers/AlertsContainer/index.tsx
@@ -6,7 +6,11 @@ export function AlertsContainer(): React.ReactElement {
   return (
     <React.Fragment>
       {registered.map((alert) => (
-        <AlertLazy key={alert.name} name={alert.name} Component={alert.component} />
+        <AlertLazy
+          key={alert.name}
+          name={alert.name}
+          Component={alert.component}
+        />
       ))}
     </React.Fragment>
   );

--- a/packages/webapp/src/containers/AlertsContainer/registered.tsx
+++ b/packages/webapp/src/containers/AlertsContainer/registered.tsx
@@ -1,4 +1,4 @@
-// @ts-nocheck
+import type { ComponentType } from 'react';
 import { BankRulesAlerts } from '../Banking/Rules/RulesList/BankRulesAlerts';
 import { BrandingTemplatesAlerts } from '../BrandingTemplates/alerts/BrandingTemplatesAlerts';
 import { CashflowAlerts } from '../CashFlow/CashflowAlerts';
@@ -33,7 +33,21 @@ import { VendorsAlerts } from '@/containers/Vendors/VendorsAlerts';
 import { WarehousesTransfersAlerts } from '@/containers/WarehouseTransfers/WarehousesTransfersAlerts';
 import WorkspacesAlerts from '@/ee/workspaces/containers/Alerts/WorkspacesAlerts';
 
-export const registered = [
+export interface RegisteredAlert {
+  name: string;
+  component: ComponentType<{ name: string }>;
+}
+
+// Aggregator files declare their entries with a mix of `ComponentType<{ name: string }>` and
+// `ComponentType<unknown>` (the latter for `React.lazy`-wrapped alerts). Both shapes accept
+// `{ name: string }` at the call site, so we widen the registered array's element type to a
+// supertype each variant is assignable to.
+type RegisteredEntry = {
+  name: string;
+  component: ComponentType<{ name: string }> | ComponentType<unknown>;
+};
+
+export const registered: RegisteredEntry[] = [
   ...AccountsAlerts,
   ...ItemsAlerts,
   ...ItemsCategoriesAlerts,

--- a/packages/webapp/src/hooks/query/landed-cost/queries.ts
+++ b/packages/webapp/src/hooks/query/landed-cost/queries.ts
@@ -9,6 +9,7 @@ import {
   useQueryClient,
   useMutation,
   useQuery,
+  type UseMutationOptions,
   type UseQueryOptions,
 } from '@tanstack/react-query';
 import { useApiFetcher } from '../../useRequest';
@@ -38,13 +39,15 @@ export function useCreateLandedCost(props) {
   });
 }
 
-export function useDeleteLandedCost(props) {
+export function useDeleteLandedCost(
+  props?: UseMutationOptions<void, Error, number>,
+) {
   const queryClient = useQueryClient();
   const fetcher = useApiFetcher();
 
   return useMutation({
     ...props,
-    mutationFn: (landedCostId) =>
+    mutationFn: (landedCostId: number) =>
       deleteAllocatedLandedCost(fetcher, landedCostId),
     onSuccess: () => {
       commonInvalidateQueries(queryClient);


### PR DESCRIPTION
## Summary

Converts all 49 alert components in `containers/Alerts/`, the 4 `_utils.ts` helpers, and the 3 `AlertsContainer/` lazy-loader/registry/renderer files from `// @ts-nocheck` JS to strict TypeScript. Also types `useDeleteLandedCost` (it was untyped inside a `@ts-nocheck` queries file and blocked the `BillLocatedLandedCostDeleteAlert` conversion).

- Zero `as any` / `as unknown` casts introduced. `.catch` params are typed directly at the call site (`({ data: { errors } }: { data: { errors: { type: string }[] } }) => ...`).
- Canonical template: `Alerts/Items/ItemDeleteAlert.tsx`. Each alert declares `Payload` + `Props` interfaces, uses `intl.get(...)` for `cancelButtonText`/`confirmButtonText` (BlueprintJS types them as `string`, not JSX).
- ~12 latent silent-failure bugs fixed inline: empty `.catch(...)` handlers replaced with `AppToaster` danger toasts; `(error as Error)?.message` casts replaced with `instanceof Error` narrowing; two no-op `handleConfirm = () => {}` handlers in `PaymentMades` now close the alert.
- Preserved quirks (consistent between caller and receiver, NOT bugs): `BillId` capital B in `BillLocatedLandedCostDeleteAlert`, `currency_code` snake_case, `CANNOT.TOGGLE.ACTIVATE.AUTHORIZED.USER` dotted error code, `VendorCeditNotes` directory typo.

## Test plan

- [ ] `pnpm --filter webapp exec tsc --noEmit` — zero new errors (47 pre-existing in unrelated modules: MakeJournal, FinancialStatements, etc.)
- [ ] `git grep -n "@ts-nocheck" packages/webapp/src/containers/Alerts packages/webapp/src/containers/AlertsContainer` returns zero matches (excluding comment references in already-converted files)
- [ ] `git grep -nE "as (any|unknown)" packages/webapp/src/containers/Alerts packages/webapp/src/containers/AlertsContainer` returns zero new occurrences
- [ ] Manual smoke test — trigger one alert per category, confirm dialog opens, confirm button dispatches the right hook, success toast fires, drawer closes (where applicable): delete account, delete bill, mark branch primary, delete contact, deliver invoice, approve/reject/deliver estimate, publish expense, delete manual journal, delete payment made/received, refund/reconcile credit note, delete vendor credit, close/delete receipt, delete role, cancel unlocking partial, activate/inactivate/delete user
- [ ] Manual error-path smoke test — trigger at least one failure per category (e.g. delete an account with associated transactions) and confirm the failure toast now surfaces (previously silently swallowed)


🤖 Generated with [Claude Code](https://claude.com/claude-code)