### PR TITLE
feat: add sms notification feature flag

### DIFF
--- a/packages/server/src/common/types/Features.ts
+++ b/packages/server/src/common/types/Features.ts
@@ -3,6 +3,7 @@ export enum Features {
   BRANCHES = 'branches',
   BankSyncing = 'BankSyncing',
   LANDED_COST = 'landed_cost',
+  SMS_NOTIFICATION = 'sms_notification',
 }
 
 export interface IFeatureAllItem {

--- a/packages/server/src/constants/metable-options.ts
+++ b/packages/server/src/constants/metable-options.ts
@@ -268,5 +268,8 @@ export const SettingsOptions = {
     landed_cost: {
       type: 'boolean',
     },
+    sms_notification: {
+      type: 'boolean',
+    },
   },
 };

--- a/packages/server/src/modules/Features/FeaturesConfigure.ts
+++ b/packages/server/src/modules/Features/FeaturesConfigure.ts
@@ -30,6 +30,10 @@ export class FeaturesConfigure {
         name: Features.LANDED_COST,
         defaultValue: false,
       },
+      {
+        name: Features.SMS_NOTIFICATION,
+        defaultValue: false,
+      },
     ];
   }
 }

--- a/packages/server/src/modules/Features/SmsNotificationFeatureGuard.ts
+++ b/packages/server/src/modules/Features/SmsNotificationFeatureGuard.ts
@@ -1,0 +1,31 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { Features } from '@/common/types/Features';
+import { FeaturesManager } from './FeaturesManager';
+import { ServiceError } from '@/modules/Items/ServiceError';
+
+/**
+ * Guard that rejects the SMS notification endpoints once the SMS notification
+ * feature is not enabled.
+ */
+@Injectable()
+export class SmsNotificationFeatureGuard implements CanActivate {
+  constructor(private readonly featuresManager: FeaturesManager) {}
+
+  /**
+   * Validates the SMS notification feature is accessible.
+   * @param {ExecutionContext} _context
+   * @returns {Promise<boolean>}
+   */
+  async canActivate(_context: ExecutionContext): Promise<boolean> {
+    const isAccessible = await this.featuresManager.accessible(
+      Features.SMS_NOTIFICATION,
+    );
+    if (!isAccessible) {
+      throw new ServiceError(
+        'SMS_NOTIFICATION_FEATURE_NOT_ENABLED',
+        'The SMS notification feature is not enabled.',
+      );
+    }
+    return true;
+  }
+}

--- a/packages/server/src/modules/SaleEstimates/SaleEstimates.controller.ts
+++ b/packages/server/src/modules/SaleEstimates/SaleEstimates.controller.ts
@@ -46,6 +46,7 @@ import { PermissionGuard } from '@/modules/Roles/Permission.guard';
 import { AuthorizationGuard } from '@/modules/Roles/Authorization.guard';
 import { AbilitySubject } from '@/modules/Roles/Roles.types';
 import { SaleEstimateAction } from './types/SaleEstimates.types';
+import { SmsNotificationFeatureGuard } from '../Features/SmsNotificationFeatureGuard';
 
 @Controller('sale-estimates')
 @ApiTags('Sale Estimates')
@@ -255,6 +256,7 @@ export class SaleEstimatesController {
   }
 
   @Post(':id/notify-sms')
