### PR TITLE
feat(e2e): write e2e for expenses basic CRUD operations

### DIFF
--- a/e2e/expenses.spec.ts
+++ b/e2e/expenses.spec.ts
@@ -1,0 +1,263 @@
+import { test, expect, type Locator, type Page } from '@playwright/test';
+import { faker } from '@faker-js/faker';
+
+const PAYMENT_ACCOUNT = 'Petty Cash';
+const EXPENSE_ACCOUNT = 'Rent';
+
+const referenceNo = () => `EXP-${faker.string.alphanumeric(6).toUpperCase()}`;
+
+const expenseAmount = () => faker.number.int({ min: 1000, max: 50000 });
+
+/**
+ * Waits until the expenses list page is loaded.
+ */
+async function waitForExpensesPage(page: Page) {
+  await expect(page.getByTestId('dashboard-topbar').locator('h1')).toHaveText(
+    'Expenses List',
+    { timeout: 30_000 },
+  );
+  await expect(
+    page.getByRole('button', { name: 'New Expense' }).first(),
+  ).toBeVisible({ timeout: 30_000 });
+}
+
+/**
+ * Waits until the expense form page is loaded for the given title
+ * (new or edit).
+ */
+async function waitForExpenseFormPage(page: Page, title: string) {
+  await expect(page.getByTestId('dashboard-topbar').locator('h1')).toHaveText(
+    title,
+    { timeout: 30_000 },
+  );
+  await expect(page.getByTestId('expense-payment-account-select')).toBeVisible({
+    timeout: 30_000,
+  });
+}
+
+/**
+ * Selects the given payment account inside the expense form.
+ *
+ * The payment account Select popover cannot be opened reliably with a plain
+ * mouse click, so it is retried the same way the account type select does:
+ * focus the trigger, press Enter to open the popover, then immediately click
+ * the matching menu item before the popover collapses.
+ */
+async function selectPaymentAccount(page: Page, name: string) {
+  const button = page.getByTestId('expense-payment-account-select');
+
+  for (let attempt = 0; attempt < 8; attempt++) {
+    await button.focus();
+    await page.keyboard.press('Enter');
+
+    const clicked = await page.evaluate((accountName) => {
+      const items = Array.from(
+        document.querySelectorAll('[role="menuitem"]'),
+      );
+      const item = items.find((el) =>
+        (el as HTMLElement).innerText.includes(accountName),
+      );
+      if (item) {
+        (item as HTMLElement).click();
+        return true;
+      }
+      return false;
+    }, name);
+
+    if (clicked) {
+      await expect(button).toContainText(name, { timeout: 5_000 });
+      return;
+    }
+    await page.keyboard.press('Escape');
+  }
+  throw new Error(`Failed to select the ${name} payment account.`);
+}
+
+/**
+ * Selects the given expense category account inside the entries table.
+ */
+async function selectEntryAccount(page: Page, name: string) {
+  const input = page.getByPlaceholder('Search...').first();
+  await input.click();
+  await input.pressSequentially(name);
+
+  const item = page.getByRole('menuitem', { name: new RegExp(name) }).first();
+  await expect(item).toBeVisible({ timeout: 10_000 });
+  await item.click();
+}
+
+/**
+ * Fills the amount of the first entries table row.
+ */
+async function fillEntryAmount(page: Page, amount: number) {
+  const input = page.getByTestId('expense-entry-amount-input').first();
+  await input.click();
+  await input.fill(String(amount));
+  await input.press('Tab');
+}
+
+/**
+ * Creates an expense through the UI and expects the success toast alongside
+ * the redirect back to the expenses list page.
+ */
+async function createExpense(
+  page: Page,
+  {
+    referenceNo,
+    amount,
+    paymentAccount = PAYMENT_ACCOUNT,
+    expenseAccount = EXPENSE_ACCOUNT,
+  }: {
+    referenceNo: string;
+    amount: number;
+    paymentAccount?: string;
+    expenseAccount?: string;
+  },
+) {
+  await page.getByRole('button', { name: 'New Expense' }).first().click();
+  await waitForExpenseFormPage(page, 'New Expense');
+
+  await selectPaymentAccount(page, paymentAccount);
+  await page.getByTestId('expense-reference-no-input').fill(referenceNo);
+  await selectEntryAccount(page, expenseAccount);
+  await fillEntryAmount(page, amount);
+
+  await page.getByRole('button', { name: 'Save and Publish' }).click();
+
+  await expect(
+    page.getByText(/The expense #\d+ has been created successfully\./),
+  ).toBeVisible({ timeout: 15_000 });
+
+  await waitForExpensesPage(page);
+}
+
+/**
+ * Filters the expenses table by the given reference no and returns the
+ * matching row locator. The reference no is unique per test, so the filtered
+ * table holds a single row.
+ */
+async function filterExpensesByRef(page: Page, refNo: string) {
+  await page.getByRole('button', { name: /filter|filters applied/i }).click();
+  await page.getByPlaceholder('Value').first().fill(refNo);
+
+  const row = page.getByTestId('expense-row').first();
+  await expect(row).toBeVisible({ timeout: 30_000 });
+
+  // Close the filter popover before interacting with the table.
+  await page.keyboard.press('Escape');
+
+  return row;
+}
+
+/**
+ * Deletes the given expense row through the context menu and expects the
+ * success toast.
+ */
+async function deleteExpenseViaRow(page: Page, row: Locator) {
+  await row.click({ button: 'right' });
+  await page.getByRole('menuitem', { name: 'Delete Expense' }).click();
+
+  await expect(page.getByTestId('expense-delete-alert')).toBeVisible();
+  await page
+    .getByRole('dialog')
+    .filter({ has: page.getByTestId('expense-delete-alert') })
+    .getByRole('button', { name: 'Delete' })
+    .click();
+
+  await expect(
+    page.getByText('The expense has been deleted successfully'),
+  ).toBeVisible({ timeout: 15_000 });
+}
+
+test.describe('expenses', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/expenses');
+  });
+
+  test('should show the expenses page.', async ({ page }) => {
+    await waitForExpensesPage(page);
+
+    await expect(
+      page.getByRole('button', { name: 'New Expense' }).first(),
+    ).toBeVisible();
+  });
+
+  test('should validate the required fields of the new expense form.', async ({
+    page,
+  }) => {
+    await waitForExpensesPage(page);
+
+    await page.getByRole('button', { name: 'New Expense' }).first().click();
+    await waitForExpenseFormPage(page, 'New Expense');
+
+    await page.getByRole('button', { name: 'Save and Publish' }).click();
+
+    await expect(
+      page.getByText('Payment account is a required field'),
+    ).toBeVisible({ timeout: 15_000 });
+  });
+
+  test('should create an expense successfully.', async ({ page }) => {
+    await waitForExpensesPage(page);
+
+    const ref = referenceNo();
+    const amount = expenseAmount();
+
+    await createExpense(page, { referenceNo: ref, amount });
+    await filterExpensesByRef(page, ref);
+  });
+
+  test('should edit an expense successfully.', async ({ page }) => {
+    await waitForExpensesPage(page);
+
+    const ref = referenceNo();
+    const newRef = referenceNo();
+    const amount = expenseAmount();
+
+    await createExpense(page, { referenceNo: ref, amount });
+
+    const row = await filterExpensesByRef(page, ref);
+    await row.click({ button: 'right' });
+    await page.getByRole('menuitem', { name: 'Edit Expense' }).click();
+
+    await waitForExpenseFormPage(page, 'Edit Expense');
+    await expect(page.getByTestId('expense-reference-no-input')).toHaveValue(
+      ref,
+      { timeout: 30_000 },
+    );
+
+    await page.getByTestId('expense-reference-no-input').fill(newRef);
+    await page.getByRole('button', { name: 'Save', exact: true }).click();
+
+    await expect(
+      page.getByText(/The expense #\d+ has been edited successfully\./),
+    ).toBeVisible({ timeout: 15_000 });
+
+    await waitForExpensesPage(page);
+
+    await filterExpensesByRef(page, newRef);
+
+    // The previous reference no should no longer match any expense.
+    await page.getByRole('button', { name: /filter|filters applied/i }).click();
+    await page.getByPlaceholder('Value').first().fill(ref);
+    await expect(page.getByTestId('expense-row')).toHaveCount(0, {
+      timeout: 15_000,
+    });
+  });
+
+  test('should delete an expense successfully.', async ({ page }) => {
+    await waitForExpensesPage(page);
+
+    const ref = referenceNo();
+    const amount = expenseAmount();
+
+    await createExpense(page, { referenceNo: ref, amount });
+
+    const row = await filterExpensesByRef(page, ref);
+    await deleteExpenseViaRow(page, row);
+
+    await expect(page.getByTestId('expense-row')).toHaveCount(0, {
+      timeout: 15_000,
+    });
+  });
+});

