### PR TITLE
fix(webapp): use camelCase currency fields in currency selects

### DIFF
--- a/packages/webapp/src/components/Currencies/CurrencySelect.tsx
+++ b/packages/webapp/src/components/Currencies/CurrencySelect.tsx
@@ -12,14 +12,14 @@ import { FSelect } from '../Forms';
  * @returns
  */
 const currencyItemPredicate = (query, currency, _index, exactMatch) => {
-  const normalizedTitle = currency.currency_code.toLowerCase();
+  const normalizedTitle = currency.currencyCode.toLowerCase();
   const normalizedQuery = query.toLowerCase();
 
   if (exactMatch) {
     return normalizedTitle === normalizedQuery;
   } else {
     return (
-      `${currency.currency_code}. ${normalizedTitle}`.indexOf(
+      `${currency.currencyCode}. ${normalizedTitle}`.indexOf(
         normalizedQuery,
       ) >= 0
     );
@@ -35,9 +35,9 @@ export function CurrencySelect({ currencies, ...rest }) {
   return (
     <FSelect
       itemPredicate={currencyItemPredicate}
-      valueAccessor={'currency_code'}
-      textAccessor={'currency_name'}
-      labelAccessor={'currency_code'}
+      valueAccessor={'currencyCode'}
+      textAccessor={'currencyName'}
+      labelAccessor={'currencyCode'}
       {...rest}
       items={currencies}
       placeholder={intl.get('select_currency_code')}

--- a/packages/webapp/src/components/Currencies/CurrencySelectList.tsx
+++ b/packages/webapp/src/components/Currencies/CurrencySelectList.tsx
@@ -18,8 +18,8 @@ export function CurrencySelectList({
     <FSelect
       name={name}
       items={items}
-      textAccessor={'currency_code'}
-      valueAccessor={'currency_code'}
+      textAccessor={'currencyCode'}
+      valueAccessor={'currencyCode'}
       placeholder={placeholder}
       popoverProps={{ minimal: true, usePortal: true, inline: false }}
       {...props}

--- a/packages/webapp/src/containers/Accounting/MakeJournal/MakeJournalEntriesHeaderFields.tsx
+++ b/packages/webapp/src/containers/Accounting/MakeJournal/MakeJournalEntriesHeaderFields.tsx
@@ -114,7 +114,7 @@ export function MakeJournalEntriesHeader() {
           name={'currencyCode'}
           items={currencies}
           onItemChange={(currencyItem: Record<string, unknown>) => {
-            form.setFieldValue('currencyCode', currencyItem.currency_code);
+            form.setFieldValue('currencyCode', currencyItem.currencyCode);
             form.setFieldValue('exchangeRate', '');
           }}
           popoverProps={{
@@ -122,9 +122,9 @@ export function MakeJournalEntriesHeader() {
             minimal: true,
             captureDismiss: true,
           }}
-          valueAccessor={'currency_code'}
-          labelAccessor={'currency_name'}
-          textAccessor={'currency_code'}
+          valueAccessor={'currencyCode'}
+          labelAccessor={'currencyName'}
+          textAccessor={'currencyCode'}
           fastField
         />
       </FFormGroup>

--- a/packages/webapp/src/containers/Expenses/ExpenseForm/ExpenseFormHeaderFields.tsx
+++ b/packages/webapp/src/containers/Expenses/ExpenseForm/ExpenseFormHeaderFields.tsx
@@ -113,9 +113,9 @@ export function ExpenseFormHeader() {
         <FSelect
           name={'currencyCode'}
           items={currencies}
-          valueAccessor={'currency_code'}
-          textAccessor={'currency_code'}
-          labelAccessor={'currency_code'}
+          valueAccessor={'currencyCode'}
+          textAccessor={'currencyCode'}
+          labelAccessor={'currencyCode'}
           popoverProps={{ minimal: true }}
           fill={true}
           fastField={true}

--- a/packages/webapp/src/containers/Preferences/Currencies/components.tsx
+++ b/packages/webapp/src/containers/Preferences/Currencies/components.tsx
@@ -92,14 +92,14 @@ export function useCurrenciesTableColumns() {
       },
       {
         Header: intl.get('currency_code'),
-        accessor: 'currency_code',
+        accessor: 'currencyCode',
         className: 'currency_code',
         width: 120,
       },
       {
         Header: intl.get('currency_sign'),
         width: 120,
-        accessor: 'currency_sign',
+        accessor: 'currencySign',
       },
       {
         id: 'actions',


### PR DESCRIPTION
## What changed

Fixes the blank page / `TypeError` when opening the **Create Bank Account** dialog (Banking > Cash / Bank Accounts), reported in #1191.

The currencies API returns camelCase keys (`currencyCode`, `currencyName`, `currencySign`, `isBaseCurrency`), but the currency UI components and consumers still read snake_case keys (`currency_code`, `currency_name`, `currency_sign`). This caused:

- `CurrencySelect`'s item predicate to call `currency.currency_code.toLowerCase()` on an undefined value → `TypeError` → blank page when creating a bank account.
- Blank **Currency Code** / **Sign** columns in Preferences > Currencies.
- Empty currency values in the Make Journal, Expense, Customer and Vendor currency selects.

Updated the affected files to use the camelCase keys returned by the API:

- `components/Currencies/CurrencySelect.tsx` — predicate + accessors → camelCase.
- `components/Currencies/CurrencySelectList.tsx` — accessors → camelCase.
- `containers/Accounting/MakeJournal/MakeJournalEntriesHeaderFields.tsx` — accessors → camelCase.
- `containers/Expenses/ExpenseForm/ExpenseFormHeaderFields.tsx` — accessors → camelCase.
- `containers/Preferences/Currencies/components.tsx` — table column accessors → camelCase.

### pr_agent:summary

The currencies list from `useCurrencies()` is returned in camelCase, while the currency select components and consumers were reading snake_case fields. Updated all of them to use the camelCase field names, fixing the crash when creating a bank account, blank currency codes in the Preferences > Currencies table, and empty values in the Make Journal, Expense, Customer and Vendor currency selects.

### pr_agent:walkthrough

- `packages/webapp/src/components/Currencies/CurrencySelect.tsx`: Changed `currencyItemPredicate` and the `valueAccessor`/`textAccessor`/`labelAccessor` from `currency_code`/`currency_name` to `currencyCode`/`currencyName`. Fixes the `TypeError: can't access property "toLowerCase"` crash.
- `packages/webapp/src/components/Currencies/CurrencySelectList.tsx`: Changed `textAccessor`/`valueAccessor` to `currencyCode` (fixes Customer/Vendor form currency selects).
- `packages/webapp/src/containers/Accounting/MakeJournal/MakeJournalEntriesHeaderFields.tsx`: Changed `onItemChange` handler and accessors to `currencyCode`/`currencyName`.
- `packages/webapp/src/containers/Expenses/ExpenseForm/ExpenseFormHeaderFields.tsx`: Changed accessors to `currencyCode`.
- `packages/webapp/src/containers/Preferences/Currencies/components.tsx`: Changed table column accessors to `currencyCode`/`currencySign`, fixing the blank Code/Sign columns.
