### PR TITLE
fix(server): mark existing transactions with primary branch/warehouse on activation

### DIFF
--- a/packages/server/src/modules/Branches/Branches.module.ts
+++ b/packages/server/src/modules/Branches/Branches.module.ts
@@ -33,9 +33,21 @@ import { ExpensesActivateBranches } from './integrations/Expense/ExpensesActivat
 import { BillActivateBranches } from './integrations/Purchases/BillBranchesActivate';
 import { VendorCreditActivateBranches } from './integrations/Purchases/VendorCreditBranchesActivate';
 import { BillPaymentsActivateBranches } from './integrations/Purchases/PaymentMadeBranchesActivate';
+import { SaleInvoiceActivateBranches } from './integrations/Sales/SaleInvoiceBranchesActivate';
+import { SaleReceiptActivateBranches } from './integrations/Sales/SaleReceiptBranchesActivate';
+import { SaleEstimateActivateBranches } from './integrations/Sales/SaleEstimatesBranchesActivate';
+import { PaymentReceiveActivateBranches } from './integrations/Sales/PaymentReceiveBranchesActivate';
+import { CreditNoteActivateBranches } from './integrations/Sales/CreditNoteBranchesActivate';
 import { BillBranchesActivateSubscriber } from './subscribers/Activate/BillBranchesActivateSubscriber';
 import { VendorCreditBranchesActivateSubscriber } from './subscribers/Activate/VendorCreditBranchesActivateSubscriber';
 import { PaymentMadeActivateBranchesSubscriber } from './subscribers/Activate/PaymentMadeBranchesActivateSubscriber';
