### PR TITLE
fix(webapp): open customize report drawer in financial reports

### DIFF
--- a/packages/webapp/src/containers/FinancialStatements/ProfitLossSheet/ProfitLossActionsBar.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/ProfitLossSheet/ProfitLossActionsBar.tsx
@@ -48,7 +48,7 @@ function ProfitLossActionsBarInner({
   const { sheetRefetch, isLoading } = useProfitLossSheetContext();
 
   const handleFilterClick = () => {
-    toggleFilterDrawer(false);
+    toggleFilterDrawer();
   };
 
   const handleRecalcReport = () => {

--- a/packages/webapp/src/containers/FinancialStatements/VendorsBalanceSummary/VendorsBalanceSummaryActionsBar.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/VendorsBalanceSummary/VendorsBalanceSummaryActionsBar.tsx
@@ -60,7 +60,7 @@ function VendorsBalanceSummaryActionsBarInner({
     useVendorsBalanceSummaryContext();
 
   const handleFilterToggleClick = () => {
-    toggleVendorSummaryFilterDrawer(false);
+    toggleVendorSummaryFilterDrawer();
   };
 
   // handle recalculate report button.

--- a/packages/webapp/src/containers/FinancialStatements/VendorsTransactions/VendorsTransactionsActionsBar.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/VendorsTransactions/VendorsTransactionsActionsBar.tsx
@@ -64,7 +64,7 @@ function VendorsTransactionsActionsBarInner({
 
   // Handle filter toggle click.
   const handleFilterToggleClick = () => {
-    toggleVendorsTransactionsFilterDrawer(false);
+    toggleVendorsTransactionsFilterDrawer();
   };
 
   // Handle recalculate the report button.


### PR DESCRIPTION
## Description

The "Customize report" button in the actions bar failed to open the customizer drawer for the Profit and Loss, Vendors Balance Summary, and Vendors Transactions reports. The toggle handler passed `false` to the filter drawer toggle action, so the drawer was always forced closed and never opened.

This change removes the argument so the action toggles the drawer state instead, matching the pattern used by every other financial report actions bar.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

The drawer toggle action was already implemented to toggle, and sibling reports (e.g. Customers Balance Summary, General Ledger) already follow the no-argument pattern. The fix aligns these three reports with the working pattern. Verification done by code inspection; UI verification should confirm the customizer drawer now opens/closes on each of the three reports.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>