### PR TITLE
fix(webapp): show loading skeleton in workspaces list table

### DIFF
--- a/packages/webapp/src/ee/workspaces/hooks/query/queries.ts
+++ b/packages/webapp/src/ee/workspaces/hooks/query/queries.ts
@@ -52,8 +52,6 @@ export function useWorkspaces(
         includeInactive: String(includeInactive),
         currentOrganizationId: currentOrganizationId ?? '',
       }),
-    initialDataUpdatedAt: 0,
-    initialData: [],
   });
 }
 


### PR DESCRIPTION
## Description

The "View All Workspaces" drawer (organizations list) table rendered empty while loading because the loading skeleton never appeared. The `useWorkspaces` query hook set `initialData: []` and `initialDataUpdatedAt: 0`, which in TanStack Query v5 keeps the query in `success` status immediately, so `isLoading` was always `false`. This also prevented the workspaces sidebar spinner from ever showing.

Removed `initialData`/`initialDataUpdatedAt` from the `useWorkspaces` hook so `isLoading` becomes `true` during the initial fetch and the `TableSkeletonRows` skeleton renders correctly. All consumers already guard against `undefined` data with optional chaining or `|| []`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Verified with `eslint` on the changed file.
- Ran `npm run typecheck` in `packages/webapp`; no new errors introduced (pre-existing errors in unrelated files remain unchanged).
- Manual test: opened "View All Workspaces" and confirmed the table shows the loading skeleton during fetch.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>
