### PR TITLE
fix(sdk-ts): pass Accept header via request headers in report export fetchers

### DIFF
--- a/shared/sdk-ts/src/reports/balance-sheet.ts
+++ b/shared/sdk-ts/src/reports/balance-sheet.ts
@@ -55,8 +55,11 @@ export async function fetchBalanceSheetCsv(
   query: BalanceSheetCsvQuery
 ): Promise<BalanceSheetCsvResponse> {
   const get = fetcher.path(BALANCE_SHEET_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/csv" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/csv" },
+  });
   return response.data as unknown as BalanceSheetCsvResponse;
 }
 
@@ -69,8 +72,11 @@ export async function fetchBalanceSheetXlsx(
   query: BalanceSheetXlsxQuery
 ): Promise<BalanceSheetXlsxResponse> {
   const get = fetcher.path(BALANCE_SHEET_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/xlsx" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/xlsx" },
+  });
   return response.data as unknown as BalanceSheetXlsxResponse;
 }
 
@@ -83,7 +89,10 @@ export async function fetchBalanceSheetPdf(
   query: BalanceSheetPdfQuery
 ): Promise<BalanceSheetPdfResponse> {
   const get = fetcher.path(BALANCE_SHEET_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/pdf" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/pdf" },
+  });
   return response.data as unknown as BalanceSheetPdfResponse;
 }

--- a/shared/sdk-ts/src/reports/cashflow.ts
+++ b/shared/sdk-ts/src/reports/cashflow.ts
@@ -55,8 +55,11 @@ export async function fetchCashflowStatementCsv(
   query: CashflowStatementCsvQuery
 ): Promise<CashflowStatementCsvResponse> {
   const get = fetcher.path(CASHFLOW_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/csv" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/csv" },
+  });
   return response.data as unknown as CashflowStatementCsvResponse;
 }
 
@@ -69,8 +72,11 @@ export async function fetchCashflowStatementXlsx(
   query: CashflowStatementXlsxQuery
 ): Promise<CashflowStatementXlsxResponse> {
   const get = fetcher.path(CASHFLOW_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/xlsx" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/xlsx" },
+  });
   return response.data as unknown as CashflowStatementXlsxResponse;
 }
 
@@ -83,7 +89,10 @@ export async function fetchCashflowStatementPdf(
   query: CashflowStatementPdfQuery
 ): Promise<CashflowStatementPdfResponse> {
   const get = fetcher.path(CASHFLOW_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/pdf" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/pdf" },
+  });
   return response.data as unknown as CashflowStatementPdfResponse;
 }

--- a/shared/sdk-ts/src/reports/customer-balance.ts
+++ b/shared/sdk-ts/src/reports/customer-balance.ts
@@ -55,8 +55,11 @@ export async function fetchCustomerBalanceCsv(
   query: CustomerBalanceCsvQuery
 ): Promise<CustomerBalanceCsvResponse> {
   const get = fetcher.path(CUSTOMER_BALANCE_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/csv" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/csv" },
+  });
   return response.data as unknown as CustomerBalanceCsvResponse;
 }
 
@@ -69,8 +72,11 @@ export async function fetchCustomerBalanceXlsx(
   query: CustomerBalanceXlsxQuery
 ): Promise<CustomerBalanceXlsxResponse> {
   const get = fetcher.path(CUSTOMER_BALANCE_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/xlsx" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/xlsx" },
+  });
   return response.data as unknown as CustomerBalanceXlsxResponse;
 }
 
@@ -83,7 +89,10 @@ export async function fetchCustomerBalancePdf(
   query: CustomerBalancePdfQuery
 ): Promise<CustomerBalancePdfResponse> {
   const get = fetcher.path(CUSTOMER_BALANCE_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/pdf" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/pdf" },
+  });
   return response.data as unknown as CustomerBalancePdfResponse;
 }

