### PR TITLE
fix(server): normalize single uncategorized transaction id query param

### DIFF
--- a/packages/server/src/modules/BankingMatching/BankingMatching.controller.ts
+++ b/packages/server/src/modules/BankingMatching/BankingMatching.controller.ts
@@ -15,6 +15,7 @@ import {
   Post,
   Query,
 } from '@nestjs/common';
+import { castArray } from 'lodash';
 import { BankingMatchingApplication } from './BankingMatchingApplication';
 import { MatchBankTransactionDto } from './dtos/MatchBankTransaction.dto';
 import { GetMatchedTransactionsQueryDto } from './dtos/GetMatchedTransactionsQuery.dto';
@@ -48,8 +49,12 @@ export class BankingMatchingController {
     @Query('uncategorizedTransactionIds') uncategorizedTransactionIds: number[],
     @Query() filter: GetMatchedTransactionsQueryDto,
   ) {
+    const ids = castArray(uncategorizedTransactionIds ?? []).map((id) =>
+      Number(id),
+    );
+
     return this.bankingMatchingApplication.getMatchedTransactions(
-      uncategorizedTransactionIds ?? [],
+      ids,
       filter as any,
     );
   }

--- a/shared/sdk-ts/src/bank-rules.ts
+++ b/shared/sdk-ts/src/bank-rules.ts
@@ -1,4 +1,5 @@
 import type { ApiFetcher } from './fetch-utils';
+import { withNestedQuery } from './fetch-utils';
 import { paths } from './schema';
 import { OpForPath, OpQueryParams, OpRequestBody, OpResponseBody } from './utils';
 
@@ -160,7 +161,11 @@ export async function fetchMatchedTransactions(
     .method('get')
     .create();
   const ids = uncategorizedTransactionIds.map(String);
-  const { data } = await get({ uncategorizedTransactionIds: ids, ...query });
+  const { payload, init } = withNestedQuery({
+    uncategorizedTransactionIds: ids,
+    ...query,
+  });
+  const { data } = await get(payload, init);
   return data;
 }
 


### PR DESCRIPTION
## Description

Fixes `GET /api/banking/matching/matched` throwing a MariaDB parse error (`where ID in '6'`) when a single uncategorized transaction id is passed as a query param.

When the endpoint receives a bare scalar query param (e.g. `?uncategorized_transaction_ids=6`), NestJS binds it as a string instead of an array. The controller then passes that string into the Knex `whereIn('id', uncategorizedTransactionIds)` call, generating invalid SQL (`where ID in '6'`) and a 500 error.

Changes:
- Server: normalize the `uncategorizedTransactionIds` query param into a real `number[]` using lodash `castArray` before invoking the matched-transactions service.
- SDK (`sdk-ts`): route the ids through `withNestedQuery` in `fetchMatchedTransactions`, emitting `uncategorized_transaction_ids[]=6` (bracket form) so the server's qs parser produces an array for single-element arrays.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Verified `tsc --noEmit` passes for both `packages/server` and `shared/sdk-ts`.
- Reproduced the failure against a running server with `curl 'http://localhost:4000/api/banking/matching/matched?uncategorized_transaction_ids=6'` and confirmed the fix returns a valid response instead of the SQL parse error.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>