### PR TITLE
fix(webapp): align universal search resource transformers with list API response shape

### DIFF
--- a/packages/webapp/src/hooks/query/GenericResource/index.tsx
+++ b/packages/webapp/src/hooks/query/GenericResource/index.tsx
@@ -62,39 +62,39 @@ function getResourceUrlFromType(type: string): string {
  * Transformes invoices to resource data.
  */
 const transformInvoices: ResourceDataTransformer = (response) => ({
-  items: response.data.sales_invoices,
+  items: response.data.data,
 });
 
 /**
  * Transformes items to resource data.
  */
 const transformItems: ResourceDataTransformer = (response) => ({
-  items: response.data.items,
+  items: response.data.data,
 });
 
 /**
  * Transformes payment receives to resource data.
  */
 const transformPaymentReceives: ResourceDataTransformer = (response) => ({
-  items: response.data.payment_receives,
+  items: response.data.data,
 });
 
 /**
  * Transformes customers to resoruce data.
  */
 const transformCustomers: ResourceDataTransformer = (response) => ({
-  items: response.data.customers,
+  items: response.data.data,
 });
 
 /**
  * Transformes customers to resoruce data.
  */
 const transformVendors: ResourceDataTransformer = (response) => ({
-  items: response.data.vendors,
+  items: response.data.data,
 });
 
 const transformPaymentMades: ResourceDataTransformer = (response) => ({
-  items: response.data.bill_payments,
+  items: response.data.data,
 });
 
 const transformSaleReceipts: ResourceDataTransformer = (response) => ({
@@ -102,15 +102,15 @@ const transformSaleReceipts: ResourceDataTransformer = (response) => ({
 });
 
 const transformBills: ResourceDataTransformer = (response) => ({
-  items: response.data.bills,
+  items: response.data.data,
 });
 
 const transformManualJournals: ResourceDataTransformer = (response) => ({
-  items: response.data.manual_journals,
+  items: response.data.data,
 });
 
 const transformsEstimates: ResourceDataTransformer = (response) => ({
-  items: response.data.sales_estimates,
+  items: response.data.data,
 });
 
 const transformAccounts: ResourceDataTransformer = (response) => ({
@@ -118,11 +118,11 @@ const transformAccounts: ResourceDataTransformer = (response) => ({
 });
 
 const transformCreditNotes: ResourceDataTransformer = (response) => ({
-  items: response.data.credit_notes,
+  items: response.data.data,
 });
 
 const transformVendorCredits: ResourceDataTransformer = (response) => ({
-  items: response.data.vendor_credits,
+  items: response.data.data,
 });
 
 /**


### PR DESCRIPTION
## Description

Fixed the universal search crash (`Uncaught TypeError: Cannot read properties of undefined (reading 'map')`) that occurred when typing a search character.

The resource transformers in `GenericResource/index.tsx` read the wrong response field for 11 of 13 list endpoints. After the server-side NestJS migration, every paginated list endpoint returns the array under `data` (e.g. `{ data: [...items], pagination, filter_meta }`), but the transformers still read legacy keys such as `sales_invoices`, `customers`, `items`, `bills`, etc. As a result, `resource.items` was `undefined` and `transfromResourceDataToSearch` crashed on `.map()`.

The transformers now read `response.data.data` for all list resources except `sale-receipts` and `accounts`, which already matched the current API shape.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Verified the response shape of all 13 list endpoints against the NestJS server getter services and ListResponse DTOs.
- Ran `eslint` and `tsc --noEmit` for the changed files with no new warnings or errors.
- Manually tested by opening universal search (Cmd+K), typing a character, and confirming results render without the runtime error.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>
