### PR TITLE
fix(sdk-ts): add export endpoint support and fix resource export download

### DIFF
--- a/packages/webapp/src/hooks/query/FinancialReports/use-export.ts
+++ b/packages/webapp/src/hooks/query/FinancialReports/use-export.ts
@@ -1,7 +1,8 @@
 import { useMutation } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
+import { fetchExportResource } from '@bigcapital/sdk-ts';
 import { downloadFile } from '@/hooks/useDownloadFile';
-import useApiRequest from '@/hooks/useRequest';
+import { useApiFetcher } from '@/hooks/useRequest';
 
 interface ResourceExportValues {
   resource: string;
@@ -9,26 +10,21 @@ interface ResourceExportValues {
 }
 
 /**
- * Initiates a download of the balance sheet in XLSX format.
- * @param {Object} query - The query parameters for the request.
- * @param {Object} args - Additional configurations for the download.
+ * Initiates a download of the given resource in CSV or XLSX format.
+ * @param {Object} data - The export resource values.
  * @returns {Function} A function to trigger the file download.
  */
 export const useResourceExport = () => {
-  const apiRequest = useApiRequest();
+  const fetcher = useApiFetcher();
 
-  return useMutation<unknown, AxiosError, ResourceExportValues>({
+  return useMutation<Blob, AxiosError, ResourceExportValues>({
     mutationFn: (data: ResourceExportValues) => {
-      return apiRequest.get('/export', {
-        responseType: 'blob',
-        headers: {
-          accept:
-            data.format === 'xlsx' ? 'application/xlsx' : 'application/csv',
-        },
-        params: {
-          resource: data.resource,
-          format: data.format,
-        },
+      return fetchExportResource(fetcher, {
+        resource: data.resource,
+        format: data.format as 'csv' | 'xlsx',
+      }).then((blob) => {
+        downloadFile(blob, `${data.resource}.${data.format}`);
+        return blob;
       });
     },
   });

--- a/shared/sdk-ts/src/export.ts
+++ b/shared/sdk-ts/src/export.ts
@@ -1,0 +1,41 @@
+import type { ApiFetcher } from './fetch-utils';
+import { paths } from './schema';
+
+export const EXPORT_ROUTES = {
+  RESOURCE: '/api/export',
+} as const satisfies Record<string, keyof paths>;
+
+export interface ExportResourceParams {
+  resource: string;
+  format: 'csv' | 'xlsx' | 'pdf';
+}
+
+export type ExportResourceResponse = Blob;
+
+/**
+ * Download an exported resource (csv/xlsx/pdf) as a binary Blob. The server
+ * picks the output format from the `accept` header, so the header is set based
+ * on the requested format. The raw-response middleware returns XLSX/PDF as a
+ * Blob; CSV comes back as text from the default fetcher and is wrapped in a
+ * Blob here for a consistent return type.
+ */
+export async function fetchExportResource(
+  fetcher: ApiFetcher,
+  params: ExportResourceParams,
+): Promise<ExportResourceResponse> {
+  const get = fetcher.path(EXPORT_ROUTES.RESOURCE).method('get').create();
+  const accept =
+    params.format === 'xlsx'
+      ? 'application/xlsx'
+      : params.format === 'pdf'
+        ? 'application/pdf'
+        : 'application/csv';
+  const response = await get(
+    { resource: params.resource, format: params.format } as never,
+    {
+      headers: { Accept: accept },
+    },
+  );
+  const data = response.data as Blob | string;
+  return data instanceof Blob ? data : new Blob([data]);
+}

--- a/shared/sdk-ts/src/index.ts
+++ b/shared/sdk-ts/src/index.ts
@@ -16,6 +16,7 @@ export * from './branches';
 export * from './warehouses';
 export * from './exchange-rates';
 export * from './expenses';
+export * from './export';
 export * from './import';
 export * from './manual-journals';
 export * from './roles';


### PR DESCRIPTION
## Description

This PR adds first-class SDK support for the resource export endpoint (`GET /api/export`) to `@bigcapital/sdk-ts` and migrates the webapp Export dialog hook from a raw axios request to the SDK. It also fixes a regression introduced in `01b2f0e1d` (TypeScript migration refactor) where the `downloadFile()` call was accidentally dropped: the export request returned HTTP 200 with the file blob but the browser never downloaded it.

### Changes

- **`shared/sdk-ts/src/export.ts`** (new): `fetchExportResource()` downloads an exported resource (CSV/XLSX, PDF supported in the type) as a `Blob`. Mirrors the existing `downloadImportSample()` pattern in `import.ts` — the server selects the output format from the `accept` header, and the raw-response middleware returns XLSX/PDF as a Blob while CSV text is wrapped into a Blob for a consistent return type.
- **`shared/sdk-ts/src/index.ts`**: registers the new `./export` module in the package barrel.
- **`packages/webapp/src/hooks/query/FinancialReports/use-export.ts`**: replaces `useApiRequest()` (axios) with `useApiFetcher()` + `fetchExportResource()`, and restores the missing `downloadFile(blob, ...)` call so the export actually downloads.

No changes are required in the Export dialog components or the resource action bars — `ExportDialogForm` continues to consume `useResourceExport()` unchanged.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- `pnpm --filter @bigcapital/sdk-ts typecheck` — passes.
- `pnpm --filter @bigcapital/sdk-ts build` — builds CJS + ESM + type declarations successfully.
- `pnpm --filter @bigcapital/webapp typecheck` — no new errors; the export-related files are clean (the remaining 46 typecheck errors are pre-existing on the base branch and unrelated to this change).
- Manual verification pending: open the Export dialog on a resource list, select CSV/XLSX, and confirm the file downloads and the dialog closes.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>