+import { CashflowActivateBranchesSubscriber } from './subscribers/Activate/CashflowBranchesActivateSubscriber';
+import { CreditNoteActivateBranchesSubscriber } from './subscribers/Activate/CreditNoteBranchesActivateSubscriber';
+import { ExpenseActivateBranchesSubscriber } from './subscribers/Activate/ExpenseBranchesActivateSubscriber';
+import { PaymentReceiveActivateBranchesSubscriber } from './subscribers/Activate/PaymentReceiveBranchesActivateSubscriber';
+import { SaleEstimatesActivateBranchesSubscriber } from './subscribers/Activate/SaleEstiamtesBranchesActivateSubscriber';
+import { SaleInvoicesActivateBranchesSubscriber } from './subscribers/Activate/SaleInvoiceBranchesActivateSubscriber';
+import { SaleReceiptsActivateBranchesSubscriber } from './subscribers/Activate/SaleReceiptsBranchesActivateSubscriber';
 import { FeaturesModule } from '../Features/Features.module';
 
 @Module({
@@ -73,9 +85,21 @@ import { FeaturesModule } from '../Features/Features.module';
     BillActivateBranches,
     VendorCreditActivateBranches,
     BillPaymentsActivateBranches,
+    SaleInvoiceActivateBranches,
+    SaleReceiptActivateBranches,
+    SaleEstimateActivateBranches,
+    PaymentReceiveActivateBranches,
+    CreditNoteActivateBranches,
     BillBranchesActivateSubscriber,
     VendorCreditBranchesActivateSubscriber,
     PaymentMadeActivateBranchesSubscriber,
+    CashflowActivateBranchesSubscriber,
+    CreditNoteActivateBranchesSubscriber,
+    ExpenseActivateBranchesSubscriber,
+    PaymentReceiveActivateBranchesSubscriber,
+    SaleEstimatesActivateBranchesSubscriber,
+    SaleInvoicesActivateBranchesSubscriber,
+    SaleReceiptsActivateBranchesSubscriber,
   ],
   exports: [
     BranchesSettingsService,

--- a/packages/server/src/modules/Branches/integrations/Sales/CreditNoteBranchesActivate.ts
+++ b/packages/server/src/modules/Branches/integrations/Sales/CreditNoteBranchesActivate.ts
@@ -1,11 +1,12 @@
 import { Knex } from 'knex';
 import { CreditNote } from '@/modules/CreditNotes/models/CreditNote';
 import { TenantModelProxy } from '@/modules/System/models/TenantBaseModel';
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 
 @Injectable()
 export class CreditNoteActivateBranches {
   constructor(
+    @Inject(CreditNote.name)
     private readonly creditNoteModel: TenantModelProxy<typeof CreditNote>,
   ) {}
 

--- a/packages/server/src/modules/Branches/integrations/Sales/PaymentReceiveBranchesActivate.ts
+++ b/packages/server/src/modules/Branches/integrations/Sales/PaymentReceiveBranchesActivate.ts
@@ -1,11 +1,12 @@
 import { PaymentReceived } from '@/modules/PaymentReceived/models/PaymentReceived';
 import { TenantModelProxy } from '@/modules/System/models/TenantBaseModel';
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { Knex } from 'knex';
 
 @Injectable()
 export class PaymentReceiveActivateBranches {
   constructor(
+    @Inject(PaymentReceived.name)
     private readonly paymentReceivedModel: TenantModelProxy<
       typeof PaymentReceived
     >,

--- a/packages/server/src/modules/Branches/integrations/Sales/SaleEstimatesBranchesActivate.ts
+++ b/packages/server/src/modules/Branches/integrations/Sales/SaleEstimatesBranchesActivate.ts
@@ -1,15 +1,13 @@
 import { Knex } from 'knex';
 import { TenantModelProxy } from '@/modules/System/models/TenantBaseModel';
-import { PaymentReceived } from '@/modules/PaymentReceived/models/PaymentReceived';
+import { SaleEstimate } from '@/modules/SaleEstimates/models/SaleEstimate';
 import { Inject, Injectable } from '@nestjs/common';
 
 @Injectable()
 export class SaleEstimateActivateBranches {
   constructor(
-    @Inject(PaymentReceived.name)
-    private readonly paymentReceivedModel: TenantModelProxy<
-      typeof PaymentReceived
-    >,
+    @Inject(SaleEstimate.name)
+    private readonly saleEstimateModel: TenantModelProxy<typeof SaleEstimate>,
   ) {}
 
   /**
@@ -21,8 +19,8 @@ export class SaleEstimateActivateBranches {
     primaryBranchId: number,
     trx?: Knex.Transaction,
   ) => {
-    // Updates the sale invoice with primary branch.
-    await this.paymentReceivedModel()
+    // Updates the sale estimates with primary branch.
+    await this.saleEstimateModel()
       .query(trx)
       .update({ branchId: primaryBranchId });
   };

--- a/packages/server/src/modules/Branches/integrations/Sales/SaleInvoiceBranchesActivate.ts
+++ b/packages/server/src/modules/Branches/integrations/Sales/SaleInvoiceBranchesActivate.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { Knex } from 'knex';
 import { SaleInvoice } from '@/modules/SaleInvoices/models/SaleInvoice';
 import { TenantModelProxy } from '@/modules/System/models/TenantBaseModel';
@@ -6,6 +6,7 @@ import { TenantModelProxy } from '@/modules/System/models/TenantBaseModel';
 @Injectable()
 export class SaleInvoiceActivateBranches {
   constructor(
+    @Inject(SaleInvoice.name)
     private readonly saleInvoiceModel: TenantModelProxy<typeof SaleInvoice>,
   ) {}
 

--- a/packages/server/src/modules/Branches/integrations/Sales/SaleReceiptBranchesActivate.ts
+++ b/packages/server/src/modules/Branches/integrations/Sales/SaleReceiptBranchesActivate.ts
@@ -1,11 +1,12 @@
 import { Knex } from 'knex';
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { SaleReceipt } from '@/modules/SaleReceipts/models/SaleReceipt';
 import { TenantModelProxy } from '@/modules/System/models/TenantBaseModel';
 
 @Injectable()
 export class SaleReceiptActivateBranches {
   constructor(
+    @Inject(SaleReceipt.name)
     private readonly saleReceiptModel: TenantModelProxy<typeof SaleReceipt>,
   ) {}
 

--- a/packages/server/src/modules/Branches/subscribers/Activate/CashflowBranchesActivateSubscriber.ts
+++ b/packages/server/src/modules/Branches/subscribers/Activate/CashflowBranchesActivateSubscriber.ts
@@ -5,7 +5,7 @@ import { IBranchesActivatedPayload } from '../../Branches.types';
 import { events } from '@/common/events/events';
 
 @Injectable()
-export class CreditNoteActivateBranchesSubscriber {
+export class CashflowActivateBranchesSubscriber {
   constructor(
     private readonly cashflowActivateBranches: CashflowTransactionsActivateBranches,
   ) {}

--- a/packages/server/src/modules/Warehouses/Activate/EstimateWarehousesActivate.ts
+++ b/packages/server/src/modules/Warehouses/Activate/EstimateWarehousesActivate.ts
@@ -1,13 +1,16 @@
 import { ItemEntry } from '@/modules/TransactionItemEntry/models/ItemEntry';
 import { SaleEstimate } from '@/modules/SaleEstimates/models/SaleEstimate';
 import { TenantModelProxy } from '@/modules/System/models/TenantBaseModel';
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { Warehouse } from '../models/Warehouse.model';
 
 @Injectable()
 export class EstimatesActivateWarehouses {
   constructor(
+    @Inject(SaleEstimate.name)
     private readonly saleEstimateModel: TenantModelProxy<typeof SaleEstimate>,
+
+    @Inject(ItemEntry.name)
     private readonly itemEntryModel: TenantModelProxy<typeof ItemEntry>,
   ) {}
 

--- a/packages/server/src/modules/Warehouses/Activate/InventoryTransactionsWarehousesActivate.ts
+++ b/packages/server/src/modules/Warehouses/Activate/InventoryTransactionsWarehousesActivate.ts
@@ -1,15 +1,18 @@
 import { InventoryTransaction } from '@/modules/InventoryCost/models/InventoryTransaction';
 import { TenantModelProxy } from '@/modules/System/models/TenantBaseModel';
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { Warehouse } from '../models/Warehouse.model';
 import { InventoryCostLotTracker } from '@/modules/InventoryCost/models/InventoryCostLotTracker';
 
 @Injectable()
 export class InventoryActivateWarehouses {
   constructor(
+    @Inject(InventoryTransaction.name)
     private readonly inventoryTransactionModel: TenantModelProxy<
       typeof InventoryTransaction
     >,
+
+    @Inject(InventoryCostLotTracker.name)
     private readonly inventoryCostLotTrackerModel: TenantModelProxy<
       typeof InventoryCostLotTracker
     >,

--- a/packages/server/src/modules/Warehouses/Integrations/WarehousesItemsQuantitySync.ts
+++ b/packages/server/src/modules/Warehouses/Integrations/WarehousesItemsQuantitySync.ts
@@ -1,5 +1,5 @@
 import { InventoryTransaction } from '@/modules/InventoryCost/models/InventoryTransaction';
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { Knex } from 'knex';
 import { omit } from 'lodash';
 import { IItemWarehouseQuantityChange } from '../Warehouse.types';
@@ -10,7 +10,7 @@ import { ItemWarehouseQuantity } from '../models/ItemWarehouseQuantity';
 @Injectable()
 export class WarehousesItemsQuantitySync {
   constructor(
-    private readonly warehouseItemsQuantityModel: WarehousesItemsQuantity,
+    @Inject(ItemWarehouseQuantity.name)
     private readonly itemWarehouseQuantityModel: TenantModelProxy<
       typeof ItemWarehouseQuantity
     >,

--- a/packages/server/src/modules/Warehouses/Warehouses.module.ts
+++ b/packages/server/src/modules/Warehouses/Warehouses.module.ts
@@ -24,6 +24,8 @@ import { InvoicesActivateWarehousesSubscriber } from './subscribers/Activate/Inv
 import { CreditsActivateWarehousesSubscriber } from './subscribers/Activate/CreditNoteWarehousesActivateSubscriber';
 import { InventoryAdjustmentWarehouseValidatorSubscriber } from './subscribers/Validators/InventoryAdjustment/InventoryAdjustmentWarehouseValidatorSubscriber';
 import { DeleteItemWarehousesQuantitySubscriber } from './subscribers/DeleteItemWarehousesQuantitySubscriber';
+import { EstimatesActivateWarehousesSubscriber } from './subscribers/Activate/EstimateWarehousesActivateSubscriber';
+import { InventoryActivateWarehousesSubscriber } from './subscribers/Activate/InventoryTransactionsWarehousesActivateSubscriber';
 import { VendorCreditWarehousesValidateSubscriber } from './subscribers/Validators/Purchases/VendorCreditWarehousesSubscriber';
 import { SaleInvoicesWarehousesValidateSubscriber } from './subscribers/Validators/Sales/SaleInvoicesWarehousesSubscriber';
 import { SaleEstimateWarehousesValidateSubscriber } from './subscribers/Validators/Sales/SaleEstimateWarehousesSubscriber';
@@ -36,6 +38,12 @@ import { CreditNotesActivateWarehouses } from './Activate/CreditNoteWarehousesAc
 import { VendorCreditActivateWarehouses } from './Activate/VendorCreditWarehousesActivate';
 import { InvoicesActivateWarehouses } from './Activate/InvoiceWarehousesActivate';
 import { ReceiptActivateWarehouses } from './Activate/ReceiptWarehousesActivate';
+import { EstimatesActivateWarehouses } from './Activate/EstimateWarehousesActivate';
+import { InventoryActivateWarehouses } from './Activate/InventoryTransactionsWarehousesActivate';
+import { ActivateWarehousesSubscriber } from './ActivateWarehousesSubscriber';
+import { UpdateInventoryTransactionsWithWarehouse } from './UpdateInventoryTransactionsWithWarehouse';
+import { CreateInitialWarehousesItemsQuantity } from './CreateInitialWarehousesitemsQuantity';
+import { WarehousesItemsQuantitySync } from './Integrations/WarehousesItemsQuantitySync';
 import { WarehousesDTOValidators } from './Integrations/WarehousesDTOValidators';
 import { DeleteItemWarehousesQuantity } from './commands/DeleteItemWarehousesQuantity';
 import { InventoryTransactionsWarehouses } from './AccountsTransactionsWarehouses';
@@ -83,6 +91,14 @@ const models = [RegisterTenancyModel(Warehouse)];
     CreditNotesActivateWarehouses,
     InvoicesActivateWarehouses,
     ReceiptActivateWarehouses,
+    EstimatesActivateWarehouses,
+    InventoryActivateWarehouses,
+    ActivateWarehousesSubscriber,
+    UpdateInventoryTransactionsWithWarehouse,
+    CreateInitialWarehousesItemsQuantity,
+    WarehousesItemsQuantitySync,
+    EstimatesActivateWarehousesSubscriber,
+    InventoryActivateWarehousesSubscriber,
     WarehousesDTOValidators,
     DeleteItemWarehousesQuantity,
     InventoryTransactionsWarehouses,


### PR DESCRIPTION
## Description

When activating the multi-branches or multi-warehouses feature, existing transactions were not marked with the default primary branch/warehouse. The primary branch/warehouse was created and the setting was toggled, but existing transactions (invoices, receipts, estimates, credit notes, payment receives, cashflow, expenses, inventory transactions, GL transactions, etc.) were not backfilled.

**Root cause:** After the NestJS migration, most `onActivated` event subscribers that assign the primary branch/warehouse to existing transactions were never registered as NestJS module providers, so their handlers silently never ran. An earlier fix (#935) only re-registered the branches subscribers for bills, vendor credits and bill payments.

**Changes:**

- Branches: register the missing activate subscribers/services for sale invoices, sale receipts, sale estimates, credit notes, payment receives, cashflow and expenses in `BranchesModule`.
- Branches: rename `CashflowActivateBranchesSubscriber` (was incorrectly named `CreditNoteActivateBranchesSubscriber`, colliding with the credit note subscriber) to resolve the DI collision.
- Branches: fix `SaleEstimateActivateBranches` to update the `SaleEstimate` model instead of `PaymentReceived` (longstanding copy-paste bug).
- Warehouses: register the missing activate subscribers/services for sale estimates and inventory transactions, plus the legacy `ActivateWarehousesSubscriber` (inventory transaction update + initial item-warehouse quantity seeding) and its dependencies.
- Add the missing `@Inject` decorators to model-proxy dependencies so NestJS can resolve them.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- `npm run typecheck` and `npm run build` pass in `packages/server`.
- Verified all `@OnEvent(events.branch.onActivated)` / `@OnEvent(events.warehouse.onActivated)` listeners are now registered as module providers.
- Manual verification recommended: activate multi-branches and multi-warehouses on an organization with existing transactions and confirm existing transactions are assigned the default branch/warehouse.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>
