### PR TITLE
fix(webapp): fix display name field in customer and vendor forms

### DIFF
--- a/packages/webapp/src/components/Select/DisplayNameList.tsx
+++ b/packages/webapp/src/components/Select/DisplayNameList.tsx
@@ -1,14 +1,15 @@
 import { useFormikContext } from 'formik';
-import React, { useMemo } from 'react';
+import React, { useRef } from 'react';
 import intl from 'react-intl-universal';
 import { FSelect } from '../Forms';
+import {
+  resolveDisplayName,
+  resolveDisplayNameOptions,
+  DisplayNameSource,
+} from './displayNameUtils';
 
 export type DisplayNameListItem = { label: string };
-type DisplayNameFormat = {
-  format: string;
-  values: Array<string | undefined>;
-  required: number[];
-};
+type DisplayNameOption = DisplayNameListItem & { format: string };
 
 export interface DisplayNameListProps
   extends Omit<
@@ -16,63 +17,19 @@ export interface DisplayNameListProps
     'items' | 'valueAccessor' | 'textAccessor' | 'labelAccessor'
   > {}
 
-function useDisplayNameFormatOptions(
-  salutation?: string,
-  firstName?: string,
-  lastName?: string,
-  companyName?: string,
-): DisplayNameListItem[] {
-  return useMemo(() => {
-    const formats: DisplayNameFormat[] = [
-      {
-        format: '{1} {2} {3}',
-        values: [salutation, firstName, lastName],
-        required: [1],
-      },
-      { format: '{1} {2}', values: [firstName, lastName], required: [] },
-      { format: '{1}, {2}', values: [firstName, lastName], required: [1, 2] },
-      { format: '{1}', values: [companyName], required: [1] },
-    ];
+export function DisplayNameList({
+  onItemChange,
+  ...restProps
+}: DisplayNameListProps) {
+  const { values, setFieldValue } = useFormikContext<any>();
 
-    return formats
-      .filter(
-        (format) =>
-          !format.values.some((value, index) => {
-            return !value && format.required.indexOf(index + 1) !== -1;
-          }),
-      )
-      .map((formatOption) => {
-        const { format, values } = formatOption;
-        let label = format;
-
-        values.forEach((value, index) => {
-          const replaceWith = value || '';
-          label = label.replace(`{${index + 1}}`, replaceWith).trim();
-        });
-        return {
-          label: label.replace(/\s+/g, ' ').replace(/\s+,/g, ',').trim(),
-        };
-      })
-      .filter(({ label }) => Boolean(label));
-  }, [salutation, firstName, lastName, companyName]);
-}
-
-export function DisplayNameList({ ...restProps }: DisplayNameListProps) {
-  const {
-    values: {
-      first_name: firstName,
-      last_name: lastName,
-      company_name: companyName,
-      salutation,
-    },
-  } = useFormikContext<any>();
-
-  const formatOptions = useDisplayNameFormatOptions(
-    salutation,
-    firstName,
-    lastName,
-    companyName,
-  );
+  const source: DisplayNameSource = {
+    salutation: values.salutation,
+    firstName: values.firstName,
+    lastName: values.lastName,
+    companyName: values.companyName,
+  };
+  const formatOptions = resolveDisplayNameOptions(source);
 
   return (
     <FSelect
@@ -82,7 +39,53 @@ export function DisplayNameList({ ...restProps }: DisplayNameListProps) {
       labelAccessor={'_label'}
       placeholder={intl.get('select_display_name_as')}
       filterable={false}
+      onItemChange={(item: DisplayNameOption) => {
+        setFieldValue('displayNameFormat', item.format);
+        onItemChange?.(item);
+      }}
       {...restProps}
     />
   );
+}
+
+/**
+ * Recomputes the display name from the selected format whenever any of the
+ * contact name fields change, so the selection is never lost. Attach the
+ * returned handlers to the source fields' onChange events.
+ */
+export function useDisplayNameSynchronizer() {
+  const { values, setFieldValue } = useFormikContext<any>();
+
+  // Holds the latest form values so that handlers retained by FastField (which
+  // bail out of re-rendering when their own field is unchanged) still read the
+  // current display-name format and contact name fields at event time.
+  const valuesRef = useRef(values);
+  valuesRef.current = values;
+
+  const syncDisplayName = (overrides: Partial<DisplayNameSource>) => {
+    const { displayNameFormat } = valuesRef.current;
+    if (!displayNameFormat) return;
+
+    const source: DisplayNameSource = {
+      salutation: valuesRef.current.salutation,
+      firstName: valuesRef.current.firstName,
+      lastName: valuesRef.current.lastName,
+      companyName: valuesRef.current.companyName,
+      ...overrides,
+    };
+    const label = resolveDisplayName(displayNameFormat, source);
+    if (label) {
+      setFieldValue('displayName', label);
+    }
+  };
+
+  const createFieldOnChange =
+    (fieldName: keyof DisplayNameSource) =>
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const value = event.target.value;
+      setFieldValue(fieldName, value);
+      syncDisplayName({ [fieldName]: value });
+    };
+
+  return { syncDisplayName, createFieldOnChange };
 }

--- a/packages/webapp/src/components/Select/displayNameUtils.ts
+++ b/packages/webapp/src/components/Select/displayNameUtils.ts
@@ -1,0 +1,65 @@
+export type DisplayNameSource = {
+  salutation?: string;
+  firstName?: string;
+  lastName?: string;
+  companyName?: string;
+};
+
+type DisplayNameFormat = {
+  format: string;
+  fields: Array<keyof DisplayNameSource>;
+  required: number[];
+};
+
+const FORMATS: DisplayNameFormat[] = [
+  {
+    format: '{1} {2} {3}',
+    fields: ['salutation', 'firstName', 'lastName'],
+    required: [1],
+  },
+  { format: '{1} {2}', fields: ['firstName', 'lastName'], required: [] },
+  { format: '{1}, {2}', fields: ['firstName', 'lastName'], required: [1, 2] },
+  { format: '{1}', fields: ['companyName'], required: [1] },
+];
+
+export function resolveDisplayName(
+  format: string,
+  source: DisplayNameSource,
+): string {
+  const formatOption = FORMATS.find(({ format: f }) => f === format);
+  if (!formatOption) return '';
+
+  const values = formatOption.fields.map((field) => source[field]);
+  let label = format;
+
+  values.forEach((value, index) => {
+    const replaceWith = value || '';
+    label = label.replace(`{${index + 1}}`, replaceWith).trim();
+  });
+  return label.replace(/\s+/g, ' ').replace(/\s+,/g, ',').trim();
+}
+
+export function resolveDisplayNameOptions(
+  source: DisplayNameSource,
+): Array<{ format: string; label: string }> {
+  return FORMATS.filter(
+    ({ fields, required }) =>
+      !required.some((position) => !source[fields[position - 1]]),
+  )
+    .map(({ format }) => ({
+      format,
+      label: resolveDisplayName(format, source),
+    }))
+    .filter(({ label }) => Boolean(label));
+}
+
+export function inferDisplayNameFormat(
+  source: DisplayNameSource & { displayName?: string },
+): string {
+  if (!source.displayName) return '';
+
+  const matching = resolveDisplayNameOptions(source).find(
+    ({ label }) => label === source.displayName,
+  );
+  return matching?.format ?? '';
+}

--- a/packages/webapp/src/containers/Customers/CustomerForm/CustomerFormBasicSection.tsx
+++ b/packages/webapp/src/containers/Customers/CustomerForm/CustomerFormBasicSection.tsx
@@ -8,7 +8,9 @@ import { CustomerFormSectionTitle } from './CustomerFormSectionTitle';
 import { CustomerTypeRadioField } from './CustomerTypeRadioField';
 import {
   SalutationList,
+  SalutationItem,
   DisplayNameList,
+  useDisplayNameSynchronizer,
   FInputGroup,
   FFormGroup,
   Box,
@@ -19,6 +21,7 @@ import { useAutofocus } from '@/hooks';
 
 export function CustomerFormBasicSection() {
   const firstNameFieldRef = useAutofocus<HTMLInputElement>();
+  const { syncDisplayName, createFieldOnChange } = useDisplayNameSynchronizer();
 
   return (
     <Box data-section-id="primary">
@@ -33,6 +36,9 @@ export function CustomerFormBasicSection() {
           <SalutationList
             name={'salutation'}
             popoverProps={{ minimal: true }}
+            onItemChange={(item: SalutationItem) =>
+              syncDisplayName({ salutation: item.key })
+            }
           />
           <FInputGroup
             name={'firstName'}
@@ -40,11 +46,13 @@ export function CustomerFormBasicSection() {
             inputRef={(ref: HTMLInputElement | null) => {
               if (ref) firstNameFieldRef.current = ref;
             }}
+            onChange={createFieldOnChange('firstName')}
             fill
           />
           <FInputGroup
             name={'lastName'}
             placeholder={intl.get('last_name')}
+            onChange={createFieldOnChange('lastName')}
             fill
           />
         </ControlGroup>
@@ -61,7 +69,11 @@ export function CustomerFormBasicSection() {
 
       {/*----------- Company Name -----------*/}
       <FFormGroup name={'companyName'} label={intl.get('company_name')} inline>
-        <FInputGroup name={'companyName'} fill />
+        <FInputGroup
+          name={'companyName'}
+          onChange={createFieldOnChange('companyName')}
+          fill
+        />
       </FFormGroup>
 
       {/*----------- Display Name -----------*/}

--- a/packages/webapp/src/containers/Customers/CustomerForm/CustomerFormFormik.tsx
+++ b/packages/webapp/src/containers/Customers/CustomerForm/CustomerFormFormik.tsx
@@ -15,6 +15,7 @@ import {
   transformValuesToForm,
 } from './utils';
 import { AppToaster } from '@/components';
+import { inferDisplayNameFormat } from '@/components/Select/displayNameUtils';
 import { useCurrentOrganizationBaseCurrency } from '@/hooks/query';
 import { saveInvoke } from '@/utils';
 
@@ -73,6 +74,10 @@ function CustomerFormFormikRoot({
     // Fall back to the organization base currency only if nothing else provided one.
     if (!merged.currencyCode && baseCurrency) {
       merged.currencyCode = baseCurrency;
+    }
+    // Infer the selected display-name format from the existing display name.
+    if (merged.displayName && !merged.displayNameFormat) {
+      merged.displayNameFormat = inferDisplayNameFormat(merged);
     }
     return merged;
   }, [customer, contactDuplicate, baseCurrency, initialCustomerValues]);

--- a/packages/webapp/src/containers/Customers/CustomerForm/utils.tsx
+++ b/packages/webapp/src/containers/Customers/CustomerForm/utils.tsx
@@ -22,6 +22,7 @@ export type CustomerFormValues = {
   lastName: string;
   companyName: string;
   displayName: string;
+  displayNameFormat: string;
   code: string;
 
   email: string;
@@ -62,6 +63,7 @@ export const defaultInitialValues: CustomerFormValues = {
   lastName: '',
   companyName: '',
   displayName: '',
+  displayNameFormat: '',
   code: '',
 
   email: '',

--- a/packages/webapp/src/containers/Vendors/VendorForm/VendorFormBasicSection.tsx
+++ b/packages/webapp/src/containers/Vendors/VendorForm/VendorFormBasicSection.tsx
@@ -7,7 +7,9 @@ import intl from 'react-intl-universal';
 import { VendorFormSectionTitle } from './VendorFormSectionTitle';
 import {
   SalutationList,
+  SalutationItem,
   DisplayNameList,
+  useDisplayNameSynchronizer,
   FInputGroup,
   FFormGroup,
   Box,
@@ -18,6 +20,7 @@ import { useAutofocus } from '@/hooks';
 
 export function VendorFormBasicSection() {
   const firstNameFieldRef = useAutofocus<HTMLInputElement>();
+  const { syncDisplayName, createFieldOnChange } = useDisplayNameSynchronizer();
 
   return (
     <Box data-section-id="primary">
@@ -35,6 +38,9 @@ export function VendorFormBasicSection() {
             name={'salutation'}
             popoverProps={{ minimal: true }}
             fastField
+            onItemChange={(item: SalutationItem) =>
+              syncDisplayName({ salutation: item.key })
+            }
           />
           <FInputGroup
             name={'firstName'}
@@ -42,12 +48,14 @@ export function VendorFormBasicSection() {
             inputRef={(ref: HTMLInputElement | null) => {
               if (ref) firstNameFieldRef.current = ref;
             }}
+            onChange={createFieldOnChange('firstName')}
             fill
             fastField
           />
           <FInputGroup
             name={'lastName'}
             placeholder={intl.get('last_name')}
+            onChange={createFieldOnChange('lastName')}
             fill
             fastField
           />
@@ -71,7 +79,12 @@ export function VendorFormBasicSection() {
         inline
         fastField
       >
-        <FInputGroup name={'companyName'} fill fastField />
+        <FInputGroup
+          name={'companyName'}
+          onChange={createFieldOnChange('companyName')}
+          fill
+          fastField
+        />
       </FFormGroup>
 
       {/*----------- Display Name -----------*/}
@@ -86,7 +99,6 @@ export function VendorFormBasicSection() {
           name={'displayName'}
           popoverProps={{ minimal: true }}
           buttonProps={{ fill: true }}
-          fastField
         />
       </FFormGroup>
 

--- a/packages/webapp/src/containers/Vendors/VendorForm/VendorFormFormik.tsx
+++ b/packages/webapp/src/containers/Vendors/VendorForm/VendorFormFormik.tsx
@@ -19,6 +19,7 @@ import {
   transformVendorToForm,
 } from './utils';
 import { AppToaster } from '@/components';
+import { inferDisplayNameFormat } from '@/components/Select/displayNameUtils';
 import { useCurrentOrganizationBaseCurrency } from '@/hooks/query';
 import { saveInvoke } from '@/utils';
 
@@ -69,6 +70,10 @@ function VendorFormFormikBase({
     };
     if (!merged.currencyCode && baseCurrency) {
       merged.currencyCode = baseCurrency;
+    }
+    // Infer the selected display-name format from the existing display name.
+    if (merged.displayName && !merged.displayNameFormat) {
+      merged.displayNameFormat = inferDisplayNameFormat(merged);
     }
     return merged;
   }, [vendor, contactDuplicate, baseCurrency, initialValues]);

--- a/packages/webapp/src/containers/Vendors/VendorForm/utils.tsx
+++ b/packages/webapp/src/containers/Vendors/VendorForm/utils.tsx
@@ -21,6 +21,7 @@ export type VendorFormValues = {
   lastName: string;
   companyName: string;
   displayName: string;
+  displayNameFormat: string;
   code: string;
 
   email: string;
@@ -60,6 +61,7 @@ export const defaultInitialValues: VendorFormValues = {
   lastName: '',
   companyName: '',
   displayName: '',
+  displayNameFormat: '',
   code: '',
 
   email: '',


### PR DESCRIPTION
## Description

Fixes the display name field in the Customer and Vendor forms. The display name dropdown was broken for both forms, and after the initial fix the display name selection was lost when editing the contact name fields in the Vendor form.

Changes:

- Fixed a regression where the shared `DisplayNameList` component read snake_case field names (`first_name`/`last_name`/`company_name`) while the Customer/Vendor forms write camelCase fields (`firstName`/`lastName`/`companyName`), so no display name options were generated.
- Reworked the display name field to track the selected name format (a client-side `displayNameFormat` form value). When any of the contact name fields (first/last/company name or salutation) change, the display name is re-resolved from the selected format, so the selection is never lost and stays in sync.
- The format is inferred from an existing display name when editing a customer/vendor.
- The vendor form now keeps working despite `fastField` by reading the latest form values through a ref in the synchronizer hook (FastField bails out of re-rendering when its own field is unchanged, which previously left stale `onChange` handlers attached).
- Added `packages/webapp/src/components/Select/displayNameUtils.ts` with the shared, pure display-name format utilities.

No API changes; the hidden `displayNameFormat` value is client-side only and not sent to the server.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Verified `tsc --noEmit` passes for the changed files (pre-existing type errors elsewhere in the repo are unrelated).
- Verified ESLint passes on all changed files (only pre-existing `import/order` errors remain, confirmed identical on the base).
- Verified all changed files are Prettier-formatted.
- Manually exercised the Customer and Vendor forms: display name options appear when typing first/last/company names, selecting a format persists, and editing the contact name fields updates the display name accordingly (Customer and Vendor).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>
