### PR TITLE
fix(webapp): feature activation not reflected for branches and warehouses

### DIFF
--- a/packages/server/src/constants/metable-options.ts
+++ b/packages/server/src/constants/metable-options.ts
@@ -259,10 +259,10 @@ export const SettingsOptions = {
     ]),
   },
   features: {
-    'multi-warehouses': {
+    warehouses: {
       type: 'boolean',
     },
-    'multi-branches': {
+    branches: {
       type: 'boolean',
     },
   },

--- a/packages/webapp/src/containers/Subscriptions/BillingPage.tsx
+++ b/packages/webapp/src/containers/Subscriptions/BillingPage.tsx
@@ -23,7 +23,7 @@ function BillingPageRoot({
   }, [changePreferencesPageTitle]);
 
   // In case the edition is not Bigcapital Cloud, redirect to the homepage.
-  if (!dashboardMeta.is_bigcapital_cloud) {
+  if (!dashboardMeta.isBigcapitalCloud) {
     return <Redirect to={{ pathname: '/' }} />;
   }
 

--- a/packages/webapp/src/hooks/query/users/queries.ts
+++ b/packages/webapp/src/hooks/query/users/queries.ts
@@ -164,7 +164,7 @@ export const useDashboardMeta = (
   >,
 ) => {
   const setFeatureDashboardMeta = useSetFeatureDashboardMeta();
-  const fetcher = useApiFetcher();
+  const fetcher = useApiFetcher({ enableCamelCaseTransform: true });
 
   const state = useQuery({
     ...props,


### PR DESCRIPTION
## Description

Fixes activating the **Branches** and **Warehouses** features having no visible effect in the web app, even though the activation is successfully stored in the database.

### Root cause

The `dashboard/boot` API returns feature flags with snake_case keys (`is_accessible`, `default_accessible`) because of the server's global `SerializeInterceptor`. The web app's `useDashboardMeta` hook fetched this response without the SDK's camelCase transform, so the `SET_FEATURE_DASHBOARD_META` reducer read `feature.isAccessible` (camelCase), which was `undefined`.

As a result every feature was stored as `undefined` in the Redux store and `featureCan(...)` always returned `false`, so the UI never reflected activated features — no branch/warehouse pages, fields, or menus appeared even though the setting existed in the database.

### Changes

- `useDashboardMeta` now uses `useApiFetcher({ enableCamelCaseTransform: true })`, normalizing the boot meta features to the camelCase keys the reducer expects.
- Updated `BillingPage` to read the camelCase `isBigcapitalCloud` field (the only other consumer of the raw snake_case boot meta).
- Aligned the server settings schema `features` group keys (`branches`/`warehouses`) with the actual setting keys so feature flags parse as real booleans instead of the string `"1"`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Server `npm run typecheck` passes.
- Web app ESLint passes on the changed files; `npm run typecheck` reports only pre-existing errors in unrelated files.
- Verified live that `GET /api/dashboard/boot` returns the feature flags; with the camelCase transform enabled the app now stores `branches`/`warehouses` as truthy, and the Preferences pages render the activated state (branch table / warehouse grid) after activation.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>
