### PR TITLE
fix(webapp): declare missing openapi-typescript-fetch dependency

### DIFF
--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -78,6 +78,7 @@
     "lodash": "^4.17.15",
     "moment": "^2.24.0",
     "moment-timezone": "^0.5.33",
+    "openapi-typescript-fetch": "^2.2.1",
     "path-browserify": "^1.0.1",
     "plaid": "^9.3.0",
     "plaid-threads": "^11.4.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -646,6 +646,9 @@ importers:
       moment-timezone:
         specifier: ^0.5.33
         version: 0.5.45
+      openapi-typescript-fetch:
+        specifier: ^2.2.1
+        version: 2.2.1
       path-browserify:
         specifier: ^1.0.1
         version: 1.0.1


### PR DESCRIPTION
## Summary

The webapp production build (`pnpm --filter @bigcapital/webapp build`) failed with:

```
[vite]: Rollup failed to resolve import "openapi-typescript-fetch" from
src/ee/workspaces/containers/CreateWorkspaceDrawer/CreateWorkspaceForm.tsx
```

`CreateWorkspaceForm.tsx` does a **runtime** import of the `ApiError` class (used in an `error instanceof ApiError` check to map server validation errors onto the formik form), but `openapi-typescript-fetch` was only declared as a dependency of `shared/sdk-ts`. Under pnpm's isolated `node_modules`, undeclared transitive dependencies are not linked into `packages/webapp/node_modules`, so Rollup could not resolve the import. The breakage was introduced when the workspaces flow was migrated to tanstack-query hooks (63351d304).

This PR declares `openapi-typescript-fetch` directly in `packages/webapp/package.json` with the same `^2.2.1` range that `shared/sdk-ts` uses, so pnpm reuses the same store entry (2.2.1). No source changes. It also legitimizes the two existing `import type { ApiError }` usages in `src/hooks/useRequest.tsx` and `src/hooks/useApiFetcherOnError.tsx`.

## Test plan

- [x] `pnpm --filter @bigcapital/webapp build` — completes successfully (previously failed at the Rollup resolve step)
- [ ] Manual smoke test — open the Create Workspace drawer, submit a workspace with a duplicate/invalid name, and confirm the server validation errors are mapped onto the form fields (the `instanceof ApiError` path)


🤖 Generated with [Claude Code](https://claude.com/claude-code)