### PR TITLE
fix(webapp): vendor/customer select accessors and payment entries loading

### DIFF
--- a/packages/webapp/src/components/Vendors/VendorsSelect.tsx
+++ b/packages/webapp/src/components/Vendors/VendorsSelect.tsx
@@ -58,8 +58,8 @@ function VendorsSelectRoot({
     <FSelect
       name={name}
       items={items}
-      textAccessor={'display_name'}
-      labelAccessor={'formatted_balance'}
+      textAccessor={'displayName'}
+      labelAccessor={'formattedBalance'}
       valueAccessor={'id'}
       popoverProps={{ minimal: true, usePortal: true, inline: false }}
       createNewItemRenderer={maybeCreateNewItemRenderer}

--- a/packages/webapp/src/components/Vendors/utils.tsx
+++ b/packages/webapp/src/components/Vendors/utils.tsx
@@ -12,7 +12,7 @@ interface CreatedItem {
 
 /**
  * Vendor row used by the select dropdown. The backend list response carries
- * `formatted_balance` for display; we extend the SDK `Vendor` shape via the
+ * `formattedBalance` for display; we extend the SDK `Vendor` shape via the
  * drawer's `VendorDetails` augmentation.
  */
 type VendorSelectRow = Pick<VendorDetails, 'id' | 'displayName'> &

--- a/packages/webapp/src/containers/Purchases/Bills/BillForm/BillFormHeaderFields.tsx
+++ b/packages/webapp/src/containers/Purchases/Bills/BillForm/BillFormHeaderFields.tsx
@@ -144,7 +144,7 @@ function BillFormHeader() {
   );
 }
 
-type VendorOption = { id: number; currency_code?: string };
+type VendorOption = { id: number; currencyCode?: string };
 
 /**
  * Vendor select field of bill form.
@@ -169,7 +169,7 @@ function BillFormVendorField() {
           placeholder={<T id={'select_vender_account'} />}
           onItemChange={(contact: VendorOption) => {
             setFieldValue('vendorId', contact.id);
-            setFieldValue('currencyCode', contact?.currency_code);
+            setFieldValue('currencyCode', contact?.currencyCode);
           }}
           allowCreate={true}
           fastField={true}

--- a/packages/webapp/src/containers/Purchases/CreditNotes/CreditNoteForm/VendorCreditNoteFormHeaderFields.tsx
+++ b/packages/webapp/src/containers/Purchases/CreditNotes/CreditNoteForm/VendorCreditNoteFormHeaderFields.tsx
@@ -166,7 +166,7 @@ function VendorCreditNoteFormHeaderFieldsInner({
   );
 }
 
-type VendorOption = { id: number; currency_code: string };
+type VendorOption = { id: number; currencyCode: string };
 
 /**
  * Vendor select field of vendor credit form.
@@ -192,7 +192,7 @@ function VendorCreditFormVendorSelect() {
           placeholder={<T id={'select_vender_account'} />}
           onItemChange={(contact: VendorOption) => {
             setFieldValue('vendorId', contact.id);
-            setFieldValue('currencyCode', contact?.currency_code);
+            setFieldValue('currencyCode', contact?.currencyCode);
           }}
           popoverFill={true}
           allowCreate={true}

--- a/packages/webapp/src/containers/Purchases/PaymentsMade/PaymentForm/PaymentMadeFormHeaderFields.tsx
+++ b/packages/webapp/src/containers/Purchases/PaymentsMade/PaymentForm/PaymentMadeFormHeaderFields.tsx
@@ -40,7 +40,6 @@ import { momentFormatter, safeSumBy } from '@/utils';
 
 type VendorContact = {
   id: string | number;
-  currency_code?: string;
   currencyCode?: string;
 };
 
@@ -232,7 +231,7 @@ function PaymentFormVendorSelect() {
           placeholder={<T id={'select_vender_account'} />}
           onItemChange={(contact: VendorContact) => {
             setFieldValue('vendorId', contact.id);
-            setFieldValue('currencyCode', contact?.currency_code);
+            setFieldValue('currencyCode', contact?.currencyCode);
             setPaymentVendorId(Number(contact.id));
           }}
           disabled={!isNewMode}

--- a/packages/webapp/src/containers/Purchases/PaymentsMade/PaymentForm/PaymentMadeInnerProvider.tsx
+++ b/packages/webapp/src/containers/Purchases/PaymentsMade/PaymentForm/PaymentMadeInnerProvider.tsx
@@ -1,7 +1,7 @@
 import { useFormikContext } from 'formik';
 import React, { createContext, useContext, useEffect } from 'react';
 import { usePaymentMadeFormContext } from './PaymentMadeFormProvider';
-import { transformToNewPageEntries } from './utils';
+import { transformToNewPageEntries, type PaymentMadeFormValues } from './utils';
 import { usePaymentMadeNewPageEntries } from '@/hooks/query';
 
 type BillRow = {
@@ -38,12 +38,10 @@ function PaymentMadeInnerProvider({
   const { isNewMode } = usePaymentMadeFormContext();
 
   // Formik context.
-  // Note: `vendor_id` is destructured to preserve historical runtime behavior;
-  // the form values type uses `vendorId` (camelCase), so this reads undefined.
   const {
-    values: { vendor_id: vendorId },
+    values: { vendorId },
     setFieldValue,
-  } = useFormikContext<{ vendor_id?: string | number }>();
+  } = useFormikContext<PaymentMadeFormValues>();
 
   // `usePaymentMadeNewPageEntries` manages `enabled` internally based on vendorId.
   const {

--- a/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentReceiveForm/PaymentReceiveHeaderFields.tsx
+++ b/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentReceiveForm/PaymentReceiveHeaderFields.tsx
@@ -238,7 +238,7 @@ const CustomerButtonLink = styled(CustomerDrawerLink)`
 
 type CustomerOption = {
   id: string | number;
-  currency_code?: string;
+  currencyCode?: string;
 };
 
 /**
@@ -269,7 +269,7 @@ function PaymentReceiveCustomerSelect() {
           onItemChange={(customer: CustomerOption) => {
             setFieldValue('customerId', customer.id);
             setFieldValue('amount', '');
-            setFieldValue('currencyCode', customer?.currency_code);
+            setFieldValue('currencyCode', customer?.currencyCode);
           }}
           popoverFill={true}
           disabled={!isNewMode}

--- a/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentReceiveForm/PaymentReceiveInnerProvider.tsx
+++ b/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentReceiveForm/PaymentReceiveInnerProvider.tsx
@@ -40,11 +40,9 @@ function PaymentReceiveInnerProvider({
   const { isNewMode } = usePaymentReceiveFormContext();
 
   const {
-    values: { customer_id: customerId },
+    values: { customerId },
     setFieldValue,
-  } = useFormikContext<
-    PaymentReceiveFormValues & { customer_id?: string | number }
-  >();
+  } = useFormikContext<PaymentReceiveFormValues>();
 
   // `useDueInvoices` types its options as a full UseQueryOptions (which requires queryKey/queryFn),
   // but it supplies those internally — so we pass only the partial options.


### PR DESCRIPTION
## Description

Fixes vendor/customer names not showing in selects and billable entries not loading after selecting a customer/vendor in payment forms.

## Changes

- Update `VendorsSelect` accessors to camelCase (`displayName`, `formattedBalance`).
- Fix customer/vendor `currencyCode` references in payment and bill forms.
- Fix `PaymentReceiveInnerProvider` to read `customerId` instead of `customer_id`.
- Fix `PaymentMadeInnerProvider` to read `vendorId` instead of `vendor_id`.

## Related issues

- Vendors select does not show names in the bill form.
- Payment received form: selecting a customer does not show billable invoices.
- Bill payment form: selecting a vendor does not show billable bills.