### PR TITLE
feat(webapp): add customers and vendors CRUD e2e tests

### DIFF
--- a/e2e/customers.spec.ts
+++ b/e2e/customers.spec.ts
@@ -1,0 +1,263 @@
+import { test, expect, type Locator, type Page } from '@playwright/test';
+import { faker } from '@faker-js/faker';
+
+/**
+ * Generates a unique contact name pair (first + last) alongside the display
+ * name that the form derives from them (`{first} {last}`).
+ */
+function contactName() {
+  const firstName = faker.person.firstName();
+  const lastName = `${faker.person.lastName()} ${faker.string.alphanumeric(4)}`;
+  return {
+    firstName,
+    lastName,
+    displayName: `${firstName} ${lastName}`,
+  };
+}
+
+const companyName = () => `${faker.company.name()} ${faker.string.alphanumeric(4)}`;
+
+/**
+ * Closes the TanStack Query devtools panel.
+ *
+ * The devtools panel is opened by default in the dev webapp and overlays the
+ * bottom of the viewport, which covers the form's sticky floating actions bar.
+ */
+async function closeQueryDevtools(page: Page) {
+  const closeButton = page
+    .getByRole('button', { name: 'Close tanstack query devtools' })
+    .first();
+  if (await closeButton.isVisible().catch(() => false)) {
+    await closeButton.click();
+  }
+}
+
+/**
+ * Waits until the customers list page is loaded.
+ */
+async function waitForCustomersList(page: Page) {
+  await expect(page.getByTestId('dashboard-topbar').locator('h1')).toHaveText(
+    'Customers List',
+    { timeout: 30_000 },
+  );
+  await expect(
+    page.getByRole('button', { name: 'New Customer' }).first(),
+  ).toBeVisible({ timeout: 30_000 });
+}
+
+/**
+ * Waits until the customer form page is loaded for the given title
+ * (New Customer or Edit Customer).
+ */
+async function waitForCustomerForm(page: Page, title: string) {
+  await expect(page.getByTestId('dashboard-topbar').locator('h1')).toHaveText(
+    title,
+    { timeout: 30_000 },
+  );
+  await expect(page.getByTestId('customer-first-name-input')).toBeVisible({
+    timeout: 30_000,
+  });
+}
+
+/**
+ * Selects the display name inside the customer form.
+ *
+ * The display name Select popover cannot be opened reliably with a plain mouse
+ * click, so it is retried the same way the account type select does: focus the
+ * trigger, press Enter to open the popover, then immediately click the matching
+ * menu item before the popover collapses.
+ */
+async function selectDisplayName(
+  page: Page,
+  selector: string,
+  displayName: string,
+) {
+  const button = page.getByTestId(selector);
+
+  for (let attempt = 0; attempt < 8; attempt++) {
+    await button.focus();
+    await page.keyboard.press('Enter');
+
+    const clicked = await page.evaluate((name) => {
+      const items = Array.from(
+        document.querySelectorAll('[role="menuitem"]'),
+      );
+      const item = items.find(
+        (el) => (el as HTMLElement).innerText.trim() === name,
+      );
+      if (item) {
+        (item as HTMLElement).click();
+        return true;
+      }
+      return false;
+    }, displayName);
+
+    if (clicked) {
+      await expect(button).toContainText(displayName, { timeout: 5_000 });
+      return;
+    }
+    await page.keyboard.press('Escape');
+  }
+  throw new Error(`Failed to select the "${displayName}" display name.`);
+}
+
+/**
+ * Creates a customer through the UI and expects the success toast alongside
+ * the redirect back to the customers list page.
+ */
+async function createCustomer(
+  page: Page,
+  {
+    firstName,
+    lastName,
+    companyName: customerCompanyName,
+  }: {
+    firstName: string;
+    lastName: string;
+    companyName: string;
+  },
+) {
+  await page.goto('/customers/new');
+  await waitForCustomerForm(page, 'New Customer');
+
+  await page.getByTestId('customer-first-name-input').fill(firstName);
+  await page.getByTestId('customer-last-name-input').fill(lastName);
+  await page.getByTestId('customer-company-name-input').fill(customerCompanyName);
+
+  await selectDisplayName(
+    page,
+    'customer-display-name-select',
+    `${firstName} ${lastName}`,
+  );
+
+  await closeQueryDevtools(page);
+  await page.getByRole('button', { name: 'Save', exact: true }).click();
+
+  await expect(
+    page.getByText('The customer has been created successfully.'),
+  ).toBeVisible({ timeout: 15_000 });
+
+  await waitForCustomersList(page);
+}
+
+/**
+ * Filters the customers table by the given display name and returns the
+ * matching row locator.
+ */
+async function filterCustomersBy(page: Page, displayName: string) {
+  await page.getByRole('button', { name: /filter|filters applied/i }).click();
+  await page.getByPlaceholder('Value').first().fill(displayName);
+
+  const row = page
+    .getByTestId('customer-row')
+    .filter({ hasText: displayName })
+    .first();
+  await expect(row).toBeVisible({ timeout: 30_000 });
+
+  // Close the filter popover before interacting with the table.
+  await page.keyboard.press('Escape');
+
+  return row;
+}
+
+/**
+ * Deletes the given customer row through the context menu and expects the
+ * success toast.
+ */
+async function deleteCustomerViaRow(page: Page, row: Locator) {
+  await row.click({ button: 'right' });
+  await page.getByRole('menuitem', { name: 'Delete Customer' }).click();
+
+  await expect(page.getByTestId('customer-delete-alert')).toBeVisible();
+  await page
+    .getByRole('dialog')
+    .filter({ has: page.getByTestId('customer-delete-alert') })
+    .getByRole('button', { name: 'Delete' })
+    .click();
+
+  await expect(
+    page.getByText('The customer has been deleted successfully.'),
+  ).toBeVisible({ timeout: 15_000 });
+}
+
+test.describe('customers', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/customers');
+  });
+
+  test('should show the customers page.', async ({ page }) => {
+    await waitForCustomersList(page);
+
+    await expect(
+      page.getByRole('button', { name: 'New Customer' }).first(),
+    ).toBeVisible();
+  });
+
+  test('should create a customer successfully.', async ({ page }) => {
+    await waitForCustomersList(page);
+
+    const { firstName, lastName, displayName } = contactName();
+    await createCustomer(page, {
+      firstName,
+      lastName,
+      companyName: companyName(),
+    });
+
+    await filterCustomersBy(page, displayName);
+  });
+
+  test('should edit a customer successfully.', async ({ page }) => {
+    await waitForCustomersList(page);
+
+    const { firstName, lastName, displayName } = contactName();
+    const newCompanyName = companyName();
+
+    await createCustomer(page, {
+      firstName,
+      lastName,
+      companyName: companyName(),
+    });
+
+    const row = await filterCustomersBy(page, displayName);
+    await row.click({ button: 'right' });
+    await page.getByRole('menuitem', { name: 'Edit Customer' }).click();
+
+    await waitForCustomerForm(page, 'Edit Customer');
+    await expect(
+      page.getByTestId('customer-display-name-select'),
+    ).toContainText(displayName, { timeout: 30_000 });
+
+    await page.getByTestId('customer-company-name-input').fill(newCompanyName);
+    await closeQueryDevtools(page);
+    await page.getByRole('button', { name: 'Edit', exact: true }).click();
+
+    await expect(
+      page.getByText('The item customer has been edited successfully.'),
+    ).toBeVisible({ timeout: 15_000 });
+
+    await waitForCustomersList(page);
+
+    const editedRow = await filterCustomersBy(page, displayName);
+    await expect(editedRow).toContainText(newCompanyName, {
+      timeout: 15_000,
+    });
+  });
+
+  test('should delete a customer successfully.', async ({ page }) => {
+    await waitForCustomersList(page);
+
+    const { firstName, lastName, displayName } = contactName();
+    await createCustomer(page, {
+      firstName,
+      lastName,
+      companyName: companyName(),
+    });
+
+    const row = await filterCustomersBy(page, displayName);
+    await deleteCustomerViaRow(page, row);
+
+    await expect(page.getByTestId('customer-row')).toHaveCount(0, {
+      timeout: 15_000,
+    });
+  });
+});