--- a/shared/sdk-ts/src/reports/general-ledger.ts
+++ b/shared/sdk-ts/src/reports/general-ledger.ts
@@ -55,8 +55,11 @@ export async function fetchGeneralLedgerCsv(
   query: GeneralLedgerCsvQuery
 ): Promise<GeneralLedgerCsvResponse> {
   const get = fetcher.path(GENERAL_LEDGER_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/csv" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/csv" },
+  });
   return response.data as unknown as GeneralLedgerCsvResponse;
 }
 
@@ -69,8 +72,11 @@ export async function fetchGeneralLedgerXlsx(
   query: GeneralLedgerXlsxQuery
 ): Promise<GeneralLedgerXlsxResponse> {
   const get = fetcher.path(GENERAL_LEDGER_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/xlsx" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/xlsx" },
+  });
   return response.data as unknown as GeneralLedgerXlsxResponse;
 }
 
@@ -83,7 +89,10 @@ export async function fetchGeneralLedgerPdf(
   query: GeneralLedgerPdfQuery
 ): Promise<GeneralLedgerPdfResponse> {
   const get = fetcher.path(GENERAL_LEDGER_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/pdf" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/pdf" },
+  });
   return response.data as unknown as GeneralLedgerPdfResponse;
 }

--- a/shared/sdk-ts/src/reports/inventory-details.ts
+++ b/shared/sdk-ts/src/reports/inventory-details.ts
@@ -55,8 +55,11 @@ export async function fetchInventoryItemDetailsCsv(
   query: InventoryItemDetailsCsvQuery
 ): Promise<InventoryItemDetailsCsvResponse> {
   const get = fetcher.path(INVENTORY_DETAILS_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/csv" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/csv" },
+  });
   return response.data as unknown as InventoryItemDetailsCsvResponse;
 }
 
@@ -69,8 +72,11 @@ export async function fetchInventoryItemDetailsXlsx(
   query: InventoryItemDetailsXlsxQuery
 ): Promise<InventoryItemDetailsXlsxResponse> {
   const get = fetcher.path(INVENTORY_DETAILS_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/xlsx" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/xlsx" },
+  });
   return response.data as unknown as InventoryItemDetailsXlsxResponse;
 }
 
@@ -83,7 +89,10 @@ export async function fetchInventoryItemDetailsPdf(
   query: InventoryItemDetailsPdfQuery
 ): Promise<InventoryItemDetailsPdfResponse> {
   const get = fetcher.path(INVENTORY_DETAILS_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/pdf" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/pdf" },
+  });
   return response.data as unknown as InventoryItemDetailsPdfResponse;
 }

--- a/shared/sdk-ts/src/reports/inventory-valuation.ts
+++ b/shared/sdk-ts/src/reports/inventory-valuation.ts
@@ -55,8 +55,11 @@ export async function fetchInventoryValuationCsv(
   query: InventoryValuationCsvQuery
 ): Promise<InventoryValuationCsvResponse> {
   const get = fetcher.path(INVENTORY_VALUATION_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/csv" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/csv" },
+  });
   return response.data as unknown as InventoryValuationCsvResponse;
 }
 
@@ -69,8 +72,11 @@ export async function fetchInventoryValuationXlsx(
   query: InventoryValuationXlsxQuery
 ): Promise<InventoryValuationXlsxResponse> {
   const get = fetcher.path(INVENTORY_VALUATION_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/xlsx" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/xlsx" },
+  });
   return response.data as unknown as InventoryValuationXlsxResponse;
 }
 
@@ -83,7 +89,10 @@ export async function fetchInventoryValuationPdf(
   query: InventoryValuationPdfQuery
 ): Promise<InventoryValuationPdfResponse> {
   const get = fetcher.path(INVENTORY_VALUATION_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/pdf" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/pdf" },
+  });
   return response.data as unknown as InventoryValuationPdfResponse;
 }

--- a/shared/sdk-ts/src/reports/journal.ts
+++ b/shared/sdk-ts/src/reports/journal.ts
@@ -55,8 +55,11 @@ export async function fetchJournalCsv(
   query: JournalCsvQuery
 ): Promise<JournalCsvResponse> {
   const get = fetcher.path(JOURNAL_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/csv" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/csv" },
+  });
   return response.data as unknown as JournalCsvResponse;
 }
 
