### PR TITLE
fix(server): inventory item details crash on unknown transaction types and import cleanup

### DIFF
--- a/packages/server/src/i18n/en/transaction_type.json
+++ b/packages/server/src/i18n/en/transaction_type.json
@@ -21,5 +21,6 @@
   "refund_credit_note": "Refund Credit Note",
   "refund_vendor_credit": "Refund Vendor Credit",
   "landed_cost": "Landed Cost",
+  "warehouse_transfer": "Warehouse transfer",
   "payment_made": "Payment made"
 }

--- a/packages/server/src/modules/BankingTransactions/constants.ts
+++ b/packages/server/src/modules/BankingTransactions/constants.ts
@@ -143,5 +143,6 @@ export const TransactionTypes = {
   RefundCreditNote: 'transaction_type.refund_credit_note',
   RefundVendorCredit: 'transaction_type.refund_vendor_credit',
   LandedCost: 'transaction_type.landed_cost',
+  WarehouseTransfer: 'transaction_type.warehouse_transfer',
   CashflowTransaction: CashflowTransactionTypes,
 };

--- a/packages/server/src/modules/FinancialStatements/modules/InventoryItemDetails/InventoryItemDetails.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/InventoryItemDetails/InventoryItemDetails.ts
@@ -202,7 +202,9 @@ export class InventoryDetails extends FinancialSheet {
     return {
       nodeType: INodeTypes.TRANSACTION,
       date: this.getDateMeta(transaction.date),
-      transactionType: this.i18n.t(transaction.transcationTypeFormatted),
+      transactionType: transaction.transcationTypeFormatted
+        ? this.i18n.t(transaction.transcationTypeFormatted)
+        : '',
       transactionNumber: transaction?.meta?.transactionNumber,
       direction: transaction.direction,
 

--- a/packages/server/src/modules/Import/_utils.ts
+++ b/packages/server/src/modules/Import/_utils.ts
@@ -456,7 +456,12 @@ export const deleteImportFile = async (filename: string) => {
   const filePath = getImportsStoragePath();
 
   // Deletes the imported file.
-  await fs.unlink(`${filePath}/${filename}`);
+  await fs.unlink(`${filePath}/${filename}`).catch((error) => {
+    // Ignore the error if the file does not exist.
+    if (error.code !== 'ENOENT') {
+      throw error;
+    }
+  });
 };
 
 /**


### PR DESCRIPTION
## Description

Fixes a server crash (`TypeError: Cannot read properties of null (reading 'split')`) thrown by the **Inventory Item Details** financial report when an item has warehouse transfer transactions.

**Root cause:** Warehouse transfers write inventory transactions with `transactionType: 'WarehouseTransfer'`, but that type was missing from the `TransactionTypes` map in `BankingTransactions/constants.ts`. As a result, `InventoryTransaction.transcationTypeFormatted` returned `null`, and passing `null` to `i18n.t()` crashed inside `nestjs-i18n` (`translateObject` calls `key.split('.')`).

This also hardens the report so an unknown/unmapped transaction type can never take down the whole report again, and fixes a secondary issue where the expired import files cleanup job failed with `ENOENT` and left expired import records in the database.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Verified the server package type-checks (`tsc --noEmit`) with no errors.
- Manually traced the failing path: `InventoryItemDetails.itemTransactionMapper` no longer passes `null` to `i18n.t()`.
- The `WarehouseTransfer` transaction type is now mapped to the `transaction_type.warehouse_transfer` translation key and rendered by the report.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>
