### PR TITLE
fix(warehouse-transfers): resolve detail drawer data, edit save, and inventory cost errors

### DIFF
--- a/packages/server/src/modules/WarehousesTransfers/WarehouseTransfers.controller.ts
+++ b/packages/server/src/modules/WarehousesTransfers/WarehouseTransfers.controller.ts
@@ -75,7 +75,7 @@ export class WarehouseTransfersController {
   /**
    * Edits warehouse transfer transaction.
    */
-  @Post(':id')
+  @Put(':id')
   @RequirePermission(WarehouseTransferAction.EDIT, AbilitySubject.Warehouse)
   @ApiOperation({ summary: 'Edit the given warehouse transfer transaction.' })
   @ApiResponse({
@@ -195,7 +195,7 @@ export class WarehouseTransfersController {
     const warehouseTransfer =
       await this.warehouseTransferApplication.getWarehouseTransfer(id);
 
-    return { data: warehouseTransfer };
+    return warehouseTransfer;
   }
 
   /**

--- a/packages/server/test/warehouse-transfers.e2e-spec.ts
+++ b/packages/server/test/warehouse-transfers.e2e-spec.ts
@@ -93,7 +93,7 @@ describe('Warehouse Transfers (e2e)', () => {
       .expect(200);
   });
 
-  it('/warehouse-transfers/:id (POST)', async () => {
+  it('/warehouse-transfers/:id (PUT)', async () => {
     const response = await request(app.getHttpServer())
       .post('/warehouse-transfers')
       .set('organization-id', orgainzationId)
@@ -102,7 +102,7 @@ describe('Warehouse Transfers (e2e)', () => {
     const transferId = response.body.id;
 
     return request(app.getHttpServer())
-      .post(`/warehouse-transfers/${transferId}`)
+      .put(`/warehouse-transfers/${transferId}`)
       .set('organization-id', orgainzationId)
       .set('Authorization', AuthorizationHeader)
       .send(createWarehouseTransferRequest())

--- a/packages/webapp/src/hooks/query/warehouses-transfers/queries.ts
+++ b/packages/webapp/src/hooks/query/warehouses-transfers/queries.ts
@@ -124,7 +124,7 @@ export function useWarehouseTransfer(
   props?: Omit<UseQueryOptions<WarehouseTransfer>, 'queryKey' | 'queryFn'>,
   _requestProps?: Record<string, unknown>,
 ) {
-  const fetcher = useApiFetcher();
+  const fetcher = useApiFetcher({ enableCamelCaseTransform: true });
   return useQuery({
     ...props,
     queryKey: warehousesTransfersKeys.detail(id),

--- a/shared/sdk-ts/openapi.json
+++ b/shared/sdk-ts/openapi.json
@@ -7142,7 +7142,7 @@
       }
     },
     "/api/warehouse-transfers/{id}": {
-      "post": {
+      "put": {
         "operationId": "WarehouseTransfersController_editWarehouseTransfer",
         "summary": "Edit the given warehouse transfer transaction.",
         "parameters": [

--- a/shared/sdk-ts/src/fetch-utils.ts
+++ b/shared/sdk-ts/src/fetch-utils.ts
@@ -14,13 +14,17 @@ import {
 
 /**
  * Splits a query object into a primitive-only payload and a per-call `init`
- * carrying any nested object values via the SDK's sentinel header. The
- * snake-case request middleware reads that header and re-serializes the
- * nested values as bracket-style query params (`number_format[no_cents]=true`)
- * so Express's `extended` qs parser can reconstruct them server-side.
+ * carrying any nested object or array values via the SDK's sentinel header.
+ * The snake-case request middleware reads that header and re-serializes the
+ * nested values as bracket-style query params (`number_format[no_cents]=true`,
+ * `items_ids[]=1003`) so Express's `extended` qs parser can reconstruct them
+ * server-side.
  *
  * openapi-typescript-fetch's built-in query serializer calls `String(value)`,
  * which would otherwise turn nested objects into the literal `[object Object]`.
+ * Arrays are routed the same way so that a single-element array is emitted as
+ * `key[]=value` instead of a bare scalar, which `qs` would parse as a string
+ * rather than an array.
  */
 export function withNestedQuery<T>(
   query: T,
@@ -32,7 +36,6 @@ export function withNestedQuery<T>(
     if (
       value !== null &&
       typeof value === 'object' &&
-      !Array.isArray(value) &&
       !(value instanceof Date) &&
       !(value instanceof Blob)
     ) {

--- a/shared/sdk-ts/src/inventory-cost.ts
+++ b/shared/sdk-ts/src/inventory-cost.ts
@@ -1,5 +1,6 @@
 import type { OpArgType } from 'openapi-typescript-fetch';
 import type { ApiFetcher } from './fetch-utils';
+import { withNestedQuery } from './fetch-utils';
 import { paths } from './schema';
 import { OpForPath, OpQueryParams } from './utils';
 
@@ -29,6 +30,7 @@ export async function fetchInventoryCostItems(
   query: GetInventoryItemsCostQuery
 ): Promise<GetInventoryItemsCostResponse> {
   const get = fetcher.path(INVENTORY_COST_ROUTES.ITEMS).method('get').create();
-  const { data } = await get(query as GetItemsCostArg);
+  const { payload, init } = withNestedQuery(query);
+  const { data } = await get(payload as GetItemsCostArg, init);
   return (data ?? { costs: [] }) as GetInventoryItemsCostResponse;
 }

--- a/shared/sdk-ts/src/schema.ts
+++ b/shared/sdk-ts/src/schema.ts
@@ -1869,9 +1869,9 @@ export interface paths {
         };
         /** Retrieve warehouse transfer transaction details. */
         get: operations["WarehouseTransfersController_getWarehouseTransfer"];
-        put?: never;
         /** Edit the given warehouse transfer transaction. */
-        post: operations["WarehouseTransfersController_editWarehouseTransfer"];
+        put: operations["WarehouseTransfersController_editWarehouseTransfer"];
+        post?: never;
         /** Delete the given warehouse transfer transaction. */
         delete: operations["WarehouseTransfersController_deleteWarehouseTransfer"];
         options?: never;


### PR DESCRIPTION
## Description

Fixes several issues in the Warehouse Transfers feature that left the details drawer and edit form without data and broke saving a single-item transfer.

- **Detail drawer showed no data**: the server wrapped the warehouse transfer detail response in `{ data: ... }`, but the SDK already unwraps the response body, so the drawer received `{ data: <transfer> }` and every field (`entries`, `transactionNumber`, `fromWarehouse`, ...) was `undefined`. The controller now returns the transfer directly, matching the SDK shape and OpenAPI spec.
- **Detail drawer/form fields empty**: the drawer and edit form were migrated to the typed camelCase SDK fields, but `useWarehouseTransfer` did not enable the response camelCase transform, so snake_case API keys left the header/form details empty. Enabled the transform to match the other detail queries.
- **Saving a transfer failed with 404**: the edit endpoint was registered as `POST /api/warehouse-transfers/:id` while every other module and the SDK use `PUT`, so `PUT /warehouse-transfers/:id` matched no route. Switched the controller to `@Put(':id')`, updated the e2e test, and regenerated the OpenAPI spec and SDK schema so the edit operation is declared as `PUT`.
- **Inventory cost request returned 400 for a single item**: `openapi-typescript-fetch` serializes array query params as repeated keys, so a single-element array (`itemsIds: ['1003']`) reached the server as a bare scalar that Express's `qs` parser reads as a string, failing the `@IsArray` validation. Arrays are now routed through the `withNestedQuery` sentinel header so the snake-case middleware emits bracket-style params (`items_ids[]=1003`), and `fetchInventoryCostItems` uses `withNestedQuery`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- `pnpm typecheck` passes for `@bigcapital/server`, `@bigcapital/webapp` (no new errors; pre-existing unrelated errors unchanged), and `@bigcapital/sdk-ts`.
- Rebuilt the SDK and verified the generated `openapi.json`/`schema.ts` diff is limited to the warehouse transfers edit method (`post` → `put`).
- Verified `withNestedQuery({ date, itemsIds: ['1003'] })` now serializes to `date=...&items_ids[]=1003`, which the server's `qs` parser reconstructs as an array.
- Updated `packages/server/test/warehouse-transfers.e2e-spec.ts` to exercise the edit endpoint via `PUT`.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>
