### PR TITLE
feat(webapp): add e2e tests covering bank rules CRUD

### DIFF
--- a/e2e/bank-rules.spec.ts
+++ b/e2e/bank-rules.spec.ts
@@ -1,0 +1,200 @@
+import { test, expect, type Locator, type Page } from "@playwright/test";
+import { faker } from "@faker-js/faker";
+
+const ruleName = () =>
+  `${faker.company.name()} Rule ${faker.string.alphanumeric(4)}`;
+
+/**
+ * Waits until the bank rules page is loaded.
+ */
+async function waitForBankRulesPage(page: Page) {
+  await expect(page.getByTestId("dashboard-topbar").locator("h1")).toHaveText(
+    "Bank Rules",
+    { timeout: 30_000 },
+  );
+  await expect(
+    page.getByRole("button", { name: "New Bank Rule" }).first(),
+  ).toBeVisible({ timeout: 30_000 });
+}
+
+/**
+ * Opens the new bank rule dialog.
+ */
+async function openNewBankRuleDialog(page: Page) {
+  await page.getByRole("button", { name: "New Bank Rule" }).first().click();
+
+  const dialog = page.getByTestId("rule-form-dialog");
+  await expect(dialog).toBeVisible({ timeout: 30_000 });
+  await expect(dialog.getByTestId("rule-name-input")).toBeVisible({
+    timeout: 30_000,
+  });
+
+  return dialog;
+}
+
+/**
+ * Opens a Blueprint select popover by its test id and picks the option whose
+ * text matches the given pattern.
+ */
+async function selectOption(
+  page: Page,
+  dialog: Locator,
+  selectTestId: string,
+  optionText: RegExp,
+) {
+  await dialog.getByTestId(selectTestId).click();
+  await page.getByRole("menuitem", { name: optionText }).click();
+}
+
+/**
+ * Creates a bank rule through the UI and expects the success toast alongside
+ * the new row in the table.
+ */
+async function createBankRule(
+  page: Page,
+  { name }: { name: string },
+): Promise<Locator> {
+  const dialog = await openNewBankRuleDialog(page);
+
+  await dialog.getByTestId("rule-name-input").fill(name);
+  await selectOption(page, dialog, "rule-apply-account-select", /Petty Cash/);
+  await selectOption(page, dialog, "rule-apply-type-select", /Deposit/);
+  await dialog
+    .getByTestId("rule-condition-value-input")
+    .fill(faker.lorem.word());
+  await selectOption(
+    page,
+    dialog,
+    "rule-assign-category-select",
+    /Other income/,
+  );
+  await selectOption(
+    page,
+    dialog,
+    "rule-assign-account-select",
+    /Sales of Product Income/,
+  );
+
+  await dialog.getByRole("button", { name: "Save" }).click();
+
+  await expect(dialog).toBeHidden({ timeout: 30_000 });
+  await expect(
+    page.getByText("The bank rule has been created successfully.").first(),
+  ).toBeVisible({ timeout: 15_000 });
+
+  const row = page
+    .getByTestId("bank-rule-row")
+    .filter({ hasText: name })
+    .first();
+  await expect(row).toBeVisible({ timeout: 15_000 });
+
+  return row;
+}
+
+/**
+ * Deletes the given bank rule row through the context menu and expects the
+ * success toast.
+ */
+async function deleteBankRuleViaRow(page: Page, row: Locator) {
+  await row.click({ button: "right" });
+  await page.getByRole("menuitem", { name: "Delete Rule" }).click();
+
+  await expect(page.getByTestId("bank-rule-delete-alert")).toBeVisible();
+  await page
+    .getByRole("dialog")
+    .filter({ has: page.getByTestId("bank-rule-delete-alert") })
+    .getByRole("button", { name: "Delete" })
+    .click();
+
+  await expect(
+    page.getByText("The bank rule has deleted successfully."),
+  ).toBeVisible({ timeout: 15_000 });
+}
+
+test.describe("bank rules", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/bank-rules");
+
+    // The TanStack Query devtools panel (rendered in dev with `initialIsOpen`)
+    // overlays the app and intercepts pointer events, blocking UI clicks.
+    // Make it click-through so the tests below are not affected by it.
+    await page.addStyleTag({
+      content: '[class*="tsqd"] { pointer-events: none !important; }',
+    });
+  });
+
+  test("should show the bank rules page.", async ({ page }) => {
+    await waitForBankRulesPage(page);
+
+    await expect(
+      page.getByRole("button", { name: "New Bank Rule" }).first(),
+    ).toBeVisible();
+  });
+
+  test("should validate the required fields of the new bank rule dialog.", async ({
+    page,
+  }) => {
+    await waitForBankRulesPage(page);
+
+    const dialog = await openNewBankRuleDialog(page);
+    await dialog.getByRole("button", { name: "Save" }).click();
+
+    await expect(dialog).toContainText("Rule name is a required field");
+    await expect(dialog).toContainText("Apply to account is a required field");
+    await expect(dialog).toContainText(
+      "Assign to category is a required field",
+    );
+    await expect(dialog).toContainText("Assign to account is a required field");
+    await expect(dialog).toContainText("Value is a required field");
+  });
+
+  test("should create a bank rule successfully.", async ({ page }) => {
+    await waitForBankRulesPage(page);
+
+    const name = ruleName();
+    await createBankRule(page, { name });
+  });
+
+  test("should edit a bank rule successfully.", async ({ page }) => {
+    await waitForBankRulesPage(page);
+
+    const name = ruleName();
+    const newName = ruleName();
+
+    const row = await createBankRule(page, { name });
+
+    await row.click({ button: "right" });
+    await page.getByRole("menuitem", { name: "Edit Rule" }).click();
+
+    const dialog = page.getByTestId("rule-form-dialog");
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByTestId("rule-name-input")).toHaveValue(name, {
+      timeout: 30_000,
+    });
+
+    await dialog.getByTestId("rule-name-input").fill(newName);
+    await dialog.getByRole("button", { name: "Save" }).click();
+
+    await expect(dialog).toBeHidden({ timeout: 30_000 });
+    await expect(
+      page.getByText("The bank rule has been created successfully.").first(),
+    ).toBeVisible({ timeout: 15_000 });
+
+    await expect(
+      page.getByTestId("bank-rule-row").filter({ hasText: newName }).first(),
+    ).toBeVisible({ timeout: 15_000 });
+  });
+
+  test("should delete a bank rule successfully.", async ({ page }) => {
+    await waitForBankRulesPage(page);
+
+    const name = ruleName();
+
+    const row = await createBankRule(page, { name });
+    await deleteBankRuleViaRow(page, row);
+
+    await expect(
+      page.getByTestId("bank-rule-row").filter({ hasText: name }),
+    ).toHaveCount(0, { timeout: 15_000 });
+  });
+});

