### PR TITLE
fix(server): enforce permission guards on financial report controllers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "bigcapital-monorepo",
   "private": true,
+  "packageManager": "pnpm@9.15.9",
   "scripts": {
     "dev": "lerna run dev",
     "build": "lerna run build",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "bigcapital-monorepo",
   "private": true,
-  "packageManager": "pnpm@9.15.9",
   "scripts": {
     "dev": "lerna run dev",
     "build": "lerna run build",

--- a/packages/server/src/i18n/en/ability.json
+++ b/packages/server/src/i18n/en/ability.json
@@ -24,6 +24,7 @@
   "transactions_locking": "Ability to transactions locking.",
 
   "balance_sheet_report": "Balance sheet.",
+  "trial_balance_sheet_report": "Trial balance sheet.",
   "profit_loss_sheet": "Profit/loss sheet",
   "journal": "Journal",
   "general_ledger": "General ledger",
@@ -37,5 +38,7 @@
   "customers_summary_balance_report": "Customers summary balance",
   "vendors_summary_balance_report": "Vendors summary balance",
   "inventory_valuation_summary": "Inventory valuation summary",
-  "inventory_items_details": "Inventory items details"
+  "inventory_items_details": "Inventory items details",
+  "cashflow_account_transactions": "Cashflow account transactions",
+  "sales_tax_liability_summary_report": "Sales tax liability summary"
 }

--- a/packages/server/src/modules/FinancialStatements/modules/CustomerBalanceSummary/CustomerBalanceSummary.controller.spec.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/CustomerBalanceSummary/CustomerBalanceSummary.controller.spec.ts
@@ -1,0 +1,60 @@
+import { ForbiddenException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Ability } from '@casl/ability';
+import { PermissionGuard } from '@/modules/Roles/Permission.guard';
+import { CustomerBalanceSummaryController } from './CustomerBalanceSummary.controller';
+import { AbilitySubject } from '@/modules/Roles/Roles.types';
+import { ReportsAction } from '../../types/Report.types';
+
+describe('CustomerBalanceSummaryController authorization', () => {
+  const reflector = new Reflector();
+  const guard = new PermissionGuard(reflector);
+
+  const ctx = (handler: any, ability: Ability) =>
+    ({
+      switchToHttp: () => ({ getRequest: () => ({ ability }) }),
+      getHandler: () => handler,
+      getClass: () => CustomerBalanceSummaryController,
+    }) as any;
+
+  const cases: Array<[string, string]> = [
+    ['customerBalanceSummary', ReportsAction.READ_CUSTOMERS_SUMMARY_BALANCE],
+  ];
+
+  it.each(cases)(
+    '%s is denied (403) for a role without the Report permission',
+    (method) => {
+      const deny = new Ability([]);
+      expect(() =>
+        guard.canActivate(
+          ctx(CustomerBalanceSummaryController.prototype[method], deny),
+        ),
+      ).toThrow(ForbiddenException);
+    },
+  );
+
+  it.each(cases)(
+    '%s is allowed for a role that grants the matching Report permission',
+    (method, action) => {
+      const allow = new Ability([
+        { action, subject: AbilitySubject.Report },
+      ] as any);
+      expect(
+        guard.canActivate(
+          ctx(CustomerBalanceSummaryController.prototype[method], allow),
+        ),
+      ).toBe(true);
+    },
+  );
+
+  it('grants all report operations to a manage-all (admin) ability', () => {
+    const admin = new Ability([{ action: 'manage', subject: 'all' }] as any);
+    for (const [method] of cases) {
+      expect(
+        guard.canActivate(
+          ctx(CustomerBalanceSummaryController.prototype[method], admin),
+        ),
+      ).toBe(true);
+    }
+  });
+});

--- a/packages/server/src/modules/FinancialStatements/modules/CustomerBalanceSummary/CustomerBalanceSummary.controller.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/CustomerBalanceSummary/CustomerBalanceSummary.controller.ts
@@ -8,7 +8,14 @@ import {
   ApiTags,
   getSchemaPath,
 } from '@nestjs/swagger';
-import { Controller, Get, Headers, Query, Res } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Headers,
+  Query,
+  Res,
+  UseGuards,
+} from '@nestjs/common';
 import { CustomerBalanceSummaryApplication } from './CustomerBalanceSummaryApplication';
 import { NumberFormatQueryDto } from '@/modules/BankingTransactions/dtos/NumberFormatQuery.dto';
 import { CustomerBalanceSummaryQueryDto } from './CustomerBalanceSummaryQuery.dto';
@@ -18,6 +25,11 @@ import {
   CustomerBalanceSummaryTableResponseDto,
 } from './CustomerBalanceSummaryResponse.dto';
 import { ApiCommonHeaders } from '@/common/decorators/ApiCommonHeaders';
+import { RequirePermission } from '@/modules/Roles/RequirePermission.decorator';
+import { PermissionGuard } from '@/modules/Roles/Permission.guard';
+import { AuthorizationGuard } from '@/modules/Roles/Authorization.guard';
+import { AbilitySubject } from '@/modules/Roles/Roles.types';
+import { ReportsAction } from '../../types/Report.types';
 
 @Controller('/reports/customer-balance-summary')
 @ApiTags('Reports')