@@ -69,8 +72,11 @@ export async function fetchJournalXlsx(
   query: JournalXlsxQuery
 ): Promise<JournalXlsxResponse> {
   const get = fetcher.path(JOURNAL_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/xlsx" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/xlsx" },
+  });
   return response.data as unknown as JournalXlsxResponse;
 }
 
@@ -83,7 +89,10 @@ export async function fetchJournalPdf(
   query: JournalPdfQuery
 ): Promise<JournalPdfResponse> {
   const get = fetcher.path(JOURNAL_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/pdf" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/pdf" },
+  });
   return response.data as unknown as JournalPdfResponse;
 }

--- a/shared/sdk-ts/src/reports/payable-aging.ts
+++ b/shared/sdk-ts/src/reports/payable-aging.ts
@@ -55,8 +55,11 @@ export async function fetchPayableAgingCsv(
   query: PayableAgingCsvQuery
 ): Promise<PayableAgingCsvResponse> {
   const get = fetcher.path(PAYABLE_AGING_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/csv" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/csv" },
+  });
   return response.data as unknown as PayableAgingCsvResponse;
 }
 
@@ -69,8 +72,11 @@ export async function fetchPayableAgingXlsx(
   query: PayableAgingXlsxQuery
 ): Promise<PayableAgingXlsxResponse> {
   const get = fetcher.path(PAYABLE_AGING_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/xlsx" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/xlsx" },
+  });
   return response.data as unknown as PayableAgingXlsxResponse;
 }
 
@@ -83,7 +89,10 @@ export async function fetchPayableAgingPdf(
   query: PayableAgingPdfQuery
 ): Promise<PayableAgingPdfResponse> {
   const get = fetcher.path(PAYABLE_AGING_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/pdf" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/pdf" },
+  });
   return response.data as unknown as PayableAgingPdfResponse;
 }

--- a/shared/sdk-ts/src/reports/profit-loss.ts
+++ b/shared/sdk-ts/src/reports/profit-loss.ts
@@ -55,8 +55,11 @@ export async function fetchProfitLossCsv(
   query: ProfitLossCsvQuery
 ): Promise<ProfitLossCsvResponse> {
   const get = fetcher.path(PROFIT_LOSS_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/csv" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/csv" },
+  });
   return response.data as unknown as ProfitLossCsvResponse;
 }
 
@@ -69,8 +72,11 @@ export async function fetchProfitLossXlsx(
   query: ProfitLossXlsxQuery
 ): Promise<ProfitLossXlsxResponse> {
   const get = fetcher.path(PROFIT_LOSS_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/xlsx" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/xlsx" },
+  });
   return response.data as unknown as ProfitLossXlsxResponse;
 }
 
@@ -83,7 +89,10 @@ export async function fetchProfitLossPdf(
   query: ProfitLossPdfQuery
 ): Promise<ProfitLossPdfResponse> {
   const get = fetcher.path(PROFIT_LOSS_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/pdf" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/pdf" },
+  });
   return response.data as unknown as ProfitLossPdfResponse;
 }

--- a/shared/sdk-ts/src/reports/purchases-by-items.ts
+++ b/shared/sdk-ts/src/reports/purchases-by-items.ts
@@ -55,8 +55,11 @@ export async function fetchPurchasesByItemsCsv(
   query: PurchasesByItemsCsvQuery
 ): Promise<PurchasesByItemsCsvResponse> {
   const get = fetcher.path(PURCHASES_BY_ITEMS_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/csv" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/csv" },
+  });
   return response.data as unknown as PurchasesByItemsCsvResponse;
 }
 