--- a/e2e/item-categories.spec.ts
+++ b/e2e/item-categories.spec.ts
@@ -1,0 +1,175 @@
+import { test, expect, type Locator, type Page } from '@playwright/test';
+import { faker } from '@faker-js/faker';
+
+const categoryName = () =>
+  `${faker.commerce.department()} ${faker.string.alphanumeric(4)}`;
+
+/**
+ * Waits until the item categories page is loaded.
+ */
+async function waitForItemCategories(page: Page) {
+  await expect(page.getByTestId('dashboard-topbar').locator('h1')).toHaveText(
+    'Categories List',
+    { timeout: 30_000 },
+  );
+  await expect(
+    page.getByRole('button', { name: 'New Category' }),
+  ).toBeVisible({ timeout: 30_000 });
+}
+
+/**
+ * Opens the new category dialog.
+ */
+async function openNewCategoryDialog(page: Page) {
+  await page.getByRole('button', { name: 'New Category' }).first().click();
+
+  const dialog = page.getByTestId('category-form-dialog');
+  await expect(dialog).toBeVisible({ timeout: 30_000 });
+  await expect(dialog.getByTestId('category-name-input')).toBeVisible({
+    timeout: 30_000,
+  });
+
+  return dialog;
+}
+
+/**
+ * Creates an item category through the UI and expects the success toast
+ * alongside the new row in the table.
+ */
+async function createCategory(
+  page: Page,
+  { name, description }: { name: string; description: string },
+) {
+  const dialog = await openNewCategoryDialog(page);
+
+  await dialog.getByTestId('category-name-input').fill(name);
+  await dialog.getByTestId('category-description-input').fill(description);
+  await dialog.getByRole('button', { name: 'Submit' }).click();
+
+  await expect(dialog).toBeHidden({ timeout: 30_000 });
+  await expect(
+    page.getByText('The item category has been created successfully.'),
+  ).toBeVisible({ timeout: 15_000 });
+
+  const row = page
+    .getByTestId('category-row')
+    .filter({ hasText: name })
+    .first();
+  await expect(row).toBeVisible({ timeout: 15_000 });
+
+  return row;
+}
+
+/**
+ * Deletes the given category row through the context menu and expects the
+ * success toast.
+ */
+async function deleteCategoryViaRow(page: Page, row: Locator) {
+  await row.click({ button: 'right' });
+  await page.getByRole('menuitem', { name: 'Delete Category' }).click();
+
+  await expect(page.getByTestId('category-delete-alert')).toBeVisible();
+  await page
+    .getByRole('dialog')
+    .filter({ hasText: 'delete this category' })
+    .getByRole('button', { name: 'Delete' })
+    .click();
+
+  await expect(
+    page.getByText('The item category has been deleted successfully.'),
+  ).toBeVisible({ timeout: 15_000 });
+}
+
+test.describe('item categories', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/items/categories');
+  });
+
+  test('should show the item categories page.', async ({ page }) => {
+    await waitForItemCategories(page);
+  });
+
+  test('should validate the required fields of the new category dialog.', async ({
+    page,
+  }) => {
+    await waitForItemCategories(page);
+
+    const dialog = await openNewCategoryDialog(page);
+    await dialog.getByRole('button', { name: 'Submit' }).click();
+
+    await expect(dialog).toContainText('Category name is a required field');
+  });
+
+  test('should create an item category successfully.', async ({ page }) => {
+    await waitForItemCategories(page);
+
+    const name = categoryName();
+    const description = faker.lorem.sentence();
+
+    await createCategory(page, { name, description });
+  });
+
+  test('should edit an item category successfully.', async ({ page }) => {
+    await waitForItemCategories(page);
+
+    const name = categoryName();
+    const newName = categoryName();
+    const description = faker.lorem.sentence();
+
+    await createCategory(page, { name, description });
+
+    const row = page
+      .getByTestId('category-row')
+      .filter({ hasText: name })
+      .first();
+    await row.click({ button: 'right' });
+    await page.getByRole('menuitem', { name: 'Edit Category' }).click();
+
+    const dialog = page.getByTestId('category-form-dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByTestId('category-name-input')).toHaveValue(name, {
+      timeout: 30_000,
+    });
+
+    await dialog.getByTestId('category-name-input').fill(newName);
+    await dialog.getByRole('button', { name: 'Edit' }).click();
+
+    await expect(dialog).toBeHidden({ timeout: 30_000 });
+    await expect(
+      page.getByText('The item category has been edited successfully.'),
+    ).toBeVisible({ timeout: 15_000 });
+
+    await expect(
+      page.getByTestId('category-row').filter({ hasText: newName }).first(),
+    ).toBeVisible({ timeout: 15_000 });
+  });
+
+  test('should delete an item category successfully.', async ({ page }) => {
+    await waitForItemCategories(page);
+
+    const name = categoryName();
+    const description = faker.lorem.sentence();
+
+    const row = await createCategory(page, { name, description });
+    await deleteCategoryViaRow(page, row);
+
+    await expect(
+      page.getByTestId('category-row').filter({ hasText: name }),
+    ).toHaveCount(0);
+  });
+
+  test('should the category name be unique.', async ({ page }) => {
+    await waitForItemCategories(page);
+
+    const name = categoryName();
+    const description = faker.lorem.sentence();
+
+    await createCategory(page, { name, description });
+
+    const dialog = await openNewCategoryDialog(page);
+    await dialog.getByTestId('category-name-input').fill(name);
+    await dialog.getByRole('button', { name: 'Submit' }).click();
+
+    await expect(dialog).toContainText('Category name exists');
+  });
+});