@@ -27,12 +39,18 @@ import { ApiCommonHeaders } from '@/common/decorators/ApiCommonHeaders';
   CustomerBalanceSummaryTableResponseDto,
   NumberFormatQueryDto,
 )
+// Restrict this financial report to authenticated users granted the customer-balance read permission.
+@UseGuards(AuthorizationGuard, PermissionGuard)
 export class CustomerBalanceSummaryController {
   constructor(
     private readonly customerBalanceSummaryApp: CustomerBalanceSummaryApplication,
   ) {}
 
   @Get()
+  @RequirePermission(
+    ReportsAction.READ_CUSTOMERS_SUMMARY_BALANCE,
+    AbilitySubject.Report,
+  )
   @ApiResponse({
     status: 200,
     description: 'Customer balance summary report',

--- a/packages/server/src/modules/FinancialStatements/modules/InventoryItemDetails/InventoryItemDetails.controller.spec.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/InventoryItemDetails/InventoryItemDetails.controller.spec.ts
@@ -1,0 +1,60 @@
+import { ForbiddenException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Ability } from '@casl/ability';
+import { PermissionGuard } from '@/modules/Roles/Permission.guard';
+import { InventoryItemDetailsController } from './InventoryItemDetails.controller';
+import { AbilitySubject } from '@/modules/Roles/Roles.types';
+import { ReportsAction } from '../../types/Report.types';
+
+describe('InventoryItemDetailsController authorization', () => {
+  const reflector = new Reflector();
+  const guard = new PermissionGuard(reflector);
+
+  const ctx = (handler: any, ability: Ability) =>
+    ({
+      switchToHttp: () => ({ getRequest: () => ({ ability }) }),
+      getHandler: () => handler,
+      getClass: () => InventoryItemDetailsController,
+    }) as any;
+
+  const cases: Array<[string, string]> = [
+    ['inventoryItemDetails', ReportsAction.READ_INVENTORY_ITEM_DETAILS],
+  ];
+
+  it.each(cases)(
+    '%s is denied (403) for a role without the Report permission',
+    (method) => {
+      const deny = new Ability([]);
+      expect(() =>
+        guard.canActivate(
+          ctx(InventoryItemDetailsController.prototype[method], deny),
+        ),
+      ).toThrow(ForbiddenException);
+    },
+  );
+
+  it.each(cases)(
+    '%s is allowed for a role that grants the matching Report permission',
+    (method, action) => {
+      const allow = new Ability([
+        { action, subject: AbilitySubject.Report },
+      ] as any);
+      expect(
+        guard.canActivate(
+          ctx(InventoryItemDetailsController.prototype[method], allow),
+        ),
+      ).toBe(true);
+    },
+  );
+
+  it('grants all report operations to a manage-all (admin) ability', () => {
+    const admin = new Ability([{ action: 'manage', subject: 'all' }] as any);
+    for (const [method] of cases) {
+      expect(
+        guard.canActivate(
+          ctx(InventoryItemDetailsController.prototype[method], admin),
+        ),
+      ).toBe(true);
+    }
+  });
+});

--- a/packages/server/src/modules/FinancialStatements/modules/InventoryItemDetails/InventoryItemDetails.controller.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/InventoryItemDetails/InventoryItemDetails.controller.ts
@@ -8,7 +8,14 @@ import {
   ApiQuery,
   getSchemaPath,
 } from '@nestjs/swagger';
-import { Controller, Get, Headers, Query, Res } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Headers,
+  Query,
+  Res,
+  UseGuards,
+} from '@nestjs/common';
 import { InventoryItemDetailsApplication } from './InventoryItemDetailsApplication';
 import { AcceptType } from '@/constants/accept-type';
 import { NumberFormatQueryDto } from '@/modules/BankingTransactions/dtos/NumberFormatQuery.dto';
@@ -18,6 +25,11 @@ import {
   InventoryItemDetailsTableResponseDto,
 } from './InventoryItemDetailsResponse.dto';
 import { ApiCommonHeaders } from '@/common/decorators/ApiCommonHeaders';
+import { RequirePermission } from '@/modules/Roles/RequirePermission.decorator';
+import { PermissionGuard } from '@/modules/Roles/Permission.guard';
+import { AuthorizationGuard } from '@/modules/Roles/Authorization.guard';
+import { AbilitySubject } from '@/modules/Roles/Roles.types';
+import { ReportsAction } from '../../types/Report.types';
 
 @Controller('reports/inventory-item-details')
 @ApiTags('Reports')
@@ -27,12 +39,18 @@ import { ApiCommonHeaders } from '@/common/decorators/ApiCommonHeaders';
   InventoryItemDetailsTableResponseDto,
   NumberFormatQueryDto,
 )
+// Restrict this financial report to authenticated users granted the inventory-item-details read permission.
+@UseGuards(AuthorizationGuard, PermissionGuard)
 export class InventoryItemDetailsController {
   constructor(
     private readonly inventoryItemDetailsApp: InventoryItemDetailsApplication,
   ) {}
 
   @Get('/')
+  @RequirePermission(
+    ReportsAction.READ_INVENTORY_ITEM_DETAILS,
+    AbilitySubject.Report,
+  )
   @ApiOperation({ summary: 'Get inventory item details' })
   @ApiQuery({
     name: 'numberFormat',

--- a/packages/server/src/modules/FinancialStatements/modules/PurchasesByItems/PurchasesByItems.controller.spec.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/PurchasesByItems/PurchasesByItems.controller.spec.ts
@@ -1,0 +1,60 @@
+import { ForbiddenException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Ability } from '@casl/ability';
+import { PermissionGuard } from '@/modules/Roles/Permission.guard';
+import { PurchasesByItemReportController } from './PurchasesByItems.controller';
+import { AbilitySubject } from '@/modules/Roles/Roles.types';
+import { ReportsAction } from '../../types/Report.types';
+
+describe('PurchasesByItemReportController authorization', () => {
+  const reflector = new Reflector();
+  const guard = new PermissionGuard(reflector);
+
+  const ctx = (handler: any, ability: Ability) =>
+    ({
+      switchToHttp: () => ({ getRequest: () => ({ ability }) }),
+      getHandler: () => handler,
+      getClass: () => PurchasesByItemReportController,
+    }) as any;
+
+  const cases: Array<[string, string]> = [
+    ['purchasesByItems', ReportsAction.READ_PURCHASES_BY_ITEMS],
+  ];
+
+  it.each(cases)(
+    '%s is denied (403) for a role without the Report permission',
+    (method) => {
+      const deny = new Ability([]);
+      expect(() =>
+        guard.canActivate(
+          ctx(PurchasesByItemReportController.prototype[method], deny),
+        ),
+      ).toThrow(ForbiddenException);
+    },
+  );
+
+  it.each(cases)(
+    '%s is allowed for a role that grants the matching Report permission',
+    (method, action) => {
+      const allow = new Ability([
+        { action, subject: AbilitySubject.Report },
+      ] as any);
+      expect(
+        guard.canActivate(
+          ctx(PurchasesByItemReportController.prototype[method], allow),
+        ),
+      ).toBe(true);
+    },
+  );
+
+  it('grants all report operations to a manage-all (admin) ability', () => {
+    const admin = new Ability([{ action: 'manage', subject: 'all' }] as any);
+    for (const [method] of cases) {
+      expect(
+        guard.canActivate(
+          ctx(PurchasesByItemReportController.prototype[method], admin),
+        ),
+      ).toBe(true);
+    }
+  });
+});

--- a/packages/server/src/modules/FinancialStatements/modules/PurchasesByItems/PurchasesByItems.controller.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/PurchasesByItems/PurchasesByItems.controller.ts
@@ -1,5 +1,12 @@
 import { Response } from 'express';
-import { Controller, Get, Headers, Query, Res } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Headers,
+  Query,
+  Res,
+  UseGuards,
+} from '@nestjs/common';
 import { PurchasesByItemsApplication } from './PurchasesByItemsApplication';
 import { AcceptType } from '@/constants/accept-type';
 import {
@@ -17,6 +24,11 @@ import {
   PurchasesByItemsTableResponseDto,
 } from './PurchasesByItemsResponse.dto';
 import { ApiCommonHeaders } from '@/common/decorators/ApiCommonHeaders';
+import { RequirePermission } from '@/modules/Roles/RequirePermission.decorator';
+import { PermissionGuard } from '@/modules/Roles/Permission.guard';
+import { AuthorizationGuard } from '@/modules/Roles/Authorization.guard';
+import { AbilitySubject } from '@/modules/Roles/Roles.types';
+import { ReportsAction } from '../../types/Report.types';
 
 @Controller('/reports/purchases-by-items')
 @ApiTags('Reports')
@@ -26,12 +38,18 @@ import { ApiCommonHeaders } from '@/common/decorators/ApiCommonHeaders';
   PurchasesByItemsTableResponseDto,
   NumberFormatQueryDto,
 )
+// Restrict this financial report to authenticated users granted the purchases-by-items read permission.
+@UseGuards(AuthorizationGuard, PermissionGuard)
 export class PurchasesByItemReportController {
   constructor(
     private readonly purchasesByItemsApp: PurchasesByItemsApplication,
   ) {}
 
   @Get()
+  @RequirePermission(
+    ReportsAction.READ_PURCHASES_BY_ITEMS,
+    AbilitySubject.Report,
+  )
   @ApiResponse({
     status: 200,
     description: 'Purchases by items report',

--- a/packages/server/src/modules/FinancialStatements/modules/SalesByItems/SalesByItems.controller.spec.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/SalesByItems/SalesByItems.controller.spec.ts
@@ -1,0 +1,54 @@
+import { ForbiddenException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Ability } from '@casl/ability';
+import { PermissionGuard } from '@/modules/Roles/Permission.guard';
+import { SalesByItemsController } from './SalesByItems.controller';
+import { AbilitySubject } from '@/modules/Roles/Roles.types';
+import { ReportsAction } from '../../types/Report.types';
+
+describe('SalesByItemsController authorization', () => {
+  const reflector = new Reflector();
+  const guard = new PermissionGuard(reflector);
+
+  const ctx = (handler: any, ability: Ability) =>
+    ({
+      switchToHttp: () => ({ getRequest: () => ({ ability }) }),
+      getHandler: () => handler,
+      getClass: () => SalesByItemsController,
+    }) as any;
+
+  const cases: Array<[string, string]> = [
+    ['salesByitems', ReportsAction.READ_SALES_BY_ITEMS],
+  ];
+
+  it.each(cases)(
+    '%s is denied (403) for a role without the Report permission',
+    (method) => {
+      const deny = new Ability([]);
+      expect(() =>
+        guard.canActivate(ctx(SalesByItemsController.prototype[method], deny)),
+      ).toThrow(ForbiddenException);
+    },
+  );
+
+  it.each(cases)(
+    '%s is allowed for a role that grants the matching Report permission',
+    (method, action) => {
+      const allow = new Ability([
+        { action, subject: AbilitySubject.Report },
+      ] as any);
+      expect(
+        guard.canActivate(ctx(SalesByItemsController.prototype[method], allow)),
+      ).toBe(true);
+    },
+  );
+
+  it('grants all report operations to a manage-all (admin) ability', () => {
+    const admin = new Ability([{ action: 'manage', subject: 'all' }] as any);
+    for (const [method] of cases) {
+      expect(
+        guard.canActivate(ctx(SalesByItemsController.prototype[method], admin)),
+      ).toBe(true);
+    }
+  });
+});

--- a/packages/server/src/modules/FinancialStatements/modules/SalesByItems/SalesByItems.controller.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/SalesByItems/SalesByItems.controller.ts
@@ -6,6 +6,7 @@ import {
   Query,
   Req,
   Res,
+  UseGuards,
 } from '@nestjs/common';
 import { AcceptType } from '@/constants/accept-type';
 import { SalesByItemsApplication } from './SalesByItemsApplication';
@@ -25,6 +26,11 @@ import {
   SalesByItemsTableResponseDto,
 } from './SalesByItemsResponse.dto';
 import { ApiCommonHeaders } from '@/common/decorators/ApiCommonHeaders';
+import { RequirePermission } from '@/modules/Roles/RequirePermission.decorator';
+import { PermissionGuard } from '@/modules/Roles/Permission.guard';
+import { AuthorizationGuard } from '@/modules/Roles/Authorization.guard';
+import { AbilitySubject } from '@/modules/Roles/Roles.types';
+import { ReportsAction } from '../../types/Report.types';
 
 @Controller('/reports/sales-by-items')
 @ApiTags('Reports')
@@ -34,10 +40,13 @@ import { ApiCommonHeaders } from '@/common/decorators/ApiCommonHeaders';
   SalesByItemsTableResponseDto,
   NumberFormatQueryDto,
 )
+// Restrict this financial report to authenticated users granted the sales-by-items read permission.
+@UseGuards(AuthorizationGuard, PermissionGuard)
 export class SalesByItemsController {
   constructor(private readonly salesByItemsApp: SalesByItemsApplication) {}
 
   @Get()
+  @RequirePermission(ReportsAction.READ_SALES_BY_ITEMS, AbilitySubject.Report)
   @ApiResponse({
     status: 200,
     description: 'Sales by items report',

--- a/packages/server/src/modules/FinancialStatements/modules/SalesTaxLiabilitySummary/SalesTaxLiabilitySummary.controller.spec.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/SalesTaxLiabilitySummary/SalesTaxLiabilitySummary.controller.spec.ts
@@ -1,0 +1,63 @@
+import { ForbiddenException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Ability } from '@casl/ability';
+import { PermissionGuard } from '@/modules/Roles/Permission.guard';
+import { SalesTaxLiabilitySummaryController } from './SalesTaxLiabilitySummary.controller';
+import { AbilitySubject } from '@/modules/Roles/Roles.types';
+import { ReportsAction } from '../../types/Report.types';
+
+describe('SalesTaxLiabilitySummaryController authorization', () => {
+  const reflector = new Reflector();
+  const guard = new PermissionGuard(reflector);
+
+  const ctx = (handler: any, ability: Ability) =>
+    ({
+      switchToHttp: () => ({ getRequest: () => ({ ability }) }),
+      getHandler: () => handler,
+      getClass: () => SalesTaxLiabilitySummaryController,
+    }) as any;
+
+  const cases: Array<[string, string]> = [
+    [
+      'getSalesTaxLiabilitySummary',
+      ReportsAction.READ_SALES_TAX_LIABILITY_SUMMARY,
+    ],
+  ];
+
+  it.each(cases)(
+    '%s is denied (403) for a role without the Report permission',
+    (method) => {
+      const deny = new Ability([]);
+      expect(() =>
+        guard.canActivate(
+          ctx(SalesTaxLiabilitySummaryController.prototype[method], deny),
+        ),
+      ).toThrow(ForbiddenException);
+    },
+  );
+
+  it.each(cases)(
+    '%s is allowed for a role that grants the matching Report permission',
+    (method, action) => {
+      const allow = new Ability([
+        { action, subject: AbilitySubject.Report },
+      ] as any);
+      expect(
+        guard.canActivate(
+          ctx(SalesTaxLiabilitySummaryController.prototype[method], allow),
+        ),
+      ).toBe(true);
+    },
+  );
+
+  it('grants all report operations to a manage-all (admin) ability', () => {
+    const admin = new Ability([{ action: 'manage', subject: 'all' }] as any);
+    for (const [method] of cases) {
+      expect(
+        guard.canActivate(
+          ctx(SalesTaxLiabilitySummaryController.prototype[method], admin),
+        ),
+      ).toBe(true);
+    }
+  });
+});

--- a/packages/server/src/modules/FinancialStatements/modules/SalesTaxLiabilitySummary/SalesTaxLiabilitySummary.controller.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/SalesTaxLiabilitySummary/SalesTaxLiabilitySummary.controller.ts
@@ -8,7 +8,14 @@ import {
   ApiTags,
   getSchemaPath,
 } from '@nestjs/swagger';
-import { Controller, Get, Headers, Query, Res } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Headers,
+  Query,
+  Res,
+  UseGuards,
+} from '@nestjs/common';
 import { AcceptType } from '@/constants/accept-type';
 import { SalesTaxLiabilitySummaryApplication } from './SalesTaxLiabilitySummaryApplication';
 import { NumberFormatQueryDto } from '@/modules/BankingTransactions/dtos/NumberFormatQuery.dto';
@@ -18,6 +25,11 @@ import {
   SalesTaxLiabilitySummaryTableResponseDto,
 } from './SalesTaxLiabilitySummaryResponse.dto';
 import { ApiCommonHeaders } from '@/common/decorators/ApiCommonHeaders';
+import { RequirePermission } from '@/modules/Roles/RequirePermission.decorator';
+import { PermissionGuard } from '@/modules/Roles/Permission.guard';
+import { AuthorizationGuard } from '@/modules/Roles/Authorization.guard';
+import { AbilitySubject } from '@/modules/Roles/Roles.types';
+import { ReportsAction } from '../../types/Report.types';
 
 @Controller('/reports/sales-tax-liability-summary')
 @ApiTags('Reports')
@@ -27,12 +39,18 @@ import { ApiCommonHeaders } from '@/common/decorators/ApiCommonHeaders';
   SalesTaxLiabilitySummaryTableResponseDto,
   NumberFormatQueryDto,
 )
+// Restrict this financial report to authenticated users granted the sales-tax-liability read permission.
+@UseGuards(AuthorizationGuard, PermissionGuard)
 export class SalesTaxLiabilitySummaryController {
   constructor(
     private readonly salesTaxLiabilitySummaryApp: SalesTaxLiabilitySummaryApplication,
   ) {}
 
   @Get()
+  @RequirePermission(
+    ReportsAction.READ_SALES_TAX_LIABILITY_SUMMARY,
+    AbilitySubject.Report,
+  )
   @ApiResponse({
     status: 200,
     description: 'Sales tax liability summary report',

--- a/packages/server/src/modules/FinancialStatements/modules/TransactionsByCustomer/TransactionsByCustomer.controller.spec.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/TransactionsByCustomer/TransactionsByCustomer.controller.spec.ts
@@ -1,0 +1,60 @@
+import { ForbiddenException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Ability } from '@casl/ability';
+import { PermissionGuard } from '@/modules/Roles/Permission.guard';
+import { TransactionsByCustomerController } from './TransactionsByCustomer.controller';
+import { AbilitySubject } from '@/modules/Roles/Roles.types';
+import { ReportsAction } from '../../types/Report.types';
+
+describe('TransactionsByCustomerController authorization', () => {
+  const reflector = new Reflector();
+  const guard = new PermissionGuard(reflector);
+
+  const ctx = (handler: any, ability: Ability) =>
+    ({
+      switchToHttp: () => ({ getRequest: () => ({ ability }) }),
+      getHandler: () => handler,
+      getClass: () => TransactionsByCustomerController,
+    }) as any;
+
+  const cases: Array<[string, string]> = [
+    ['transactionsByCustomer', ReportsAction.READ_CUSTOMERS_TRANSACTIONS],
+  ];
+
+  it.each(cases)(
+    '%s is denied (403) for a role without the Report permission',
+    (method) => {
+      const deny = new Ability([]);
+      expect(() =>
+        guard.canActivate(
+          ctx(TransactionsByCustomerController.prototype[method], deny),
+        ),
+      ).toThrow(ForbiddenException);
+    },
+  );
+
+  it.each(cases)(
+    '%s is allowed for a role that grants the matching Report permission',
+    (method, action) => {
+      const allow = new Ability([
+        { action, subject: AbilitySubject.Report },
+      ] as any);
+      expect(
+        guard.canActivate(
+          ctx(TransactionsByCustomerController.prototype[method], allow),
+        ),
+      ).toBe(true);
+    },
+  );
+
+  it('grants all report operations to a manage-all (admin) ability', () => {
+    const admin = new Ability([{ action: 'manage', subject: 'all' }] as any);
+    for (const [method] of cases) {
+      expect(
+        guard.canActivate(
+          ctx(TransactionsByCustomerController.prototype[method], admin),
+        ),
+      ).toBe(true);
+    }
+  });
+});

--- a/packages/server/src/modules/FinancialStatements/modules/TransactionsByCustomer/TransactionsByCustomer.controller.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/TransactionsByCustomer/TransactionsByCustomer.controller.ts
@@ -1,4 +1,11 @@
-import { Controller, Get, Headers, Query, Res } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Headers,
+  Query,
+  Res,
+  UseGuards,
+} from '@nestjs/common';
 import {
   ApiExtraModels,
   ApiOperation,
@@ -18,6 +25,11 @@ import { Response } from 'express';
 import { NumberFormatQueryDto } from '@/modules/BankingTransactions/dtos/NumberFormatQuery.dto';
 import { TransactionsByCustomerQueryDto } from './TransactionsByCustomerQuery.dto';
 import { ApiCommonHeaders } from '@/common/decorators/ApiCommonHeaders';
+import { RequirePermission } from '@/modules/Roles/RequirePermission.decorator';
+import { PermissionGuard } from '@/modules/Roles/Permission.guard';
+import { AuthorizationGuard } from '@/modules/Roles/Authorization.guard';
+import { AbilitySubject } from '@/modules/Roles/Roles.types';
+import { ReportsAction } from '../../types/Report.types';
 
 @Controller('/reports/transactions-by-customers')
 @ApiTags('Reports')
@@ -27,12 +39,18 @@ import { ApiCommonHeaders } from '@/common/decorators/ApiCommonHeaders';
   TransactionsByCustomerTableResponseDto,
   NumberFormatQueryDto,
 )
+// Restrict this financial report to authenticated users granted the customers-transactions read permission.
+@UseGuards(AuthorizationGuard, PermissionGuard)
 export class TransactionsByCustomerController {
   constructor(
     private readonly transactionsByCustomersApp: TransactionsByCustomerApplication,
   ) {}
 
   @Get()
+  @RequirePermission(
+    ReportsAction.READ_CUSTOMERS_TRANSACTIONS,
+    AbilitySubject.Report,
+  )
   @ApiOperation({ summary: 'Get transactions by customer' })
   @ApiQuery({
     name: 'numberFormat',

--- a/packages/server/src/modules/FinancialStatements/modules/TransactionsByVendor/TransactionsByVendor.controller.spec.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/TransactionsByVendor/TransactionsByVendor.controller.spec.ts
@@ -1,0 +1,60 @@
+import { ForbiddenException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Ability } from '@casl/ability';
+import { PermissionGuard } from '@/modules/Roles/Permission.guard';
+import { TransactionsByVendorController } from './TransactionsByVendor.controller';
+import { AbilitySubject } from '@/modules/Roles/Roles.types';
+import { ReportsAction } from '../../types/Report.types';
+
+describe('TransactionsByVendorController authorization', () => {
+  const reflector = new Reflector();
+  const guard = new PermissionGuard(reflector);
+
+  const ctx = (handler: any, ability: Ability) =>
+    ({
+      switchToHttp: () => ({ getRequest: () => ({ ability }) }),
+      getHandler: () => handler,
+      getClass: () => TransactionsByVendorController,
+    }) as any;
+
+  const cases: Array<[string, string]> = [
+    ['transactionsByVendor', ReportsAction.READ_VENDORS_TRANSACTIONS],
+  ];
+
+  it.each(cases)(
+    '%s is denied (403) for a role without the Report permission',
+    (method) => {
+      const deny = new Ability([]);
+      expect(() =>
+        guard.canActivate(
+          ctx(TransactionsByVendorController.prototype[method], deny),
+        ),
+      ).toThrow(ForbiddenException);
+    },
+  );
+
+  it.each(cases)(
+    '%s is allowed for a role that grants the matching Report permission',
+    (method, action) => {
+      const allow = new Ability([
+        { action, subject: AbilitySubject.Report },
+      ] as any);
+      expect(
+        guard.canActivate(
+          ctx(TransactionsByVendorController.prototype[method], allow),
+        ),
+      ).toBe(true);
+    },
+  );
+
+  it('grants all report operations to a manage-all (admin) ability', () => {
+    const admin = new Ability([{ action: 'manage', subject: 'all' }] as any);
+    for (const [method] of cases) {
+      expect(
+        guard.canActivate(
+          ctx(TransactionsByVendorController.prototype[method], admin),
+        ),
+      ).toBe(true);
+    }
+  });
+});

--- a/packages/server/src/modules/FinancialStatements/modules/TransactionsByVendor/TransactionsByVendor.controller.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/TransactionsByVendor/TransactionsByVendor.controller.ts
@@ -1,4 +1,11 @@
-import { Controller, Get, Headers, Query, Res } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Headers,
+  Query,
+  Res,
+  UseGuards,
+} from '@nestjs/common';
 import { ITransactionsByVendorsFilter } from './TransactionsByVendor.types';
 import { AcceptType } from '@/constants/accept-type';
 import { Response } from 'express';
@@ -18,6 +25,11 @@ import {
 import { NumberFormatQueryDto } from '@/modules/BankingTransactions/dtos/NumberFormatQuery.dto';
 import { TransactionsByVendorQueryDto } from './TransactionsByVendorQuery.dto';
 import { ApiCommonHeaders } from '@/common/decorators/ApiCommonHeaders';
+import { RequirePermission } from '@/modules/Roles/RequirePermission.decorator';
+import { PermissionGuard } from '@/modules/Roles/Permission.guard';
+import { AuthorizationGuard } from '@/modules/Roles/Authorization.guard';
+import { AbilitySubject } from '@/modules/Roles/Roles.types';
+import { ReportsAction } from '../../types/Report.types';
 
 @Controller('/reports/transactions-by-vendors')
 @ApiTags('Reports')
@@ -27,12 +39,18 @@ import { ApiCommonHeaders } from '@/common/decorators/ApiCommonHeaders';
   TransactionsByVendorTableResponseDto,
   NumberFormatQueryDto,
 )
+// Restrict this financial report to authenticated users granted the vendors-transactions read permission.
+@UseGuards(AuthorizationGuard, PermissionGuard)
 export class TransactionsByVendorController {
   constructor(
     private readonly transactionsByVendorsApp: TransactionsByVendorApplication,
   ) {}
 
   @Get()
+  @RequirePermission(
+    ReportsAction.READ_VENDORS_TRANSACTIONS,
+    AbilitySubject.Report,
+  )
   @ApiOperation({ summary: 'Get transactions by vendor' })
   @ApiQuery({
     name: 'numberFormat',

--- a/packages/server/src/modules/FinancialStatements/modules/VendorBalanceSummary/VendorBalanceSummary.controller.spec.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/VendorBalanceSummary/VendorBalanceSummary.controller.spec.ts
@@ -1,0 +1,60 @@
+import { ForbiddenException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Ability } from '@casl/ability';
+import { PermissionGuard } from '@/modules/Roles/Permission.guard';
+import { VendorBalanceSummaryController } from './VendorBalanceSummary.controller';
+import { AbilitySubject } from '@/modules/Roles/Roles.types';
+import { ReportsAction } from '../../types/Report.types';
+
+describe('VendorBalanceSummaryController authorization', () => {
+  const reflector = new Reflector();
+  const guard = new PermissionGuard(reflector);
+
+  const ctx = (handler: any, ability: Ability) =>
+    ({
+      switchToHttp: () => ({ getRequest: () => ({ ability }) }),
+      getHandler: () => handler,
+      getClass: () => VendorBalanceSummaryController,
+    }) as any;
+
+  const cases: Array<[string, string]> = [
+    ['vendorBalanceSummary', ReportsAction.READ_VENDORS_SUMMARY_BALANCE],
+  ];
+
+  it.each(cases)(
+    '%s is denied (403) for a role without the Report permission',
+    (method) => {
+      const deny = new Ability([]);
+      expect(() =>
+        guard.canActivate(
+          ctx(VendorBalanceSummaryController.prototype[method], deny),
+        ),
+      ).toThrow(ForbiddenException);
+    },
+  );
+
+  it.each(cases)(
+    '%s is allowed for a role that grants the matching Report permission',
+    (method, action) => {
+      const allow = new Ability([
+        { action, subject: AbilitySubject.Report },
+      ] as any);
+      expect(
+        guard.canActivate(
+          ctx(VendorBalanceSummaryController.prototype[method], allow),
+        ),
+      ).toBe(true);
+    },
+  );
+
+  it('grants all report operations to a manage-all (admin) ability', () => {
+    const admin = new Ability([{ action: 'manage', subject: 'all' }] as any);
+    for (const [method] of cases) {
+      expect(
+        guard.canActivate(
+          ctx(VendorBalanceSummaryController.prototype[method], admin),
+        ),
+      ).toBe(true);
+    }
+  });
+});

--- a/packages/server/src/modules/FinancialStatements/modules/VendorBalanceSummary/VendorBalanceSummary.controller.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/VendorBalanceSummary/VendorBalanceSummary.controller.ts
@@ -1,4 +1,11 @@
-import { Controller, Get, Headers, Query, Res } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Headers,
+  Query,
+  Res,
+  UseGuards,
+} from '@nestjs/common';
 import { IVendorBalanceSummaryQuery } from './VendorBalanceSummary.types';
 import { VendorBalanceSummaryApplication } from './VendorBalanceSummaryApplication';
 import { Response } from 'express';
@@ -19,6 +26,11 @@ import {
   VendorBalanceSummaryTableResponseDto,
 } from './VendorBalanceSummaryResponse.dto';
 import { ApiCommonHeaders } from '@/common/decorators/ApiCommonHeaders';
+import { RequirePermission } from '@/modules/Roles/RequirePermission.decorator';
+import { PermissionGuard } from '@/modules/Roles/Permission.guard';
+import { AuthorizationGuard } from '@/modules/Roles/Authorization.guard';
+import { AbilitySubject } from '@/modules/Roles/Roles.types';
+import { ReportsAction } from '../../types/Report.types';
 
 @Controller('/reports/vendor-balance-summary')
 @ApiTags('Reports')
@@ -28,12 +40,18 @@ import { ApiCommonHeaders } from '@/common/decorators/ApiCommonHeaders';
   VendorBalanceSummaryTableResponseDto,
   NumberFormatQueryDto,
 )
+// Restrict this financial report to authenticated users granted the vendor-balance read permission.
+@UseGuards(AuthorizationGuard, PermissionGuard)
 export class VendorBalanceSummaryController {
   constructor(
     private readonly vendorBalanceSummaryApp: VendorBalanceSummaryApplication,
   ) {}
 
   @Get()
+  @RequirePermission(
+    ReportsAction.READ_VENDORS_SUMMARY_BALANCE,
+    AbilitySubject.Report,
+  )
   @ApiOperation({ summary: 'Get vendor balance summary' })
   @ApiQuery({
     name: 'numberFormat',

--- a/packages/server/src/modules/Roles/AbilitySchema.ts
+++ b/packages/server/src/modules/Roles/AbilitySchema.ts
@@ -255,6 +255,10 @@ export const AbilitySchema: ISubjectAbilitiesSchema[] = [
         label: 'ability.balance_sheet_report',
       },
       {
+        key: ReportsAction.READ_TRIAL_BALANCE_SHEET,
+        label: 'ability.trial_balance_sheet_report',
+      },
+      {
         key: ReportsAction.READ_PROFIT_LOSS,
         label: 'ability.profit_loss_sheet',
       },
@@ -303,6 +307,14 @@ export const AbilitySchema: ISubjectAbilitiesSchema[] = [
       {
         key: ReportsAction.READ_INVENTORY_ITEM_DETAILS,
         label: 'ability.inventory_items_details',
+      },
+      {
+        key: ReportsAction.READ_CASHFLOW_ACCOUNT_TRANSACTION,
+        label: 'ability.cashflow_account_transactions',
+      },
+      {
+        key: ReportsAction.READ_SALES_TAX_LIABILITY_SUMMARY,
+        label: 'ability.sales_tax_liability_summary_report',
       },
     ],
   },

--- a/packages/webapp/src/constants/permissionsSchema.tsx
+++ b/packages/webapp/src/constants/permissionsSchema.tsx
@@ -660,6 +660,10 @@ export const getPermissionsSchema = (): PermissionModule[] => [
             label: intl.get('permissions.cashflow_account_transactions'),
             key: ReportsAction.READ_CASHFLOW_ACCOUNT_TRANSACTION,
           },
+          {
+            label: intl.get('permissions.sales_tax_liability_summary'),
+            key: ReportsAction.READ_SALES_TAX_LIABILITY_SUMMARY,
+          },
         ],
       },
     ],

--- a/packages/webapp/src/lang/ar/index.json
+++ b/packages/webapp/src/lang/ar/index.json
@@ -1766,6 +1766,7 @@
   "permissions.inventory_valuation_summary": "ملخص تقييم المخزون ",
   "permissions.inventory_items_details": "تفاصيل منتج المخزون",
   "permissions.cashflow_account_transactions": "معاملات حسابات التدفقات النقدية",
+  "permissions.sales_tax_liability_summary": "ملخص التزامات ضريبة المبيعات",
   "permissions.more_permissions": "عرض المزيد ",
   "estimate.status.expired": "منتهية الصلاحية",
   "refund_credit.drawer.title": " تفاصيل استرجاع الأموال لإشعار الدائن ",

--- a/packages/webapp/src/lang/en/index.json
+++ b/packages/webapp/src/lang/en/index.json
@@ -1830,6 +1830,7 @@
   "permissions.inventory_valuation_summary": "Inventory valuation summary",
   "permissions.inventory_items_details": "Inventory valuation summary",
   "permissions.cashflow_account_transactions": "Bank account transactions",
+  "permissions.sales_tax_liability_summary": "Sales tax liability summary",
   "permissions.more_permissions": "More Permissions",
   "estimate.status.expired": "Expired",
   "refund_credit.drawer.title": "Refund credit note",

--- a/packages/webapp/src/lang/es/index.json
+++ b/packages/webapp/src/lang/es/index.json
@@ -1768,6 +1768,7 @@
   "permissions.inventory_valuation_summary": "Resumen de valoración de inventario",
   "permissions.inventory_items_details": "Resumen de valoración de inventario",
   "permissions.cashflow_account_transactions": "Transacciones de cuentas de flujo de caja",
+  "permissions.sales_tax_liability_summary": "Resumen de impuestos de ventas por pagar",
   "permissions.more_permissions": "Más permisos",
   "estimate.status.expired": "Expirado",
   "refund_credit.drawer.title": "Reembolsar nota de crédito",

--- a/packages/webapp/src/lang/sv/index.json
+++ b/packages/webapp/src/lang/sv/index.json
@@ -1746,6 +1746,7 @@
   "permissions.inventory_valuation_summary": "Sammanställning av lagervärdering",
   "permissions.inventory_items_details": "Sammanställning av lagervärdering",
   "permissions.cashflow_account_transactions": "Transaktioner på bankkonto",
+  "permissions.sales_tax_liability_summary": "Sammanfattning av momsattsskuld",
   "permissions.more_permissions": "Fler behörigheter",
   "estimate.status.expired": "Utgått",
   "refund_credit.drawer.title": "Återbetalning kreditnota",


### PR DESCRIPTION
## Description

Enforce `@RequirePermission` + `PermissionGuard` on the financial statement report controllers (Customer Balance Summary, Vendor Balance Summary, Inventory Item Details, Purchases by Items, Sales by Items, Sales Tax Liability Summary, Transactions by Customer, and Transactions by Vendor), so these endpoints are restricted to authenticated users granted the matching report permission.

Also:
- Added controller authorization spec tests covering deny (403), allow, and admin (manage-all) cases.
- Registered the new customer/vendor balance report permissions in the server ability schema and the webapp permissions schema.
- Updated i18n translations for the new permissions.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Added `*.controller.spec.ts` unit tests for each report controller asserting:
  - A role without the report permission receives a `403 Forbidden`.
  - A role granted the matching report permission is allowed.
  - A manage-all (admin) ability is allowed for all report operations.
- Ran the new spec files locally with Jest.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>
