### PR TITLE
fix(webapp): categorize bank transaction aside not showing on transaction select

### DIFF
--- a/packages/webapp/src/containers/CashFlow/AccountTransactions/UncategorizedTransactions/AccountTransactionsUncategorizedTable.tsx
+++ b/packages/webapp/src/containers/CashFlow/AccountTransactions/UncategorizedTransactions/AccountTransactionsUncategorizedTable.tsx
@@ -31,7 +31,6 @@ interface AccountTransactionsDataTableProps
     >,
     Pick<
       WithBankingActionsProps,
-      | 'setUncategorizedTransactionIdForMatching'
       | 'setUncategorizedTransactionsSelected'
       | 'addTransactionsToCategorizeSelected'
       | 'setTransactionsToCategorizeSelected'
@@ -45,7 +44,6 @@ function AccountTransactionsDataTable({
   enableMultipleCategorization,
 
   // #withBankingActions
-  setUncategorizedTransactionIdForMatching,
   setUncategorizedTransactionsSelected,
   addTransactionsToCategorizeSelected,
   setTransactionsToCategorizeSelected,
@@ -88,7 +86,7 @@ function AccountTransactionsDataTable({
     transaction: UncategorizedTransactionRow,
   ) => {
     if (transaction.id == null) return;
-    setUncategorizedTransactionIdForMatching(transaction.id);
+    setTransactionsToCategorizeSelected([transaction.id]);
   };
   // handles table selected rows change.
   const handleSelectedRowsChange = (

--- a/packages/webapp/src/containers/CashFlow/CategorizeTransactionAside/CategorizeTransactionAside.tsx
+++ b/packages/webapp/src/containers/CashFlow/CategorizeTransactionAside/CategorizeTransactionAside.tsx
@@ -1,3 +1,4 @@
+import { isEmpty } from 'lodash';
 import { useEffect } from 'react';
 import { withBanking } from '../withBanking';
 import { withBankingActions } from '../withBankingActions';
@@ -16,7 +17,7 @@ interface CategorizeTransactionAsideProps
       | 'resetTransactionsToCategorizeSelected'
       | 'enableMultipleCategorization'
     >,
-    Pick<WithBankingProps, 'selectedUncategorizedTransactionId'> {}
+    Pick<WithBankingProps, 'transactionsToCategorizeIdsSelected'> {}
 
 function CategorizeTransactionAsideRoot({
   // #withBankingActions
@@ -26,7 +27,7 @@ function CategorizeTransactionAsideRoot({
   enableMultipleCategorization,
 
   // #withBanking
-  selectedUncategorizedTransactionId,
+  transactionsToCategorizeIdsSelected,
 }: CategorizeTransactionAsideProps) {
   useEffect(
     () => () => {
@@ -50,14 +51,16 @@ function CategorizeTransactionAsideRoot({
     closeMatchingTransactionAside();
   };
   // Cannot continue if there is no selected transaction.
-  if (!selectedUncategorizedTransactionId) {
+  if (isEmpty(transactionsToCategorizeIdsSelected)) {
     return null;
   }
   return (
     <Aside title={'Categorize Bank Transaction'} onClose={handleClose}>
       <Aside.Body>
         <CategorizeTransactionTabsBoot
-          uncategorizedTransactionIds={selectedUncategorizedTransactionId}
+          uncategorizedTransactionIds={transactionsToCategorizeIdsSelected.filter(
+            (id): id is number => typeof id === 'number',
+          )}
         >
           <CategorizeTransactionTabs />
         </CategorizeTransactionTabsBoot>
@@ -68,7 +71,7 @@ function CategorizeTransactionAsideRoot({
 
 export const CategorizeTransactionAside = compose(
   withBankingActions,
-  withBanking(({ selectedUncategorizedTransactionId }) => ({
-    selectedUncategorizedTransactionId,
+  withBanking(({ transactionsToCategorizeIdsSelected }) => ({
+    transactionsToCategorizeIdsSelected,
   })),
 )(CategorizeTransactionAsideRoot);


### PR DESCRIPTION
## Description

Fixed a regression introduced in commit `6c1a2d4e1` (typescript refactor) where the **Categorize Bank Transaction** aside does not render after selecting a bank transaction.

Root cause: the aside was gated on `uncategorizedTransactionIdForMatching`, but selecting a transaction row dispatches `setTransactionsToCategorizeSelected`, which only populates `transactionsToCategorizeSelected` and `openMatchingTransactionAside`. As a result the shell reserved space for the aside, but the aside itself returned `null`.

Fix:
- `CategorizeTransactionAside` now gates and boots from `transactionsToCategorizeIdsSelected`, the same source used by `CategorizeTransactionContent` for the autofill data.
- The uncategorized transactions table's "Categorize" menu now uses `setTransactionsToCategorizeSelected` (consistent with the recognized transactions table), so both the row-click and right-click entry points open the aside.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Ran `yarn typecheck` for the affected files (no new errors).
- Ran ESLint on the changed files (no warnings/errors).
- Manual verification steps: open Cashflow > Bank Account > Uncategorized transactions, click a transaction row and/or use the right-click "Categorize" menu; the Categorize Bank Transaction aside should now appear.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>
