### PR TITLE
fix(server): handle missing default pdf template when printing documents

### DIFF
--- a/packages/server/src/modules/CreditNotes/queries/CreditNoteBrandingTemplate.service.ts
+++ b/packages/server/src/modules/CreditNotes/queries/CreditNoteBrandingTemplate.service.ts
@@ -16,10 +16,7 @@ export class CreditNoteBrandingTemplate {
    * @param {number} templateId
    * @returns {}
    */
-  public async getCreditNoteBrandingTemplate(templateId: number) {
-    const template =
-      await this.getPdfTemplateService.getPdfTemplate(templateId);
-
+  public async getCreditNoteBrandingTemplate(templateId?: number) {
     // Retrieves the organization branding attributes.
     const commonOrgBrandingAttrs =
       await this.getOrgBrandingAttributes.execute();
@@ -29,6 +26,21 @@ export class CreditNoteBrandingTemplate {
       ...defaultCreditNoteBrandingAttributes,
       ...commonOrgBrandingAttrs,
     };
+
+    // The credit note may have no assigned template and no default template set
+    // for the resource, in which case we fall back to the default branding attributes.
+    let template = null;
+    if (templateId != null) {
+      try {
+        template = await this.getPdfTemplateService.getPdfTemplate(templateId);
+      } catch {
+        template = null;
+      }
+    }
+    if (!template) {
+      return { attributes: organizationBrandingAttrs };
+    }
+
     const brandingTemplateAttrs = {
       ...template.attributes,
       companyLogoUri: template.companyLogoUri,

--- a/packages/server/src/modules/PaymentReceived/queries/PaymentReceivedBrandingTemplate.service.ts
+++ b/packages/server/src/modules/PaymentReceived/queries/PaymentReceivedBrandingTemplate.service.ts
@@ -16,9 +16,7 @@ export class PaymentReceivedBrandingTemplate {
    * @param {number} paymentTemplateId
    * @returns
    */
-  public async getPaymentReceivedPdfTemplate(paymentTemplateId: number) {
-    const template =
-      await this.getPdfTemplateService.getPdfTemplate(paymentTemplateId);
+  public async getPaymentReceivedPdfTemplate(paymentTemplateId?: number) {
     // Retrieves the organization branding attributes.
     const commonOrgBrandingAttrs =
       await this.getOrgBrandingAttributes.execute();
@@ -28,6 +26,22 @@ export class PaymentReceivedBrandingTemplate {
       ...defaultPaymentReceivedPdfTemplateAttributes,
       ...commonOrgBrandingAttrs,
     };
+
+    // The payment may have no assigned template and no default template set for
+    // the resource, in which case we fall back to the default branding attributes.
+    let template = null;
+    if (paymentTemplateId != null) {
+      try {
+        template =
+          await this.getPdfTemplateService.getPdfTemplate(paymentTemplateId);
+      } catch {
+        template = null;
+      }
+    }
+    if (!template) {
+      return { attributes: organizationBrandingAttrs };
+    }
+
     const brandingTemplateAttrs = {
       ...template.attributes,
       companyLogoUri: template.companyLogoUri,

--- a/packages/server/src/modules/PdfTemplate/commands/DeletePdfTemplate.service.ts
+++ b/packages/server/src/modules/PdfTemplate/commands/DeletePdfTemplate.service.ts
@@ -42,6 +42,23 @@ export class DeletePdfTemplateService {
       });
       await this.pdfTemplateModel().query(trx).deleteById(templateId);
 
+      // If the deleted template was the resource default, assign the default to
+      // the remaining predefined template of the resource, if any.
+      if (oldPdfTemplate.default) {
+        const fallbackTemplate = await this.pdfTemplateModel()
+          .query(trx)
+          .where('resource', oldPdfTemplate.resource)
+          .where('predefined', true)
+          .first();
+
+        if (fallbackTemplate) {
+          await this.pdfTemplateModel()
+            .query(trx)
+            .findById(fallbackTemplate.id)
+            .patch({ default: true });
+        }
+      }
+
       // Triggers `onPdfTemplateDeleted` event.
       await this.eventEmitter.emitAsync(events.pdfTemplate.onDeleted, {
         templateId,

--- a/packages/server/src/modules/SaleInvoices/SaleInvoices.controller.ts
+++ b/packages/server/src/modules/SaleInvoices/SaleInvoices.controller.ts
@@ -241,6 +241,7 @@ export class SaleInvoicesController {
       res.set({
         'Content-Type': 'application/pdf',
         'Content-Length': pdfContent.length,
+        'Content-Disposition': `attachment; filename="${filename}.pdf"`,
       });
       res.send(pdfContent);
     } else if (acceptHeader?.includes(AcceptType.ApplicationTextHtml)) {

--- a/packages/server/src/modules/SaleInvoices/queries/SaleEstimatePdfTemplate.service.ts
+++ b/packages/server/src/modules/SaleInvoices/queries/SaleEstimatePdfTemplate.service.ts
@@ -16,11 +16,8 @@ export class SaleEstimatePdfTemplate {
    * @param {number} invoiceTemplateId
    * @returns
    */
-  public async getEstimatePdfTemplate(estimateTemplateId: number) {
-    const template =
-      await this.getPdfTemplateService.getPdfTemplate(estimateTemplateId);
-
-    // Retreives the organization branding attributes.
+  public async getEstimatePdfTemplate(estimateTemplateId?: number) {
+    // Retrieves the organization branding attributes.
     const commonOrgBrandingAttrs = await this.getOrgBrandingAttrs.execute();
 
     // Merge the default branding attributes with organization attrs.
@@ -28,6 +25,22 @@ export class SaleEstimatePdfTemplate {
       ...defaultEstimatePdfBrandingAttributes,
       ...commonOrgBrandingAttrs,
     };
+
+    // The estimate may have no assigned template and no default template set for
+    // the resource, in which case we fall back to the default branding attributes.
+    let template = null;
+    if (estimateTemplateId != null) {
+      try {
+        template =
+          await this.getPdfTemplateService.getPdfTemplate(estimateTemplateId);
+      } catch {
+        template = null;
+      }
+    }
+    if (!template) {
+      return { attributes: orgainizationBrandingAttrs };
+    }
+
     const brandingTemplateAttrs = {
       ...template.attributes,
       companyLogoUri: template.companyLogoUri,

--- a/packages/server/src/modules/SaleInvoices/queries/SaleInvoicePdfTemplate.service.ts
+++ b/packages/server/src/modules/SaleInvoices/queries/SaleInvoicePdfTemplate.service.ts
@@ -16,10 +16,7 @@ export class SaleInvoicePdfTemplate {
    * @param {number} invoiceTemplateId
    * @returns
    */
-  async getInvoicePdfTemplate(invoiceTemplateId: number) {
-    const template =
-      await this.getPdfTemplateService.getPdfTemplate(invoiceTemplateId);
-
+  async getInvoicePdfTemplate(invoiceTemplateId?: number) {
     // Retrieves the organization branding attributes.
     const commonOrgBrandingAttrs =
       await this.getOrgBrandingAttributes.execute();
@@ -28,6 +25,22 @@ export class SaleInvoicePdfTemplate {
       ...defaultInvoicePdfTemplateAttributes,
       ...commonOrgBrandingAttrs,
     };
+
+    // The invoice may have no assigned template and no default template set for
+    // the resource, in which case we fall back to the default branding attributes.
+    let template = null;
+    if (invoiceTemplateId != null) {
+      try {
+        template =
+          await this.getPdfTemplateService.getPdfTemplate(invoiceTemplateId);
+      } catch {
+        template = null;
+      }
+    }
+    if (!template) {
+      return { attributes: organizationBrandingAttrs };
+    }
+
     const brandingTemplateAttrs = {
       ...template.attributes,
       companyLogoUri: template.companyLogoUri,

--- a/packages/server/src/modules/SaleReceipts/queries/SaleReceiptBrandingTemplate.service.ts
+++ b/packages/server/src/modules/SaleReceipts/queries/SaleReceiptBrandingTemplate.service.ts
@@ -20,10 +20,7 @@ export class SaleReceiptBrandingTemplate {
    * @param {number} templateId - The ID of the PDF template.
    * @returns {Promise<Object>} The sale receipt branding template with merged attributes.
    */
-  public async getSaleReceiptBrandingTemplate(templateId: number) {
-    const template =
-      await this.getPdfTemplateService.getPdfTemplate(templateId);
-
+  public async getSaleReceiptBrandingTemplate(templateId?: number) {
     // Retrieves the organization branding attributes.
     const commonOrgBrandingAttrs =
       await this.getOrgBrandingAttributes.execute();
@@ -33,6 +30,21 @@ export class SaleReceiptBrandingTemplate {
       ...defaultSaleReceiptBrandingAttributes,
       ...commonOrgBrandingAttrs,
     };
+
+    // The receipt may have no assigned template and no default template set for
+    // the resource, in which case we fall back to the default branding attributes.
+    let template = null;
+    if (templateId != null) {
+      try {
+        template = await this.getPdfTemplateService.getPdfTemplate(templateId);
+      } catch {
+        template = null;
+      }
+    }
+    if (!template) {
+      return { attributes: organizationBrandingAttrs };
+    }
+
     const brandingTemplateAttrs = {
       ...template.attributes,
       companyLogoUri: template.companyLogoUri,

--- a/packages/webapp/src/components/PdfPreview/index.tsx
+++ b/packages/webapp/src/components/PdfPreview/index.tsx
@@ -6,9 +6,19 @@ import React from 'react';
 /**
  * Previews the pdf document of the given object url.
  */
-export function PdfDocumentPreview({ url, height, width, isLoading }) {
+export function PdfDocumentPreview({
+  url,
+  height,
+  width,
+  isLoading,
+  isError = false,
+}) {
   const content = isLoading ? (
     <Spinner size={30} />
+  ) : isError ? (
+    <div className="pdf-preview__error">
+      Failed to load the PDF document. Please try again.
+    </div>
   ) : (
     <embed src={url} height={height} width={width} />
   );

--- a/packages/webapp/src/containers/Dialogs/CreditNotePdfPreviewDialog/CreditNotePdfPreviewDialogContent.tsx
+++ b/packages/webapp/src/containers/Dialogs/CreditNotePdfPreviewDialog/CreditNotePdfPreviewDialogContent.tsx
@@ -15,20 +15,16 @@ interface CreditNotePdfPreviewDialogContentProps
 function CreditNotePdfPreviewDialogContentInner({
   subscriptionForm: { creditNoteId },
 }: CreditNotePdfPreviewDialogContentProps): React.ReactElement {
-  // Latent bug preserved: payload default is `{ creditNoteId: null }` — the
-  // hook builds URL `credit-notes/null` when the dialog opens without a real id.
-  const { isLoading, pdfUrl, filename } = usePdfCreditNote(
+  const { isLoading, isError, pdfUrl, filename } = usePdfCreditNote(
     creditNoteId as number | string,
   );
 
-  // FIXME: `target={'__blank'}` should be `_blank` (single underscore) — left
-  // as-is to avoid a behavior change in a TS-only slice.
   return (
     <DialogContent>
       <div className="dialog__header-actions">
         <AnchorButton
           href={pdfUrl}
-          target={'__blank'}
+          target="_blank"
           minimal={true}
           outlined={true}
         >
@@ -49,6 +45,7 @@ function CreditNotePdfPreviewDialogContentInner({
         height={760}
         width={1000}
         isLoading={isLoading}
+        isError={isError}
         url={pdfUrl}
       />
     </DialogContent>

--- a/packages/webapp/src/containers/Dialogs/EstimatePdfPreviewDialog/EstimatePdfPreviewDialogContent.tsx
+++ b/packages/webapp/src/containers/Dialogs/EstimatePdfPreviewDialog/EstimatePdfPreviewDialogContent.tsx
@@ -14,18 +14,16 @@ interface EstimatePdfPreviewDialogContentProps extends WithDialogActionsProps {
 function EstimatePdfPreviewDialogContentInner({
   subscriptionForm: { estimateId },
 }: EstimatePdfPreviewDialogContentProps): React.ReactElement {
-  // Latent bug preserved: payload default is `{ estimateId: null }` — the hook
-  // builds URL `sales-estimates/null` when the dialog opens without a real id.
-  const { isLoading, pdfUrl, filename } = usePdfEstimate(estimateId as number);
+  const { isLoading, isError, pdfUrl, filename } = usePdfEstimate(
+    estimateId as number,
+  );
 
-  // FIXME: `target={'__blank'}` should be `_blank` (single underscore) — left
-  // as-is to avoid a behavior change in a TS-only slice.
   return (
     <DialogContent>
       <div className="dialog__header-actions">
         <AnchorButton
           href={pdfUrl}
-          target={'__blank'}
+          target="_blank"
           minimal={true}
           outlined={true}
         >
@@ -46,6 +44,7 @@ function EstimatePdfPreviewDialogContentInner({
         height={760}
         width={1000}
         isLoading={isLoading}
+        isError={isError}
         url={pdfUrl}
       />
     </DialogContent>

--- a/packages/webapp/src/containers/Dialogs/InvoicePdfPreviewDialog/InvoicePdfPreviewDialogContent.tsx
+++ b/packages/webapp/src/containers/Dialogs/InvoicePdfPreviewDialog/InvoicePdfPreviewDialogContent.tsx
@@ -14,18 +14,16 @@ interface InvoicePdfPreviewDialogContentProps extends WithDialogActionsProps {
 function InvoicePdfPreviewDialogContentInner({
   subscriptionForm: { invoiceId },
 }: InvoicePdfPreviewDialogContentProps): React.ReactElement {
-  // Latent bug preserved: payload default is `{ invoiceId: null }` — the hook
-  // builds URL `sale-invoices/null` when the dialog opens without a real id.
-  const { isLoading, pdfUrl, filename } = usePdfInvoice(invoiceId as number);
+  const { isLoading, isError, pdfUrl, filename } = usePdfInvoice(
+    invoiceId as number,
+  );
 
-  // FIXME: `target={'__blank'}` should be `_blank` (single underscore) — left
-  // as-is to avoid a behavior change in a TS-only slice.
   return (
     <DialogContent>
       <div className="dialog__header-actions">
         <AnchorButton
           href={pdfUrl}
-          target={'__blank'}
+          target="_blank"
           minimal={true}
           outlined={true}
         >
@@ -46,6 +44,7 @@ function InvoicePdfPreviewDialogContentInner({
         height={760}
         width={1000}
         isLoading={isLoading}
+        isError={isError}
         url={pdfUrl}
       />
     </DialogContent>

--- a/packages/webapp/src/containers/Dialogs/PaymentReceivePdfPreviewDialog/PaymentReceivePdfPreviewContent.tsx
+++ b/packages/webapp/src/containers/Dialogs/PaymentReceivePdfPreviewDialog/PaymentReceivePdfPreviewContent.tsx
@@ -14,20 +14,16 @@ interface PaymentReceivePdfPreviewContentProps extends WithDialogActionsProps {
 function PaymentReceivePdfPreviewDialogContent({
   subscriptionForm: { paymentReceiveId },
 }: PaymentReceivePdfPreviewContentProps): React.ReactElement {
-  // Latent bug preserved: payload default is `{ paymentReceiveId: null }` — the
-  // hook builds URL `payment-receives/null` when the dialog opens without a real id.
-  const { isLoading, pdfUrl, filename } = usePdfPaymentReceive(
+  const { isLoading, isError, pdfUrl, filename } = usePdfPaymentReceive(
     paymentReceiveId as number,
   );
 
-  // FIXME: `target={'__blank'}` should be `_blank` (single underscore) — left
-  // as-is to avoid a behavior change in a TS-only slice.
   return (
     <DialogContent>
       <div className="dialog__header-actions">
         <AnchorButton
           href={pdfUrl}
-          target={'__blank'}
+          target="_blank"
           minimal={true}
           outlined={true}
         >
@@ -48,6 +44,7 @@ function PaymentReceivePdfPreviewDialogContent({
         height={760}
         width={1000}
         isLoading={isLoading}
+        isError={isError}
         url={pdfUrl}
       />
     </DialogContent>

--- a/packages/webapp/src/containers/Dialogs/ReceiptPdfPreviewDialog/ReceiptPdfPreviewDialogContent.tsx
+++ b/packages/webapp/src/containers/Dialogs/ReceiptPdfPreviewDialog/ReceiptPdfPreviewDialogContent.tsx
@@ -14,18 +14,16 @@ interface ReceiptPdfPreviewDialogContentProps extends WithDialogActionsProps {
 function ReceiptPdfPreviewDialogContentInner({
   subscriptionForm: { receiptId },
 }: ReceiptPdfPreviewDialogContentProps): React.ReactElement {
-  // Latent bug preserved: payload default is `{ receiptId: null }` — the hook
-  // builds URL `receipts/null` when the dialog opens without a real id.
-  const { isLoading, pdfUrl, filename } = usePdfReceipt(receiptId as number);
+  const { isLoading, isError, pdfUrl, filename } = usePdfReceipt(
+    receiptId as number,
+  );
 
-  // FIXME: `target={'__blank'}` should be `_blank` (single underscore) — left
-  // as-is to avoid a behavior change in a TS-only slice.
   return (
     <DialogContent>
       <div className="dialog__header-actions">
         <AnchorButton
           href={pdfUrl}
-          target={'__blank'}
+          target="_blank"
           minimal={true}
           outlined={true}
         >
@@ -46,6 +44,7 @@ function ReceiptPdfPreviewDialogContentInner({
         height={760}
         width={1000}
         isLoading={isLoading}
+        isError={isError}
         url={pdfUrl}
       />
     </DialogContent>

--- a/packages/webapp/src/hooks/query/FinancialReports/use-export-pdf.ts
+++ b/packages/webapp/src/hooks/query/FinancialReports/use-export-pdf.ts
@@ -44,12 +44,17 @@ export const useDownloadExportPdf = () => {
   const downloadAsync = (values: ResourceExportValues) => {
     if (!isExportPdfLoading) {
       startProgress();
-      return mutateAsync(values).then((res) => {
-        downloadFile(res.data, `${values.resource}.pdf`);
-        stopProgress();
+      return mutateAsync(values)
+        .then((res) => {
+          downloadFile(res.data, `${values.resource}.pdf`);
+          stopProgress();
 
-        return res;
-      });
+          return res;
+        })
+        .catch((error) => {
+          stopProgress();
+          throw error;
+        });
     }
     return undefined;
   };

--- a/packages/webapp/src/hooks/useRequestPdf.tsx
+++ b/packages/webapp/src/hooks/useRequestPdf.tsx
@@ -15,22 +15,34 @@ export const useRequestPdf = (httpProps?: PdfRequestProps) => {
   const apiRequest = useApiRequest();
   const [isLoading, setIsLoading] = React.useState(false);
   const [isLoaded, setIsLoaded] = React.useState(false);
+  const [isError, setIsError] = React.useState(false);
   const [pdfUrl, setPdfUrl] = React.useState('');
   const [response, setResponse] = React.useState<AxiosResponse<Blob> | null>(
     null,
   );
   const [filename, setFilename] = React.useState<string>('');
 
+  const url = `/api/${normalizeApiPath(httpProps?.url || '')}`;
+
   React.useEffect(() => {
+    if (!httpProps?.url) {
+      return;
+    }
+    let isCancelled = false;
     setIsLoading(true);
+    setIsError(false);
+
     apiRequest
       .http({
         headers: { accept: 'application/pdf' },
         responseType: 'blob',
         ...httpProps,
-        url: `/api/${normalizeApiPath(httpProps?.url || '')}`,
+        url,
       })
       .then((response) => {
+        if (isCancelled) {
+          return;
+        }
         // Create a Blob from the PDF Stream.
         const file = new Blob([response.data], { type: 'application/pdf' });
 
@@ -54,12 +66,28 @@ export const useRequestPdf = (httpProps?: PdfRequestProps) => {
         setIsLoaded(true);
         setResponse(response);
         setFilename(_filename);
+      })
+      .catch(() => {
+        if (isCancelled) {
+          return;
+        }
+        setIsLoading(false);
+        setIsLoaded(false);
+        setIsError(true);
       });
-  }, []);
+
+    return () => {
+      isCancelled = true;
+    };
+    // `httpProps` intentionally omitted from deps — refetching only depends on
+    // the resolved URL, and callers pass a fresh object on every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [url, apiRequest]);
 
   return {
     isLoading,
     isLoaded,
+    isError,
     pdfUrl,
     response,
     filename,


### PR DESCRIPTION
## Description

Fixes invoice printing (and the equivalent flow for receipts, estimates, credit notes and payment receives) when a tenant has no default PDF branding template for the resource.

**Root cause:** `SaleInvoicePdf.getInvoiceBrandingAttributes` computed a `templateId` that could be `undefined` (no assigned template and no `default: true` template for the resource) and passed it to `getInvoicePdfTemplate`, which crashed with `Error: undefined was passed to findById`. The webapp's `useRequestPdf` had no error handling, turning the 500 into an infinite spinner in the print preview dialog.

**Fix:**
- Server: the branding-template services now fall back to the built-in default branding attributes when no template is assigned or set as default, instead of crashing.
- Server: deleting a template that was its resource's default now reassigns the default to the remaining predefined template of that resource.
- Server: the invoice PDF response now sets `Content-Disposition`, so downloads keep the real invoice filename instead of `default.pdf`.
- Webapp: `useRequestPdf` and the resource export-PDF download now surface errors instead of an infinite spinner, and the PDF preview dialogs use `target="_blank"`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Server: `pnpm --filter @bigcapital/server typecheck` and `pnpm --filter @bigcapital/server build` pass.
- Webapp: `pnpm --filter @bigcapital/webapp typecheck` reports no new errors (remaining errors are pre-existing in unrelated files).
- Reproduced the failing flow against a tenant with no default SaleInvoice template; printing now returns a valid PDF instead of a 500.
- Restored the missing `default=true` flag on the affected tenant's SaleInvoice template.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>
