### PR TITLE
fix(server): store blank contact code as NULL to avoid unique key violation

### DIFF
--- a/packages/server/src/database/tenant/migrations/20260811000000_contacts_blank_code_to_null.ts
+++ b/packages/server/src/database/tenant/migrations/20260811000000_contacts_blank_code_to_null.ts
@@ -1,0 +1,7 @@
+exports.up = function (knex) {
+  return knex.raw("UPDATE `contacts` SET `code` = NULL WHERE `code` = ''");
+};
+
+exports.down = function (knex) {
+  return Promise.resolve();
+};

--- a/packages/server/src/modules/Customers/commands/CreateEditCustomerDTO.service.ts
+++ b/packages/server/src/modules/Customers/commands/CreateEditCustomerDTO.service.ts
@@ -20,9 +20,15 @@ export class CreateEditCustomerDTO {
   private transformCommonDTO = (
     customerDTO: ICustomerNewDTO | ICustomerEditDTO,
   ) => {
+    const { code, ...rest } = customerDTO;
+
     return {
-      ...omit(customerDTO, ['customerType']),
+      ...omit(rest, ['customerType']),
       contactType: customerDTO.customerType,
+      // Blank codes are stored as NULL to avoid `CONTACTS_CODE_UNIQUE` collisions.
+      ...(typeof code === 'string'
+        ? { code: code.trim() ? code.trim() : null }
+        : {}),
     };
   };
 

--- a/packages/server/src/modules/Vendors/commands/CreateEditVendorDTO.ts
+++ b/packages/server/src/modules/Vendors/commands/CreateEditVendorDTO.ts
@@ -20,8 +20,14 @@ export class CreateEditVendorDTOService {
    * @returns {IVendorNewDTO | IVendorEditDTO}
    */
   private transformCommonDTO = (vendorDTO: IVendorNewDTO | IVendorEditDTO) => {
+    const { code, ...rest } = vendorDTO;
+
     return {
-      ...vendorDTO,
+      ...rest,
+      // Blank codes are stored as NULL to avoid `CONTACTS_CODE_UNIQUE` collisions.
+      ...(typeof code === 'string'
+        ? { code: code.trim() ? code.trim() : null }
+        : {}),
     };
   };
 


### PR DESCRIPTION
## Description

Creating a second customer or vendor with the **code field left blank** failed with `ER_DUP_ENTRY: Duplicate entry '' for key 'CONTACTS_CODE_UNIQUE'`.

The webapp form always submits `code: ''` when the field is blank, and the server DTO transformers passed the empty string straight through to the insert. The `contacts.code` column is nullable-unique, and MySQL unique indexes treat two empty strings as duplicates (but allow unlimited NULLs).

Changes:

- Normalize blank/whitespace codes to `NULL` in the customer and vendor `transformCommonDTO` transformers, trimming non-blank values. The normalization only applies when the `code` key is actually sent, so partial edits via the API/SDK no longer risk wiping an existing code.
- Add a tenant migration that converts existing `code = ''` rows to `NULL`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Create two customers with the code field left blank — both succeed, `CODE` is `NULL` for both.
- Create a vendor with a blank code — succeeds.
- Edit a customer with a code, clear the field, save — code becomes `NULL`.
- Verified the DTO transformers are only consumed by the Create/Edit Customer/Vendor services; no import or quick-create path bypasses them.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>
