### PR TITLE
fix(server): correct running balance of bank account transactions

### DIFF
--- a/packages/server/src/modules/BankingTransactions/queries/GetBankAccountTransactions/GetBankAccountTransactions.ts
+++ b/packages/server/src/modules/BankingTransactions/queries/GetBankAccountTransactions/GetBankAccountTransactions.ts
@@ -136,6 +136,8 @@ export class GetBankAccountTransactions extends FinancialSheet {
   private transactionRunningBalance = (
     transaction: ICashflowAccountTransaction,
   ): ICashflowAccountTransaction => {
+    const runningBalance = this.runningBalance.amount();
+
     const amount = transaction.deposit - transaction.withdrawal;
 
     const biggerThanZero = R.lt(0, amount);
@@ -145,8 +147,6 @@ export class GetBankAccountTransactions extends FinancialSheet {
 
     R.when(R.always(biggerThanZero), this.runningBalance.decrement)(absAmount);
     R.when(R.always(lowerThanZero), this.runningBalance.increment)(absAmount);
-
-    const runningBalance = this.runningBalance.amount();
 
     return {
       ...transaction,
@@ -163,10 +163,7 @@ export class GetBankAccountTransactions extends FinancialSheet {
   private transactionBalance = (
     transaction: ICashflowAccountTransaction,
   ): ICashflowAccountTransaction => {
-    const balance =
-      transaction.runningBalance +
-      transaction.withdrawal * -1 +
-      transaction.deposit;
+    const balance = transaction.runningBalance;
 
     return {
       ...transaction,


### PR DESCRIPTION
## Description

The running balance of bank account transactions was calculated incorrectly: each transaction row displayed the account balance **before** that transaction instead of **after** it (off-by-one).

Transactions are sorted newest-first, and the running balance closure is seeded with the page's opening balance (the balance after the newest transaction on the page). In `transactionRunningBalance`, the closure was mutated first (removing the current transaction's effect to walk back in time) and the value was captured **after** the mutation, so each row ended up with the balance of the previous (older) transaction.

Evidence:
- The DTO documents `runningBalance` as "The running balance after the transaction" (`BankTransactionResponse.dto.ts`).
- The `balance` field computed `runningBalance + withdrawal * -1 + deposit`, which equals the correct after-transaction balance — confirming the displayed `runningBalance` was shifted by exactly one transaction.
- The frontend "Running Balance" column renders `formattedRunningBalance`, so it displayed the wrong value.

### Fix

- `transactionRunningBalance`: capture `this.runningBalance.amount()` **before** applying the decrement/increment, so each row's `runningBalance` is the balance after that transaction.
- `transactionBalance`: set `balance = transaction.runningBalance` (the previous formula would double-count once `runningBalance` is already the after-balance).

No frontend change is required since the column already renders `formattedRunningBalance`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Verified the calculation against a known set of transactions: with true after-balances `220 / 250 / 50 / 100`, the previous code returned `250 / 50 / 100 / 0`; the fixed code returns the correct after-transaction balances.
- `tsc --noEmit` passes for the server package.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>