--- a/packages/webapp/src/containers/Banking/Rules/RuleFormDialog/RuleFormContentForm.tsx
+++ b/packages/webapp/src/containers/Banking/Rules/RuleFormDialog/RuleFormContentForm.tsx
@@ -101,7 +101,11 @@ function RuleFormContentFormRoot({
           style={{ maxWidth: 300 }}
           fastField
         >
-          <FInputGroup name={'name'} fastField />
+          <FInputGroup
+            name={'name'}
+            fastField
+            data-testId={'rule-name-input'}
+          />
         </FFormGroup>
 
         <FFormGroup
@@ -116,6 +120,7 @@ function RuleFormContentFormRoot({
             items={accounts}
             filterByTypes={['cash', 'bank']}
             fastField
+            buttonProps={{ 'data-testId': 'rule-apply-account-select' }}
           />
         </FFormGroup>
 
@@ -229,7 +234,11 @@ function RuleFormConditions() {
               style={{ marginBottom: 0, flex: '1 0 ', width: '40%' }}
               fastField
             >
-              <FInputGroup name={`conditions[${index}].value`} fastField />
+              <FInputGroup
+                name={`conditions[${index}].value`}
+                fastField
+                data-testId={'rule-condition-value-input'}
+              />
             </FFormGroup>
           </Group>
         ))}
@@ -311,6 +320,7 @@ function RuleApplyIfTransactionTypeField() {
         popoverProps={{ minimal: true, inline: false }}
         onItemChange={handleItemChange}
         fastField
+        buttonProps={{ 'data-testId': 'rule-apply-type-select' }}
       />
     </FFormGroup>
   );
@@ -353,6 +363,7 @@ function RuleAssignCategoryField() {
         textAccessor={'name'}
         onItemChange={handleItemChange}
         fastField
+        buttonProps={{ 'data-testId': 'rule-assign-category-select' }}
       />
     </FFormGroup>
   );
@@ -382,6 +393,7 @@ function RuleAssignCategoryAccountField() {
         filterByRootTypes={accountRoot}
         shouldUpdateDeps={{ accountRoot }}
         fastField
+        buttonProps={{ 'data-testId': 'rule-assign-account-select' }}
       />
     </FFormGroup>
   );

--- a/packages/webapp/src/containers/Banking/Rules/RuleFormDialog/RuleFormDialog.tsx
+++ b/packages/webapp/src/containers/Banking/Rules/RuleFormDialog/RuleFormDialog.tsx
@@ -25,7 +25,7 @@ function RuleFormDialogRoot({
       autoFocus={true}
       style={{ width: 600 }}
     >
-      <DialogSuspense>
+      <DialogSuspense testId={'rule-form-dialog'}>
         <RuleFormContent dialogName={dialogName} bankRuleId={bankRuleId} />
       </DialogSuspense>
     </Dialog>

--- a/packages/webapp/src/containers/Banking/Rules/RulesList/RulesTable.tsx
+++ b/packages/webapp/src/containers/Banking/Rules/RulesList/RulesTable.tsx
@@ -65,6 +65,7 @@ function RulesTable({
         ContextMenu={BankRulesTableActionsMenu}
         // onCellClick={handleCellClick}
         size={'medium'}
+        rowTestId={'bank-rule-row'}
         payload={{
           onDelete: handleDeleteBankRule,
           onEdit: handleEditBankRule,

--- a/packages/webapp/src/containers/Banking/Rules/RulesList/alerts/DeleteBankRuleAlert.tsx
+++ b/packages/webapp/src/containers/Banking/Rules/RulesList/alerts/DeleteBankRuleAlert.tsx
@@ -60,7 +60,9 @@ function BankRuleDeleteAlert({
       onConfirm={handleConfirmBtnClick}
       loading={isLoading}
     >
-      <p>Are you sure want to delete the bank rule?</p>
+      <p data-testId={'bank-rule-delete-alert'}>
+        Are you sure want to delete the bank rule?
+      </p>
     </Alert>
   );
 }


### PR DESCRIPTION
## Description

Adds Playwright e2e coverage for the basic CRUD operations of bank rules (list, validation, create, edit, delete) against the webapp UI.

- Adds `e2e/bank-rules.spec.ts` covering: page load, required-field validation of the new rule dialog, create, edit, and delete flows (with success toasts and table row assertions).
- Adds `data-testId` hooks to the bank rules webapp components (rule form dialog, form inputs/selects, table rows, delete alert) following the existing accounts/item-categories/expenses e2e conventions.
- Makes the tests resilient to the TanStack Query devtools overlay (rendered in dev with `initialIsOpen`), which otherwise intercepts pointer events and blocks UI clicks.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Ran the new spec against the local dev stack:

```
npx playwright test e2e/bank-rules.spec.ts
```

All 5 tests pass:

- should show the bank rules page.
- should validate the required fields of the new bank rule dialog.
- should create a bank rule successfully.
- should edit a bank rule successfully.
- should delete a bank rule successfully.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>
