### PR TITLE
fix(webapp): default trial balance filter to accounts with transactions

### DIFF
--- a/packages/webapp/src/containers/FinancialStatements/TrialBalanceSheet/TrialBalanceSheetHeaderGeneralPanel.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/TrialBalanceSheet/TrialBalanceSheetHeaderGeneralPanel.tsx
@@ -15,7 +15,7 @@ export function TrialBalanceSheetHeaderGeneralPanel() {
       <Row>
         <Col xs={4}>
           <FinancialStatementsFilter
-            initialSelectedItem={'with-transactions'}
+            initialSelectedValue={'with-transactions'}
           />
         </Col>
       </Row>

--- a/packages/webapp/src/containers/FinancialStatements/TrialBalanceSheet/utils.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/TrialBalanceSheet/utils.tsx
@@ -6,15 +6,17 @@ import { transformFilterFormToQuery } from '../common';
 import { useAppQueryString } from '@/hooks';
 import { transformToForm } from '@/utils';
 
+type TrialBalanceQuery = TrialBalanceTableQuery & { filterByOption?: string };
+
 /**
  * Retrieves the default trial balance query.
  */
-export function getDefaultTrialBalanceQuery(): TrialBalanceTableQuery {
+export function getDefaultTrialBalanceQuery(): TrialBalanceQuery {
   return {
     fromDate: moment().startOf('year').format('YYYY-MM-DD'),
     toDate: moment().format('YYYY-MM-DD'),
     basis: 'accrual',
-    // filterByOption: 'with-transactions',
+    filterByOption: 'with-transactions',
     branchesIds: [] as number[],
     // numberFormat: {},
   };
@@ -25,7 +27,7 @@ export function getDefaultTrialBalanceQuery(): TrialBalanceTableQuery {
  */
 const parseTrialBalanceSheetQuery = (
   locationQuery: Record<string, unknown>,
-): TrialBalanceTableQuery => {
+): TrialBalanceQuery => {
   const defaultQuery = getDefaultTrialBalanceQuery();
   const transformed = {
     ...defaultQuery,


### PR DESCRIPTION
## Description

Fixes the Trial Balance report default account filter.

Two related bugs:
- The "Filter accounts" field in the report drawer was never selected by default (showed "Select an item...").
- The report always included accounts with no transactions and zero balance.

Root cause: commit `3ed024355` commented out `filterByOption: 'with-transactions'` from `getDefaultTrialBalanceQuery()`. Since `filterByOption` was absent from the query, `transformAccountsFilter` sent `none_transactions: false` to the backend (overriding the server-side default of `noneTransactions: true`), so accounts without transactions were no longer filtered out. The same missing value also left the Formik field `filterByOption` undefined, so the header select showed no default selection (the `initialSelectedItem` prop passed to `FormikSelect` was also ignored — it expects `initialSelectedValue`).

This change restores `filterByOption: 'with-transactions'` as the default and fixes the prop name so the field is preselected and accounts without transactions / with zero balance are hidden by default.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Ran `tsc --noEmit` and ESLint on the changed files; no new errors/warnings.
- Manual: opening `/financial-reports/trial-balance-sheet` preselects "Filter accounts" to "Accounts with transactions" and hides accounts with no transactions / zero balance. The selected option persists in the URL.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>
