### PR TITLE
fix: hydrate general preferences form by aligning keys with camelCase API

### DIFF
--- a/packages/server/src/modules/Organization/dtos/Organization.dto.ts
+++ b/packages/server/src/modules/Organization/dtos/Organization.dto.ts
@@ -6,10 +6,44 @@ import {
   IsISO4217CurrencyCode,
   IsOptional,
   IsString,
+  ValidateNested,
 } from 'class-validator';
+import { Type } from 'class-transformer';
 import { MONTHS } from '../Organization/constants';
 import { ACCEPTED_LOCALES, DATE_FORMATS } from '../Organization.constants';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class OrganizationAddressDto {
+  @IsOptional()
+  @IsString()
+  @ApiPropertyOptional({ example: '123 Main St' })
+  address1?: string;
+
+  @IsOptional()
+  @IsString()
+  @ApiPropertyOptional({ example: 'Suite 100' })
+  address2?: string;
+
+  @IsOptional()
+  @IsString()
+  @ApiPropertyOptional({ example: '10001' })
+  postalCode?: string;
+
+  @IsOptional()
+  @IsString()
+  @ApiPropertyOptional({ example: 'New York' })
+  city?: string;
+
+  @IsOptional()
+  @IsString()
+  @ApiPropertyOptional({ example: 'NY' })
+  stateProvince?: string;
+
+  @IsOptional()
+  @IsString()
+  @ApiPropertyOptional({ example: '+1-555-123-4567' })
+  phone?: string;
+}
 
 export class BuildOrganizationDto {
   @IsString()
@@ -137,25 +171,13 @@ export class UpdateOrganizationDto {
   dateFormat?: string;
 
   @IsOptional()
+  @ValidateNested()
+  @Type(() => OrganizationAddressDto)
   @ApiPropertyOptional({
     description: 'Organization address details',
-    example: {
-      address_1: '123 Main St',
-      address_2: 'Suite 100',
-      postal_code: '10001',
-      city: 'New York',
-      stateProvince: 'NY',
-      phone: '+1-555-123-4567',
-    },
+    type: () => OrganizationAddressDto,
   })
-  address?: {
-    address_1?: string;
-    address_2?: string;
-    postal_code?: string;
-    city?: string;
-    stateProvince?: string;
-    phone?: string;
-  };
+  address?: OrganizationAddressDto;
 
   @IsOptional()
   @IsHexColor()

--- a/packages/webapp/src/containers/Preferences/General/General.schema.tsx
+++ b/packages/webapp/src/containers/Preferences/General/General.schema.tsx
@@ -3,16 +3,16 @@ import * as Yup from 'yup';
 
 const Schema = Yup.object().shape({
   name: Yup.string().required().label(intl.get('organization_name_')),
-  tax_number: Yup.string()
+  taxNumber: Yup.string()
     .nullable()
     .label(intl.get('organization_tax_number_')),
   industry: Yup.string().nullable().label(intl.get('organization_industry_')),
   location: Yup.string().nullable().label(intl.get('location')),
-  base_currency: Yup.string().required().label(intl.get('base_currency_')),
-  fiscal_year: Yup.string().required().label(intl.get('fiscal_year_')),
+  baseCurrency: Yup.string().required().label(intl.get('base_currency_')),
+  fiscalYear: Yup.string().required().label(intl.get('fiscal_year_')),
   language: Yup.string().required().label(intl.get('language')),
   timezone: Yup.string().required().label(intl.get('time_zone_')),
-  date_format: Yup.string().required().label(intl.get('date_format_')),
+  dateFormat: Yup.string().required().label(intl.get('date_format_')),
 });
 
 export const PreferencesGeneralSchema = Schema;

--- a/packages/webapp/src/containers/Preferences/General/GeneralForm.tsx
+++ b/packages/webapp/src/containers/Preferences/General/GeneralForm.tsx
@@ -70,13 +70,13 @@ export function PreferencesGeneralForm({
 
       {/* ---------- Organization Tax Number ----------  */}
       <FFormGroup
-        name={'tax_number'}
+        name={'taxNumber'}
         label={intl.get('organization_tax_number')}
         inline={true}
         helperText={<T id={'shown_on_sales_forms_and_purchase_orders'} />}
         fastField={true}
       >
-        <FInputGroup medium={true} name={'tax_number'} fastField={true} />
+        <FInputGroup medium={true} name={'taxNumber'} fastField={true} />
       </FFormGroup>
 
       {/* ---------- Industry ----------  */}
@@ -129,14 +129,14 @@ export function PreferencesGeneralForm({
           <Group spacing={15}>
             <FInputGroup name={'address.city'} placeholder={'City'} fastField />
             <FInputGroup
-              name={'address.postal_code'}
+              name={'address.postalCode'}
               placeholder={'ZIP Code'}
               fastField
             />
           </Group>
           <Group spacing={15}>
             <FInputGroup
-              name={'address.state_province'}
+              name={'address.stateProvince'}
               placeholder={'State or Province'}
               fastField
             />
@@ -151,7 +151,7 @@ export function PreferencesGeneralForm({
 
       {/* ----------  Base currency ----------  */}
       <FFormGroup
-        name={'base_currency'}
+        name={'baseCurrency'}
         baseCurrencyDisabled={baseCurrencyDisabled}
         label={intl.get('base_currency')}
         labelInfo={<FieldRequiredHint />}
@@ -165,7 +165,7 @@ export function PreferencesGeneralForm({
         shouldUpdate={shouldBaseCurrencyUpdate}
       >
         <FSelect
-          name={'base_currency'}
+          name={'baseCurrency'}
           items={Currencies}
           valueAccessor={'key'}
           textAccessor={'name'}
@@ -181,7 +181,7 @@ export function PreferencesGeneralForm({
 
       {/* --------- Fiscal Year ----------- */}
       <FFormGroup
-        name={'fiscal_year'}
+        name={'fiscalYear'}
         label={intl.get('fiscal_year')}
         labelInfo={<FieldRequiredHint />}
         inline={true}
@@ -189,7 +189,7 @@ export function PreferencesGeneralForm({
         fastField={true}
       >
         <FSelect
-          name={'fiscal_year'}
+          name={'fiscalYear'}
           items={FiscalYear}
           valueAccessor={'key'}
           textAccessor={'name'}
@@ -223,15 +223,15 @@ export function PreferencesGeneralForm({
 
       {/* --------- Data format ----------- */}
       <FFormGroup
-        name={'date_format'}
+        name={'dateFormat'}
         label={intl.get('date_format')}
         labelInfo={<FieldRequiredHint />}
         inline={true}
-        helperText={<ErrorMessage name="date_format" />}
+        helperText={<ErrorMessage name="dateFormat" />}
         fastField={true}
       >
         <FSelect
-          name={'date_format'}
+          name={'dateFormat'}
           items={dateFormats ?? []}
           valueAccessor={'key'}
           textAccessor={'label'}

--- a/packages/webapp/src/containers/Preferences/General/GeneralFormPage.tsx
+++ b/packages/webapp/src/containers/Preferences/General/GeneralFormPage.tsx
@@ -18,12 +18,12 @@ const defaultValues: GeneralFormValues = {
   name: '',
   industry: '',
   location: '',
-  base_currency: '',
+  baseCurrency: '',
   language: '',
-  fiscal_year: '',
-  date_format: '',
+  fiscalYear: '',
+  dateFormat: '',
   timezone: '',
-  tax_number: '',
+  taxNumber: '',
   address: {},
 };
 
@@ -77,7 +77,7 @@ function GeneralFormPageInner({
     const onError = () => {
       setSubmitting(false);
     };
-    updateOrganization({ ...values } as never)
+    updateOrganization({ ...values })
       .then(onSuccess)
       .catch(onError);
   };

--- a/packages/webapp/src/containers/Preferences/General/types.ts
+++ b/packages/webapp/src/containers/Preferences/General/types.ts
@@ -2,30 +2,26 @@ export interface GeneralFormAddress {
   address1?: string;
   address2?: string;
   city?: string;
-  postal_code?: string;
-  state_province?: string;
+  postalCode?: string;
+  stateProvince?: string;
   phone?: string;
 }
 
 /**
  * General preferences form values.
  *
- * NOTE: snake_case keys are preserved for `tax_number`, `base_currency`,
- * `fiscal_year`, `date_format`, and the nested `address` object because they
- * are read from / written to `organization.metadata`, which is a free-form
- * JSON blob stored as-is by the server. Renaming would silently break the
- * round-trip without a migration. The Address sub-interface mirrors the same
- * constraint.
+ * Keys are camelCase to match the organization metadata API
+ * (`GET/PUT /api/organization`), so values hydrate and persist as-is.
  */
 export interface GeneralFormValues {
   name: string;
   industry?: string;
   location?: string;
-  base_currency: string;
+  baseCurrency: string;
   language: string;
-  fiscal_year: string;
-  date_format: string;
+  fiscalYear: string;
+  dateFormat: string;
   timezone: string;
-  tax_number?: string;
+  taxNumber?: string;
   address: GeneralFormAddress;
 }

--- a/packages/webapp/src/containers/Preferences/Invoices/PreferencesInvoiceFormPage.tsx
+++ b/packages/webapp/src/containers/Preferences/Invoices/PreferencesInvoiceFormPage.tsx
@@ -1,7 +1,7 @@
 import { Intent } from '@blueprintjs/core';
 import { Formik, FormikHelpers } from 'formik';
 import * as R from 'ramda';
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import intl from 'react-intl-universal';
 import { transferObjectOptionsToArray } from '../Accountant/utils';
 import { PreferencesInvoiceFormSchema } from './PreferencesInvoiceForm.schema';

--- a/shared/sdk-ts/openapi.json
+++ b/shared/sdk-ts/openapi.json
@@ -42800,6 +42800,35 @@
           "language"
         ]
       },
+      "OrganizationAddressDto": {
+        "type": "object",
+        "properties": {
+          "address1": {
+            "type": "string",
+            "example": "123 Main St"
+          },
+          "address2": {
+            "type": "string",
+            "example": "Suite 100"
+          },
+          "postalCode": {
+            "type": "string",
+            "example": "10001"
+          },
+          "city": {
+            "type": "string",
+            "example": "New York"
+          },
+          "stateProvince": {
+            "type": "string",
+            "example": "NY"
+          },
+          "phone": {
+            "type": "string",
+            "example": "+1-555-123-4567"
+          }
+        }
+      },
       "UpdateOrganizationDto": {
         "type": "object",
         "properties": {
@@ -42844,16 +42873,12 @@
             "example": "MM/DD/YYYY"
           },
           "address": {
-            "type": "object",
             "description": "Organization address details",
-            "example": {
-              "address_1": "123 Main St",
-              "address_2": "Suite 100",
-              "postal_code": "10001",
-              "city": "New York",
-              "stateProvince": "NY",
-              "phone": "+1-555-123-4567"
-            }
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OrganizationAddressDto"
+              }
+            ]
           },
           "primaryColor": {
             "type": "string",

--- a/shared/sdk-ts/src/pdf-templates.ts
+++ b/shared/sdk-ts/src/pdf-templates.ts
@@ -72,7 +72,7 @@ export async function createPdfTemplate(
   values: CreatePdfTemplateBody
 ): Promise<void> {
   const post = fetcher.path(PDF_TEMPLATES_ROUTES.LIST).method('post').create();
-  await (post as (body: CreatePdfTemplateBody) => Promise<unknown>)(values);
+  await post(values as never);
 }
 
 export async function editPdfTemplate(
@@ -81,7 +81,7 @@ export async function editPdfTemplate(
   values: EditPdfTemplateBody
 ): Promise<void> {
   const put = fetcher.path(PDF_TEMPLATES_ROUTES.BY_ID).method('put').create();
-  await (put as (params: { id: number } & EditPdfTemplateBody) => Promise<unknown>)({ id, ...values });
+  await put({ id, ...values } as never);
 }
 
 export async function deletePdfTemplate(fetcher: ApiFetcher, id: number): Promise<void> {

--- a/shared/sdk-ts/src/schema.ts
+++ b/shared/sdk-ts/src/schema.ts
@@ -15994,6 +15994,20 @@ export interface components {
              */
             dateFormat?: string;
         };
+        OrganizationAddressDto: {
+            /** @example 123 Main St */
+            address1?: string;
+            /** @example Suite 100 */
+            address2?: string;
+            /** @example 10001 */
+            postalCode?: string;
+            /** @example New York */
+            city?: string;
+            /** @example NY */
+            stateProvince?: string;
+            /** @example +1-555-123-4567 */
+            phone?: string;
+        };
         UpdateOrganizationDto: {
             /**
              * @description Organization name
@@ -16035,18 +16049,8 @@ export interface components {
              * @example MM/DD/YYYY
              */
             dateFormat?: string;
-            /**
-             * @description Organization address details
-             * @example {
-             *       "address_1": "123 Main St",
-             *       "address_2": "Suite 100",
-             *       "postal_code": "10001",
-             *       "city": "New York",
-             *       "stateProvince": "NY",
-             *       "phone": "+1-555-123-4567"
-             *     }
-             */
-            address?: Record<string, never>;
+            /** @description Organization address details */
+            address?: components["schemas"]["OrganizationAddressDto"];
             /**
              * @description Primary brand color in hex format
              * @example #4285F4


### PR DESCRIPTION
## Summary

The **General preferences** form did not hydrate most of its fields, and saving it silently dropped those same fields. Root cause was a casing mismatch across the whole round-trip:

- `GET /api/organization/current` returns `metadata` with **camelCase** keys (`baseCurrency`, `fiscalYear`, `dateFormat`, `taxNumber`, `address: { address1, address2, city, postalCode, stateProvince, phone }`) — the canonical shape per `TenantMetadataModel` and `OrganizationAddressDTO`.
- The form's `defaultValues` and Formik field names were **snake_case** (`base_currency`, `fiscal_year`, `date_format`, `tax_number`, `address.postal_code`, `address.state_province`).
- Hydration goes through `transformToForm(obj, defaults)`, which keeps only keys present in `defaultValues` — so the camelCase API keys were dropped and the fields stayed empty.
- On submit, the snake_case keys hit the server's global `ValidationPipe` with `whitelist: true`, which stripped every undecorated property — they were silently **not persisted**.

Changes:

- **Webapp** (`Preferences/General/`): renamed form value keys to camelCase in `types.ts`, `GeneralFormPage.tsx`, `General.schema.tsx`, and `GeneralForm.tsx`; removed the `as never` submit cast — values now type-check against `UpdateOrganizationBody` directly.
- **Server** (`Organization.dto.ts`): added a proper nested `OrganizationAddressDto` (camelCase, mirroring `OrganizationAddressDTO` in `Organization.types.ts`) wired into `UpdateOrganizationDto.address` with `@ValidateNested()`/`@Type()`, replacing the inline object whose example keys were stale.
- **SDK**: regenerated `openapi.json`/`schema.ts` and rebuilt `dist` — `UpdateOrganizationBody['address']` is now the typed nested DTO instead of `Record<string, never>`.
- **SDK build fix** (separate commit): create/edit PDF template endpoints have untyped `Record<string, never>` request bodies, which failed the sdk-ts DTS build; cast the call argument `as never` (pattern already used in `organization.ts`) to unblock the build.
- Note: address blobs saved before this fix contain the old sub-keys (`postal_code`, `state_province`); they will not re-hydrate those two subfields (accepted — the server's own address formatter already reads the camelCase keys).

## Test plan

- [x] `pnpm --filter @bigcapital/server typecheck` — passes
- [x] webapp `tsc --noEmit` — zero errors in `Preferences/General` or SDK areas (remaining errors are pre-existing in unrelated containers)
- [x] `pnpm run generate:sdk-types` regenerates cleanly; sdk-ts CJS/ESM/DTS builds succeed
- [ ] Manual smoke test — open **Preferences → General**: base currency, fiscal year, date format, tax number, and all six address subfields hydrate (previously empty despite saved data)
- [ ] Manual smoke test — edit those fields, save, reload: values persist; confirm the PUT body is camelCase and `GET /api/organization/current` metadata reflects the save


🤖 Generated with [Claude Code](https://claude.com/claude-code)