@@ -69,8 +72,11 @@ export async function fetchPurchasesByItemsXlsx(
   query: PurchasesByItemsXlsxQuery
 ): Promise<PurchasesByItemsXlsxResponse> {
   const get = fetcher.path(PURCHASES_BY_ITEMS_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/xlsx" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/xlsx" },
+  });
   return response.data as unknown as PurchasesByItemsXlsxResponse;
 }
 
@@ -83,7 +89,10 @@ export async function fetchPurchasesByItemsPdf(
   query: PurchasesByItemsPdfQuery
 ): Promise<PurchasesByItemsPdfResponse> {
   const get = fetcher.path(PURCHASES_BY_ITEMS_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/pdf" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/pdf" },
+  });
   return response.data as unknown as PurchasesByItemsPdfResponse;
 }

--- a/shared/sdk-ts/src/reports/receivable-aging.ts
+++ b/shared/sdk-ts/src/reports/receivable-aging.ts
@@ -55,8 +55,11 @@ export async function fetchReceivableAgingCsv(
   query: ReceivableAgingCsvQuery
 ): Promise<ReceivableAgingCsvResponse> {
   const get = fetcher.path(RECEIVABLE_AGING_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/csv" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/csv" },
+  });
   return response.data as unknown as ReceivableAgingCsvResponse;
 }
 
@@ -69,8 +72,11 @@ export async function fetchReceivableAgingXlsx(
   query: ReceivableAgingXlsxQuery
 ): Promise<ReceivableAgingXlsxResponse> {
   const get = fetcher.path(RECEIVABLE_AGING_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/xlsx" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/xlsx" },
+  });
   return response.data as unknown as ReceivableAgingXlsxResponse;
 }
 
@@ -83,7 +89,10 @@ export async function fetchReceivableAgingPdf(
   query: ReceivableAgingPdfQuery
 ): Promise<ReceivableAgingPdfResponse> {
   const get = fetcher.path(RECEIVABLE_AGING_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/pdf" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/pdf" },
+  });
   return response.data as unknown as ReceivableAgingPdfResponse;
 }

--- a/shared/sdk-ts/src/reports/sales-by-items.ts
+++ b/shared/sdk-ts/src/reports/sales-by-items.ts
@@ -55,8 +55,11 @@ export async function fetchSalesByItemsCsv(
   query: SalesByItemsCsvQuery
 ): Promise<SalesByItemsCsvResponse> {
   const get = fetcher.path(SALES_BY_ITEMS_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/csv" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/csv" },
+  });
   return response.data as unknown as SalesByItemsCsvResponse;
 }
 
@@ -69,8 +72,11 @@ export async function fetchSalesByItemsXlsx(
   query: SalesByItemsXlsxQuery
 ): Promise<SalesByItemsXlsxResponse> {
   const get = fetcher.path(SALES_BY_ITEMS_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/xlsx" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/xlsx" },
+  });
   return response.data as unknown as SalesByItemsXlsxResponse;
 }
 
@@ -83,7 +89,10 @@ export async function fetchSalesByItemsPdf(
   query: SalesByItemsPdfQuery
 ): Promise<SalesByItemsPdfResponse> {
   const get = fetcher.path(SALES_BY_ITEMS_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/pdf" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/pdf" },
+  });
   return response.data as unknown as SalesByItemsPdfResponse;
 }

--- a/shared/sdk-ts/src/reports/sales-tax-liability.ts
+++ b/shared/sdk-ts/src/reports/sales-tax-liability.ts
@@ -55,8 +55,11 @@ export async function fetchSalesTaxLiabilityCsv(
   query: SalesTaxLiabilityCsvQuery
 ): Promise<SalesTaxLiabilityCsvResponse> {
   const get = fetcher.path(SALES_TAX_LIABILITY_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/csv" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/csv" },
+  });
   return response.data as unknown as SalesTaxLiabilityCsvResponse;
 }
 
@@ -69,8 +72,11 @@ export async function fetchSalesTaxLiabilityXlsx(
   query: SalesTaxLiabilityXlsxQuery
 ): Promise<SalesTaxLiabilityXlsxResponse> {
   const get = fetcher.path(SALES_TAX_LIABILITY_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/xlsx" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/xlsx" },
+  });
   return response.data as unknown as SalesTaxLiabilityXlsxResponse;
 }
 
