### PR TITLE
fix: PDF template create/edit failures and drawer form hydration

### DIFF
--- a/packages/server/src/modules/PdfTemplate/dtos/PdfTemplate.dto.ts
+++ b/packages/server/src/modules/PdfTemplate/dtos/PdfTemplate.dto.ts
@@ -20,10 +20,6 @@ export class EditPdfTemplateDto {
   @IsNotEmpty()
   templateName: string;
 
-  @IsString()
-  @IsNotEmpty()
-  resource: string;
-
   @IsObject()
   @IsNotEmpty()
   attributes: Record<string, any>;

--- a/packages/server/src/modules/PdfTemplate/utils/sanitizePdfTemplateAttributes.ts
+++ b/packages/server/src/modules/PdfTemplate/utils/sanitizePdfTemplateAttributes.ts
@@ -1,4 +1,4 @@
-import sanitizeHtml from 'sanitize-html';
+import * as sanitizeHtml from 'sanitize-html';
 
 const SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
   allowedTags: [

--- a/packages/webapp/src/containers/BrandingTemplates/BrandingTemplatesSelectFields.tsx
+++ b/packages/webapp/src/containers/BrandingTemplates/BrandingTemplatesSelectFields.tsx
@@ -29,6 +29,6 @@ export const convertBrandingTemplatesToOptions = (
   brandingTemplates: Array<any>,
 ) => {
   return brandingTemplates?.map(
-    (template) => ({ text: template.template_name, value: template.id }) || [],
+    (template) => ({ text: template.templateName, value: template.id }) || [],
   );
 };

--- a/packages/webapp/src/containers/BrandingTemplates/_hooks.tsx
+++ b/packages/webapp/src/containers/BrandingTemplates/_hooks.tsx
@@ -8,7 +8,7 @@ export const useBrandingTemplatesColumns = () => {
       Header: 'Template Name',
       accessor: (row: any) => (
         <Group spacing={10}>
-          {row.template_name} {row.default && <Tag round>Default</Tag>}
+          {row.templateName} {row.default && <Tag round>Default</Tag>}
         </Group>
       ),
       width: 65,
@@ -16,7 +16,7 @@ export const useBrandingTemplatesColumns = () => {
     },
     {
       Header: 'Created At',
-      accessor: 'created_at_formatted',
+      accessor: 'createdAtFormatted',
       width: 35,
       className: clsx(Classes.TEXT_MUTED),
       clickable: true,

--- a/packages/webapp/src/hooks/query/pdf-templates/queries.ts
+++ b/packages/webapp/src/hooks/query/pdf-templates/queries.ts
@@ -138,7 +138,7 @@ export function useGetPdfTemplate(
     'queryKey' | 'queryFn'
   >,
 ): UseQueryResult<GetPdfTemplateResponse, Error> {
-  const fetcher = useApiFetcher();
+  const fetcher = useApiFetcher({ enableCamelCaseTransform: true });
 
   return useQuery({
     queryKey: pdfTemplatesKeys.detail(templateId),
@@ -153,7 +153,7 @@ export function useGetPdfTemplates(
   query?: GetPdfTemplatesQuery,
   options?: UseQueryOptions<GetPdfTemplatesResponse, Error>,
 ): UseQueryResult<GetPdfTemplatesResponse, Error> {
-  const fetcher = useApiFetcher();
+  const fetcher = useApiFetcher({ enableCamelCaseTransform: true });
 
   return useQuery({
     queryKey: pdfTemplatesKeys.list(query),
@@ -196,7 +196,7 @@ export function useAssignPdfTemplateAsDefault(
 export function useGetPdfTemplateBrandingState(
   options?: UseQueryOptions<GetPdfTemplateBrandingStateResponse, Error>,
 ): UseQueryResult<GetPdfTemplateBrandingStateResponse, Error> {
-  const fetcher = useApiFetcher();
+  const fetcher = useApiFetcher({ enableCamelCaseTransform: true });
 
   return useQuery({
     queryKey: pdfTemplatesKeys.state(),


### PR DESCRIPTION
## Summary

Three fixes that together restore creating and editing PDF (branding) templates from the UI:

- **Edit endpoint 400 (`resource should not be empty`)**: `EditPdfTemplateDto` required `resource` — a copy-paste artifact from the NestJS migration. The webapp/SDK intentionally omit `resource` on edit (a template's resource is immutable) and `EditPdfTemplateService` never reads it, so every edit save was rejected. Dropped the field from the edit DTO; the global `ValidationPipe` (`whitelist: true`) harmlessly strips it from any legacy client.
- **Create/edit 500 (`sanitize_html_1.default is not a function`)**: the server compiles CommonJS without `esModuleInterop`, so `import sanitizeHtml from 'sanitize-html'` emitted `.default(...)`, which is `undefined` at runtime. Switched to the codebase's namespace-import convention (`import * as`), matching the existing precedent in `address-text-format.ts`.
- **Drawer form not hydrated**: the global `SerializeInterceptor` snake_cases every response, but the pdf-template query hooks never enabled the SDK's camelCase response middleware, so `useBrandingTemplateFormInitialValues` read undefined camelCase keys and silently fell back to defaults. Enabled `enableCamelCaseTransform` on `useGetPdfTemplate`, `useGetPdfTemplates`, and `useGetPdfTemplateBrandingState`, and migrated the two snake_case readers (list table columns, `convertBrandingTemplatesToOptions` — shared by all 5 form providers) to camelCase, matching the SDK types. This also fixes the live paper preview's company branding props.

## Test plan

- [ ] `pnpm --filter server typecheck` — clean
- [ ] `pnpm --filter webapp typecheck` — no new errors (pre-existing errors in unrelated modules remain)
- [ ] Edit flow: Branding Templates list → open an existing template → fields show saved values (not defaults); paper preview shows company name/logo/colors; Save succeeds (200, no `resource` 400)
- [ ] Create flow: create a new template from the customize drawer → succeeds (no sanitize TypeError); reopen it → saved values hydrated
- [ ] Regression: templates list shows names and formatted created dates; invoice/estimate/receipt/credit-note/payment forms' branding-template select lists template names
- [ ] Sanitization still applies: an HTML field containing `<script>` is stored stripped

🤖 Generated with [Claude Code](https://claude.com/claude-code)