--- a/e2e/vendors.spec.ts
+++ b/e2e/vendors.spec.ts
@@ -1,0 +1,263 @@
+import { test, expect, type Locator, type Page } from '@playwright/test';
+import { faker } from '@faker-js/faker';
+
+/**
+ * Generates a unique contact name pair (first + last) alongside the display
+ * name that the form derives from them (`{first} {last}`).
+ */
+function contactName() {
+  const firstName = faker.person.firstName();
+  const lastName = `${faker.person.lastName()} ${faker.string.alphanumeric(4)}`;
+  return {
+    firstName,
+    lastName,
+    displayName: `${firstName} ${lastName}`,
+  };
+}
+
+const companyName = () => `${faker.company.name()} ${faker.string.alphanumeric(4)}`;
+
+/**
+ * Closes the TanStack Query devtools panel.
+ *
+ * The devtools panel is opened by default in the dev webapp and overlays the
+ * bottom of the viewport, which covers the form's sticky floating actions bar.
+ */
+async function closeQueryDevtools(page: Page) {
+  const closeButton = page
+    .getByRole('button', { name: 'Close tanstack query devtools' })
+    .first();
+  if (await closeButton.isVisible().catch(() => false)) {
+    await closeButton.click();
+  }
+}
+
+/**
+ * Waits until the vendors list page is loaded.
+ */
+async function waitForVendorsList(page: Page) {
+  await expect(page.getByTestId('dashboard-topbar').locator('h1')).toHaveText(
+    'Vendors List',
+    { timeout: 30_000 },
+  );
+  await expect(
+    page.getByRole('button', { name: 'New Vendor' }).first(),
+  ).toBeVisible({ timeout: 30_000 });
+}
+
+/**
+ * Waits until the vendor form page is loaded for the given title
+ * (New Vendor or Edit Vendor).
+ */
+async function waitForVendorForm(page: Page, title: string) {
+  await expect(page.getByTestId('dashboard-topbar').locator('h1')).toHaveText(
+    title,
+    { timeout: 30_000 },
+  );
+  await expect(page.getByTestId('vendor-first-name-input')).toBeVisible({
+    timeout: 30_000,
+  });
+}
+
+/**
+ * Selects the display name inside the vendor form.
+ *
+ * The display name Select popover cannot be opened reliably with a plain mouse
+ * click, so it is retried the same way the account type select does: focus the
+ * trigger, press Enter to open the popover, then immediately click the matching
+ * menu item before the popover collapses.
+ */
+async function selectDisplayName(
+  page: Page,
+  selector: string,
+  displayName: string,
+) {
+  const button = page.getByTestId(selector);
+
+  for (let attempt = 0; attempt < 8; attempt++) {
+    await button.focus();
+    await page.keyboard.press('Enter');
+
+    const clicked = await page.evaluate((name) => {
+      const items = Array.from(
+        document.querySelectorAll('[role="menuitem"]'),
+      );
+      const item = items.find(
+        (el) => (el as HTMLElement).innerText.trim() === name,
+      );
+      if (item) {
+        (item as HTMLElement).click();
+        return true;
+      }
+      return false;
+    }, displayName);
+
+    if (clicked) {
+      await expect(button).toContainText(displayName, { timeout: 5_000 });
+      return;
+    }
+    await page.keyboard.press('Escape');
+  }
+  throw new Error(`Failed to select the "${displayName}" display name.`);
+}
+
+/**
+ * Creates a vendor through the UI and expects the success toast alongside
+ * the redirect back to the vendors list page.
+ */
+async function createVendor(
+  page: Page,
+  {
+    firstName,
+    lastName,
+    companyName: vendorCompanyName,
+  }: {
+    firstName: string;
+    lastName: string;
+    companyName: string;
+  },
+) {
+  await page.goto('/vendors/new');
+  await waitForVendorForm(page, 'New Vendor');
+
+  await page.getByTestId('vendor-first-name-input').fill(firstName);
+  await page.getByTestId('vendor-last-name-input').fill(lastName);
+  await page.getByTestId('vendor-company-name-input').fill(vendorCompanyName);
+
+  await selectDisplayName(
+    page,
+    'vendor-display-name-select',
+    `${firstName} ${lastName}`,
+  );
+
+  await closeQueryDevtools(page);
+  await page.getByRole('button', { name: 'Save', exact: true }).click();
+
+  await expect(
+    page.getByText('The vendor has been successfully created.'),
+  ).toBeVisible({ timeout: 15_000 });
+
+  await waitForVendorsList(page);
+}
+
+/**
+ * Filters the vendors table by the given display name and returns the
+ * matching row locator.
+ */
+async function filterVendorsBy(page: Page, displayName: string) {
+  await page.getByRole('button', { name: /filter|filters applied/i }).click();
+  await page.getByPlaceholder('Value').first().fill(displayName);
+
+  const row = page
+    .getByTestId('vendor-row')
+    .filter({ hasText: displayName })
+    .first();
+  await expect(row).toBeVisible({ timeout: 30_000 });
+
+  // Close the filter popover before interacting with the table.
+  await page.keyboard.press('Escape');
+
+  return row;
+}
+
+/**
+ * Deletes the given vendor row through the context menu and expects the
+ * success toast.
+ */
+async function deleteVendorViaRow(page: Page, row: Locator) {
+  await row.click({ button: 'right' });
+  await page.getByRole('menuitem', { name: 'Delete Vendor' }).click();
+
+  await expect(page.getByTestId('vendor-delete-alert')).toBeVisible();
+  await page
+    .getByRole('dialog')
+    .filter({ has: page.getByTestId('vendor-delete-alert') })
+    .getByRole('button', { name: 'Delete' })
+    .click();
+
+  await expect(
+    page.getByText('The vendor has been deleted successfully.'),
+  ).toBeVisible({ timeout: 15_000 });
+}
+
+test.describe('vendors', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/vendors');
+  });
+
+  test('should show the vendors page.', async ({ page }) => {
+    await waitForVendorsList(page);
+
+    await expect(
+      page.getByRole('button', { name: 'New Vendor' }).first(),
+    ).toBeVisible();
+  });
+
+  test('should create a vendor successfully.', async ({ page }) => {
+    await waitForVendorsList(page);
+
+    const { firstName, lastName, displayName } = contactName();
+    await createVendor(page, {
+      firstName,
+      lastName,
+      companyName: companyName(),
+    });
+
+    await filterVendorsBy(page, displayName);
+  });
+
+  test('should edit a vendor successfully.', async ({ page }) => {
+    await waitForVendorsList(page);
+
+    const { firstName, lastName, displayName } = contactName();
+    const newCompanyName = companyName();
+
+    await createVendor(page, {
+      firstName,
+      lastName,
+      companyName: companyName(),
+    });
+
+    const row = await filterVendorsBy(page, displayName);
+    await row.click({ button: 'right' });
+    await page.getByRole('menuitem', { name: 'Edit Vendor' }).click();
+
+    await waitForVendorForm(page, 'Edit Vendor');
+    await expect(
+      page.getByTestId('vendor-display-name-select'),
+    ).toContainText(displayName, { timeout: 30_000 });
+
+    await page.getByTestId('vendor-company-name-input').fill(newCompanyName);
+    await closeQueryDevtools(page);
+    await page.getByRole('button', { name: 'Edit', exact: true }).click();
+
+    await expect(
+      page.getByText('The item vendor has been edited successfully.'),
+    ).toBeVisible({ timeout: 15_000 });
+
+    await waitForVendorsList(page);
+
+    const editedRow = await filterVendorsBy(page, displayName);
+    await expect(editedRow).toContainText(newCompanyName, {
+      timeout: 15_000,
+    });
+  });
+
+  test('should delete a vendor successfully.', async ({ page }) => {
+    await waitForVendorsList(page);
+
+    const { firstName, lastName, displayName } = contactName();
+    await createVendor(page, {
+      firstName,
+      lastName,
+      companyName: companyName(),
+    });
+
+    const row = await filterVendorsBy(page, displayName);
+    await deleteVendorViaRow(page, row);
+
+    await expect(page.getByTestId('vendor-row')).toHaveCount(0, {
+      timeout: 15_000,
+    });
+  });
+});