@@ -83,7 +89,10 @@ export async function fetchSalesTaxLiabilityPdf(
   query: SalesTaxLiabilityPdfQuery
 ): Promise<SalesTaxLiabilityPdfResponse> {
   const get = fetcher.path(SALES_TAX_LIABILITY_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/pdf" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/pdf" },
+  });
   return response.data as unknown as SalesTaxLiabilityPdfResponse;
 }

--- a/shared/sdk-ts/src/reports/transactions-customers.ts
+++ b/shared/sdk-ts/src/reports/transactions-customers.ts
@@ -55,8 +55,11 @@ export async function fetchTransactionsByCustomersCsv(
   query: TransactionsByCustomersCsvQuery
 ): Promise<TransactionsByCustomersCsvResponse> {
   const get = fetcher.path(TRANSACTIONS_CUSTOMERS_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/csv" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/csv" },
+  });
   return response.data as unknown as TransactionsByCustomersCsvResponse;
 }
 
@@ -69,8 +72,11 @@ export async function fetchTransactionsByCustomersXlsx(
   query: TransactionsByCustomersXlsxQuery
 ): Promise<TransactionsByCustomersXlsxResponse> {
   const get = fetcher.path(TRANSACTIONS_CUSTOMERS_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/xlsx" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/xlsx" },
+  });
   return response.data as unknown as TransactionsByCustomersXlsxResponse;
 }
 
@@ -83,7 +89,10 @@ export async function fetchTransactionsByCustomersPdf(
   query: TransactionsByCustomersPdfQuery
 ): Promise<TransactionsByCustomersPdfResponse> {
   const get = fetcher.path(TRANSACTIONS_CUSTOMERS_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/pdf" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/pdf" },
+  });
   return response.data as unknown as TransactionsByCustomersPdfResponse;
 }

--- a/shared/sdk-ts/src/reports/transactions-reference.ts
+++ b/shared/sdk-ts/src/reports/transactions-reference.ts
@@ -55,8 +55,11 @@ export async function fetchTransactionsByReferenceCsv(
   query: TransactionsByReferenceCsvQuery
 ): Promise<TransactionsByReferenceCsvResponse> {
   const get = fetcher.path(TRANSACTIONS_REFERENCE_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/csv" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/csv" },
+  });
   return response.data as unknown as TransactionsByReferenceCsvResponse;
 }
 
@@ -69,8 +72,11 @@ export async function fetchTransactionsByReferenceXlsx(
   query: TransactionsByReferenceXlsxQuery
 ): Promise<TransactionsByReferenceXlsxResponse> {
   const get = fetcher.path(TRANSACTIONS_REFERENCE_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/xlsx" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/xlsx" },
+  });
   return response.data as unknown as TransactionsByReferenceXlsxResponse;
 }
 
@@ -83,7 +89,10 @@ export async function fetchTransactionsByReferencePdf(
   query: TransactionsByReferencePdfQuery
 ): Promise<TransactionsByReferencePdfResponse> {
   const get = fetcher.path(TRANSACTIONS_REFERENCE_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/pdf" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/pdf" },
+  });
   return response.data as unknown as TransactionsByReferencePdfResponse;
 }

--- a/shared/sdk-ts/src/reports/transactions-vendors.ts
+++ b/shared/sdk-ts/src/reports/transactions-vendors.ts
@@ -55,8 +55,11 @@ export async function fetchTransactionsByVendorsCsv(
   query: TransactionsByVendorsCsvQuery
 ): Promise<TransactionsByVendorsCsvResponse> {
   const get = fetcher.path(TRANSACTIONS_VENDORS_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/csv" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/csv" },
+  });
   return response.data as unknown as TransactionsByVendorsCsvResponse;
 }
 