+  @UseGuards(SmsNotificationFeatureGuard)
   @RequirePermission(
     SaleEstimateAction.NotifyBySms,
     AbilitySubject.SaleEstimate,
@@ -275,6 +277,7 @@ export class SaleEstimatesController {
   }
 
   @Get(':id/sms-details')
+  @UseGuards(SmsNotificationFeatureGuard)
   @RequirePermission(SaleEstimateAction.View, AbilitySubject.SaleEstimate)
   @ApiOperation({ summary: 'Retrieves the sale estimate SMS details.' })
   public getSaleEstimateSmsDetails(

--- a/packages/server/src/modules/SaleEstimates/SaleEstimates.module.ts
+++ b/packages/server/src/modules/SaleEstimates/SaleEstimates.module.ts
@@ -44,6 +44,8 @@ import { SaleEstimateAutoIncrementSubscriber } from './subscribers/SaleEstimateA
 import { BulkDeleteSaleEstimatesService } from './BulkDeleteSaleEstimates.service';
 import { ValidateBulkDeleteSaleEstimatesService } from './ValidateBulkDeleteSaleEstimates.service';
 import { SendSaleEstimateMailProcess } from './processes/SendSaleEstimateMail.process';
+import { FeaturesModule } from '../Features/Features.module';
+import { SmsNotificationFeatureGuard } from '../Features/SmsNotificationFeatureGuard';
 
 @Module({
   imports: [
@@ -60,6 +62,7 @@ import { SendSaleEstimateMailProcess } from './processes/SendSaleEstimateMail.pr
       name: SendSaleEstimateMailQueue,
       adapter: BullMQAdapter,
     }),
+    FeaturesModule,
   ],
   controllers: [SaleEstimatesController],
   providers: [
@@ -95,6 +98,7 @@ import { SendSaleEstimateMailProcess } from './processes/SendSaleEstimateMail.pr
     BulkDeleteSaleEstimatesService,
     ValidateBulkDeleteSaleEstimatesService,
     SendSaleEstimateMailProcess,
+    SmsNotificationFeatureGuard,
   ],
   exports: [
     SaleEstimatesExportable,

--- a/packages/webapp/src/components/DialogsContainer.tsx
+++ b/packages/webapp/src/components/DialogsContainer.tsx
@@ -84,20 +84,24 @@ export default function DialogsContainer() {
       <MoneyInDialog dialogName={DialogsName.MoneyInForm} />
       <MoneyOutDialog dialogName={DialogsName.MoneyOutForm} />
 
-      <NotifyInvoiceViaSMSDialog
-        dialogName={DialogsName.NotifyInvoiceViaForm}
-      />
-      <NotifyReceiptViaSMSDialog
-        dialogName={DialogsName.NotifyReceiptViaForm}
-      />
-      <NotifyEstimateViaSMSDialog
-        dialogName={DialogsName.NotifyEstimateViaForm}
-      />
-      <NotifyPaymentReceiveViaSMSDialog
-        dialogName={DialogsName.NotifyPaymentViaForm}
-      />
+      <FeatureCan feature={Features.SmsNotification}>
+        <NotifyInvoiceViaSMSDialog
+          dialogName={DialogsName.NotifyInvoiceViaForm}
+        />
+        <NotifyReceiptViaSMSDialog
+          dialogName={DialogsName.NotifyReceiptViaForm}
+        />
+        <NotifyEstimateViaSMSDialog
+          dialogName={DialogsName.NotifyEstimateViaForm}
+        />
+        <NotifyPaymentReceiveViaSMSDialog
+          dialogName={DialogsName.NotifyPaymentViaForm}
+        />
+      </FeatureCan>
       <BadDebtDialog dialogName={DialogsName.BadDebtForm} />
-      <SMSMessageDialog dialogName={DialogsName.SMSMessageForm} />
+      <FeatureCan feature={Features.SmsNotification}>
+        <SMSMessageDialog dialogName={DialogsName.SMSMessageForm} />
+      </FeatureCan>
       <RefundCreditNoteDialog dialogName={DialogsName.RefundCreditNote} />
       <RefundVendorCreditDialog dialogName={DialogsName.RefundVendorCredit} />
       <ReconcileCreditNoteDialog dialogName={DialogsName.ReconcileCreditNote} />

--- a/packages/webapp/src/components/Preferences/PreferencesContentRoute.tsx
+++ b/packages/webapp/src/components/Preferences/PreferencesContentRoute.tsx
@@ -3,10 +3,14 @@ import { Spinner } from '@blueprintjs/core';
 import React, { Suspense } from 'react';
 import { Route, Switch } from 'react-router-dom';
 import { Box } from '../Layout';
+import { useFeatureCan } from '@/hooks/state/feature';
 import { getPreferenceRoutes } from '@/routes/preferences';
 
 export default function DashboardContentRoute() {
-  const preferencesRoutes = getPreferenceRoutes();
+  const { featureCan } = useFeatureCan();
+  const preferencesRoutes = getPreferenceRoutes().filter(
+    (route) => !route.feature || featureCan(route.feature),
+  );
 
   return (
     <Route pathname="/preferences">

--- a/packages/webapp/src/components/Preferences/PreferencesSidebar.tsx
+++ b/packages/webapp/src/components/Preferences/PreferencesSidebar.tsx
@@ -5,6 +5,7 @@ import { useHistory, useLocation } from 'react-router-dom';
 import PreferencesSidebarContainer from './PreferencesSidebarContainer';
 import { FormattedMessage as T } from '@/components';
 import { PreferencesMenu } from '@/constants/preferencesMenu';
+import { useFeatureCan } from '@/hooks/state/feature';
 
 import '@/style/pages/Preferences/Sidebar.scss';
 
@@ -14,8 +15,11 @@ import '@/style/pages/Preferences/Sidebar.scss';
 export default function PreferencesSidebar() {
   const history = useHistory();
   const location = useLocation();
+  const { featureCan } = useFeatureCan();
 
-  const items = PreferencesMenu.map((item) =>
+  const items = PreferencesMenu.filter(
+    (item) => !item.feature || featureCan(item.feature),
+  ).map((item) =>
     item.divider ? (
       <MenuDivider title={item.title} />
     ) : (

--- a/packages/webapp/src/constants/features.tsx
+++ b/packages/webapp/src/constants/features.tsx
@@ -5,4 +5,5 @@ export const Features = {
   Projects: 'Projects',
   BankSyncing: 'BankSyncing',
   LandedCost: 'landed_cost',
+  SmsNotification: 'sms_notification',
 };

--- a/packages/webapp/src/constants/preferencesMenu.tsx
+++ b/packages/webapp/src/constants/preferencesMenu.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { PreferencesMenuItem } from './types';
 import { FormattedMessage as T } from '@/components';
+import { Features } from '@/constants/features';
 
 export const PreferencesMenu: PreferencesMenuItem[] = [
   {
@@ -78,9 +79,10 @@ export const PreferencesMenu: PreferencesMenuItem[] = [
     disabled: false,
     href: '/preferences/api-keys',
   },
-  // {
-  //   text: <T id={'sms_integration.label'} />,
-  //   disabled: false,
-  //   href: '/preferences/sms-message',
-  // },
+  {
+    text: <T id={'sms_integration.label'} />,
+    disabled: false,
+    href: '/preferences/sms-message',
+    feature: Features.SmsNotification,
+  },
 ];

--- a/packages/webapp/src/constants/types.ts
+++ b/packages/webapp/src/constants/types.ts
@@ -25,6 +25,7 @@ export interface PreferencesMenuItem {
   text: ReactNode;
   disabled?: boolean;
   href: string;
+  feature?: string;
 }
 
 export interface QuickNewActionOption {

--- a/packages/webapp/src/containers/Drawers/EstimateDetailDrawer/components.tsx
+++ b/packages/webapp/src/containers/Drawers/EstimateDetailDrawer/components.tsx
@@ -14,8 +14,9 @@ import {
   useEstimateDetailDrawerContext,
   EstimateDetail,
 } from './EstimateDetailDrawerProvider';
-import { Icon, T, Choose, Can } from '@/components';
+import { Icon, T, Choose, Can, FeatureCan } from '@/components';
 import { AbilitySubject, SaleEstimateAction } from '@/constants/abilityOption';
+import { Features } from '@/constants/features';
 import {
   withAlertActions,
   WithAlertActionsProps,
@@ -96,10 +97,12 @@ function EstimateMoreMenuItemsInner({
       minimal={true}
       content={
         <Menu>
-          <MenuItem
-            onClick={onNotifyViaSMS}
-            text={<T id={'notify_via_sms.dialog.notify_via_sms'} />}
-          />
+          <FeatureCan feature={Features.SmsNotification}>
+            <MenuItem
+              onClick={onNotifyViaSMS}
+              text={<T id={'notify_via_sms.dialog.notify_via_sms'} />}
+            />
+          </FeatureCan>
           <MenuDivider />
           <Choose>
             <Choose.When

--- a/packages/webapp/src/containers/Drawers/InvoiceDetailDrawer/utils.tsx
+++ b/packages/webapp/src/containers/Drawers/InvoiceDetailDrawer/utils.tsx
@@ -20,8 +20,10 @@ import {
   Can,
   If,
   TextOverviewTooltipCell,
+  FeatureCan,
 } from '@/components';
 import { SaleInvoiceAction, AbilitySubject } from '@/constants/abilityOption';
+import { Features } from '@/constants/features';
 import { getColumnWidth } from '@/utils';
 
 interface InvoiceDetailsStatusProps {
@@ -166,10 +168,12 @@ export const BadDebtMenuItem = ({ payload }: BadDebtMenuItemProps) => {
             />
           </Can>
           <Can I={SaleInvoiceAction.NotifyBySms} a={AbilitySubject.Invoice}>
-            <MenuItem
-              onClick={onNotifyViaSMS}
-              text={<T id={'notify_via_sms.dialog.notify_via_sms'} />}
-            />
+            <FeatureCan feature={Features.SmsNotification}>
+              <MenuItem
+                onClick={onNotifyViaSMS}
+                text={<T id={'notify_via_sms.dialog.notify_via_sms'} />}
+              />
+            </FeatureCan>
           </Can>
         </Menu>
       }

--- a/packages/webapp/src/containers/Drawers/PaymentReceiveDetailDrawer/PaymentReceiveActionsBar.tsx
+++ b/packages/webapp/src/containers/Drawers/PaymentReceiveDetailDrawer/PaymentReceiveActionsBar.tsx
@@ -14,12 +14,14 @@ import {
   Icon,
   FormattedMessage as T,
   DrawerActionsBar,
+  FeatureCan,
 } from '@/components';
 import {
   PaymentReceiveAction,
   AbilitySubject,
 } from '@/constants/abilityOption';
 import { DRAWERS } from '@/constants/drawers';
+import { Features } from '@/constants/features';
 import {
   withAlertActions,
   WithAlertActionsProps,
@@ -126,12 +128,14 @@ function PaymentsReceivedActionsBar({
           I={PaymentReceiveAction.NotifyBySms}
           a={AbilitySubject.PaymentReceive}
         >
-          <NavbarDivider />
-          <PaymentReceiveMoreMenuItems
-            payload={{
-              onNotifyViaSMS: handleNotifyViaSMS,
-            }}
-          />
+          <FeatureCan feature={Features.SmsNotification}>
+            <NavbarDivider />
+            <PaymentReceiveMoreMenuItems
+              payload={{
+                onNotifyViaSMS: handleNotifyViaSMS,
+              }}
+            />
+          </FeatureCan>
         </Can>
       </NavbarGroup>
     </DrawerActionsBar>

--- a/packages/webapp/src/containers/Drawers/PaymentReceiveDetailDrawer/utils.tsx
+++ b/packages/webapp/src/containers/Drawers/PaymentReceiveDetailDrawer/utils.tsx
@@ -9,7 +9,8 @@ import {
 import React from 'react';
 import intl from 'react-intl-universal';
 import { usePaymentReceiveDetailContext } from './PaymentReceiveDetailProvider';
-import { Icon } from '@/components';
+import { Icon, FeatureCan } from '@/components';
+import { Features } from '@/constants/features';
 import { getColumnWidth } from '@/utils';
 
 /**
@@ -90,10 +91,12 @@ export function PaymentReceiveMoreMenuItems({
       minimal={true}
       content={
         <Menu>
-          <MenuItem
-            onClick={onNotifyViaSMS}
-            text={intl.get('notify_via_sms.dialog.notify_via_sms')}
-          />
+          <FeatureCan feature={Features.SmsNotification}>
+            <MenuItem
+              onClick={onNotifyViaSMS}
+              text={intl.get('notify_via_sms.dialog.notify_via_sms')}
+            />
+          </FeatureCan>
         </Menu>
       }
       interactionKind={PopoverInteractionKind.CLICK}

--- a/packages/webapp/src/containers/Drawers/ReceiptDetailDrawer/ReceiptDetailActionBar.tsx
+++ b/packages/webapp/src/containers/Drawers/ReceiptDetailDrawer/ReceiptDetailActionBar.tsx
@@ -14,9 +14,11 @@ import {
   Icon,
   FormattedMessage as T,
   DrawerActionsBar,
+  FeatureCan,
 } from '@/components';
 import { SaleReceiptAction, AbilitySubject } from '@/constants/abilityOption';
 import { DRAWERS } from '@/constants/drawers';
+import { Features } from '@/constants/features';
 import {
   withAlertActions,
   WithAlertActionsProps,
@@ -112,12 +114,14 @@ function ReceiptDetailActionBarInner({
           />
         </Can>
         <Can I={SaleReceiptAction.NotifyBySms} a={AbilitySubject.Receipt}>
-          <NavbarDivider />
-          <ReceiptMoreMenuItems
-            payload={{
-              onNotifyViaSMS: handleNotifyViaSMS,
-            }}
-          />
+          <FeatureCan feature={Features.SmsNotification}>
+            <NavbarDivider />
+            <ReceiptMoreMenuItems
+              payload={{
+                onNotifyViaSMS: handleNotifyViaSMS,
+              }}
+            />
+          </FeatureCan>
         </Can>
       </NavbarGroup>
     </DrawerActionsBar>

--- a/packages/webapp/src/containers/Drawers/ReceiptDetailDrawer/components.tsx
+++ b/packages/webapp/src/containers/Drawers/ReceiptDetailDrawer/components.tsx
@@ -10,7 +10,8 @@ import {
 } from '@blueprintjs/core';
 import React from 'react';
 import type { ReceiptDetail } from './ReceiptDetailDrawerProvider';
-import { Icon, Choose, T } from '@/components';
+import { Icon, Choose, T, FeatureCan } from '@/components';
+import { Features } from '@/constants/features';
 
 interface ReceiptDetailsStatusProps {
   receipt: ReceiptDetail;
@@ -53,10 +54,12 @@ export function ReceiptMoreMenuItems({ payload }: ReceiptMoreMenuItemsProps) {
       minimal={true}
       content={
         <Menu>
-          <MenuItem
-            onClick={onNotifyViaSMS}
-            text={<T id={'notify_via_sms.dialog.notify_via_sms'} />}
-          />
+          <FeatureCan feature={Features.SmsNotification}>
+            <MenuItem
+              onClick={onNotifyViaSMS}
+              text={<T id={'notify_via_sms.dialog.notify_via_sms'} />}
+            />
+          </FeatureCan>
         </Menu>
       }
       interactionKind={PopoverInteractionKind.CLICK}

--- a/packages/webapp/src/routes/preferences.tsx
+++ b/packages/webapp/src/routes/preferences.tsx
@@ -1,5 +1,6 @@
 // @ts-nocheck
 import { lazy } from 'react';
+import { Features } from '@/constants/features';
 
 const BASE_URL = '/preferences';
 
@@ -156,6 +157,16 @@ export const getPreferenceRoutes = () => [
       })),
     ),
     exact: true,
+  },
+  {
+    path: `${BASE_URL}/sms-message`,
+    component: lazy(() =>
+      import('@/containers/Preferences/SMSIntegration').then((m) => ({
+        default: m.SMSIntegration,
+      })),
+    ),
+    exact: true,
+    feature: Features.SmsNotification,
   },
   {
     path: `${BASE_URL}/api-keys`,


### PR DESCRIPTION
## Description

Adds an `sms_notification` feature flag that gates all SMS functionality end-to-end, mirroring the existing `landed_cost` feature-flag pattern.

**Server:**
- Registers `Features.SMS_NOTIFICATION = 'sms_notification'` in the `Features` enum, `FeaturesConfigure` (default `false`), and the settings schema (`metable-options.ts`).
- Adds a new `SmsNotificationFeatureGuard` and applies it to the only active SMS endpoints (`POST /sale-estimates/:id/notify-sms`, `GET /sale-estimates/:id/sms-details`), which are now rejected when the feature is disabled.

**Webapp:**
- Hides all SMS UI surfaces behind `FeatureCan` when the feature is disabled: the "Notify via SMS" actions in the Invoice/Receipt/Estimate/PaymentReceive detail drawers, the SMS dialogs in `DialogsContainer`, and the SMS Integration preferences menu entry + `/preferences/sms-message` route.

This flag defaults to disabled; it must be enabled explicitly (via settings) before any SMS functionality is shown.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- `yarn typecheck` in `packages/server` passes.
- `yarn typecheck` in `packages/webapp` shows no new errors in the touched files (the repo has pre-existing type errors in unrelated files).
- `eslint` passes on all touched files (only pre-existing warnings remain).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>