--- a/packages/webapp/src/containers/Alerts/Customers/CustomerDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Customers/CustomerDeleteAlert.tsx
@@ -79,7 +79,7 @@ function CustomerDeleteAlertInner({
       onConfirm={handleConfirmDeleteCustomer}
       loading={isLoading}
     >
-      <p>
+      <p data-testId={'customer-delete-alert'}>
         {/* `intl.formatHTMLMessage` returns a React fragment containing the
             translated HTML markup. The shape is not a JSX component so we
             inline the call here. */}

--- a/packages/webapp/src/containers/Alerts/Vendors/VendorDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Vendors/VendorDeleteAlert.tsx
@@ -79,7 +79,7 @@ function VendorDeleteAlertInner({
       onConfirm={handleConfirmDeleteVendor}
       loading={isLoading}
     >
-      <p>
+      <p data-testId={'vendor-delete-alert'}>
         {/* `intl.formatHTMLMessage` returns a React fragment containing the
             translated HTML markup. The shape is not a JSX component so we
             inline the call here. */}

--- a/packages/webapp/src/containers/Customers/CustomerForm/CustomerFormBasicSection.tsx
+++ b/packages/webapp/src/containers/Customers/CustomerForm/CustomerFormBasicSection.tsx
@@ -46,12 +46,14 @@ export function CustomerFormBasicSection() {
             inputRef={(ref: HTMLInputElement | null) => {
               if (ref) firstNameFieldRef.current = ref;
             }}
+            data-testId={'customer-first-name-input'}
             onChange={createFieldOnChange('firstName')}
             fill
           />
           <FInputGroup
             name={'lastName'}
             placeholder={intl.get('last_name')}
+            data-testId={'customer-last-name-input'}
             onChange={createFieldOnChange('lastName')}
             fill
           />
@@ -64,13 +66,14 @@ export function CustomerFormBasicSection() {
         helperText="Add a unique account number to identify, reference and search for the contact."
         inline
       >
-        <FInputGroup name={'code'} fill />
+        <FInputGroup name={'code'} data-testId={'customer-code-input'} fill />
       </FFormGroup>
 
       {/*----------- Company Name -----------*/}
       <FFormGroup name={'companyName'} label={intl.get('company_name')} inline>
         <FInputGroup
           name={'companyName'}
+          data-testId={'customer-company-name-input'}
           onChange={createFieldOnChange('companyName')}
           fill
         />
@@ -86,7 +89,10 @@ export function CustomerFormBasicSection() {
         <DisplayNameList
           name={'displayName'}
           popoverProps={{ minimal: true }}
-          buttonProps={{ fill: true }}
+          buttonProps={{
+            fill: true,
+            'data-testId': 'customer-display-name-select',
+          }}
         />
       </FFormGroup>
 

--- a/packages/webapp/src/containers/Customers/CustomersLanding/CustomersTable.tsx
+++ b/packages/webapp/src/containers/Customers/CustomersLanding/CustomersTable.tsx
@@ -161,6 +161,7 @@ function CustomersTableInner({
         sticky={true}
         spinnerProps={{ size: 30 }}
         pagination={true}
+        rowTestId={'customer-row'}
         initialPageSize={customersTableState?.pageSize ?? 10}
         manualSortBy={true}
         manualPagination={true}

--- a/packages/webapp/src/containers/Vendors/VendorForm/VendorFormBasicSection.tsx
+++ b/packages/webapp/src/containers/Vendors/VendorForm/VendorFormBasicSection.tsx
@@ -48,6 +48,7 @@ export function VendorFormBasicSection() {
             inputRef={(ref: HTMLInputElement | null) => {
               if (ref) firstNameFieldRef.current = ref;
             }}
+            data-testId={'vendor-first-name-input'}
             onChange={createFieldOnChange('firstName')}
             fill
             fastField
@@ -55,6 +56,7 @@ export function VendorFormBasicSection() {
           <FInputGroup
             name={'lastName'}
             placeholder={intl.get('last_name')}
+            data-testId={'vendor-last-name-input'}
             onChange={createFieldOnChange('lastName')}
             fill
             fastField
@@ -69,7 +71,12 @@ export function VendorFormBasicSection() {
         inline
         fastField
       >
-        <FInputGroup name={'code'} fill fastField />
+        <FInputGroup
+          name={'code'}
+          data-testId={'vendor-code-input'}
+          fill
+          fastField
+        />
       </FFormGroup>
 
       {/*----------- Company Name -----------*/}
@@ -81,6 +88,7 @@ export function VendorFormBasicSection() {
       >
         <FInputGroup
           name={'companyName'}
+          data-testId={'vendor-company-name-input'}
           onChange={createFieldOnChange('companyName')}
           fill
           fastField
@@ -98,7 +106,10 @@ export function VendorFormBasicSection() {
         <DisplayNameList
           name={'displayName'}
           popoverProps={{ minimal: true }}
-          buttonProps={{ fill: true }}
+          buttonProps={{
+            fill: true,
+            'data-testId': 'vendor-display-name-select',
+          }}
         />
       </FFormGroup>
 

--- a/packages/webapp/src/containers/Vendors/VendorsLanding/VendorsTable.tsx
+++ b/packages/webapp/src/containers/Vendors/VendorsLanding/VendorsTable.tsx
@@ -165,6 +165,7 @@ function VendorsTableInner({
         expandable={false}
         sticky={true}
         pagination={true}
+        rowTestId={'vendor-row'}
         initialPageSize={vendorsTableState?.pageSize ?? 10}
         manualSortBy={true}
         rowsCount={pagination?.total ?? 0}


### PR DESCRIPTION
    Add Playwright specs covering basic CRUD (page load, create, edit, delete)
    for customers and vendors. Add the data-testId hooks the specs rely on:
    rowTestId on both list tables, delete-alert ids on the delete alerts, and
    input/select test ids on the customer and vendor basic form sections.