@@ -69,8 +72,11 @@ export async function fetchTransactionsByVendorsXlsx(
   query: TransactionsByVendorsXlsxQuery
 ): Promise<TransactionsByVendorsXlsxResponse> {
   const get = fetcher.path(TRANSACTIONS_VENDORS_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/xlsx" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/xlsx" },
+  });
   return response.data as unknown as TransactionsByVendorsXlsxResponse;
 }
 
@@ -83,7 +89,10 @@ export async function fetchTransactionsByVendorsPdf(
   query: TransactionsByVendorsPdfQuery
 ): Promise<TransactionsByVendorsPdfResponse> {
   const get = fetcher.path(TRANSACTIONS_VENDORS_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/pdf" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/pdf" },
+  });
   return response.data as unknown as TransactionsByVendorsPdfResponse;
 }

--- a/shared/sdk-ts/src/reports/trial-balance.ts
+++ b/shared/sdk-ts/src/reports/trial-balance.ts
@@ -55,8 +55,11 @@ export async function fetchTrialBalanceCsv(
   query: TrialBalanceCsvQuery
 ): Promise<TrialBalanceCsvResponse> {
   const get = fetcher.path(TRIAL_BALANCE_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/csv" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/csv" },
+  });
   return response.data as unknown as TrialBalanceCsvResponse;
 }
 
@@ -69,8 +72,11 @@ export async function fetchTrialBalanceXlsx(
   query: TrialBalanceXlsxQuery
 ): Promise<TrialBalanceXlsxResponse> {
   const get = fetcher.path(TRIAL_BALANCE_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/xlsx" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/xlsx" },
+  });
   return response.data as unknown as TrialBalanceXlsxResponse;
 }
 
@@ -83,7 +89,10 @@ export async function fetchTrialBalancePdf(
   query: TrialBalancePdfQuery
 ): Promise<TrialBalancePdfResponse> {
   const get = fetcher.path(TRIAL_BALANCE_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/pdf" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/pdf" },
+  });
   return response.data as unknown as TrialBalancePdfResponse;
 }

--- a/shared/sdk-ts/src/reports/vendor-balance.ts
+++ b/shared/sdk-ts/src/reports/vendor-balance.ts
@@ -55,8 +55,11 @@ export async function fetchVendorBalanceCsv(
   query: VendorBalanceCsvQuery
 ): Promise<VendorBalanceCsvResponse> {
   const get = fetcher.path(VENDOR_BALANCE_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/csv" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/csv" },
+  });
   return response.data as unknown as VendorBalanceCsvResponse;
 }
 
@@ -69,8 +72,11 @@ export async function fetchVendorBalanceXlsx(
   query: VendorBalanceXlsxQuery
 ): Promise<VendorBalanceXlsxResponse> {
   const get = fetcher.path(VENDOR_BALANCE_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/xlsx" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/xlsx" },
+  });
   return response.data as unknown as VendorBalanceXlsxResponse;
 }
 
@@ -83,7 +89,10 @@ export async function fetchVendorBalancePdf(
   query: VendorBalancePdfQuery
 ): Promise<VendorBalancePdfResponse> {
   const get = fetcher.path(VENDOR_BALANCE_ROUTE).method('get').create();
-  const { payload, init } = withNestedQuery({ ...query, Accept: "application/pdf" } as Record<string, unknown>);
-  const response = await get(payload as Arg, init);
+  const { payload, init } = withNestedQuery(query);
+  const response = await get(payload as Arg, {
+    ...init,
+    headers: { ...init?.headers, accept: "application/pdf" },
+  });
   return response.data as unknown as VendorBalancePdfResponse;
 }


### PR DESCRIPTION
## Description

Moves the `Accept` header out of the query string and into request headers for the sdk-ts financial statement report export fetchers (CSV, XLSX, PDF). This prevents the `Accept` value from being serialized as a query parameter and correctly conveys the desired response format via HTTP headers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Not tested locally. The change is limited to how the header is passed to the underlying `openapi-typescript-fetch` request init; the report export fetchers compile against the existing types.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>