### PR TITLE
fix(webapp): restore number format setting in financial reports

### DIFF
--- a/packages/server/src/modules/BankingTransactions/dtos/NumberFormatQuery.dto.ts
+++ b/packages/server/src/modules/BankingTransactions/dtos/NumberFormatQuery.dto.ts
@@ -1,11 +1,5 @@
 import { Transform, Type } from 'class-transformer';
-import {
-  IsBoolean,
-  IsEnum,
-  IsNumber,
-  IsOptional,
-  IsPositive,
-} from 'class-validator';
+import { IsBoolean, IsEnum, IsNumber, IsOptional, Min } from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { parseBoolean } from '@/utils/parse-boolean';
 
@@ -16,7 +10,7 @@ export class NumberFormatQueryDto {
   })
   @Type(() => Number)
   @IsNumber()
-  @IsPositive()
+  @Min(0)
   @IsOptional()
   readonly precision: number;
 

--- a/packages/webapp/src/containers/FinancialStatements/BalanceSheet/utils.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/BalanceSheet/utils.tsx
@@ -37,6 +37,7 @@ export const getDefaultBalanceSheetQuery = (): BalanceSheetTableQuery => ({
   percentageOfRow: false,
 
   branchesIds: [],
+  numberFormat: {},
 });
 
 const parseBalanceSheetQuery = (

--- a/packages/webapp/src/containers/FinancialStatements/CustomersTransactions/_utils.ts
+++ b/packages/webapp/src/containers/FinancialStatements/CustomersTransactions/_utils.ts
@@ -22,6 +22,7 @@ export const getCustomersTransactionsDefaultQuery = () => ({
   toDate: moment().format('YYYY-MM-DD'),
   customersIds: [] as string[],
   filterByOption: 'with-transactions',
+  numberFormat: {},
 });
 
 const parseCustomersTransactionsQuery = (

--- a/packages/webapp/src/containers/FinancialStatements/InventoryValuation/utils.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/InventoryValuation/utils.tsx
@@ -24,6 +24,7 @@ export const getInventoryValuationQuery = () => ({
   itemsIds: [] as number[],
   branchesIds: [] as number[],
   warehousesIds: [] as number[],
+  numberFormat: {},
 });
 
 /**

--- a/packages/webapp/src/containers/FinancialStatements/PurchasesByItems/utils.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/PurchasesByItems/utils.tsx
@@ -15,6 +15,7 @@ export const getDefaultPurchasesByItemsQuery = () => ({
   toDate: moment().format('YYYY-MM-DD'),
   filterByOption: 'with-transactions',
   itemsIds: [] as number[],
+  numberFormat: {},
 });
 
 /**

--- a/packages/webapp/src/containers/FinancialStatements/SalesByItems/utils.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/SalesByItems/utils.tsx
@@ -28,6 +28,7 @@ export const getDefaultSalesByItemsQuery = () => ({
   toDate: moment().format('YYYY-MM-DD'),
   filterByOption: 'with-transactions',
   itemsIds: [],
+  numberFormat: {},
 });
 
 /**

--- a/packages/webapp/src/containers/FinancialStatements/SalesTaxLiabilitySummary/utils.ts
+++ b/packages/webapp/src/containers/FinancialStatements/SalesTaxLiabilitySummary/utils.ts
@@ -15,6 +15,7 @@ export const getDefaultSalesTaxLiablitySummaryQuery = () => ({
   fromDate: moment().startOf('month').format('YYYY-MM-DD'),
   toDate: moment().format('YYYY-MM-DD'),
   basis: 'cash',
+  numberFormat: {},
 });
 
 /**

--- a/packages/webapp/src/containers/FinancialStatements/TrialBalanceSheet/utils.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/TrialBalanceSheet/utils.tsx
@@ -16,7 +16,7 @@ export function getDefaultTrialBalanceQuery(): TrialBalanceTableQuery {
     basis: 'accrual',
     // filterByOption: 'with-transactions',
     branchesIds: [] as number[],
-    // numberFormat: {},
+    numberFormat: {},
   };
 }
 

--- a/packages/webapp/src/containers/FinancialStatements/VendorsBalanceSummary/utils.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/VendorsBalanceSummary/utils.tsx
@@ -11,6 +11,7 @@ export const getDefaultVendorsBalanceQuery = () => {
     asDate: moment().endOf('day').format('YYYY-MM-DD'),
     filterByOption: 'with-transactions',
     vendorsIds: [] as string[],
+    numberFormat: {},
   };
 };
 

--- a/packages/webapp/src/containers/FinancialStatements/VendorsTransactions/_utils.ts
+++ b/packages/webapp/src/containers/FinancialStatements/VendorsTransactions/_utils.ts
@@ -26,6 +26,7 @@ export const getVendorsTransactionsDefaultQuery = () => ({
   fromDate: moment().startOf('month').format('YYYY-MM-DD'),
   toDate: moment().format('YYYY-MM-DD'),
   vendorsIds: [] as string[],
+  numberFormat: {},
 });
 
 /**


### PR DESCRIPTION
## Description

The "Number format" dropdown had no effect in most financial reports. The `numberFormat` object selected by the user was silently dropped during query parsing because `transformToForm` only keeps URL query keys that exist in the report's default query object, and the reports' default queries no longer contained a `numberFormat` key. As a result, the `number_format` query parameters never reached the server, which fell back to its own defaults (2 decimals, no divide on 1000, etc.).

This is a regression introduced in commit `3ed024355` ("refactor(server): document numberFormat query param via @ApiQuery"), which removed `numberFormat` from the frontend default queries while only the server DTOs/SDK schema changes were intended.

### Changes

- Restore `numberFormat: {}` to the default query of the following reports so the URL value survives `transformToForm` and is sent to the server:
  - Balance Sheet
  - Trial Balance
  - Sales by Items
  - Purchases by Items
  - Inventory Valuation
  - Vendors Balance Summary
  - Customers Transactions
  - Vendors Transactions
  - Sales Tax Liability Summary
- Allow `precision: 0` (the "$1" decimal option) on the server by replacing `@IsPositive` with `@Min(0)` on the `precision` field of `NumberFormatQueryDto`; previously it returned a 400 error.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- `tsc --noEmit` passes for the server package.
- `eslint` passes on all modified frontend files (no new warnings introduced by these changes).
- Frontend typecheck shows no new errors beyond pre-existing baseline errors (verified by comparing against the base branch).

Manual verification steps (when running the app):

1. Open a financial report (e.g. Balance Sheet).
2. Open the Number format dropdown and change decimal places to `$0.001` and enable "Divide on 1000", then Run.
3. Verify the URL contains `numberFormat[...]` params and the request to `/api/reports/...` carries `number_format[...]` params.
4. Verify the table cells are re-formatted accordingly.
5. Repeat for Trial Balance, Sales by Items, Purchases by Items, Inventory Valuation, Vendors Balance Summary, Customers/Vendors Transactions and Sales Tax Liability.
6. Set decimal places to `$1` (0 decimal places) and verify no 400 error is returned.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>
