### PR TITLE
feat(webapp): typescript authentication, setup and tax rates containers

### DIFF
--- a/packages/webapp/src/components/Alert/index.tsx
+++ b/packages/webapp/src/components/Alert/index.tsx
@@ -1,9 +1,23 @@
 // @ts-nocheck
 import clsx from 'classnames';
-import React from 'react';
+import { ReactNode } from 'react';
 import styled from 'styled-components';
 
-export function Alert({ title, description, children, intent, className }) {
+export interface AlertProps {
+  title?: ReactNode;
+  description?: ReactNode;
+  children?: ReactNode;
+  intent?: 'danger' | 'primary';
+  className?: string;
+}
+
+export function Alert({
+  title,
+  description,
+  children,
+  intent,
+  className,
+}: AlertProps) {
   return (
     <AlertRoot className={clsx(className)} intent={intent}>
       {title && <AlertTitle>{title}</AlertTitle>}

--- a/packages/webapp/src/components/Icon/index.tsx
+++ b/packages/webapp/src/components/Icon/index.tsx
@@ -24,7 +24,7 @@ import IconSvgPaths from '@/static/json/icons';
 export interface IconProps extends Props {
   color?: string;
   htmlTitle?: string;
-  icon: IconName | MaybeElement;
+  icon: string | MaybeElement;
   iconSize?: number;
   width?: number;
   height?: number;

--- a/packages/webapp/src/containers/Authentication/AuthContainer.tsx
+++ b/packages/webapp/src/containers/Authentication/AuthContainer.tsx
@@ -1,9 +1,9 @@
-// @ts-nocheck
+import { ReactNode } from 'react';
 import styled from 'styled-components';
-import { Icon, FormattedMessage as T } from '@/components';
+import { Icon } from '@/components';
 
 interface AuthContainerProps {
-  children: React.ReactNode;
+  children: ReactNode;
 }
 
 export function AuthContainer({ children }: AuthContainerProps) {

--- a/packages/webapp/src/containers/Authentication/AuthCopyright.tsx
+++ b/packages/webapp/src/containers/Authentication/AuthCopyright.tsx
@@ -1,5 +1,3 @@
-// @ts-nocheck
-import React from 'react';
 import { Icon } from '@/components/Icon';
 
 export function AuthCopyright() {

--- a/packages/webapp/src/containers/Authentication/AuthInsider.tsx
+++ b/packages/webapp/src/containers/Authentication/AuthInsider.tsx
@@ -1,8 +1,17 @@
-// @ts-nocheck
-import React from 'react';
+import { ReactNode } from 'react';
 import styled from 'styled-components';
 import { AuthInsiderContent, AuthInsiderCopyright } from './_components';
 import { AuthCopyright } from './AuthCopyright';
+
+export interface AuthInsiderProps {
+  logo?: boolean;
+  copyright?: boolean;
+  children?: ReactNode;
+  classNames?: {
+    content?: string;
+    copyrightWrap?: string;
+  };
+}
 
 /**
  * Authentication insider page.
@@ -12,7 +21,7 @@ export function AuthInsider({
   copyright = true,
   children,
   classNames,
-}) {
+}: AuthInsiderProps) {
   return (
     <AuthInsiderContent>
       <AuthInsiderContentWrap className={classNames?.content}>

--- a/packages/webapp/src/containers/Authentication/AuthMetaBoot.tsx
+++ b/packages/webapp/src/containers/Authentication/AuthMetaBoot.tsx
@@ -1,33 +1,58 @@
-// @ts-nocheck
 import { Spinner } from '@blueprintjs/core';
-import React, { createContext } from 'react';
+import { createContext, ReactNode, useContext } from 'react';
 import styled from 'styled-components';
 import { useAuthMetadata } from '@/hooks/query';
 
-const AuthMetaBootContext = createContext();
+export interface AuthMetaBootState {
+  isAuthMetaLoading: boolean;
+  signupDisabled?: boolean;
+}
+
+export interface AuthMetaBootProviderProps {
+  children?: ReactNode;
+}
+
+const AuthMetaBootContext = createContext<AuthMetaBootState | undefined>(
+  undefined,
+);
 
 /**
  * Boots the authentication page metadata.
  */
-function AuthMetaBootProvider({ ...props }) {
+function AuthMetaBootProvider({
+  children,
+  ...props
+}: AuthMetaBootProviderProps) {
   const { isLoading: isAuthMetaLoading, data: authMeta } = useAuthMetadata();
 
-  const state = {
+  const state: AuthMetaBootState = {
     isAuthMetaLoading,
-    signupDisabled: authMeta?.meta?.signup_disabled,
+    signupDisabled: authMeta?.signupDisabled,
   };
 
   if (isAuthMetaLoading) {
     return (
       <SpinnerRoot>
-        <Spinner size={30} value={null} />
+        <Spinner size={30} />
       </SpinnerRoot>
     );
   }
-  return <AuthMetaBootContext.Provider value={state} {...props} />;
+  return (
+    <AuthMetaBootContext.Provider value={state} {...props}>
+      {children}
+    </AuthMetaBootContext.Provider>
+  );
 }
 
-const useAuthMetaBoot = () => React.useContext(AuthMetaBootContext);
+const useAuthMetaBoot = (): AuthMetaBootState => {
+  const context = useContext(AuthMetaBootContext);
+  if (!context) {
+    throw new Error(
+      'useAuthMetaBoot must be used within an AuthMetaBootProvider.',
+    );
+  }
+  return context;
+};
 
 export { AuthMetaBootContext, AuthMetaBootProvider, useAuthMetaBoot };
 

--- a/packages/webapp/src/containers/Authentication/Authentication.tsx
+++ b/packages/webapp/src/containers/Authentication/Authentication.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Spinner } from '@blueprintjs/core';
 import { Suspense } from 'react';
 import BodyClassName from 'react-body-classname';
@@ -6,7 +5,7 @@ import { Route, Switch, useLocation } from 'react-router-dom';
 import { TransitionGroup, CSSTransition } from 'react-transition-group';
 import styled from 'styled-components';
 import { AuthMetaBootProvider } from './AuthMetaBoot';
-import { Box, Icon, FormattedMessage as T } from '@/components';
+import { Box, Icon } from '@/components';
 import { BigcapitalAlt } from '@/components/Icons/BigcapitalAlt';
 import { useIsDarkMode } from '@/hooks/useDarkMode';
 import authenticationRoutes from '@/routes/authentication';
@@ -62,12 +61,7 @@ function AuthenticationRoutes() {
       >
         <Switch>
           {authenticationRoutes.map((route, index) => (
-            <Route
-              key={index}
-              path={route.path}
-              exact={route.exact}
-              component={route.component}
-            />
+            <Route key={index} path={route.path} component={route.component} />
           ))}
         </Switch>
       </CSSTransition>

--- a/packages/webapp/src/containers/Authentication/EmailConfirmation.tsx
+++ b/packages/webapp/src/containers/Authentication/EmailConfirmation.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Intent } from '@blueprintjs/core';
 import { useEffect, useMemo } from 'react';
 import { useLocation, useHistory } from 'react-router-dom';
@@ -25,6 +24,9 @@ export function EmailConfirmation() {
   }, [history, token, email]);
 
   useEffect(() => {
+    if (!token || !email) {
+      return;
+    }
     authSignupVerify({ token, email })
       .then(() => {
         AppToaster.show({

--- a/packages/webapp/src/containers/Authentication/InviteAccept.tsx
+++ b/packages/webapp/src/containers/Authentication/InviteAccept.tsx
@@ -1,5 +1,3 @@
-// @ts-nocheck
-import React from 'react';
 import { useParams } from 'react-router-dom';
 import { InviteAcceptForm } from './InviteAcceptForm';
 import { InviteAcceptProvider } from './InviteAcceptProvider';
@@ -9,7 +7,7 @@ import { AuthInsider } from '@/containers/Authentication/AuthInsider';
  * Authentication invite page.
  */
 export function Invite() {
-  const { token } = useParams();
+  const { token } = useParams<{ token: string }>();
 
   return (
     <AuthInsider>

--- a/packages/webapp/src/containers/Authentication/InviteAcceptForm.tsx
+++ b/packages/webapp/src/containers/Authentication/InviteAcceptForm.tsx
@@ -1,17 +1,16 @@
-// @ts-nocheck
-import { Intent, Position } from '@blueprintjs/core';
-import { Formik } from 'formik';
+import { Intent } from '@blueprintjs/core';
+import { Formik, FormikHelpers } from 'formik';
 import { isEmpty } from 'lodash';
-import React from 'react';
 import intl from 'react-intl-universal';
 import { useHistory } from 'react-router-dom';
 import { AuthInsiderCard } from './_components';
 import { InviteUserFormContent as InviteAcceptFormContent } from './InviteAcceptFormContent';
 import { useInviteAcceptContext } from './InviteAcceptProvider';
-import { InviteAcceptSchema } from './utils';
+import { InviteAcceptSchema, InviteAcceptFormValues } from './utils';
+import type { ApiError } from 'openapi-typescript-fetch';
 import { AppToaster } from '@/components';
 
-const initialValues = {
+const initialValues: InviteAcceptFormValues = {
   organization_name: '',
   invited_email: '',
   first_name: '',
@@ -26,44 +25,44 @@ export function InviteAcceptForm() {
   const { inviteAcceptMutate, inviteMeta, token } = useInviteAcceptContext();
 
   // Invite value.
-  const inviteFormValue = {
+  const inviteFormValue: InviteAcceptFormValues = {
     ...initialValues,
     ...(!isEmpty(inviteMeta)
       ? {
-          invited_email: inviteMeta.email,
-          organization_name: inviteMeta.organizationName,
+          invited_email: inviteMeta?.email ?? '',
+          organization_name: inviteMeta?.organizationName ?? '',
         }
       : {}),
   };
 
   // Handle form submitting.
-  const handleSubmit = (values, { setSubmitting, setErrors }) => {
+  const handleSubmit = (
+    values: InviteAcceptFormValues,
+    { setSubmitting }: FormikHelpers<InviteAcceptFormValues>,
+  ) => {
     inviteAcceptMutate([values, token])
       .then(() => {
         AppToaster.show({
           message: intl.getHTML(
             'congrats_your_account_has_been_created_and_invited',
             {
-              organization_name: inviteMeta.organizationName,
+              organization_name: inviteMeta?.organizationName ?? '',
             },
           ),
           intent: Intent.SUCCESS,
         });
         history.push('/auth/login');
       })
-      .catch(({ data: { errors } }) => {
+      .catch((response: ApiError) => {
+        const errors =
+          (response.data?.errors as Array<{ type?: string }> | undefined) ?? [];
+
         if (errors.find((e) => e.type === 'INVITE_TOKEN_INVALID')) {
           AppToaster.show({
             message: intl.get('an_unexpected_error_occurred'),
             intent: Intent.DANGER,
-            position: Position.BOTTOM,
           });
           history.push('/auth/login');
-        }
-        if (errors.find((e) => e.type === 'PHONE_MUMNER.ALREADY.EXISTS')) {
-          setErrors({
-            phone_number: 'This phone number is used in another account.',
-          });
         }
         setSubmitting(false);
       });

--- a/packages/webapp/src/containers/Authentication/InviteAcceptFormContent.tsx
+++ b/packages/webapp/src/containers/Authentication/InviteAcceptFormContent.tsx
@@ -1,13 +1,13 @@
-// @ts-nocheck
-import { Button, InputGroup, Intent } from '@blueprintjs/core';
+import { Button, Intent } from '@blueprintjs/core';
 import { Tooltip2 } from '@blueprintjs/popover2';
 import { Form, useFormikContext } from 'formik';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import intl from 'react-intl-universal';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import { AuthSubmitButton } from './_components';
 import { useInviteAcceptContext } from './InviteAcceptProvider';
+import { InviteAcceptFormValues } from './utils';
 import {
   Col,
   FFormGroup,
@@ -23,7 +23,7 @@ export function InviteUserFormContent() {
   const [showPassword, setShowPassword] = useState<boolean>(false);
 
   const { inviteMeta } = useInviteAcceptContext();
-  const { isSubmitting } = useFormikContext();
+  const { isSubmitting } = useFormikContext<InviteAcceptFormValues>();
 
   // Handle password revealer changing.
   const handleLockClick = () => {
@@ -68,13 +68,13 @@ export function InviteUserFormContent() {
 
       <InviteAcceptFooterParagraphs>
         <p>
-          <T id={'you_email_address_is'} /> <b>{inviteMeta.email},</b> <br />
+          <T id={'you_email_address_is'} /> <b>{inviteMeta?.email},</b> <br />
           <T id={'you_will_use_this_address_to_sign_in_to_bigcapital'} />
         </p>
         <p>
           {intl.getHTML('signing_in_or_creating', {
-            terms: (msg) => <Link>{msg}</Link>,
-            privacy: (msg) => <Link>{msg}</Link>,
+            terms: (msg: string) => <Link to={'#'}>{msg}</Link>,
+            privacy: (msg: string) => <Link to={'#'}>{msg}</Link>,
           })}
         </p>
       </InviteAcceptFooterParagraphs>

--- a/packages/webapp/src/containers/Authentication/InviteAcceptProvider.tsx
+++ b/packages/webapp/src/containers/Authentication/InviteAcceptProvider.tsx
@@ -1,15 +1,42 @@
-// @ts-nocheck
-import React, { createContext, useContext, useEffect } from 'react';
+import { createContext, ReactNode, useContext, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 import { InviteAcceptLoading } from './components';
 import { useInviteMetaByToken, useAuthInviteAccept } from '@/hooks/query';
 
-const InviteAcceptContext = createContext();
+export interface InviteAcceptMeta {
+  email?: string;
+  organizationName?: string;
+}
+
+export interface InviteAcceptContextState {
+  token: string;
+  inviteMeta: InviteAcceptMeta | null;
+  inviteMetaError: Error | null;
+  isInviteMetaError: boolean;
+  isInviteMetaLoading: boolean;
+  inviteAcceptMutate: (
+    values: [Record<string, unknown>, string],
+  ) => Promise<unknown>;
+}
+
+export interface InviteAcceptProviderProps {
+  token: string;
+  children?: ReactNode;
+}
+
+interface InviteMetaResponse {
+  inviteToken?: { email?: string };
+  orgName?: string;
+}
+
+const InviteAcceptContext = createContext<InviteAcceptContextState | undefined>(
+  undefined,
+);
 
 /**
  * Invite accept provider.
  */
-function InviteAcceptProvider({ token, ...props }) {
+function InviteAcceptProvider({ token, ...props }: InviteAcceptProviderProps) {
   // Invite meta by token.
   const {
     data: inviteMeta,
@@ -32,15 +59,16 @@ function InviteAcceptProvider({ token, ...props }) {
   }, [history, inviteMetaError]);
 
   // Transform the backend response to match frontend expectations.
-  const transformedInviteMeta = inviteMeta
+  const inviteMetaData = inviteMeta as InviteMetaResponse | undefined;
+  const transformedInviteMeta: InviteAcceptMeta | null = inviteMetaData
     ? {
-        email: inviteMeta.inviteToken?.email,
-        organizationName: inviteMeta.orgName,
+        email: inviteMetaData.inviteToken?.email,
+        organizationName: inviteMetaData.orgName,
       }
     : null;
 
   // Provider payload.
-  const provider = {
+  const provider: InviteAcceptContextState = {
     token,
     inviteMeta: transformedInviteMeta,
     inviteMetaError,
@@ -60,6 +88,14 @@ function InviteAcceptProvider({ token, ...props }) {
   );
 }
 
-const useInviteAcceptContext = () => useContext(InviteAcceptContext);
+const useInviteAcceptContext = (): InviteAcceptContextState => {
+  const context = useContext(InviteAcceptContext);
+  if (!context) {
+    throw new Error(
+      'useInviteAcceptContext must be used within an InviteAcceptProvider.',
+    );
+  }
+  return context;
+};
 
 export { InviteAcceptProvider, useInviteAcceptContext };

--- a/packages/webapp/src/containers/Authentication/Login.tsx
+++ b/packages/webapp/src/containers/Authentication/Login.tsx
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { Formik } from 'formik';
+import { Formik, FormikHelpers } from 'formik';
 import { Link } from 'react-router-dom';
 import {
   AuthFooterLinks,
@@ -8,12 +7,17 @@ import {
 } from './_components';
 import { useAuthMetaBoot } from './AuthMetaBoot';
 import { LoginForm } from './LoginForm';
-import { LoginSchema, transformLoginErrorsToToasts } from './utils';
+import {
+  LoginSchema,
+  transformLoginErrorsToToasts,
+  LoginValues,
+} from './utils';
+import type { ApiError } from 'openapi-typescript-fetch';
 import { AppToaster as Toaster, FormattedMessage as T } from '@/components';
 import { AuthInsider } from '@/containers/Authentication/AuthInsider';
 import { useAuthLogin } from '@/hooks/query';
 
-const initialValues = {
+const initialValues: LoginValues = {
   crediential: '',
   password: '',
   keepLoggedIn: false,
@@ -25,13 +29,15 @@ const initialValues = {
 export function Login() {
   const { mutateAsync: loginMutate } = useAuthLogin();
 
-  const handleSubmit = (values, { setSubmitting }) => {
+  const handleSubmit = (
+    values: LoginValues,
+    { setSubmitting }: FormikHelpers<LoginValues>,
+  ) => {
     loginMutate({
       email: values.crediential,
       password: values.password,
-    }).catch((response) => {
-      const { data: error } = response;
-      const toastMessages = transformLoginErrorsToToasts(error);
+    }).catch((response: ApiError) => {
+      const toastMessages = transformLoginErrorsToToasts(response.data);
 
       toastMessages.forEach((toastMessage) => {
         Toaster.show(toastMessage);

--- a/packages/webapp/src/containers/Authentication/LoginForm.tsx
+++ b/packages/webapp/src/containers/Authentication/LoginForm.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Button, Intent } from '@blueprintjs/core';
 import { Tooltip2 } from '@blueprintjs/popover2';
 import { Form } from 'formik';
@@ -10,7 +9,7 @@ import { FFormGroup, FInputGroup, FCheckbox, T } from '@/components';
 /**
  * Login form.
  */
-export function LoginForm({ isSubmitting }) {
+export function LoginForm({ isSubmitting }: { isSubmitting: boolean }) {
   const [showPassword, setShowPassword] = useState<boolean>(false);
 
   // Handle password revealer changing.

--- a/packages/webapp/src/containers/Authentication/Register.tsx
+++ b/packages/webapp/src/containers/Authentication/Register.tsx
@@ -1,6 +1,5 @@
-// @ts-nocheck
 import { Intent } from '@blueprintjs/core';
-import { Formik } from 'formik';
+import { Formik, FormikHelpers } from 'formik';
 import intl from 'react-intl-universal';
 import { Link } from 'react-router-dom';
 import {
@@ -11,14 +10,16 @@ import {
 import { RegisterForm } from './RegisterForm';
 import {
   RegisterSchema,
+  RegisterValues,
   transformRegisterErrorsToForm,
   transformRegisterToastMessages,
 } from './utils';
+import type { ApiError } from 'openapi-typescript-fetch';
 import { AppToaster, FormattedMessage as T } from '@/components';
 import { AuthInsider } from '@/containers/Authentication/AuthInsider';
 import { useAuthLogin, useAuthRegister } from '@/hooks/query/authentication';
 
-const initialValues = {
+const initialValues: RegisterValues = {
   first_name: '',
   last_name: '',
   email: '',
@@ -32,23 +33,30 @@ export function RegisterUserForm() {
   const { mutateAsync: authLoginMutate } = useAuthLogin();
   const { mutateAsync: authRegisterMutate } = useAuthRegister();
 
-  const handleSubmit = (values, { setSubmitting, setErrors }) => {
-    authRegisterMutate(values)
+  const handleSubmit = (
+    values: RegisterValues,
+    { setSubmitting, setErrors }: FormikHelpers<RegisterValues>,
+  ) => {
+    authRegisterMutate({
+      firstName: values.first_name,
+      lastName: values.last_name,
+      email: values.email,
+      password: values.password,
+    })
       .then(() => {
         authLoginMutate({
           email: values.email,
           password: values.password,
-        }).catch(({ data: { errors } }) => {
+        }).catch(() => {
           AppToaster.show({
             message: intl.get('something_wentwrong'),
             intent: Intent.SUCCESS,
           });
         });
       })
-      .catch(({ response }) => {
-        const {
-          data: { errors },
-        } = response;
+      .catch((response: ApiError) => {
+        const errors =
+          (response.data?.errors as Array<{ type?: string }> | undefined) ?? [];
 
         const formErrors = transformRegisterErrorsToForm(errors);
         const toastMessages = transformRegisterToastMessages(errors);

--- a/packages/webapp/src/containers/Authentication/RegisterForm.tsx
+++ b/packages/webapp/src/containers/Authentication/RegisterForm.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Intent, Button } from '@blueprintjs/core';
 import { Tooltip2 } from '@blueprintjs/popover2';
 import { Form } from 'formik';
@@ -18,7 +17,7 @@ import {
 /**
  * Register form.
  */
-export function RegisterForm({ isSubmitting }) {
+export function RegisterForm({ isSubmitting }: { isSubmitting: boolean }) {
   const [showPassword, setShowPassword] = React.useState<boolean>(false);
 
   // Handle password revealer changing.
@@ -69,8 +68,8 @@ export function RegisterForm({ isSubmitting }) {
 
       <TermsConditionsText>
         {intl.getHTML('signing_in_or_creating', {
-          terms: (msg) => <Link>{msg}</Link>,
-          privacy: (msg) => <Link>{msg}</Link>,
+          terms: (msg: string) => <Link to={'#'}>{msg}</Link>,
+          privacy: (msg: string) => <Link to={'#'}>{msg}</Link>,
         })}
       </TermsConditionsText>
 

--- a/packages/webapp/src/containers/Authentication/RegisterVerify.tsx
+++ b/packages/webapp/src/containers/Authentication/RegisterVerify.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Button, Intent } from '@blueprintjs/core';
 import { x } from '@xstyled/emotion';
 import { AuthInsiderCard } from './_components';
@@ -11,7 +10,7 @@ import { useIsDarkMode } from '@/hooks/useDarkMode';
 
 export function RegisterVerify() {
   const { setLogout } = useAuthActions();
-  const { mutateAsync: resendSignUpVerifyMail, isLoading } =
+  const { mutateAsync: resendSignUpVerifyMail, isPending } =
     useAuthSignUpVerifyResendMail();
 
   const emailAddress = useAuthUserVerifyEmail();
@@ -62,7 +61,7 @@ export function RegisterVerify() {
             <Button
               large
               fill
-              loading={isLoading}
+              loading={isPending}
               intent={Intent.NONE}
               onClick={handleResendMailBtnClick}
             >

--- a/packages/webapp/src/containers/Authentication/ResetPassword.tsx
+++ b/packages/webapp/src/containers/Authentication/ResetPassword.tsx
@@ -1,7 +1,5 @@
-// @ts-nocheck
-import { Intent, Position } from '@blueprintjs/core';
-import { Formik } from 'formik';
-import React, { useMemo } from 'react';
+import { Intent } from '@blueprintjs/core';
+import { Formik, FormikHelpers } from 'formik';
 import intl from 'react-intl-universal';
 import { Link, useParams, useHistory } from 'react-router-dom';
 import {
@@ -11,12 +9,13 @@ import {
 } from './_components';
 import { useAuthMetaBoot } from './AuthMetaBoot';
 import { ResetPasswordForm } from './ResetPasswordForm';
-import { ResetPasswordSchema } from './utils';
+import { ResetPasswordSchema, ResetPasswordValues } from './utils';
+import type { ApiError } from 'openapi-typescript-fetch';
 import { AppToaster, FormattedMessage as T } from '@/components';
 import { AuthInsider } from '@/containers/Authentication/AuthInsider';
 import { useAuthResetPassword } from '@/hooks/query';
 
-const initialValues = {
+const initialValues: ResetPasswordValues = {
   password: '',
   confirm_password: '',
 };
@@ -24,30 +23,35 @@ const initialValues = {
  * Reset password page.
  */
 export function ResetPassword() {
-  const { token } = useParams();
+  const { token } = useParams<{ token: string }>();
   const history = useHistory();
 
   // Authentication reset password.
   const { mutateAsync: authResetPasswordMutate } = useAuthResetPassword();
 
   // Handle the form submitting.
-  const handleSubmit = (values, { setSubmitting }) => {
-    authResetPasswordMutate([token, values])
+  const handleSubmit = (
+    values: ResetPasswordValues,
+    { setSubmitting }: FormikHelpers<ResetPasswordValues>,
+  ) => {
+    authResetPasswordMutate([token, { password: values.password }])
       .then((response) => {
         AppToaster.show({
           message: intl.get('password_successfully_updated'),
           intent: Intent.SUCCESS,
-          position: Position.BOTTOM,
         });
         history.push('/auth/login');
         setSubmitting(false);
       })
-      .catch(({ data: { errors } }) => {
-        if (errors.find((e) => e.type === 'TOKEN_INVALID')) {
+      .catch((response: ApiError) => {
+        const errors = response.data?.errors as
+          | Array<{ type?: string }>
+          | undefined;
+
+        if (errors?.find((e) => e.type === 'TOKEN_INVALID')) {
           AppToaster.show({
             message: intl.get('an_unexpected_error_occurred'),
             intent: Intent.DANGER,
-            position: Position.BOTTOM,
           });
           history.push('/auth/login');
         }

--- a/packages/webapp/src/containers/Authentication/ResetPasswordForm.tsx
+++ b/packages/webapp/src/containers/Authentication/ResetPasswordForm.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Intent } from '@blueprintjs/core';
 import { Form } from 'formik';
 import React from 'react';
@@ -9,7 +8,7 @@ import { FFormGroup, FInputGroup, FormattedMessage as T } from '@/components';
 /**
  * Reset password form.
  */
-export function ResetPasswordForm({ isSubmitting }) {
+export function ResetPasswordForm({ isSubmitting }: { isSubmitting: boolean }) {
   return (
     <Form>
       <FFormGroup name={'password'} label={intl.get('new_password')}>

--- a/packages/webapp/src/containers/Authentication/SendResetPassword.tsx
+++ b/packages/webapp/src/containers/Authentication/SendResetPassword.tsx
@@ -1,7 +1,5 @@
-// @ts-nocheck
 import { Intent } from '@blueprintjs/core';
-import { Formik } from 'formik';
-import React, { useMemo } from 'react';
+import { Formik, FormikHelpers } from 'formik';
 import intl from 'react-intl-universal';
 import { Link, useHistory } from 'react-router-dom';
 import {
@@ -14,12 +12,14 @@ import { SendResetPasswordForm } from './SendResetPasswordForm';
 import {
   SendResetPasswordSchema,
   transformSendResetPassErrorsToToasts,
+  SendResetPasswordValues,
 } from './utils';
+import type { ApiError } from 'openapi-typescript-fetch';
 import { AppToaster, FormattedMessage as T } from '@/components';
 import { AuthInsider } from '@/containers/Authentication/AuthInsider';
 import { useAuthSendResetPassword } from '@/hooks/query';
 
-const initialValues = {
+const initialValues: SendResetPasswordValues = {
   crediential: '',
 };
 
@@ -31,7 +31,10 @@ export function SendResetPassword() {
   const { mutateAsync: sendResetPasswordMutate } = useAuthSendResetPassword();
 
   // Handle form submitting.
-  const handleSubmit = (values, { setSubmitting }) => {
+  const handleSubmit = (
+    values: SendResetPasswordValues,
+    { setSubmitting }: FormikHelpers<SendResetPasswordValues>,
+  ) => {
     sendResetPasswordMutate({ email: values.crediential })
       .then(() => {
         AppToaster.show({
@@ -41,7 +44,14 @@ export function SendResetPassword() {
         history.push('/auth/login');
         setSubmitting(false);
       })
-      .catch(() => {
+      .catch((response: ApiError) => {
+        const toastMessages = transformSendResetPassErrorsToToasts(
+          response.data,
+        );
+
+        toastMessages.forEach((toastMessage) => {
+          AppToaster.show(toastMessage);
+        });
         setSubmitting(false);
       });
   };

--- a/packages/webapp/src/containers/Authentication/SendResetPasswordForm.tsx
+++ b/packages/webapp/src/containers/Authentication/SendResetPasswordForm.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Intent } from '@blueprintjs/core';
 import { Form } from 'formik';
 import React from 'react';
@@ -10,7 +9,11 @@ import { FInputGroup, FFormGroup, FormattedMessage as T } from '@/components';
 /**
  * Send reset password form.
  */
-export function SendResetPasswordForm({ isSubmitting }) {
+export function SendResetPasswordForm({
+  isSubmitting,
+}: {
+  isSubmitting: boolean;
+}) {
   return (
     <Form>
       <TopParagraph>

--- a/packages/webapp/src/containers/Authentication/_components.tsx
+++ b/packages/webapp/src/containers/Authentication/_components.tsx
@@ -1,7 +1,5 @@
-// @ts-nocheck
 import { Spinner } from '@blueprintjs/core';
 import { Button } from '@blueprintjs/core';
-import React from 'react';
 import styled from 'styled-components';
 
 export function AuthenticationLoadingOverlay() {
@@ -31,7 +29,7 @@ const AuthOverlayRoot = styled.div`
 export const AuthInsiderContent = styled.div`
   position: relative;
 `;
-export const AuthInsiderCard = styled.div`
+export const AuthInsiderCard = styled.div<{ textAlign?: string }>`
   --x-color-background: #fff;
   --x-color-border: #d5d5d5;
 
@@ -44,6 +42,7 @@ export const AuthInsiderCard = styled.div`
   padding: 26px 22px;
   background: var(--x-color-background);
   border-radius: 3px;
+  text-align: ${({ textAlign }) => textAlign || 'inherit'};
 `;
 
 export const AuthInsiderCopyright = styled.div`

--- a/packages/webapp/src/containers/Authentication/components.tsx
+++ b/packages/webapp/src/containers/Authentication/components.tsx
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import React from 'react';
+import { ReactNode } from 'react';
 import styled from 'styled-components';
 import { AuthInsiderCard } from './_components';
 import { Skeleton } from '@/components';
@@ -7,7 +6,13 @@ import { Skeleton } from '@/components';
 /**
  * Invite accept loading space.
  */
-export function InviteAcceptLoading({ isLoading, children }) {
+export function InviteAcceptLoading({
+  isLoading,
+  children,
+}: {
+  isLoading: boolean;
+  children?: ReactNode;
+}) {
   return isLoading ? (
     <AuthInsiderCard>
       <Fields>
@@ -17,15 +22,15 @@ export function InviteAcceptLoading({ isLoading, children }) {
       </Fields>
     </AuthInsiderCard>
   ) : (
-    children
+    <>{children}</>
   );
 }
 
 function SkeletonField() {
   return (
     <SkeletonFieldRoot>
-      <Skeleton>XXXX XXXX</Skeleton>
-      <Skeleton minWidth={100}>XXXX XXXX XXXX XXXX</Skeleton>
+      <Skeleton />
+      <Skeleton minWidth={100} />
     </SkeletonFieldRoot>
   );
 }

--- a/packages/webapp/src/containers/Authentication/utils.tsx
+++ b/packages/webapp/src/containers/Authentication/utils.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Intent } from '@blueprintjs/core';
 import intl from 'react-intl-universal';
 import * as Yup from 'yup';
@@ -12,6 +11,54 @@ export const LOGIN_ERRORS = {
 const REGISTER_ERRORS = {
   PHONE_NUMBER_EXISTS: 'PHONE_NUMBER_EXISTS',
   EMAIL_EXISTS: 'EMAIL_EXISTS',
+};
+
+const SEND_RESET_PASSWORD_ERRORS = {
+  EMAIL_NOT_REGISTERED: 'EMAIL_NOT_FOUND',
+};
+
+export interface AuthError {
+  code?: string;
+  message?: string;
+}
+
+export interface ApiErrorResponse {
+  errors?: Array<{ type?: string }>;
+}
+
+export interface ToastMessage {
+  message: string;
+  intent: Intent;
+}
+
+export interface LoginValues {
+  crediential: string;
+  password: string;
+  keepLoggedIn: boolean;
+}
+
+export interface RegisterValues {
+  first_name: string;
+  last_name: string;
+  email: string;
+  password: string;
+}
+
+export interface ResetPasswordValues {
+  password: string;
+  confirm_password: string;
+}
+
+export interface SendResetPasswordValues {
+  crediential: string;
+}
+
+export type InviteAcceptFormValues = {
+  organization_name: string;
+  invited_email: string;
+  first_name: string;
+  last_name: string;
+  password: string;
 };
 
 export const LoginSchema = Yup.object().shape({
@@ -29,6 +76,7 @@ export const RegisterSchema = Yup.object().shape({
 export const ResetPasswordSchema = Yup.object().shape({
   password: Yup.string().min(6).required().label(intl.get('password')),
   confirm_password: Yup.string()
+    .nullable()
     .oneOf([Yup.ref('password'), null])
     .required()
     .label(intl.get('confirm_password')),
@@ -45,10 +93,12 @@ export const InviteAcceptSchema = Yup.object().shape({
   password: Yup.string().min(4).required().label(intl.get('password')),
 });
 
-export const transformSendResetPassErrorsToToasts = (error) => {
-  const toastBuilders = [];
+export const transformSendResetPassErrorsToToasts = (
+  error: AuthError,
+): ToastMessage[] => {
+  const toastBuilders: ToastMessage[] = [];
 
-  if (error.code === ERRORS.EMAIL_NOT_REGISTERED) {
+  if (error.code === SEND_RESET_PASSWORD_ERRORS.EMAIL_NOT_REGISTERED) {
     toastBuilders.push({
       message: intl.get('we_couldn_t_find_your_account_with_that_email'),
       intent: Intent.DANGER,
@@ -57,8 +107,10 @@ export const transformSendResetPassErrorsToToasts = (error) => {
   return toastBuilders;
 };
 
-export const transformLoginErrorsToToasts = (error) => {
-  const toastBuilders = [];
+export const transformLoginErrorsToToasts = (
+  error: AuthError,
+): ToastMessage[] => {
+  const toastBuilders: ToastMessage[] = [];
 
   if (error.code === LOGIN_ERRORS.INVALID_DETAILS) {
     toastBuilders.push({
@@ -74,8 +126,10 @@ export const transformLoginErrorsToToasts = (error) => {
   return toastBuilders;
 };
 
-export const transformRegisterErrorsToForm = (errors) => {
-  const formErrors = {};
+export const transformRegisterErrorsToForm = (
+  errors: Array<{ type?: string }>,
+): Record<string, string> => {
+  const formErrors: Record<string, string> = {};
 
   if (errors.some((e) => e.type === REGISTER_ERRORS.EMAIL_EXISTS)) {
     formErrors.email = intl.get('the_email_already_used_in_another_account');
@@ -83,8 +137,10 @@ export const transformRegisterErrorsToForm = (errors) => {
   return formErrors;
 };
 
-export const transformRegisterToastMessages = (errors) => {
-  const toastErrors = [];
+export const transformRegisterToastMessages = (
+  errors: Array<{ type?: string }>,
+): ToastMessage[] => {
+  const toastErrors: ToastMessage[] = [];
 
   if (errors.some((e) => e.type === 'SIGNUP_RESTRICTED_NOT_ALLOWED')) {
     toastErrors.push({

--- a/packages/webapp/src/containers/Authentication/withAuthenticationActions.tsx
+++ b/packages/webapp/src/containers/Authentication/withAuthenticationActions.tsx
@@ -1,4 +1,3 @@
-import { ComponentType } from 'react';
 import { connect } from 'react-redux';
 import { Dispatch } from 'redux';
 
@@ -10,14 +9,9 @@ export const mapDispatchToProps = (
   _dispatch: Dispatch,
 ): WithAuthenticationActionsProps => ({});
 
-export function withAuthenticationActions<P>(
-  WrappedComponent: ComponentType<P>,
-): ComponentType<Omit<P, keyof WithAuthenticationActionsProps>> {
-  const Connected = connect(
+export function withAuthenticationActions<P>() {
+  return connect<{}, WithAuthenticationActionsProps, P>(
     null,
     mapDispatchToProps,
-  )(WrappedComponent as ComponentType<any>);
-  return Connected as unknown as ComponentType<
-    Omit<P, keyof WithAuthenticationActionsProps>
-  >;
+  );
 }

--- a/packages/webapp/src/containers/Setup/SetupCongratsPage.tsx
+++ b/packages/webapp/src/containers/Setup/SetupCongratsPage.tsx
@@ -1,19 +1,23 @@
-// @ts-nocheck
 import { Button, Intent } from '@blueprintjs/core';
 import { css } from '@emotion/css';
 import { x } from '@xstyled/emotion';
-import React from 'react';
+import { useState } from 'react';
 import { WorkflowIcon } from './WorkflowIcon';
 import { FormattedMessage as T } from '@/components';
-import { withOrganizationActions } from '@/containers/Organization/withOrganizationActions';
+import {
+  withOrganizationActions,
+  WithOrganizationActionsProps,
+} from '@/containers/Organization/withOrganizationActions';
 import { useIsDarkMode } from '@/hooks/useDarkMode';
 import { compose } from '@/utils';
 
 /**
  * Setup congrats page.
  */
-function SetupCongratsPageInner({ setOrganizationSetupCompleted }) {
-  const [isReloading, setIsReloading] = React.useState(false);
+function SetupCongratsPageInner({
+  setOrganizationSetupCompleted,
+}: WithOrganizationActionsProps) {
+  const [isReloading, setIsReloading] = useState(false);
   const isDarkMode = useIsDarkMode();
 
   const handleBtnClick = () => {

--- a/packages/webapp/src/containers/Setup/SetupInitializingForm.tsx
+++ b/packages/webapp/src/containers/Setup/SetupInitializingForm.tsx
@@ -1,17 +1,22 @@
-// @ts-nocheck
 import { ProgressBar, Intent } from '@blueprintjs/core';
 import { css } from '@emotion/css';
 import { x } from '@xstyled/emotion';
-import React, { useEffect } from 'react';
+import { useState, useEffect } from 'react';
+import type { OrganizationCurrent } from '@bigcapital/sdk-ts';
 import { FormattedMessage as T } from '@/components';
-import { withOrganizationActions } from '@/containers/Organization/withOrganizationActions';
+import {
+  withOrganizationActions,
+  WithOrganizationActionsProps,
+} from '@/containers/Organization/withOrganizationActions';
 import { useJob, useCurrentOrganization } from '@/hooks/query';
 import { useIsDarkMode } from '@/hooks/useDarkMode';
 
 /**
  * Setup initializing step form.
  */
-function SetupInitializingFormInner({ setOrganizationSetupCompleted }) {
+function SetupInitializingFormInner({
+  setOrganizationSetupCompleted,
+}: WithOrganizationActionsProps) {
   const {
     data: organization,
     refetch,
@@ -19,15 +24,16 @@ function SetupInitializingFormInner({ setOrganizationSetupCompleted }) {
   } = useCurrentOrganization({ enabled: false });
 
   // Job done state.
-  const [isJobDone, setIsJobDone] = React.useState(false);
+  const [isJobDone, setIsJobDone] = useState(false);
 
-  const { data: jobState, isFetching: isJobFetching } = useJob(
-    organization?.buildJobId,
-    {
-      refetchInterval: 2000,
-      enabled: !!organization?.buildJobId,
-    },
-  );
+  const buildJobId = (
+    organization as (OrganizationCurrent & { buildJobId?: string }) | undefined
+  )?.buildJobId;
+
+  const { data: jobState, isFetching: isJobFetching } = useJob(buildJobId, {
+    refetchInterval: 2000,
+    enabled: !!buildJobId,
+  });
   const isRunning = Boolean(jobState?.isRunning);
   const isWaiting = Boolean(jobState?.isWaiting);
   const isFailed = Boolean(jobState?.isFailed);
@@ -121,7 +127,7 @@ function SetupInitializingRunning() {
   return (
     <x.div>
       <x.div className={progressBarStyles}>
-        <ProgressBar intent={Intent.NONE} value={null} />
+        <ProgressBar intent={Intent.NONE} value={undefined} />
       </x.div>
 
       <x.div textAlign="center" mt={35}>

--- a/packages/webapp/src/containers/Setup/SetupLeftSection.tsx
+++ b/packages/webapp/src/containers/Setup/SetupLeftSection.tsx
@@ -1,19 +1,13 @@
-// @ts-nocheck
-import { Text } from '@blueprintjs/core';
-import React from 'react';
-import { useHistory } from 'react-router-dom';
-import style from './SetupLeftSection.module.scss';
-import { Icon, For, FormattedMessage as T, Stack } from '@/components';
+import { Icon, For, FormattedMessage as T } from '@/components';
 import { getFooterLinks } from '@/constants/footerLinks';
-import { useAuthMetadata } from '@/hooks/query';
 import { useAuthActions } from '@/hooks/state';
 
 /**
  * Footer item link.
  */
-function FooterLinkItem({ title, link }) {
+function FooterLinkItem({ title, link }: { title: string; link: string }) {
   return (
-    <div class="content__links-item">
+    <div className="content__links-item">
       <a href={link} target="_blank" rel="noreferrer">
         {title}
       </a>
@@ -28,24 +22,8 @@ function SetupLeftSectionFooter() {
   // Retrieve the footer links.
   const footerLinks = getFooterLinks();
 
-  const { data: authMeta } = useAuthMetadata();
-  const demoUrl = authMeta?.meta?.one_click_demo?.demo_url;
-
-  const handleDemoBtnClick = () => {
-    window.open(demoUrl);
-  };
-
   return (
     <div className={'content__footer'}>
-      {demoUrl && (
-        <Stack spacing={16}>
-          <Text className={style.demoButtonLabel}>Not Now?</Text>
-          <button className={style.demoButton} onClick={handleDemoBtnClick}>
-            Try Demo Account
-          </button>
-        </Stack>
-      )}
-
       <div className={'content__links'}>
         <For render={FooterLinkItem} of={footerLinks} />
       </div>
@@ -75,7 +53,7 @@ function SetupLeftSectionHeader() {
       </p>
 
       <div className={'content__organization'}>
-        <span class="signout">
+        <span className="signout">
           <a onClick={onClickLogout} href="#">
             <T id={'sign_out'} />
           </a>

--- a/packages/webapp/src/containers/Setup/SetupOrganizationForm.tsx
+++ b/packages/webapp/src/containers/Setup/SetupOrganizationForm.tsx
@@ -1,12 +1,9 @@
-// @ts-nocheck
 import { getAllCountries } from '@bigcapital/utils';
-import { Button, Intent, FormGroup, Classes } from '@blueprintjs/core';
-import { TimezonePicker } from '@blueprintjs/timezone';
+import { Button, Intent, Classes } from '@blueprintjs/core';
 import { x } from '@xstyled/emotion';
-import classNames from 'classnames';
-import { FastField, Form, ErrorMessage } from 'formik';
-import React from 'react';
+import { Form, FormikProps } from 'formik';
 import intl from 'react-intl-universal';
+import type { SetupOrganizationFormValues } from './SetupOrganization.schema';
 import {
   FFormGroup,
   FInputGroup,
@@ -19,14 +16,15 @@ import { getAllCurrenciesOptions } from '@/constants/currencies';
 import { getFiscalYear } from '@/constants/fiscalYearOptions';
 import { getLanguages } from '@/constants/languagesOptions';
 import { useIsDarkMode } from '@/hooks/useDarkMode';
-import { inputIntent } from '@/utils';
 
 const countries = getAllCountries();
 
 /**
  * Setup organization form.
  */
-export function SetupOrganizationForm({ isSubmitting, values }) {
+export function SetupOrganizationForm({
+  isSubmitting,
+}: FormikProps<SetupOrganizationFormValues>) {
   const FiscalYear = getFiscalYear();
   const Languages = getLanguages();
   const currencies = getAllCurrenciesOptions();
@@ -126,7 +124,7 @@ export function SetupOrganizationForm({ isSubmitting, values }) {
           name={'timezone'}
           valueDisplayFormat="composite"
           showLocalTimezone={true}
-          placeholder={<T id={'select_time_zone'} />}
+          placeholder={intl.get('select_time_zone')}
           popoverProps={{ minimal: true }}
           buttonProps={{
             alignText: 'left',

--- a/packages/webapp/src/containers/Setup/SetupOrganizationPage.tsx
+++ b/packages/webapp/src/containers/Setup/SetupOrganizationPage.tsx
@@ -1,15 +1,13 @@
-// @ts-nocheck
 import { x } from '@xstyled/emotion';
-import { Formik } from 'formik';
-import React from 'react';
+import { Formik, FormikHelpers } from 'formik';
 import { getSetupOrganizationValidation } from './SetupOrganization.schema';
 import { SetupOrganizationForm } from './SetupOrganizationForm';
-import { FormattedMessage as T } from '@/components';
+import type { SetupOrganizationFormValues } from './SetupOrganization.schema';
 import { useOrganizationSetup, useSettingsOrganization } from '@/hooks/query';
 import { setCookie, transfromToSnakeCase } from '@/utils';
 
 // Initial values.
-const defaultValues = {
+const defaultValues: SetupOrganizationFormValues = {
   name: '',
   location: '',
   baseCurrency: '',
@@ -18,44 +16,62 @@ const defaultValues = {
   timezone: '',
 };
 
+export interface SetupOrganizationPageProps {
+  wizard?: {
+    next?: () => void;
+  };
+}
+
+interface OrganizationSettings {
+  name?: string;
+  location?: string;
+  baseCurrency?: string;
+  language?: string;
+  fiscalYear?: string;
+  timezone?: string;
+}
+
 /**
  * Setup organization form.
  */
-export function SetupOrganizationPage({ wizard }) {
+export function SetupOrganizationPage({ wizard }: SetupOrganizationPageProps) {
   const { mutateAsync: organizationSetupMutate } = useOrganizationSetup();
   const { data: organizationSettings } = useSettingsOrganization();
+
+  const settings = organizationSettings as OrganizationSettings | undefined;
 
   // Validation schema.
   const validationSchema = getSetupOrganizationValidation();
 
   // Initialize values.
-  const initialValues = {
+  const initialValues: SetupOrganizationFormValues = {
     ...defaultValues,
-    ...(organizationSettings
+    ...(settings
       ? {
-          name: organizationSettings.name ?? defaultValues.name,
-          location: organizationSettings.location ?? defaultValues.location,
-          baseCurrency:
-            organizationSettings.baseCurrency ?? defaultValues.baseCurrency,
-          language: organizationSettings.language ?? defaultValues.language,
-          fiscalYear:
-            organizationSettings.fiscalYear ?? defaultValues.fiscalYear,
-          timezone: organizationSettings.timezone ?? defaultValues.timezone,
+          name: settings.name ?? defaultValues.name,
+          location: settings.location ?? defaultValues.location,
+          baseCurrency: settings.baseCurrency ?? defaultValues.baseCurrency,
+          language: settings.language ?? defaultValues.language,
+          fiscalYear: settings.fiscalYear ?? defaultValues.fiscalYear,
+          timezone: settings.timezone ?? defaultValues.timezone,
         }
       : {}),
   };
 
   // Handle the form submit.
-  const handleSubmit = (values, { setSubmitting, setErrors }) => {
+  const handleSubmit = (
+    values: SetupOrganizationFormValues,
+    { setSubmitting }: FormikHelpers<SetupOrganizationFormValues>,
+  ) => {
     organizationSetupMutate({ ...transfromToSnakeCase(values) })
-      .then((response) => {
+      .then(() => {
         setSubmitting(false);
 
         // Sets locale cookie to next boot cycle.
         setCookie('locale', values.language);
-        wizard.next();
+        wizard?.next?.();
       })
-      .catch((erros) => {
+      .catch(() => {
         setSubmitting(false);
       });
   };

--- a/packages/webapp/src/containers/Setup/SetupSubscription/SetupSubscription.tsx
+++ b/packages/webapp/src/containers/Setup/SetupSubscription/SetupSubscription.tsx
@@ -1,7 +1,9 @@
-// @ts-nocheck
 import * as R from 'ramda';
 import { useEffect } from 'react';
-import { withSubscriptionPlansActions } from '../../Subscriptions/withSubscriptionPlansActions';
+import {
+  withSubscriptionPlansActions,
+  WithSubscriptionPlansActionsProps,
+} from '../../Subscriptions/withSubscriptionPlansActions';
 import styles from './SetupSubscription.module.scss';
 import { SubscriptionPlansSection } from './SubscriptionPlansSection';
 import { Box } from '@/components';
@@ -10,15 +12,14 @@ import { Box } from '@/components';
  * Subscription step of wizard setup.
  */
 function SetupSubscriptionInner({
-  // #withSubscriptionPlansActions
   initSubscriptionPlans,
-}) {
+}: WithSubscriptionPlansActionsProps) {
   useEffect(() => {
     initSubscriptionPlans();
   }, [initSubscriptionPlans]);
 
   useEffect(() => {
-    window.LemonSqueezy.Setup({
+    window.LemonSqueezy?.Setup({
       eventHandler: (event) => {
         // Do whatever you want with this event data
         if (event.event === 'Checkout.Success') {

--- a/packages/webapp/src/containers/Setup/SetupSubscription/SubscriptionPlans.tsx
+++ b/packages/webapp/src/containers/Setup/SetupSubscription/SubscriptionPlans.tsx
@@ -1,9 +1,11 @@
-// @ts-nocheck
 import { Intent } from '@blueprintjs/core';
 import * as R from 'ramda';
 import { useSubscriptionPlans } from './hooks';
 import { AppToaster, Group, GroupProps } from '@/components';
-import { SubscriptionPlan } from '@/containers/Subscriptions/component/SubscriptionPlan';
+import {
+  SubscriptionPlan,
+  SubscriptionPricingProps,
+} from '@/containers/Subscriptions/component/SubscriptionPlan';
 import { withSubscriptionPlanMapper } from '@/containers/Subscriptions/component/withSubscriptionPlanMapper';
 import { withPlans } from '@/containers/Subscriptions/withPlans';
 import { useGetLemonSqueezyCheckout } from '@/hooks/query';
@@ -13,6 +15,15 @@ interface SubscriptionPlansProps {
   wrapProps?: GroupProps;
   onSubscribe?: (variantId: number) => void;
 }
+
+type SubscriptionPlanMappedProps = Omit<
+  SubscriptionPricingProps,
+  'onSubscribe'
+> & {
+  plansPeriod: SubscriptionPlansPeriod;
+  monthlyVariantId: string;
+  annuallyVariantId: string;
+};
 
 export function SubscriptionPlans({
   wrapProps,
@@ -32,8 +43,13 @@ export function SubscriptionPlans({
 const SubscriptionPlanMapped = R.compose(
   withSubscriptionPlanMapper,
   withPlans(({ plansPeriod }) => ({ plansPeriod })),
-)(({ plansPeriod, monthlyVariantId, annuallyVariantId, ...props }) => {
-  const { mutateAsync: getLemonCheckout, isLoading } =
+)(({
+  plansPeriod,
+  monthlyVariantId,
+  annuallyVariantId,
+  ...planProps
+}: SubscriptionPlanMappedProps) => {
+  const { mutateAsync: getLemonCheckout, isPending } =
     useGetLemonSqueezyCheckout();
 
   const handleSubscribeBtnClick = () => {
@@ -45,7 +61,7 @@ const SubscriptionPlanMapped = R.compose(
     getLemonCheckout({ variantId })
       .then((res) => {
         const checkoutUrl = res.data.data.attributes.url;
-        window.LemonSqueezy.Url.Open(checkoutUrl);
+        window.LemonSqueezy?.Url.Open(checkoutUrl);
       })
       .catch(() => {
         AppToaster.show({
@@ -56,10 +72,10 @@ const SubscriptionPlanMapped = R.compose(
   };
   return (
     <SubscriptionPlan
-      {...props}
+      {...planProps}
       onSubscribe={handleSubscribeBtnClick}
       subscribeButtonProps={{
-        loading: isLoading,
+        loading: isPending,
       }}
     />
   );

--- a/packages/webapp/src/containers/Setup/SetupWizardContent.tsx
+++ b/packages/webapp/src/containers/Setup/SetupWizardContent.tsx
@@ -1,7 +1,5 @@
-// @ts-nocheck
 import { css } from '@emotion/css';
 import { x } from '@xstyled/emotion';
-import React from 'react';
 import { SetupCongratsPage } from './SetupCongratsPage';
 import { SetupInitializingForm } from './SetupInitializingForm';
 import { SetupOrganizationPage } from './SetupOrganizationPage';
@@ -37,15 +35,15 @@ export function SetupWizardContent({
         </Stepper.Step>
 
         <Stepper.Step label={'Organization'}>
-          <SetupOrganizationPage id="organization" />
+          <SetupOrganizationPage />
         </Stepper.Step>
 
         <Stepper.Step label={'Initializing'}>
-          <SetupInitializingForm id={'initializing'} />
+          <SetupInitializingForm />
         </Stepper.Step>
 
         <Stepper.Step label={'Congrats'}>
-          <SetupCongratsPage id="congrats" />
+          <SetupCongratsPage />
         </Stepper.Step>
       </Stepper>
     </x.div>

--- a/packages/webapp/src/containers/Setup/SubscriptionForm.schema.tsx
+++ b/packages/webapp/src/containers/Setup/SubscriptionForm.schema.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import intl from 'react-intl-universal';
 import * as Yup from 'yup';
 

--- a/packages/webapp/src/containers/Setup/WizardSetupPage.tsx
+++ b/packages/webapp/src/containers/Setup/WizardSetupPage.tsx
@@ -1,5 +1,3 @@
-// @ts-nocheck
-import React from 'react';
 import { SetupLeftSection } from './SetupLeftSection';
 import { SetupRightSection } from './SetupRightSection';
 import EnsureOrganizationIsNotReady from '@/components/Guards/EnsureOrganizationIsNotReady';
@@ -9,7 +7,7 @@ import '@/style/pages/Setup/SetupPage.scss';
 export function WizardSetupPage() {
   return (
     <EnsureOrganizationIsNotReady>
-      <div class="setup-page">
+      <div className="setup-page">
         <SetupLeftSection />
         <SetupRightSection />
       </div>

--- a/packages/webapp/src/containers/Setup/WizardSetupSteps.tsx
+++ b/packages/webapp/src/containers/Setup/WizardSetupSteps.tsx
@@ -1,9 +1,13 @@
-// @ts-nocheck
 import classNames from 'classnames';
-import React from 'react';
 import { getSetupWizardSteps } from '@/constants/registerWizard';
 
-function WizardSetupStep({ label, isActive = false }) {
+function WizardSetupStep({
+  label,
+  isActive = false,
+}: {
+  label: string;
+  isActive?: boolean;
+}) {
   return (
     <li className={classNames({ 'is-active': isActive })}>
       <p className={'wizard-info'}>{label}</p>
@@ -14,7 +18,11 @@ function WizardSetupStep({ label, isActive = false }) {
 /**
  * Setup wizard setups.
  */
-export function WizardSetupSteps({ currentStep = 1 }) {
+export function WizardSetupSteps({
+  currentStep = 1,
+}: {
+  currentStep?: number;
+}) {
   const setupWizardSetups = getSetupWizardSteps();
 
   return (

--- a/packages/webapp/src/containers/Setup/WorkflowIcon.tsx
+++ b/packages/webapp/src/containers/Setup/WorkflowIcon.tsx
@@ -1,7 +1,10 @@
-// @ts-nocheck
-import React from 'react';
-
-export function WorkflowIcon({ width = '309.566', height = '356.982' }) {
+export function WorkflowIcon({
+  width = '309.566',
+  height = '356.982',
+}: {
+  width?: string;
+  height?: string;
+}) {
   return (
     <svg width={width} height={height} viewBox="0 0 309.566 356.982">
       <defs>

--- a/packages/webapp/src/containers/Subscriptions/component/SubscriptionPlan.tsx
+++ b/packages/webapp/src/containers/Subscriptions/component/SubscriptionPlan.tsx
@@ -15,7 +15,7 @@ interface SubscriptionPricingFeature {
   style?: Record<string, string>;
 }
 
-interface SubscriptionPricingProps {
+export interface SubscriptionPricingProps {
   slug: string;
   label: string;
   description: string;

--- a/packages/webapp/src/containers/Subscriptions/component/withSubscriptionPlanMapper.tsx
+++ b/packages/webapp/src/containers/Subscriptions/component/withSubscriptionPlanMapper.tsx
@@ -5,13 +5,13 @@ interface SubscriptionPlan {
   name: string;
   description: string;
   features: unknown[];
-  featured: boolean;
+  featured?: boolean;
   monthlyPrice: string;
   monthlyPriceLabel: string;
   annuallyPrice: string;
   annuallyPriceLabel: string;
-  monthlyVariantId: number;
-  annuallyVariantId: number;
+  monthlyVariantId: string;
+  annuallyVariantId: string;
 }
 
 interface WithSubscriptionPlanProps {
@@ -24,13 +24,13 @@ interface MappedSubscriptionPlanProps {
   label: string;
   description: string;
   features: unknown[];
-  featured: boolean;
+  featured?: boolean;
   monthlyPrice: string;
   monthlyPriceLabel: string;
   annuallyPrice: string;
   annuallyPriceLabel: string;
-  monthlyVariantId: number;
-  annuallyVariantId: number;
+  monthlyVariantId: string;
+  annuallyVariantId: string;
   onSubscribe?: (variantId: number) => void;
 }
 

--- a/packages/webapp/src/containers/TaxRates/alerts/TaxRateDeleteAlert.tsx
+++ b/packages/webapp/src/containers/TaxRates/alerts/TaxRateDeleteAlert.tsx
@@ -1,31 +1,41 @@
-// @ts-nocheck
 import { Intent, Alert } from '@blueprintjs/core';
-import React from 'react';
-import { AppToaster, FormattedMessage as T } from '@/components';
+import intl from 'react-intl-universal';
+import { AppToaster } from '@/components';
 import { DRAWERS } from '@/constants/drawers';
-import { withAlertActions } from '@/containers/Alert/withAlertActions';
-import { withAlertStoreConnect } from '@/containers/Alert/withAlertStoreConnect';
-import { withDrawerActions } from '@/containers/Drawer/withDrawerActions';
+import {
+  withAlertActions,
+  WithAlertActionsProps,
+} from '@/containers/Alert/withAlertActions';
+import {
+  withAlertStoreConnect,
+  WithAlertStoreConnectProps,
+} from '@/containers/Alert/withAlertStoreConnect';
+import {
+  withDrawerActions,
+  WithDrawerActionsProps,
+} from '@/containers/Drawer/withDrawerActions';
 import { useDeleteTaxRate } from '@/hooks/query/tax-rates';
 import { compose } from '@/utils';
+
+interface TaxRateDeleteAlertInnerProps
+  extends Pick<WithAlertStoreConnectProps, 'isOpen'>,
+    Pick<WithAlertActionsProps, 'closeAlert'>,
+    Pick<WithDrawerActionsProps, 'closeDrawer'> {
+  name: string;
+  payload: { taxRateId: number };
+}
 
 /**
  * Item delete alerts.
  */
 function TaxRateDeleteAlertInner({
   name,
-
-  // #withAlertStoreConnect
   isOpen,
   payload: { taxRateId },
-
-  // #withAlertActions
   closeAlert,
-
-  // #withDrawerActions
   closeDrawer,
-}) {
-  const { mutateAsync: deleteTaxRate, isLoading } = useDeleteTaxRate();
+}: TaxRateDeleteAlertInnerProps) {
+  const { mutateAsync: deleteTaxRate, isPending } = useDeleteTaxRate();
 
   // Handle cancel delete item alert.
   const handleCancelItemDelete = () => {
@@ -41,7 +51,7 @@ function TaxRateDeleteAlertInner({
         });
         closeDrawer(DRAWERS.TAX_RATE_DETAILS);
       })
-      .catch(({ data: { errors } }) => {
+      .catch(() => {
         AppToaster.show({
           message: 'Something went wrong.',
           intent: Intent.DANGER,
@@ -54,14 +64,14 @@ function TaxRateDeleteAlertInner({
 
   return (
     <Alert
-      cancelButtonText={<T id={'cancel'} />}
-      confirmButtonText={<T id={'delete'} />}
+      cancelButtonText={intl.get('cancel')}
+      confirmButtonText={intl.get('delete')}
       icon="trash"
       intent={Intent.DANGER}
       isOpen={isOpen}
       onCancel={handleCancelItemDelete}
       onConfirm={handleConfirmDeleteItem}
-      loading={isLoading}
+      loading={isPending}
     >
       <p>
         Once you delete this tax rate, you won't be able to restore the item

--- a/packages/webapp/src/containers/TaxRates/alerts/index.ts
+++ b/packages/webapp/src/containers/TaxRates/alerts/index.ts
@@ -1,7 +1,6 @@
-// @ts-nocheck
-import React from 'react';
+import { lazy } from 'react';
 
-const TaxRateDeleteAlert = React.lazy(() =>
+const TaxRateDeleteAlert = lazy(() =>
   import('./TaxRateDeleteAlert').then((m) => ({
     default: m.TaxRateDeleteAlert,
   })),

--- a/packages/webapp/src/containers/TaxRates/containers/TaxRatesImport.tsx
+++ b/packages/webapp/src/containers/TaxRates/containers/TaxRatesImport.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { useHistory } from 'react-router-dom';
 import { DashboardInsider } from '@/components';
 import { ImportView } from '@/containers/Import';

--- a/packages/webapp/src/containers/TaxRates/containers/TaxRatesLandingActionsBar.tsx
+++ b/packages/webapp/src/containers/TaxRates/containers/TaxRatesLandingActionsBar.tsx
@@ -1,6 +1,4 @@
-// @ts-nocheck
 import { NavbarGroup, NavbarDivider, Button, Classes } from '@blueprintjs/core';
-import React from 'react';
 import { useHistory } from 'react-router-dom';
 import {
   DashboardActionsBar,
@@ -10,16 +8,18 @@ import {
 } from '@/components';
 import { AbilitySubject, TaxRateAction } from '@/constants/abilityOption';
 import { DialogsName } from '@/constants/dialogs';
-import { withDialogActions } from '@/containers/Dialog/withDialogActions';
+import {
+  withDialogActions,
+  WithDialogActionsProps,
+} from '@/containers/Dialog/withDialogActions';
 import { compose } from '@/utils';
 
 /**
  * Tax rates actions bar.
  */
 function TaxRatesActionsBar({
-  // #withDialogActions
   openDialog,
-}) {
+}: Pick<WithDialogActionsProps, 'openDialog'>) {
   const history = useHistory();
 
   // Handle `new item` button click.

--- a/packages/webapp/src/containers/TaxRates/containers/TaxRatesLandingEmptyState.tsx
+++ b/packages/webapp/src/containers/TaxRates/containers/TaxRatesLandingEmptyState.tsx
@@ -1,16 +1,16 @@
-// @ts-nocheck
 import { Button, Intent } from '@blueprintjs/core';
 import * as R from 'ramda';
-import React from 'react';
 import { EmptyStatus, Can, FormattedMessage as T } from '@/components';
 import { SaleInvoiceAction, AbilitySubject } from '@/constants/abilityOption';
 import { DialogsName } from '@/constants/dialogs';
-import { withDialogActions } from '@/containers/Dialog/withDialogActions';
+import {
+  withDialogActions,
+  WithDialogActionsProps,
+} from '@/containers/Dialog/withDialogActions';
 
 function TaxRatesLandingEmptyStateRoot({
-  // #withDialogAction
   openDialog,
-}) {
+}: Pick<WithDialogActionsProps, 'openDialog'>) {
   return (
     <EmptyStatus
       title={"The organization doesn't have taxes, yet!"}

--- a/packages/webapp/src/containers/TaxRates/containers/TaxRatesLandingProvider.tsx
+++ b/packages/webapp/src/containers/TaxRates/containers/TaxRatesLandingProvider.tsx
@@ -1,27 +1,45 @@
-// @ts-nocheck
+import { keepPreviousData } from '@tanstack/react-query';
 import { isEmpty } from 'lodash';
-import React from 'react';
+import { createContext, ReactNode, useContext } from 'react';
+import type { TaxRate } from '@bigcapital/sdk-ts';
 import { DashboardInsider } from '@/components/Dashboard';
 import { useTaxRates } from '@/hooks/query/tax-rates';
 
-const TaxRatesLandingContext = React.createContext();
+export interface TaxRatesLandingContextValue {
+  taxRates: TaxRate[] | undefined;
+  isTaxRatesFetching: boolean;
+  isTaxRatesLoading: boolean;
+  isEmptyStatus: boolean;
+}
+
+export interface TaxRatesLandingProviderProps {
+  tableState?: unknown;
+  children?: ReactNode;
+}
+
+const TaxRatesLandingContext = createContext<
+  TaxRatesLandingContextValue | undefined
+>(undefined);
 
 /**
  * Cash Flow data provider.
  */
-function TaxRatesLandingProvider({ tableState, ...props }) {
+function TaxRatesLandingProvider({
+  tableState,
+  ...props
+}: TaxRatesLandingProviderProps) {
   // Fetch cash flow list .
   const {
     data: taxRates,
     isFetching: isTaxRatesFetching,
     isLoading: isTaxRatesLoading,
-  } = useTaxRates({}, { keepPreviousData: true });
+  } = useTaxRates({ placeholderData: keepPreviousData });
 
   // Detarmines whether the table should show empty state.
   const isEmptyStatus = isEmpty(taxRates) && !isTaxRatesLoading;
 
   // Provider payload.
-  const provider = {
+  const provider: TaxRatesLandingContextValue = {
     taxRates,
     isTaxRatesFetching,
     isTaxRatesLoading,
@@ -35,7 +53,14 @@ function TaxRatesLandingProvider({ tableState, ...props }) {
   );
 }
 
-const useTaxRatesLandingContext = () =>
-  React.useContext(TaxRatesLandingContext);
+const useTaxRatesLandingContext = (): TaxRatesLandingContextValue => {
+  const context = useContext(TaxRatesLandingContext);
+  if (!context) {
+    throw new Error(
+      'useTaxRatesLandingContext must be used within a TaxRatesLandingProvider.',
+    );
+  }
+  return context;
+};
 
 export { TaxRatesLandingProvider, useTaxRatesLandingContext };

--- a/packages/webapp/src/containers/TaxRates/containers/TaxRatesLandingTable.tsx
+++ b/packages/webapp/src/containers/TaxRates/containers/TaxRatesLandingTable.tsx
@@ -1,10 +1,9 @@
-// @ts-nocheck
 import { Intent } from '@blueprintjs/core';
-import React from 'react';
 import { TaxRatesTableActionsMenu } from './_components';
 import { useTaxRatesTableColumns } from './_utils';
 import { TaxRatesLandingEmptyState } from './TaxRatesLandingEmptyState';
 import { useTaxRatesLandingContext } from './TaxRatesLandingProvider';
+import type { TaxRate } from '@bigcapital/sdk-ts';
 import {
   DataTable,
   DashboardContentTable,
@@ -14,35 +13,38 @@ import {
 } from '@/components';
 import { DialogsName } from '@/constants/dialogs';
 import { DRAWERS } from '@/constants/drawers';
-import { withAlertActions } from '@/containers/Alert/withAlertActions';
+import {
+  withAlertActions,
+  WithAlertActionsProps,
+} from '@/containers/Alert/withAlertActions';
 import { withDashboardActions } from '@/containers/Dashboard/withDashboardActions';
-import { withDialogActions } from '@/containers/Dialog/withDialogActions';
-import { withDrawerActions } from '@/containers/Drawer/withDrawerActions';
+import {
+  withDialogActions,
+  WithDialogActionsProps,
+} from '@/containers/Dialog/withDialogActions';
+import {
+  withDrawerActions,
+  WithDrawerActionsProps,
+} from '@/containers/Drawer/withDrawerActions';
 import {
   useActivateTaxRate,
   useInactivateTaxRate,
 } from '@/hooks/query/tax-rates';
-import { useSettingsInvoices, useSettingsOrganization } from '@/hooks/query';
 import { compose } from '@/utils';
+
+interface TaxRatesDataTableProps
+  extends Pick<WithAlertActionsProps, 'openAlert'>,
+    Pick<WithDrawerActionsProps, 'openDrawer'>,
+    Pick<WithDialogActionsProps, 'openDialog'> {}
 
 /**
  * Invoices datatable.
  */
 function TaxRatesDataTable({
-  // #withAlertActions
   openAlert,
-
-  // #withDrawerActions
   openDrawer,
-
-  // #withDialogAction
   openDialog,
-}) {
-  // Settings hooks.
-  const { data: organizationSettings } = useSettingsOrganization();
-  const { data: invoiceSettings } = useSettingsInvoices();
-  const invoicesTableSize = invoiceSettings?.tableSize;
-
+}: TaxRatesDataTableProps) {
   // Invoices list context.
   const { taxRates, isTaxRatesLoading, isEmptyStatus } =
     useTaxRatesLandingContext();
@@ -54,23 +56,26 @@ function TaxRatesDataTable({
   const { mutateAsync: inactivateTaxRateMutate } = useInactivateTaxRate();
 
   // Handle delete tax rate.
-  const handleDeleteTaxRate = ({ id }) => {
+  const handleDeleteTaxRate = ({ id }: { id: number }) => {
     openAlert('tax-rate-delete', { taxRateId: id });
   };
   // Handle edit tax rate.
-  const handleEditTaxRate = (taxRate) => {
+  const handleEditTaxRate = (taxRate: TaxRate) => {
     openDialog(DialogsName.TaxRateForm, { id: taxRate.id });
   };
   // Handle view details tax rate.
-  const handleViewDetails = (taxRate) => {
+  const handleViewDetails = (taxRate: TaxRate) => {
     openDrawer(DRAWERS.TAX_RATE_DETAILS, { taxRateId: taxRate.id });
   };
   // Handle table cell click.
-  const handleCellClick = (cell, event) => {
+  const handleCellClick = (
+    cell: { row: { original: TaxRate } },
+    event: unknown,
+  ) => {
     openDrawer(DRAWERS.TAX_RATE_DETAILS, { taxRateId: cell.row.original.id });
   };
   // Handles activating the given tax rate.
-  const handleActivateTaxRate = (taxRate) => {
+  const handleActivateTaxRate = (taxRate: TaxRate) => {
     activateTaxRateMutate(taxRate.id)
       .then(() => {
         AppToaster.show({
@@ -86,7 +91,7 @@ function TaxRatesDataTable({
       });
   };
   // Handles inactivating the given tax rate.
-  const handleInactivateTaxRate = (taxRate) => {
+  const handleInactivateTaxRate = (taxRate: TaxRate) => {
     inactivateTaxRateMutate(taxRate.id)
       .then(() => {
         AppToaster.show({

--- a/packages/webapp/src/containers/TaxRates/containers/_components.tsx
+++ b/packages/webapp/src/containers/TaxRates/containers/_components.tsx
@@ -1,9 +1,21 @@
-// @ts-nocheck
 import { Intent, Menu, MenuDivider, MenuItem } from '@blueprintjs/core';
-import React from 'react';
+import type { TaxRate } from '@bigcapital/sdk-ts';
 import { Can, Icon } from '@/components';
 import { AbilitySubject, TaxRateAction } from '@/constants/abilityOption';
 import { safeCallback } from '@/utils';
+
+interface TaxRatesTableActionsMenuProps {
+  payload: {
+    onEdit: (taxRate: TaxRate) => void;
+    onDelete: (taxRate: TaxRate) => void;
+    onViewDetails: (taxRate: TaxRate) => void;
+    onActivate: (taxRate: TaxRate) => void;
+    onInactivate: (taxRate: TaxRate) => void;
+  };
+  row: {
+    original: TaxRate;
+  };
+}
 
 /**
  * Tax rates table actions menu.
@@ -12,7 +24,7 @@ import { safeCallback } from '@/utils';
 export function TaxRatesTableActionsMenu({
   payload: { onEdit, onDelete, onViewDetails, onActivate, onInactivate },
   row: { original },
-}) {
+}: TaxRatesTableActionsMenuProps) {
   return (
     <Menu>
       <MenuItem

--- a/packages/webapp/src/containers/TaxRates/containers/_utils.tsx
+++ b/packages/webapp/src/containers/TaxRates/containers/_utils.tsx
@@ -1,10 +1,9 @@
-// @ts-nocheck
 import { Intent, Tag, Classes } from '@blueprintjs/core';
 import clsx from 'classnames';
-import React from 'react';
+import type { TaxRate } from '@bigcapital/sdk-ts';
 import { Align } from '@/constants';
 
-const codeAccessor = (taxRate) => {
+const codeAccessor = (taxRate: TaxRate) => {
   return (
     <Tag minimal={true} round={false} intent={Intent.NONE} interactive={true}>
       {taxRate.code}
@@ -12,7 +11,7 @@ const codeAccessor = (taxRate) => {
   );
 };
 
-const statusAccessor = (taxRate) => {
+const statusAccessor = (taxRate: TaxRate) => {
   return taxRate.active ? (
     <Tag round={false} intent={Intent.SUCCESS}>
       Active
@@ -24,18 +23,18 @@ const statusAccessor = (taxRate) => {
   );
 };
 
-const nameAccessor = (taxRate) => {
+const nameAccessor = (taxRate: TaxRate) => {
   return (
     <>
       <span>{taxRate.name}</span>
-      {!!taxRate.is_compound && (
+      {!!taxRate.isCompound && (
         <span className={clsx(Classes.TEXT_MUTED)}>(Compound tax)</span>
       )}
     </>
   );
 };
 
-const DescriptionAccessor = (taxRate) => {
+const DescriptionAccessor = (taxRate: TaxRate) => {
   return (
     <span className={clsx(Classes.TEXT_MUTED)}>{taxRate.description}</span>
   );
@@ -58,7 +57,7 @@ export const useTaxRatesTableColumns = () => {
     },
     {
       Header: 'Rate',
-      accessor: 'rate_formatted',
+      accessor: 'rateFormatted',
       align: Align.Right,
       width: 30,
     },

--- a/packages/webapp/src/containers/TaxRates/dialogs/TaxRateFormDialog/TaxRateForm.schema.ts
+++ b/packages/webapp/src/containers/TaxRates/dialogs/TaxRateFormDialog/TaxRateForm.schema.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import * as Yup from 'yup';
 
 const getSchema = () =>
@@ -6,15 +5,15 @@ const getSchema = () =>
     name: Yup.string().required().label('Name'),
     code: Yup.string().required().label('Code'),
     active: Yup.boolean().optional().label('Active'),
-    describtion: Yup.string().optional().label('Description'),
+    description: Yup.string().optional().label('Description'),
     rate: Yup.number()
       .min(0, 'Enter a rate percentage of at least 0%')
       .max(100, 'Enter a rate percentage of at most 100%')
       .required()
       .label('Rate'),
-    is_compound: Yup.boolean().optional().label('Is Compound'),
-    is_non_recoverable: Yup.boolean().optional().label('Is Non Recoverable'),
-    confirm_edit: Yup.boolean().optional(),
+    isCompound: Yup.boolean().optional().label('Is Compound'),
+    isNonRecoverable: Yup.boolean().optional().label('Is Non Recoverable'),
+    confirmEdit: Yup.boolean().optional(),
   });
 
 export const CreateTaxRateFormSchema = getSchema;

--- a/packages/webapp/src/containers/TaxRates/dialogs/TaxRateFormDialog/TaxRateFormDialogBoot.tsx
+++ b/packages/webapp/src/containers/TaxRates/dialogs/TaxRateFormDialog/TaxRateFormDialogBoot.tsx
@@ -1,29 +1,33 @@
-// @ts-nocheck
-import React from 'react';
+import { createContext, ReactNode, useContext } from 'react';
+import type { TaxRate } from '@bigcapital/sdk-ts';
 import { DialogContent } from '@/components';
-import { DialogsName } from '@/constants/dialogs';
 import { useTaxRate } from '@/hooks/query/tax-rates';
 
-const TaxRateFormDialogContext = React.createContext();
-
-interface TaxRateFormDialogBootProps {
+export interface TaxRateFormDialogBootContext {
   taxRateId: number;
-  children?: JSX.Element;
-}
-
-interface TaxRateFormDialogBootContext {
-  taxRateId: number;
-  taxRate: any;
+  taxRate: TaxRate | undefined;
   isTaxRateLoading: boolean;
   isTaxRateSuccess: boolean;
   isNewMode: boolean;
+  dialogName: string;
 }
+
+export interface TaxRateFormDialogBootProps {
+  taxRateId: number;
+  dialogName: string;
+  children?: ReactNode;
+}
+
+const TaxRateFormDialogContext = createContext<
+  TaxRateFormDialogBootContext | undefined
+>(undefined);
 
 /**
  * Money in dialog provider.
  */
 function TaxRateFormDialogBoot({
   taxRateId,
+  dialogName,
   ...props
 }: TaxRateFormDialogBootProps) {
   const {
@@ -37,13 +41,13 @@ function TaxRateFormDialogBoot({
   const isNewMode = !taxRateId;
 
   // Provider data.
-  const provider = {
+  const provider: TaxRateFormDialogBootContext = {
     taxRateId,
     taxRate,
     isTaxRateLoading,
     isTaxRateSuccess,
     isNewMode,
-    dialogName: DialogsName.TaxRateForm,
+    dialogName,
   };
   const isLoading = isTaxRateLoading;
 
@@ -54,7 +58,14 @@ function TaxRateFormDialogBoot({
   );
 }
 
-const useTaxRateFormDialogContext = () =>
-  React.useContext<TaxRateFormDialogBootContext>(TaxRateFormDialogContext);
+const useTaxRateFormDialogContext = (): TaxRateFormDialogBootContext => {
+  const context = useContext(TaxRateFormDialogContext);
+  if (!context) {
+    throw new Error(
+      'useTaxRateFormDialogContext must be used within a TaxRateFormDialogBoot.',
+    );
+  }
+  return context;
+};
 
 export { TaxRateFormDialogBoot, useTaxRateFormDialogContext };

--- a/packages/webapp/src/containers/TaxRates/dialogs/TaxRateFormDialog/TaxRateFormDialogContent.tsx
+++ b/packages/webapp/src/containers/TaxRates/dialogs/TaxRateFormDialog/TaxRateFormDialogContent.tsx
@@ -1,5 +1,3 @@
-// @ts-nocheck
-import React from 'react';
 import { TaxRateFormDialogBoot } from './TaxRateFormDialogBoot';
 import { TaxRateFormDialogForm } from './TaxRateFormDialogForm';
 

--- a/packages/webapp/src/containers/TaxRates/dialogs/TaxRateFormDialog/TaxRateFormDialogForm.tsx
+++ b/packages/webapp/src/containers/TaxRates/dialogs/TaxRateFormDialog/TaxRateFormDialogForm.tsx
@@ -1,7 +1,5 @@
-// @ts-nocheck
 import { Classes, Intent } from '@blueprintjs/core';
-import { Form, Formik } from 'formik';
-import React from 'react';
+import { Form, Formik, FormikHelpers } from 'formik';
 import {
   CreateTaxRateFormSchema,
   EditTaxRateFormSchema,
@@ -15,24 +13,33 @@ import {
   transformApiErrors,
   transformFormToReq,
   transformTaxRateToForm,
+  TaxRateFormValues,
 } from './utils';
+import type { ApiError } from 'openapi-typescript-fetch';
 import { AppToaster } from '@/components';
 import { DRAWERS } from '@/constants/drawers';
-import { withDialogActions } from '@/containers/Dialog/withDialogActions';
-import { withDrawerActions } from '@/containers/Drawer/withDrawerActions';
+import {
+  withDialogActions,
+  WithDialogActionsProps,
+} from '@/containers/Dialog/withDialogActions';
+import {
+  withDrawerActions,
+  WithDrawerActionsProps,
+} from '@/containers/Drawer/withDrawerActions';
 import { useCreateTaxRate, useEditTaxRate } from '@/hooks/query/tax-rates';
 import { compose } from '@/utils';
+
+interface TaxRateFormDialogFormProps
+  extends Pick<WithDialogActionsProps, 'closeDialog'>,
+    Pick<WithDrawerActionsProps, 'closeDrawer'> {}
 
 /**
  * Tax rate form dialog content.
  */
 function TaxRateFormDialogFormInner({
-  // #withDialogActions
   closeDialog,
-
-  // #withDrawerActions
   closeDrawer,
-}) {
+}: TaxRateFormDialogFormProps) {
   // Account form context.
   const { taxRate, taxRateId, isNewMode, dialogName } =
     useTaxRateFormDialogContext();
@@ -49,14 +56,17 @@ function TaxRateFormDialogFormInner({
   const initialValues = transformTaxRateToForm(taxRate);
 
   // Callbacks handles form submit.
-  const handleFormSubmit = (values, { setSubmitting, setErrors }) => {
+  const handleFormSubmit = (
+    values: TaxRateFormValues,
+    { setSubmitting, setErrors }: FormikHelpers<TaxRateFormValues>,
+  ) => {
     const isTaxChanged = isTaxRateChange(initialValues, values);
 
     // Detarmines whether in edit mode and tax rate has been changed
     // and confirm box is not checked.
-    if (!isNewMode && isTaxChanged && !values.confirm_edit) {
+    if (!isNewMode && isTaxChanged && !values.confirmEdit) {
       setErrors({
-        confirm_edit:
+        confirmEdit:
           'Please review the terms and conditions below before proceeding',
       });
       setSubmitting(false);
@@ -65,10 +75,8 @@ function TaxRateFormDialogFormInner({
     const form = transformFormToReq(values);
 
     // Handle request success on edit.
-    const handleSuccessOnEdit = (response) => {
-      if (response?.data?.data?.id !== taxRateId) {
-        closeDrawer(DRAWERS.TAX_RATE_DETAILS);
-      }
+    const handleSuccessOnEdit = () => {
+      closeDrawer(DRAWERS.TAX_RATE_DETAILS);
     };
     // Handle request success.
     const handleSuccess = () => {
@@ -79,21 +87,18 @@ function TaxRateFormDialogFormInner({
       });
     };
     // Handle request error.
-    const handleError = (error) => {
-      const {
-        data: { errors },
-      } = error;
+    const handleError = (error: ApiError) => {
+      const errors =
+        (error.data?.errors as Array<{ type?: string }> | undefined) ?? [];
 
       const errorsTransformed = transformApiErrors(errors);
       setErrors({ ...errorsTransformed });
       setSubmitting(false);
     };
     if (isNewMode) {
-      createTaxRateMutate({ ...form })
-        .then(handleSuccess)
-        .catch(handleError);
+      createTaxRateMutate(form).then(handleSuccess).catch(handleError);
     } else {
-      editTaxRateMutate([taxRateId, { ...form }])
+      editTaxRateMutate([String(taxRateId), form])
         .then(handleSuccessOnEdit)
         .then(handleSuccess)
         .catch(handleError);

--- a/packages/webapp/src/containers/TaxRates/dialogs/TaxRateFormDialog/TaxRateFormDialogFormContent.tsx
+++ b/packages/webapp/src/containers/TaxRates/dialogs/TaxRateFormDialog/TaxRateFormDialogFormContent.tsx
@@ -1,10 +1,13 @@
-// @ts-nocheck
 import { Tag, Text } from '@blueprintjs/core';
 import { useFormikContext } from 'formik';
-import React from 'react';
+import { ChangeEvent } from 'react';
 import styled from 'styled-components';
 import { useTaxRateFormDialogContext } from './TaxRateFormDialogBoot';
-import { transformTaxRateCodeValue, useIsTaxRateChanged } from './utils';
+import {
+  TaxRateFormValues,
+  transformTaxRateCodeValue,
+  useIsTaxRateChanged,
+} from './utils';
 import { FCheckbox, FFormGroup, FInputGroup, Hint } from '@/components';
 
 /**
@@ -52,18 +55,14 @@ export function TaxRateFormDialogContent() {
         <FInputGroup name={'description'} fastField={true} />
       </FFormGroup>
 
-      <CompoundFormGroup name={'is_compound'} fastField={true}>
-        <FCheckbox
-          label={'Is compound'}
-          name={'is_compound'}
-          fastField={true}
-        />
+      <CompoundFormGroup name={'isCompound'} fastField={true}>
+        <FCheckbox label={'Is compound'} name={'isCompound'} fastField={true} />
       </CompoundFormGroup>
 
-      <CompoundFormGroup name={'is_non_recoverable'} fastField={true}>
+      <CompoundFormGroup name={'isNonRecoverable'} fastField={true}>
         <FCheckbox
           label={'Is non recoverable'}
-          name={'is_non_recoverable'}
+          name={'isNonRecoverable'}
           fastField={true}
         />
       </CompoundFormGroup>
@@ -78,10 +77,10 @@ export function TaxRateFormDialogContent() {
  * @returns {JSX.Element}
  */
 function TaxRateCodeField() {
-  const { setFieldValue } = useFormikContext();
+  const { setFieldValue } = useFormikContext<TaxRateFormValues>();
 
   // Handle the field change.
-  const handleChange = (event) => {
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     const transformedValue = transformTaxRateCodeValue(event.target.value);
     setFieldValue('code', transformedValue);
   };
@@ -108,9 +107,9 @@ function ConfirmEditingTaxRate() {
   return (
     <EditWarningWrap>
       <Text color={'#766f58'}>Please Note:</Text>
-      <ConfirmEditFormGroup name={'confirm_edit'} helperText={''}>
+      <ConfirmEditFormGroup name={'confirmEdit'} helperText={''}>
         <FCheckbox
-          name={'confirm_edit'}
+          name={'confirmEdit'}
           label={`I understand that updating the
           tax will mark the existing tax inactive, create a new tax, and update
           it in the chosen transactions.`}

--- a/packages/webapp/src/containers/TaxRates/dialogs/TaxRateFormDialog/TaxRateFormDialogFormErrors.tsx
+++ b/packages/webapp/src/containers/TaxRates/dialogs/TaxRateFormDialog/TaxRateFormDialogFormErrors.tsx
@@ -1,13 +1,12 @@
-// @ts-nocheck
 import { Intent } from '@blueprintjs/core';
 import { useFormikContext } from 'formik';
-import React from 'react';
+import { TaxRateFormValues } from './utils';
 import { Alert } from '@/components';
 
 export function TaxRateFormDialogFormErrors() {
-  const { errors } = useFormikContext();
+  const { errors } = useFormikContext<TaxRateFormValues>();
 
-  if (!errors.confirm_edit) return null;
+  if (!errors.confirmEdit) return null;
 
-  return <Alert intent={Intent.DANGER}>{errors.confirm_edit}</Alert>;
+  return <Alert intent={Intent.DANGER}>{errors.confirmEdit}</Alert>;
 }

--- a/packages/webapp/src/containers/TaxRates/dialogs/TaxRateFormDialog/TaxRateFormDialogFormFooter.tsx
+++ b/packages/webapp/src/containers/TaxRates/dialogs/TaxRateFormDialog/TaxRateFormDialogFormFooter.tsx
@@ -1,12 +1,15 @@
-// @ts-nocheck
 import { Button, Classes, Intent } from '@blueprintjs/core';
 import { useFormikContext } from 'formik';
 import * as R from 'ramda';
-import React from 'react';
 import { DialogsName } from '@/constants/dialogs';
-import { withDialogActions } from '@/containers/Dialog/withDialogActions';
+import {
+  withDialogActions,
+  WithDialogActionsProps,
+} from '@/containers/Dialog/withDialogActions';
 
-function TaxRateFormDialogFormFooterRoot({ closeDialog }) {
+function TaxRateFormDialogFormFooterRoot({
+  closeDialog,
+}: Pick<WithDialogActionsProps, 'closeDialog'>) {
   const { isSubmitting } = useFormikContext();
 
   const handleClose = () => {

--- a/packages/webapp/src/containers/TaxRates/dialogs/TaxRateFormDialog/utils.ts
+++ b/packages/webapp/src/containers/TaxRates/dialogs/TaxRateFormDialog/utils.ts
@@ -1,26 +1,46 @@
-// @ts-nocheck
 import { useFormikContext } from 'formik';
-import { omit } from 'lodash';
-import * as R from 'ramda';
+import type { TaxRate } from '@bigcapital/sdk-ts';
 import { transformToForm } from '@/utils';
 
+export interface TaxRateFormValues {
+  name: string;
+  code: string;
+  rate: string;
+  description: string;
+  isCompound: boolean;
+  isNonRecoverable: boolean;
+  confirmEdit: boolean;
+}
+
+export interface TaxRateFormRequestBody {
+  name: string;
+  code: string;
+  rate: number;
+  description: string;
+  isCompound: boolean;
+  isNonRecoverable: boolean;
+  active: boolean;
+}
+
 // Default initial form values.
-export const defaultInitialValues = {
+export const defaultInitialValues: TaxRateFormValues = {
   name: '',
   code: '',
   rate: '',
   description: '',
-  is_compound: false,
-  is_non_recoverable: false,
-  confirm_edit: false,
+  isCompound: false,
+  isNonRecoverable: false,
+  confirmEdit: false,
 };
 
 /**
  * Transformers response errors to form errors.
  * @returns {Record<string, string>}
  */
-export const transformApiErrors = (errors) => {
-  const fields = {};
+export const transformApiErrors = (
+  errors: Array<{ type?: string }>,
+): Record<string, string> => {
+  const fields: Record<string, string> = {};
 
   if (errors.find((e) => e.type === 'TAX_CODE_NOT_UNIQUE')) {
     fields.code = 'The tax rate is not unique.';
@@ -31,8 +51,18 @@ export const transformApiErrors = (errors) => {
 /**
  * Tranformes form values to request values.
  */
-export const transformFormToReq = (form) => {
-  return omit({ ...form }, ['confirm_edit']);
+export const transformFormToReq = (
+  form: TaxRateFormValues,
+): TaxRateFormRequestBody => {
+  return {
+    name: form.name,
+    code: form.code,
+    rate: Number(form.rate),
+    description: form.description,
+    isCompound: form.isCompound,
+    isNonRecoverable: form.isNonRecoverable,
+    active: true,
+  };
 };
 
 /**
@@ -41,7 +71,10 @@ export const transformFormToReq = (form) => {
  * @param formValues
  * @returns {boolean}
  */
-export const isTaxRateChange = (initialValues, formValues) => {
+export const isTaxRateChange = (
+  initialValues: TaxRateFormValues,
+  formValues: TaxRateFormValues,
+): boolean => {
   return initialValues.rate !== formValues.rate;
 };
 
@@ -49,33 +82,34 @@ export const isTaxRateChange = (initialValues, formValues) => {
  * Detarmines whether the tax rate changed.
  * @returns {boolean}
  */
-export const useIsTaxRateChanged = () => {
-  const { initialValues, values } = useFormikContext();
+export const useIsTaxRateChanged = (): boolean => {
+  const { initialValues, values } = useFormikContext<TaxRateFormValues>();
 
   return isTaxRateChange(initialValues, values);
 };
 
-const convertFormAttrsToBoolean = (form) => {
+const convertFormAttrsToBoolean = (
+  form: TaxRateFormValues,
+): TaxRateFormValues => {
   return {
     ...form,
-    is_compound: !!form.is_compound,
-    is_non_recoverable: !!form.is_non_recoverable,
+    isCompound: !!form.isCompound,
+    isNonRecoverable: !!form.isNonRecoverable,
   };
 };
 
-export const transformTaxRateToForm = (taxRate) => {
-  return R.compose(convertFormAttrsToBoolean)({
+export const transformTaxRateToForm = (
+  taxRate?: TaxRate,
+): TaxRateFormValues => {
+  return convertFormAttrsToBoolean({
     ...defaultInitialValues,
-    /**
-     * We only care about the fields in the form. Previously unfilled optional
-     * values such as `notes` come back from the API as null, so remove those
-     * as well.
-     */
     ...transformToForm(taxRate, defaultInitialValues),
+    rate:
+      taxRate?.rate != null ? String(taxRate.rate) : defaultInitialValues.rate,
   });
 };
 
-export const transformTaxRateCodeValue = (input: string) => {
+export const transformTaxRateCodeValue = (input: string): string => {
   // Remove non-alphanumeric characters and spaces using a regular expression
   const cleanedString = input.replace(/\s+/g, '');
 

--- a/packages/webapp/src/containers/TaxRates/drawers/TaxRateDetailsDrawer/TaxRateDetailsContent.tsx
+++ b/packages/webapp/src/containers/TaxRates/drawers/TaxRateDetailsDrawer/TaxRateDetailsContent.tsx
@@ -1,24 +1,20 @@
-// @ts-nocheck
-import React from 'react';
 import { TaxRateDetailsContentActionsBar } from './TaxRateDetailsContentActionsBar';
 import { TaxRateDetailsContentBoot } from './TaxRateDetailsContentBoot';
 import { TaxRateDetailsContentDetails } from './TaxRateDetailsContentDetails';
 import { DrawerBody, DrawerHeaderContent } from '@/components';
-import { DRAWERS } from '@/constants/drawers';
 
 interface TaxRateDetailsContentProps {
-  taxRateid: number;
+  name: string;
+  taxRateId: number;
 }
 
 export function TaxRateDetailsContent({
+  name,
   taxRateId,
 }: TaxRateDetailsContentProps) {
   return (
     <TaxRateDetailsContentBoot taxRateId={taxRateId}>
-      <DrawerHeaderContent
-        name={DRAWERS.TAX_RATE_DETAILS}
-        title={'Tax Rate Details'}
-      />
+      <DrawerHeaderContent name={name} title={'Tax Rate Details'} />
       <TaxRateDetailsContentActionsBar />
 
       <DrawerBody>

--- a/packages/webapp/src/containers/TaxRates/drawers/TaxRateDetailsDrawer/TaxRateDetailsContentActionsBar.tsx
+++ b/packages/webapp/src/containers/TaxRates/drawers/TaxRateDetailsDrawer/TaxRateDetailsContentActionsBar.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import {
   Button,
   Classes,
@@ -11,31 +10,37 @@ import {
   PopoverInteractionKind,
   Position,
 } from '@blueprintjs/core';
-import * as R from 'ramda';
-import React from 'react';
 import { useTaxRateDetailsContext } from './TaxRateDetailsContentBoot';
 import { AppToaster, Can, DrawerActionsBar, Icon } from '@/components';
 import { AbilitySubject, TaxRateAction } from '@/constants/abilityOption';
 import { DialogsName } from '@/constants/dialogs';
-import { withAlertActions } from '@/containers/Alert/withAlertActions';
-import { withDialogActions } from '@/containers/Dialog/withDialogActions';
+import {
+  withAlertActions,
+  WithAlertActionsProps,
+} from '@/containers/Alert/withAlertActions';
+import {
+  withDialogActions,
+  WithDialogActionsProps,
+} from '@/containers/Dialog/withDialogActions';
 import { withDrawerActions } from '@/containers/Drawer/withDrawerActions';
 import {
   useActivateTaxRate,
   useInactivateTaxRate,
 } from '@/hooks/query/tax-rates';
+import { compose } from '@/utils';
+
+interface TaxRateDetailsContentActionsBarInnerProps
+  extends Pick<WithDialogActionsProps, 'openDialog'>,
+    Pick<WithAlertActionsProps, 'openAlert'> {}
 
 /**
  * Tax rate details content actions bar.
  * @returns {JSX.Element}
  */
 function TaxRateDetailsContentActionsBarInner({
-  // #withDrawerActions
   openDialog,
-
-  // #withAlertActions
   openAlert,
-}) {
+}: TaxRateDetailsContentActionsBarInnerProps) {
   const { taxRateId, taxRate } = useTaxRateDetailsContext();
 
   const { mutateAsync: activateTaxRateMutate } = useActivateTaxRate();
@@ -115,13 +120,13 @@ function TaxRateDetailsContentActionsBarInner({
             }}
             content={
               <Menu>
-                {!taxRate.active && (
+                {!taxRate?.active && (
                   <MenuItem
                     text={'Activate Tax Rate'}
                     onClick={handleActivateTaxRate}
                   />
                 )}
-                {!!taxRate.active && (
+                {!!taxRate?.active && (
                   <MenuItem
                     text={'Inactivate Tax Rate'}
                     onClick={handleInactivateTaxRate}
@@ -141,7 +146,7 @@ function TaxRateDetailsContentActionsBarInner({
   );
 }
 
-export const TaxRateDetailsContentActionsBar = R.compose(
+export const TaxRateDetailsContentActionsBar = compose(
   withDrawerActions,
   withDialogActions,
   withAlertActions,

--- a/packages/webapp/src/containers/TaxRates/drawers/TaxRateDetailsDrawer/TaxRateDetailsContentBoot.tsx
+++ b/packages/webapp/src/containers/TaxRates/drawers/TaxRateDetailsDrawer/TaxRateDetailsContentBoot.tsx
@@ -1,13 +1,24 @@
-// @ts-nocheck
-import React, { createContext, useContext } from 'react';
+import { keepPreviousData } from '@tanstack/react-query';
+import { createContext, ReactNode, useContext } from 'react';
+import type { TaxRate } from '@bigcapital/sdk-ts';
 import { DrawerLoading } from '@/components';
 import { useTaxRate } from '@/hooks/query/tax-rates';
 
-const TaxRateDetailsContext = createContext();
-
-interface TaxRateDetailsContentBootProps {
+export interface TaxRateDetailsContextValue {
+  isTaxRateLoading: boolean;
+  isTaxRateFetching: boolean;
+  taxRate: TaxRate | undefined;
   taxRateId: number;
 }
+
+export interface TaxRateDetailsContentBootProps {
+  taxRateId: number;
+  children?: ReactNode;
+}
+
+const TaxRateDetailsContext = createContext<
+  TaxRateDetailsContextValue | undefined
+>(undefined);
 
 /**
  * Tax rate details content boot.
@@ -21,9 +32,9 @@ export function TaxRateDetailsContentBoot({
     data: taxRate,
     isFetching: isTaxRateFetching,
     isLoading: isTaxRateLoading,
-  } = useTaxRate(taxRateId, { keepPreviousData: true });
+  } = useTaxRate(taxRateId, { placeholderData: keepPreviousData });
 
-  const provider = {
+  const provider: TaxRateDetailsContextValue = {
     isTaxRateLoading,
     isTaxRateFetching,
     taxRate,
@@ -37,4 +48,12 @@ export function TaxRateDetailsContentBoot({
   );
 }
 
-export const useTaxRateDetailsContext = () => useContext(TaxRateDetailsContext);
+export const useTaxRateDetailsContext = (): TaxRateDetailsContextValue => {
+  const context = useContext(TaxRateDetailsContext);
+  if (!context) {
+    throw new Error(
+      'useTaxRateDetailsContext must be used within a TaxRateDetailsContentBoot.',
+    );
+  }
+  return context;
+};

--- a/packages/webapp/src/containers/TaxRates/drawers/TaxRateDetailsDrawer/TaxRateDetailsContentDetails.tsx
+++ b/packages/webapp/src/containers/TaxRates/drawers/TaxRateDetailsDrawer/TaxRateDetailsContentDetails.tsx
@@ -1,6 +1,4 @@
-// @ts-nocheck
 import { Intent, Tag } from '@blueprintjs/core';
-import React from 'react';
 import styled from 'styled-components';
 import { useTaxRateDetailsContext } from './TaxRateDetailsContentBoot';
 import { Card, DetailItem, DetailsMenu } from '@/components';
@@ -12,8 +10,8 @@ export function TaxRateDetailsContentDetails() {
     <Card>
       <div>
         <TaxRateHeader>
-          <TaxRateAmount>{taxRate.rate}%</TaxRateAmount>
-          {taxRate.active ? (
+          <TaxRateAmount>{taxRate?.rate}%</TaxRateAmount>
+          {taxRate?.active ? (
             <TaxRateActiveTag round={false} intent={Intent.SUCCESS} minimal>
               Active
             </TaxRateActiveTag>
@@ -24,16 +22,16 @@ export function TaxRateDetailsContentDetails() {
           )}
         </TaxRateHeader>
         <DetailsMenu direction={'horizantal'} minLabelSize={200}>
-          <DetailItem label={'Tax Rate Name'} children={taxRate.name} />
-          <DetailItem label={'Code'} children={taxRate.code} />
+          <DetailItem label={'Tax Rate Name'} children={taxRate?.name} />
+          <DetailItem label={'Code'} children={taxRate?.code} />
           <DetailItem
             label={'Description'}
-            children={taxRate.description || '-'}
+            children={taxRate?.description || '-'}
           />
           <DetailItem
             label={'Non Recoverable'}
             children={
-              taxRate.is_non_recoverable ? (
+              taxRate?.isNonRecoverable ? (
                 <Tag round={false} intent={Intent.SUCCESS} minimal>
                   Enabled
                 </Tag>
@@ -47,7 +45,7 @@ export function TaxRateDetailsContentDetails() {
           <DetailItem
             label={'Compound'}
             children={
-              taxRate.is_compound ? (
+              taxRate?.isCompound ? (
                 <Tag round={false} intent={Intent.SUCCESS} minimal>
                   Enabled
                 </Tag>

--- a/packages/webapp/src/containers/TaxRates/drawers/TaxRateDetailsDrawer/TaxRateDetailsDrawer.tsx
+++ b/packages/webapp/src/containers/TaxRates/drawers/TaxRateDetailsDrawer/TaxRateDetailsDrawer.tsx
@@ -1,25 +1,24 @@
-// @ts-nocheck
-import * as R from 'ramda';
-import React from 'react';
-import { Drawer, DrawerHeaderContent, DrawerSuspense } from '@/components';
-import { DRAWERS } from '@/constants/drawers';
-import { withDrawers } from '@/containers/Drawer/withDrawers';
+import { lazy } from 'react';
+import { Drawer, DrawerSuspense } from '@/components';
+import { withDrawers, WithDrawersProps } from '@/containers/Drawer/withDrawers';
+import { compose } from '@/utils';
 
-const TaxRateDetailsDrawerContent = React.lazy(() =>
+const TaxRateDetailsDrawerContent = lazy(() =>
   import('./TaxRateDetailsContent').then((m) => ({
     default: m.TaxRateDetailsContent,
   })),
 );
+
+type TaxRateDetailsDrawerInnerProps = WithDrawersProps & { name: string };
 
 /**
  * Tax rate details drawer.
  */
 function TaxRateDetailsDrawerInner({
   name,
-  // #withDrawer
   isOpen,
   payload: { taxRateId },
-}) {
+}: TaxRateDetailsDrawerInnerProps) {
   return (
     <Drawer
       isOpen={isOpen}
@@ -28,12 +27,15 @@ function TaxRateDetailsDrawerInner({
       size={'65%'}
     >
       <DrawerSuspense>
-        <TaxRateDetailsDrawerContent name={name} taxRateId={taxRateId} />
+        <TaxRateDetailsDrawerContent
+          name={name}
+          taxRateId={taxRateId as number}
+        />
       </DrawerSuspense>
     </Drawer>
   );
 }
 
-export const TaxRateDetailsDrawer = R.compose(withDrawers())(
+export const TaxRateDetailsDrawer = compose(withDrawers())(
   TaxRateDetailsDrawerInner,
 );

--- a/packages/webapp/src/containers/TaxRates/pages/TaxRatesLanding.tsx
+++ b/packages/webapp/src/containers/TaxRates/pages/TaxRatesLanding.tsx
@@ -1,5 +1,3 @@
-// @ts-nocheck
-import React, { useEffect } from 'react';
 import { TaxRatesLandingActionsBar } from '../containers/TaxRatesLandingActionsBar';
 import { TaxRatesLandingDrawers } from '../containers/TaxRatesLandingDrawers';
 import { TaxRatesLandingProvider } from '../containers/TaxRatesLandingProvider';

--- a/packages/webapp/src/hooks/query/jobs/queries.ts
+++ b/packages/webapp/src/hooks/query/jobs/queries.ts
@@ -2,20 +2,23 @@ import { fetchOrganizationBuildJob } from '@bigcapital/sdk-ts';
 import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 import { useApiFetcher } from '../../useRequest';
 import { jobsKeys } from './query-keys';
+import type { OrganizationBuildJob } from '@bigcapital/sdk-ts';
 
 /**
  * Retrieve the job metadata.
  */
 export function useJob(
   jobId: string | number | null | undefined,
-  props: Omit<UseQueryOptions, 'queryKey' | 'queryFn'> = {},
+  props: Omit<
+    UseQueryOptions<OrganizationBuildJob>,
+    'queryKey' | 'queryFn'
+  > = {},
 ) {
   const fetcher = useApiFetcher({ enableCamelCaseTransform: true });
   return useQuery({
     ...props,
     queryKey: jobsKeys.detail(jobId),
-    // @ts-expect-error - jobId is checked by enabled option
-    queryFn: () => fetchOrganizationBuildJob(fetcher, jobId),
+    queryFn: () => fetchOrganizationBuildJob(fetcher, jobId as number),
     enabled: jobId != null,
   });
 }

--- a/packages/webapp/src/hooks/query/subscriptions/queries.ts
+++ b/packages/webapp/src/hooks/query/subscriptions/queries.ts
@@ -1,16 +1,39 @@
-// @ts-nocheck
 import { getLemonCheckoutUrl } from '@bigcapital/sdk-ts';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, UseMutationOptions } from '@tanstack/react-query';
 import { useApiFetcher } from '../../useRequest';
+
+export interface LemonCheckoutRequest {
+  variantId: string;
+}
+
+export interface LemonCheckoutResponse {
+  data: {
+    data: {
+      attributes: {
+        url: string;
+      };
+    };
+  };
+}
 
 /**
  * Fetches the checkout url of the Lemon Squeezy.
  */
-export const useGetLemonSqueezyCheckout = (props = {}) => {
+export const useGetLemonSqueezyCheckout = (
+  props?: UseMutationOptions<
+    LemonCheckoutResponse,
+    Error,
+    LemonCheckoutRequest
+  >,
+) => {
   const fetcher = useApiFetcher();
 
   return useMutation({
     ...props,
-    mutationFn: (values) => getLemonCheckoutUrl(fetcher, values),
+    mutationFn: (values: LemonCheckoutRequest) =>
+      getLemonCheckoutUrl(
+        fetcher,
+        values as never,
+      ) as Promise<LemonCheckoutResponse>,
   });
 };

--- a/packages/webapp/src/types/lemon-squeezy.d.ts
+++ b/packages/webapp/src/types/lemon-squeezy.d.ts
@@ -1,0 +1,19 @@
+interface LemonSqueezyEvent {
+  event: string;
+  data?: unknown;
+}
+
+interface LemonSqueezyConfig {
+  eventHandler: (event: LemonSqueezyEvent) => void;
+}
+
+interface LemonSqueezy {
+  Setup: (config: LemonSqueezyConfig) => void;
+  Url: {
+    Open: (url?: string) => void;
+  };
+}
+
+interface Window {
+  LemonSqueezy?: LemonSqueezy;
+}


### PR DESCRIPTION
## Summary

Converts the `containers/Authentication/` (22 files), `containers/Setup/` (12 files), and `containers/TaxRates/` (23 files) containers from `// @ts-nocheck` to strict TypeScript. Also removes the last `as any` / `as unknown` casts from these containers.

- **Zero `as any` / `as unknown` casts** in the three containers. `withAuthenticationActions` now returns the typed `connect` enhancer directly (react-redux's `Matching` mapped type cannot be satisfied for generic props without a cast).
- **All 57 `@ts-nocheck` files** are now type-checked under `strict: true`: typed React contexts (`createContext<T>()` + guard hooks), Formik `onSubmit` values, HOC-injected props, react-query v5 (`isLoading` → `isPending`).
- **TaxRates aligned to the server's camelCase shape** (`rateFormatted`, `isCompound`, `isNonRecoverable`) via the SDK `TaxRate` type — fixes real bugs where the compound tag, rate column, and non-recoverable/compound flags never rendered and never persisted on submit.
- **Latent bugs fixed inline**: undefined `ERRORS` constant, `taxRateid` typo, missing `dialogName`/`wizard`/`name` props, `class=` → `className`, `ProgressBar value={null}`, dead demo-account block, dead `setErrors({ phone_number })` branch, Blueprint `Alert` button text (typed as `string`), `FTimezoneSelect` placeholder element, react-query v5 `keepPreviousData` → `placeholderData`, `active` field on the tax-rate request body, `String(taxRateId)` for the edit mutation.
- **Enabling changes** (small, shared): widen `IconProps.icon` to accept `"bigcapital"`, optional `Alert` props, `window.LemonSqueezy` ambient declaration, typed `useJob` and `useGetLemonSqueezyCheckout` hooks, corrected `SubscriptionPlan`/mapper variant-id types.

## Test plan

- [ ] `pnpm --filter webapp exec tsc --noEmit` — zero new errors (47 pre-existing in unrelated modules: MakeJournal, FinancialStatements, etc.)
- [ ] `git grep -n "@ts-nocheck" packages/webapp/src/containers/Authentication packages/webapp/src/containers/Setup packages/webapp/src/containers/TaxRates` returns zero matches
- [ ] `git grep -nE "as (any|unknown)" packages/webapp/src/containers/Authentication packages/webapp/src/containers/Setup packages/webapp/src/containers/TaxRates` returns zero matches
- [ ] Manual smoke test — login, register, reset password, send reset password, invite-accept, and email-confirmation flows render and submit
- [ ] Manual smoke test — setup wizard (subscription → organization → initializing → congrats) advances correctly
- [ ] Manual smoke test — tax rates landing table renders name/rate/compound columns; create/edit form persists compound and non-recoverable flags; details drawer and delete alert work