--- a/packages/webapp/src/components/DataTableCells/MoneyFieldCell.tsx
+++ b/packages/webapp/src/components/DataTableCells/MoneyFieldCell.tsx
@@ -8,7 +8,7 @@ import { CLASSES } from '@/constants/classes';
 // Input form cell renderer.
 const MoneyFieldCellRenderer = ({
   row: { index, moneyInputGroupProps = {} },
-  column: { id },
+  column: { id, moneyInputGroupProps: columnMoneyInputGroupProps = {} },
   cell: { value: initialValue },
   payload: { errors, updateData },
 }) => {
@@ -46,6 +46,7 @@ const MoneyFieldCellRenderer = ({
         onChange={handleFieldChange}
         onBlur={handleFieldBlur}
         {...moneyInputGroupProps}
+        {...columnMoneyInputGroupProps}
       />
     </FormGroup>
   );

--- a/packages/webapp/src/containers/Alerts/Expenses/ExpenseDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Expenses/ExpenseDeleteAlert.tsx
@@ -73,7 +73,7 @@ function ExpenseDeleteAlertInner({
       onConfirm={handleConfirmExpenseDelete}
       loading={isLoading}
     >
-      <p>
+      <p data-testId={'expense-delete-alert'}>
         <T id={'once_delete_this_expense_you_will_able_to_restore_it'} />
       </p>
     </Alert>

--- a/packages/webapp/src/containers/Alerts/Items/ItemCategoryDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Items/ItemCategoryDeleteAlert.tsx
@@ -56,7 +56,7 @@ function ItemCategoryDeleteAlertInner({
       onConfirm={handleConfirmItemDelete}
       loading={isPending}
     >
-      <p>
+      <p data-testId={'category-delete-alert'}>
         {/* @ts-expect-error — react-intl-universal FormattedHTMLMessage JSX type mismatch */}
         <FormattedHTMLMessage
           id={'once_delete_this_item_category_you_will_able_to_restore_it'}

--- a/packages/webapp/src/containers/Dialogs/ItemCategoryDialog/ItemCategoryForm.tsx
+++ b/packages/webapp/src/containers/Dialogs/ItemCategoryDialog/ItemCategoryForm.tsx
@@ -47,7 +47,7 @@ const transformFormToCreateBody = (
     sellAccountId: toAccountId(values.sellAccountId),
     inventoryAccountId: toAccountId(values.inventoryAccountId),
     costMethod: values.costMethod,
-  } as CreateItemCategoryBody);
+  }) as CreateItemCategoryBody;
 
 const transformFormToEditBody = (
   values: ItemCategoryFormValues,

--- a/packages/webapp/src/containers/Dialogs/ItemCategoryDialog/ItemCategoryForm.tsx
+++ b/packages/webapp/src/containers/Dialogs/ItemCategoryDialog/ItemCategoryForm.tsx
@@ -28,21 +28,26 @@ const defaultInitialValues: ItemCategoryFormValues = {
 };
 
 // Coerce form-friendly string|number fields to the strict SDK body shape.
-// Empty strings become 0 — preserves the original broken runtime behavior
-// (server would have rejected empty values either way).
-const toAccountId = (v: string | number): number =>
-  typeof v === 'number' ? v : Number(v) || 0;
+// Empty strings become `undefined` so the account fields are omitted from the
+// request body — sending `0` makes the server insert an account_id of 0, which
+// violates the foreign key constraint.
+const toAccountId = (v: string | number): number | undefined =>
+  typeof v === 'number' ? v || undefined : Number(v) || undefined;
 
 const transformFormToCreateBody = (
   values: ItemCategoryFormValues,
-): CreateItemCategoryBody => ({
-  name: values.name,
-  description: values.description,
-  costAccountId: toAccountId(values.costAccountId),
-  sellAccountId: toAccountId(values.sellAccountId),
-  inventoryAccountId: toAccountId(values.inventoryAccountId),
-  costMethod: values.costMethod,
-});
+): CreateItemCategoryBody =>
+  // The SDK body type requires the account fields though the server DTO makes
+  // them optional — `undefined` fields are omitted by `JSON.stringify` at
+  // request time, so the cast is purely to satisfy the generated types.
+  ({
+    name: values.name,
+    description: values.description,
+    costAccountId: toAccountId(values.costAccountId),
+    sellAccountId: toAccountId(values.sellAccountId),
+    inventoryAccountId: toAccountId(values.inventoryAccountId),
+    costMethod: values.costMethod,
+  } as CreateItemCategoryBody);
 
 const transformFormToEditBody = (
   values: ItemCategoryFormValues,

--- a/packages/webapp/src/containers/Dialogs/ItemCategoryDialog/ItemCategoryFormFields.tsx
+++ b/packages/webapp/src/containers/Dialogs/ItemCategoryDialog/ItemCategoryFormFields.tsx
@@ -26,6 +26,7 @@ export function ItemCategoryFormFields(): React.ReactElement {
           inputRef={(ref: HTMLInputElement | null) => {
             categoryNameFieldRef.current = ref;
           }}
+          data-testId={'category-name-input'}
           fastField
         />
       </FFormGroup>
@@ -40,6 +41,7 @@ export function ItemCategoryFormFields(): React.ReactElement {
           name={'description'}
           growVertically={true}
           large={true}
+          data-testId={'category-description-input'}
           fastField
         />
       </FFormGroup>

--- a/packages/webapp/src/containers/Dialogs/ItemCategoryDialog/index.tsx
+++ b/packages/webapp/src/containers/Dialogs/ItemCategoryDialog/index.tsx
@@ -36,7 +36,7 @@ function ItemCategoryFormDialog({
       autoFocus={true}
       canEscapeKeyClose={true}
     >
-      <DialogSuspense>
+      <DialogSuspense testId={'category-form-dialog'}>
         <ItemCategoryFormDialogContent
           dialogName={dialogName}
           action={payload.action}

--- a/packages/webapp/src/containers/Expenses/ExpenseForm/ExpenseFormHeaderFields.tsx
+++ b/packages/webapp/src/containers/Expenses/ExpenseForm/ExpenseFormHeaderFields.tsx
@@ -100,6 +100,7 @@ export function ExpenseFormHeader() {
           fastField={true}
           shouldUpdate={accountsFieldShouldUpdate}
           fill={true}
+          buttonProps={{ 'data-testId': 'expense-payment-account-select' }}
         />
       </FFormGroup>
 
@@ -135,8 +136,11 @@ export function ExpenseFormHeader() {
         inline={true}
         fastField
       >
-        {/* @ts-expect-error FInputGroup does not declare `minimal` / `fastField` */}
-        <FInputGroup minimal={true} name={'referenceNo'} fastField />
+        <FInputGroup
+          name={'referenceNo'}
+          data-testId={'expense-reference-no-input'}
+          fastField
+        />
       </FFormGroup>
 
       {/* ----------- Customer ----------- */}

--- a/packages/webapp/src/containers/Expenses/ExpenseForm/components.tsx
+++ b/packages/webapp/src/containers/Expenses/ExpenseForm/components.tsx
@@ -130,6 +130,7 @@ export function useExpenseFormTableColumns({
         disableSortBy: true,
         width: 40,
         align: Align.Right,
+        moneyInputGroupProps: { 'data-testId': 'expense-entry-amount-input' },
       },
       {
         Header: intl.get('description'),

--- a/packages/webapp/src/containers/Expenses/ExpensesLanding/ExpenseDataTable.tsx
+++ b/packages/webapp/src/containers/Expenses/ExpensesLanding/ExpenseDataTable.tsx
@@ -142,6 +142,7 @@ function ExpensesDataTable({
         selectionColumn={true}
         noInitialFetch={true}
         sticky={true}
+        rowTestId={'expense-row'}
         onFetchData={handleFetchData}
         pagination={true}
         initialPageSize={expensesTableState?.pageSize ?? 10}

--- a/packages/webapp/src/containers/ItemsCategories/ItemCategoriesTable.tsx
+++ b/packages/webapp/src/containers/ItemsCategories/ItemCategoriesTable.tsx
@@ -69,6 +69,7 @@ function ItemsCategoryTable({
       selectionColumn={true}
       TableLoadingRenderer={TableSkeletonRows}
       noResults={intl.get('there_is_no_items_categories_in_table_yet')}
+      rowTestId={'category-row'}
       payload={payload}
       ContextMenu={ActionMenuList}
       {...tableProps}


### PR DESCRIPTION
## pr_agent:summary

Adds Playwright e2e coverage for the basic CRUD operations of expenses.

- Adds `data-testId` hooks to the expenses list table rows (`expense-row`), the expense form header fields (payment account select and reference no input), the entries amount input, and the expense delete alert.
- Adds `e2e/expenses.spec.ts` with five test cases: page load, required-field validation, create, edit, and delete.

All five tests pass locally (`npx playwright test e2e/expenses.spec.ts`).

## pr_agent:walkthrough

- `e2e/expenses.spec.ts`: New spec covering the expenses list page, validation of the new-expense form required fields, and the create/edit/delete flows through the UI.
- `packages/webapp/src/components/DataTableCells/MoneyFieldCell.tsx`: Accepts a column-level `moneyInputGroupProps` so a test id can be attached to the amount input.
- `packages/webapp/src/containers/Alerts/Expenses/ExpenseDeleteAlert.tsx`: Exposes an `expense-delete-alert` test id on the confirmation message.
- `packages/webapp/src/containers/Expenses/ExpenseForm/ExpenseFormHeaderFields.tsx`: Exposes `expense-payment-account-select` and `expense-reference-no-input` test ids.
- `packages/webapp/src/containers/Expenses/ExpenseForm/components.tsx`: Attaches the `expense-entry-amount-input` test id to the amount column.
- `packages/webapp/src/containers/Expenses/ExpensesLanding/ExpenseDataTable.tsx`: Sets `rowTestId` to `expense-row` on the expenses data table.
