### PR TITLE
fix(server): format date field on quick inventory adjustment creation

### DIFF
--- a/packages/server/src/modules/InventoryAdjutments/commands/CreateQuickInventoryAdjustment.service.ts
+++ b/packages/server/src/modules/InventoryAdjutments/commands/CreateQuickInventoryAdjustment.service.ts
@@ -21,6 +21,7 @@ import { CreateQuickInventoryAdjustmentDto } from '../dtos/CreateQuickInventoryA
 import { TenancyContext } from '@/modules/Tenancy/TenancyContext.service';
 import { ERRORS } from '../constants/InventoryAdjustments.constants';
 import { TenantModelProxy } from '@/modules/System/models/TenantBaseModel';
+import { formatDateFields } from '@/utils/format-date-fields';
 
 @Injectable()
 export class CreateQuickInventoryAdjustmentService {
@@ -70,7 +71,10 @@ export class CreateQuickInventoryAdjustmentService {
       },
     ];
     const initialDTO = {
-      ...omit(adjustmentDTO, ['quantity', 'cost', 'itemId', 'publish']),
+      ...formatDateFields(
+        omit(adjustmentDTO, ['quantity', 'cost', 'itemId', 'publish']),
+        ['date'],
+      ),
       userId: authorizedUser.id,
       ...(adjustmentDTO.publish
         ? {


### PR DESCRIPTION
## Description

This PR fixes the date format handling when creating a quick inventory adjustment. The `date` field is now passed through `formatDateFields` to ensure it is normalized to `YYYY-MM-DD` before persistence, preventing date format inconsistencies when the adjustment is created from the quick action in the inventory adjustments list.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Manual testing by creating a quick inventory adjustment and verifying the stored date is correctly formatted.
- Existing inventory adjustment tests run locally pass.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>