### PR TITLE
fix(webapp): items filter and percentage column in financial reports

### DIFF
--- a/packages/webapp/src/containers/FinancialStatements/CustomersBalanceSummary/CustomersBalanceSummaryGeneralPanelContent.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/CustomersBalanceSummary/CustomersBalanceSummaryGeneralPanelContent.tsx
@@ -44,12 +44,12 @@ export function CustomersBalanceSummaryGeneralPanelContent() {
       <Row>
         <Col xs={5}>
           <FFormGroup
-            name={'percentage_column'}
+            name={'percentageColumn'}
             labelInfo={<FieldHint />}
             fastField
           >
             <FCheckbox
-              name={'percentage_column'}
+              name={'percentageColumn'}
               inline={true}
               label={intl.get('percentage_of_column')}
               fastField

--- a/packages/webapp/src/containers/FinancialStatements/CustomersBalanceSummary/utils.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/CustomersBalanceSummary/utils.tsx
@@ -2,7 +2,6 @@ import { castArray } from 'lodash';
 import moment from 'moment';
 import { useMemo } from 'react';
 import * as Yup from 'yup';
-import { getDefaultARAgingSummaryQuery } from '../ARAgingSummary/common';
 import { useAppQueryString } from '@/hooks';
 import { transformToForm } from '@/utils';
 
@@ -14,6 +13,8 @@ export const getDefaultCustomersBalanceQuery = () => {
     asDate: moment().endOf('day').format('YYYY-MM-DD'),
     filterByOption: 'with-transactions',
     customersIds: [],
+    numberFormat: {},
+    percentageColumn: false,
   };
 };
 
@@ -30,7 +31,7 @@ export const getCustomersBalanceQuerySchema = () => {
 const parseCustomersBalanceSummaryQuery = (
   locationQuery: Record<string, unknown>,
 ) => {
-  const defaultQuery = getDefaultARAgingSummaryQuery();
+  const defaultQuery = getDefaultCustomersBalanceQuery();
 
   const transformed = {
     ...defaultQuery,

--- a/packages/webapp/src/containers/FinancialStatements/PurchasesByItems/PurchasesByItemsGeneralPanelProvider.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/PurchasesByItems/PurchasesByItemsGeneralPanelProvider.tsx
@@ -33,7 +33,7 @@ function PurchasesByItemsGeneralPanelProvider({
   });
 
   const provider: PurchasesByItemsGeneralPanelContextValue = {
-    items: (itemsData as any)?.items,
+    items: (itemsData as any)?.data,
     isItemsLoading,
     isItemsFetching,
   };

--- a/packages/webapp/src/containers/FinancialStatements/SalesByItems/SalesByItemsHeaderGeneralPanelProvider.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/SalesByItems/SalesByItemsHeaderGeneralPanelProvider.tsx
@@ -36,7 +36,7 @@ function SalesByItemGeneralPanelProvider({
   });
 
   const provider: SalesByItemGeneralPanelContextValue = {
-    items: (itemsData as any)?.items,
+    items: (itemsData as any)?.data,
     isItemsLoading,
     isItemsFetching,
   };

--- a/packages/webapp/src/containers/FinancialStatements/VendorsBalanceSummary/VendorsBalanceSummaryHeaderGeneralContent.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/VendorsBalanceSummary/VendorsBalanceSummaryHeaderGeneralContent.tsx
@@ -58,14 +58,14 @@ export function VendorsBalanceSummaryHeaderGeneralContent() {
 
       <Row>
         <Col xs={5}>
-          <FastField name={'percentage_column'} type={'checkbox'}>
+          <FastField name={'percentageColumn'} type={'checkbox'}>
             {({ field }: { field: any }) => (
               <FormGroup labelInfo={<FieldHint />}>
                 <Checkbox
                   inline={true}
                   small={true}
                   label={intl.get('percentage_of_column')}
-                  name={'percentage_column'}
+                  name={'percentageColumn'}
                   {...field}
                 />
               </FormGroup>

--- a/packages/webapp/src/containers/FinancialStatements/VendorsBalanceSummary/utils.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/VendorsBalanceSummary/utils.tsx
@@ -12,6 +12,7 @@ export const getDefaultVendorsBalanceQuery = () => {
     filterByOption: 'with-transactions',
     vendorsIds: [] as string[],
     numberFormat: {},
+    percentageColumn: false,
   };
 };
 


### PR DESCRIPTION
## Description

This PR fixes two bugs in the financial statement reports (webapp):

1. **Items multi-select shows no items in Sales by Items and Purchases by Items reports** — The general panel providers read the items from the API response as `itemsData.items`, but `/api/items` returns items under the `data` field. As a result the "Specific items" multi-select field rendered an empty list. Fixed both providers to read `itemsData.data`.

2. **Percentage column not shown in Customers/Vendors Balance Summary** — The "% of column" checkbox value was stored under `percentage_column`, which `transformToForm` dropped during query parsing because it was missing from the report's default query. The flag therefore never reached the API and the server never included the percentage column. Aligned the checkbox field name with the API's `percentageColumn` param and added `percentageColumn: false` to both default queries. The Customers Balance Summary parser now uses its own report default query instead of the AR Aging default.

**Dependencies:** None.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Ran `npm run typecheck` for the webapp — no new type errors introduced (pre-existing errors unrelated to these changes).
- Ran ESLint on all modified files — no new warnings or errors.
- Verified the query plumbing end-to-end: the `percentageColumn` flag now survives query parsing and serializes to the `percentage_column` wire param expected by the server's `SerializeInterceptor`.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>