### PR TITLE
fix(webapp): prevent fetching billable invoices without a selected customer in payment received form

### DIFF
--- a/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentReceiveForm/PaymentReceiveInnerProvider.tsx
+++ b/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentReceiveForm/PaymentReceiveInnerProvider.tsx
@@ -57,13 +57,23 @@ function PaymentReceiveInnerProvider({
   } = useDueInvoices(customerId as number | undefined, dueInvoicesQuery);
 
   useEffect(() => {
-    if (!isDueInvoicesFetching && dueInvoices && isNewMode) {
-      const transformed = transformInvoicesNewPageEntries(
-        dueInvoices as DueInvoice[],
-      );
-      setFieldValue('entries', transformed);
+    if (!isDueInvoicesFetching && isNewMode) {
+      if (dueInvoices) {
+        const transformed = transformInvoicesNewPageEntries(
+          dueInvoices as DueInvoice[],
+        );
+        setFieldValue('entries', transformed);
+      } else if (!customerId) {
+        setFieldValue('entries', []);
+      }
     }
-  }, [isDueInvoicesFetching, dueInvoices, isNewMode, setFieldValue]);
+  }, [
+    isDueInvoicesFetching,
+    dueInvoices,
+    isNewMode,
+    customerId,
+    setFieldValue,
+  ]);
 
   const provider: PaymentReceiveInnerContextValue = {
     dueInvoices: dueInvoices as DueInvoice[] | undefined,

--- a/packages/webapp/src/hooks/query/invoices/queries.ts
+++ b/packages/webapp/src/hooks/query/invoices/queries.ts
@@ -235,7 +235,7 @@ export function useInvoiceHtml(
 }
 
 export function useDueInvoices(
-  customerId: number | null | undefined,
+  customerId: number | string | null | undefined,
   props?: UseQueryOptions<unknown, Error>,
 ) {
   const fetcher = useApiFetcher();
@@ -244,7 +244,8 @@ export function useDueInvoices(
     queryKey: invoicesKeys.due(customerId),
     queryFn: () =>
       fetchReceivableSaleInvoices(fetcher, customerId ?? undefined),
-    enabled: customerId != null,
+    enabled:
+      customerId != null && customerId !== '' && (props?.enabled ?? true),
   });
 }
 

--- a/packages/webapp/src/hooks/query/invoices/query-keys.ts
+++ b/packages/webapp/src/hooks/query/invoices/query-keys.ts
@@ -15,7 +15,7 @@ export const invoicesKeys = {
   all: () => [SALE_INVOICES] as const,
   list: (query?: Record<string, unknown>) => [SALE_INVOICES, query] as const,
   detail: (id: number | null | undefined) => [SALE_INVOICE, id] as const,
-  due: (customerId?: number | null) =>
+  due: (customerId?: number | string | null) =>
     [SALE_INVOICES, SALE_INVOICES_DUE, customerId] as const,
   paymentTransactions: (id: number | null | undefined) =>
     [SALE_INVOICE_PAYMENT_TRANSACTIONS, id] as const,

--- a/shared/sdk-ts/src/sale-invoices.ts
+++ b/shared/sdk-ts/src/sale-invoices.ts
@@ -106,11 +106,11 @@ export async function cancelWrittenOffSaleInvoice(fetcher: ApiFetcher, id: numbe
 
 export async function fetchReceivableSaleInvoices(
   fetcher: ApiFetcher,
-  customerId?: number
+  customerId?: number | string
 ): Promise<unknown> {
   const get = fetcher.path(SALE_INVOICES_ROUTES.RECEIVABLE).method('get').create();
-  const { data } = await (get as (params?: { customerId?: number }) => Promise<{ data: unknown }>)(
-    customerId != null ? { customerId } : {}
+  const { data } = await (get as (params?: { customerId?: number | string }) => Promise<{ data: unknown }>)(
+    customerId != null && customerId !== '' ? { customerId } : {}
   );
   return data;
 }


### PR DESCRIPTION
## Description

Fixes a bug where the "Create Payment Received" form displayed billable (open) invoices for all customers even when no customer was selected.

Root cause: the `useDueInvoices` hook gated its query on `customerId != null`, but the form's default `customerId` is an empty string (`''`), which passes that loose check. The caller's stricter `enabled` option was silently overridden because the hook spread `...props` before its own `enabled`. As a result the query fired with no customer, the server ignored the empty `customerId` filter, and returned open invoices across all customers.

Changes:
- `useDueInvoices` now only enables the query when a customer id is actually selected (`customerId != null && customerId !== ''`) and respects the caller's `enabled` option.
- The form provider clears the invoice entries when no customer is selected (and no longer leaves stale rows on screen after clearing the customer).
- The SDK `fetchReceivableSaleInvoices` no longer sends an empty `customerId` query param (defensive).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Verified via TypeScript typechecking for the affected packages (webapp and sdk-ts). Manually reproduced the flow: opening the payment received form with no customer selected no longer fetches or displays any invoices, and clearing a previously selected customer clears the invoice table.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>
