### PR TITLE
fix(server): type financial report column keys via shared enums

### DIFF
--- a/packages/server/src/modules/FinancialStatements/common/FinancialTablePreviousPeriod.ts
+++ b/packages/server/src/modules/FinancialStatements/common/FinancialTablePreviousPeriod.ts
@@ -5,6 +5,7 @@ import { IDateRange } from '../types/Report.types';
 import { GConstructor } from '@/common/types/Constructor';
 import { I18nService } from 'nestjs-i18n';
 import { FinancialSheet } from './FinancialSheet';
+import { COMPARISON_COLUMN_KEYS } from './constants/tableColumnKeys';
 
 export const FinancialTablePreviousPeriod = <
   T extends GConstructor<FinancialSheet>,
@@ -34,7 +35,7 @@ export const FinancialTablePreviousPeriod = <
       const PPFormatted = moment(PPDate).format('YYYY-MM-DD');
 
       return {
-        key: 'previous_period',
+        key: COMPARISON_COLUMN_KEYS.PREVIOUS_PERIOD,
         label: this.i18n.t(`financial_sheet.previoud_period_date`, {
           args: { date: PPFormatted },
         }),
@@ -47,7 +48,7 @@ export const FinancialTablePreviousPeriod = <
      */
     public getPreviousPeriodChangeColumn = (): ITableColumn => {
       return {
-        key: 'previous_period_change',
+        key: COMPARISON_COLUMN_KEYS.PREVIOUS_PERIOD_CHANGE,
         label: this.i18n.t('fianncial_sheet.previous_period_change'),
       };
     };
@@ -58,7 +59,7 @@ export const FinancialTablePreviousPeriod = <
      */
     public getPreviousPeriodPercentageColumn = (): ITableColumn => {
       return {
-        key: 'previous_period_percentage',
+        key: COMPARISON_COLUMN_KEYS.PREVIOUS_PERIOD_PERCENTAGE,
         label: this.i18n.t('financial_sheet.previous_period_percentage'),
       };
     };
@@ -69,7 +70,7 @@ export const FinancialTablePreviousPeriod = <
      */
     public getPreviousPeriodTotalAccessor = (): ITableColumnAccessor => {
       return {
-        key: 'previous_period',
+        key: COMPARISON_COLUMN_KEYS.PREVIOUS_PERIOD,
         accessor: 'previousPeriod.formattedAmount',
       };
     };
@@ -80,7 +81,7 @@ export const FinancialTablePreviousPeriod = <
      */
     public getPreviousPeriodChangeAccessor = () => {
       return {
-        key: 'previous_period_change',
+        key: COMPARISON_COLUMN_KEYS.PREVIOUS_PERIOD_CHANGE,
         accessor: 'previousPeriodChange.formattedAmount',
       };
     };
@@ -91,7 +92,7 @@ export const FinancialTablePreviousPeriod = <
      */
     public getPreviousPeriodPercentageAccessor = (): ITableColumnAccessor => {
       return {
-        key: 'previous_period_percentage',
+        key: COMPARISON_COLUMN_KEYS.PREVIOUS_PERIOD_PERCENTAGE,
         accessor: 'previousPeriodPercentage.formattedAmount',
       };
     };
@@ -105,7 +106,7 @@ export const FinancialTablePreviousPeriod = <
       index: number,
     ): ITableColumnAccessor => {
       return {
-        key: 'previous_period',
+        key: COMPARISON_COLUMN_KEYS.PREVIOUS_PERIOD,
         accessor: `horizontalTotals[${index}].previousPeriod.formattedAmount`,
       };
     };
@@ -119,7 +120,7 @@ export const FinancialTablePreviousPeriod = <
       index: number,
     ): ITableColumnAccessor => {
       return {
-        key: 'previous_period_change',
+        key: COMPARISON_COLUMN_KEYS.PREVIOUS_PERIOD_CHANGE,
         accessor: `horizontalTotals[${index}].previousPeriodChange.formattedAmount`,
       };
     };
@@ -133,7 +134,7 @@ export const FinancialTablePreviousPeriod = <
       index: number,
     ): ITableColumnAccessor => {
       return {
-        key: 'previous_period_percentage',
+        key: COMPARISON_COLUMN_KEYS.PREVIOUS_PERIOD_PERCENTAGE,
         accessor: `horizontalTotals[${index}].previousPeriodPercentage.formattedAmount`,
       };
     };

--- a/packages/server/src/modules/FinancialStatements/common/FinancialTablePreviousYear.ts
+++ b/packages/server/src/modules/FinancialStatements/common/FinancialTablePreviousYear.ts
@@ -5,6 +5,7 @@ import { IDateRange } from '../types/Report.types';
 import { GConstructor } from '@/common/types/Constructor';
 import { I18nService } from 'nestjs-i18n';
 import { FinancialSheet } from './FinancialSheet';
+import { COMPARISON_COLUMN_KEYS } from './constants/tableColumnKeys';
 
 export const FinancialTablePreviousYear = <
   T extends GConstructor<FinancialSheet>,
@@ -37,7 +38,7 @@ export const FinancialTablePreviousYear = <
       const PYFormatted = moment(PYDate).format('YYYY-MM-DD');
 
       return {
-        key: 'previous_year',
+        key: COMPARISON_COLUMN_KEYS.PREVIOUS_YEAR,
         label: this.i18n.t('financial_sheet.previous_year_date', {
           args: { date: PYFormatted },
         }),
@@ -50,7 +51,7 @@ export const FinancialTablePreviousYear = <
      */
     public getPreviousYearChangeColumn = (): ITableColumn => {
       return {
-        key: 'previous_year_change',
+        key: COMPARISON_COLUMN_KEYS.PREVIOUS_YEAR_CHANGE,
         label: this.i18n.t('financial_sheet.previous_year_change'),
       };
     };
@@ -61,7 +62,7 @@ export const FinancialTablePreviousYear = <
      */
     public getPreviousYearPercentageColumn = (): ITableColumn => {
       return {
-        key: 'previous_year_percentage',
+        key: COMPARISON_COLUMN_KEYS.PREVIOUS_YEAR_PERCENTAGE,
         label: this.i18n.t('financial_sheet.previous_year_percentage'),
       };
     };
@@ -75,7 +76,7 @@ export const FinancialTablePreviousYear = <
      */
     public getPreviousYearTotalAccessor = (): ITableColumnAccessor => {
       return {
-        key: 'previous_year',
+        key: COMPARISON_COLUMN_KEYS.PREVIOUS_YEAR,
         accessor: 'previousYear.formattedAmount',
       };
     };
@@ -86,7 +87,7 @@ export const FinancialTablePreviousYear = <
      */
     public getPreviousYearChangeAccessor = (): ITableColumnAccessor => {
       return {
-        key: 'previous_year_change',
+        key: COMPARISON_COLUMN_KEYS.PREVIOUS_YEAR_CHANGE,
         accessor: 'previousYearChange.formattedAmount',
       };
     };
@@ -97,7 +98,7 @@ export const FinancialTablePreviousYear = <
      */
     public getPreviousYearPercentageAccessor = (): ITableColumnAccessor => {
       return {
-        key: 'previous_year_percentage',
+        key: COMPARISON_COLUMN_KEYS.PREVIOUS_YEAR_PERCENTAGE,
         accessor: 'previousYearPercentage.formattedAmount',
       };
     };
@@ -111,7 +112,7 @@ export const FinancialTablePreviousYear = <
       index: number,
     ): ITableColumnAccessor => {
       return {
-        key: 'previous_year',
+        key: COMPARISON_COLUMN_KEYS.PREVIOUS_YEAR,
         accessor: `horizontalTotals[${index}].previousYear.formattedAmount`,
       };
     };
@@ -125,7 +126,7 @@ export const FinancialTablePreviousYear = <
       index: number,
     ): ITableColumnAccessor => {
       return {
-        key: 'previous_year_change',
+        key: COMPARISON_COLUMN_KEYS.PREVIOUS_YEAR_CHANGE,
         accessor: `horizontalTotals[${index}].previousYearChange.formattedAmount`,
       };
     };
@@ -139,7 +140,7 @@ export const FinancialTablePreviousYear = <
       index: number,
     ): ITableColumnAccessor => {
       return {
-        key: 'previous_year_percentage',
+        key: COMPARISON_COLUMN_KEYS.PREVIOUS_YEAR_PERCENTAGE,
         accessor: `horizontalTotals[${index}].previousYearPercentage.formattedAmount`,
       };
     };

--- a/packages/server/src/modules/FinancialStatements/common/constants/tableColumnKeys.ts
+++ b/packages/server/src/modules/FinancialStatements/common/constants/tableColumnKeys.ts
@@ -1,0 +1,212 @@
+/**
+ * Financial statement table column keys.
+ *
+ * Single source of truth for the `key` values emitted by the report table
+ * builders and consumed by the webapp column mappers. Each report has its own
+ * const/type so the values can be referenced (and type-checked) on both sides.
+ */
+
+// Shared comparison columns (previous period / previous year). Used by the
+// shared `FinancialTablePreviousPeriod`/`FinancialTablePreviousYear` mixins
+// across multiple reports.
+export const COMPARISON_COLUMN_KEYS = {
+  PREVIOUS_PERIOD: 'previous_period',
+  PREVIOUS_PERIOD_CHANGE: 'previous_period_change',
+  PREVIOUS_PERIOD_PERCENTAGE: 'previous_period_percentage',
+  PREVIOUS_YEAR: 'previous_year',
+  PREVIOUS_YEAR_CHANGE: 'previous_year_change',
+  PREVIOUS_YEAR_PERCENTAGE: 'previous_year_percentage',
+} as const;
+
+export type ComparisonColumnKey =
+  (typeof COMPARISON_COLUMN_KEYS)[keyof typeof COMPARISON_COLUMN_KEYS];
+
+// ----------------------------------------
+// # Balance sheet.
+// ----------------------------------------
+export const BALANCE_SHEET_COLUMN_KEYS = {
+  NAME: 'name',
+  TOTAL: 'total',
+  ...COMPARISON_COLUMN_KEYS,
+  PERCENTAGE_OF_COLUMN: 'percentage_of_column',
+  PERCENTAGE_OF_ROW: 'percentage_of_row',
+} as const;
+
+export type BalanceSheetColumnKey =
+  (typeof BALANCE_SHEET_COLUMN_KEYS)[keyof typeof BALANCE_SHEET_COLUMN_KEYS];
+
+// ----------------------------------------
+// # Profit & loss sheet.
+// ----------------------------------------
+export const PROFIT_LOSS_COLUMN_KEYS = {
+  NAME: 'name',
+  TOTAL: 'total',
+  ...COMPARISON_COLUMN_KEYS,
+  PERCENTAGE_OF_INCOME: 'percentage_income',
+  PERCENTAGE_OF_EXPENSES: 'percentage_expenses',
+  PERCENTAGE_OF_COLUMN: 'percentage_column',
+  PERCENTAGE_OF_ROW: 'percentage_row',
+} as const;
+
+export type ProfitLossColumnKey =
+  (typeof PROFIT_LOSS_COLUMN_KEYS)[keyof typeof PROFIT_LOSS_COLUMN_KEYS];
+
+// ----------------------------------------
+// # Trial balance sheet.
+// ----------------------------------------
+export const TRIAL_BALANCE_COLUMN_KEYS = {
+  ACCOUNT: 'account',
+  DEBIT: 'debit',
+  CREDIT: 'credit',
+  TOTAL: 'total',
+} as const;
+
+export type TrialBalanceColumnKey =
+  (typeof TRIAL_BALANCE_COLUMN_KEYS)[keyof typeof TRIAL_BALANCE_COLUMN_KEYS];
+
+// ----------------------------------------
+// # Cash flow statement.
+// ----------------------------------------
+export const CASH_FLOW_COLUMN_KEYS = {
+  NAME: 'name',
+  TOTAL: 'total',
+} as const;
+
+export type CashFlowColumnKey =
+  (typeof CASH_FLOW_COLUMN_KEYS)[keyof typeof CASH_FLOW_COLUMN_KEYS];
+
+// ----------------------------------------
+// # Aging summary (receivable & payable).
+// ----------------------------------------
+export const AGING_SUMMARY_COLUMN_KEYS = {
+  CUSTOMER_NAME: 'customer_name',
+  VENDOR_NAME: 'vendor_name',
+  CURRENT: 'current',
+  TOTAL: 'total',
+  AGING_PERIOD: 'aging_period',
+} as const;
+
+export type AgingSummaryColumnKey =
+  (typeof AGING_SUMMARY_COLUMN_KEYS)[keyof typeof AGING_SUMMARY_COLUMN_KEYS];
+
+// ----------------------------------------
+// # General ledger.
+// ----------------------------------------
+export const GENERAL_LEDGER_COLUMN_KEYS = {
+  DATE: 'date',
+  ACCOUNT_NAME: 'account_name',
+  REFERENCE_TYPE: 'reference_type',
+  REFERENCE_NUMBER: 'reference_number',
+  DESCRIPTION: 'description',
+  CREDIT: 'credit',
+  DEBIT: 'debit',
+  AMOUNT: 'amount',
+  RUNNING_BALANCE: 'running_balance',
+} as const;
+
+export type GeneralLedgerColumnKey =
+  (typeof GENERAL_LEDGER_COLUMN_KEYS)[keyof typeof GENERAL_LEDGER_COLUMN_KEYS];
+
+// ----------------------------------------
+// # Journal sheet.
+// ----------------------------------------
+export const JOURNAL_COLUMN_KEYS = {
+  DATE: 'date',
+  TRANSACTION_TYPE: 'transaction_type',
+  TRANSACTION_NUMBER: 'transaction_number',
+  DESCRIPTION: 'description',
+  ACCOUNT_CODE: 'account_code',
+  ACCOUNT_NAME: 'account_name',
+  DEBIT: 'debit',
+  CREDIT: 'credit',
+} as const;
+
+export type JournalColumnKey =
+  (typeof JOURNAL_COLUMN_KEYS)[keyof typeof JOURNAL_COLUMN_KEYS];
+
+// ----------------------------------------
+// # Customers/vendors balance summary.
+// ----------------------------------------
+export const CONTACT_BALANCE_COLUMN_KEYS = {
+  NAME: 'name',
+  TOTAL: 'total',
+  PERCENTAGE_OF_COLUMN: 'percentage_of_column',
+} as const;
+
+export type CustomersBalanceColumnKey =
+  (typeof CONTACT_BALANCE_COLUMN_KEYS)[keyof typeof CONTACT_BALANCE_COLUMN_KEYS];
+
+export type VendorsBalanceColumnKey =
+  (typeof CONTACT_BALANCE_COLUMN_KEYS)[keyof typeof CONTACT_BALANCE_COLUMN_KEYS];
+
+// ----------------------------------------
+// # Sales by items.
+// ----------------------------------------
+export const SALES_BY_ITEMS_COLUMN_KEYS = {
+  ITEM_NAME: 'item_name',
+  SOLD_QUANTITY: 'sold_quantity',
+  SOLD_AMOUNT: 'sold_amount',
+  AVERAGE_PRICE: 'average_price',
+} as const;
+
+export type SalesByItemsColumnKey =
+  (typeof SALES_BY_ITEMS_COLUMN_KEYS)[keyof typeof SALES_BY_ITEMS_COLUMN_KEYS];
+
+// ----------------------------------------
+// # Purchases by items.
+// ----------------------------------------
+export const PURCHASES_BY_ITEMS_COLUMN_KEYS = {
+  ITEM_NAME: 'item_name',
+  QUANTITY_PURCHASES: 'quantity_purchases',
+  PURCHASE_AMOUNT: 'purchase_amount',
+  AVERAGE_COST: 'average_cost',
+} as const;
+
+export type PurchasesByItemsColumnKey =
+  (typeof PURCHASES_BY_ITEMS_COLUMN_KEYS)[keyof typeof PURCHASES_BY_ITEMS_COLUMN_KEYS];
+
+// ----------------------------------------
+// # Inventory valuation.
+// ----------------------------------------
+export const INVENTORY_VALUATION_COLUMN_KEYS = {
+  ITEM_NAME: 'item_name',
+  QUANTITY: 'quantity',
+  VALUATION: 'valuation',
+  AVERAGE: 'average',
+} as const;
+
+export type InventoryValuationColumnKey =
+  (typeof INVENTORY_VALUATION_COLUMN_KEYS)[keyof typeof INVENTORY_VALUATION_COLUMN_KEYS];
+
+// ----------------------------------------
+// # Inventory item details.
+// ----------------------------------------
+export const INVENTORY_ITEM_DETAILS_COLUMN_KEYS = {
+  DATE: 'date',
+  TRANSACTION_TYPE: 'transaction_type',
+  TRANSACTION_ID: 'transaction_id',
+  QUANTITY: 'quantity',
+  RATE: 'rate',
+  TOTAL: 'total',
+  VALUE: 'value',
+  PROFIT_MARGIN: 'profit_margin',
+  RUNNING_QUANTITY: 'running_quantity',
+  RUNNING_VALUE: 'running_value',
+} as const;
+
+export type InventoryItemDetailsColumnKey =
+  (typeof INVENTORY_ITEM_DETAILS_COLUMN_KEYS)[keyof typeof INVENTORY_ITEM_DETAILS_COLUMN_KEYS];
+
+// ----------------------------------------
+// # Sales tax liability summary.
+// ----------------------------------------
+export const SALES_TAX_LIABILITY_COLUMN_KEYS = {
+  TAX_NAME: 'taxName',
+  TAX_PERCENTAGE: 'taxPercentage',
+  TAXABLE_AMOUNT: 'taxableAmount',
+  COLLECTED_TAX: 'collectedTax',
+  TAX_RATE: 'taxRate',
+} as const;
+
+export type SalesTaxLiabilityColumnKey =
+  (typeof SALES_TAX_LIABILITY_COLUMN_KEYS)[keyof typeof SALES_TAX_LIABILITY_COLUMN_KEYS];

--- a/packages/server/src/modules/FinancialStatements/modules/APAgingSummary/APAgingSummaryResponse.dto.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/APAgingSummary/APAgingSummaryResponse.dto.ts
@@ -1,10 +1,15 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { NumberFormatQueryDto } from '@/modules/BankingTransactions/dtos/NumberFormatQuery.dto';
 import {
+  FinancialTableColumnDto,
   FinancialReportTotalDto,
   FinancialReportMetaDto,
   FinancialTableDataDto,
 } from '../../dtos/FinancialReportResponse.dto';
+import {
+  AGING_SUMMARY_COLUMN_KEYS,
+  AgingSummaryColumnKey,
+} from '../../common/constants/tableColumnKeys';
 
 export class APAgingPeriodDto {
   @ApiProperty({ description: 'From period date' })
@@ -102,16 +107,30 @@ export class APAgingSummaryResponseDto {
 export {
   FinancialTableCellDto as APAgingSummaryTableCellDto,
   FinancialTableRowDto as APAgingSummaryTableRowDto,
-  FinancialTableColumnDto as APAgingSummaryTableColumnDto,
-  FinancialTableDataDto as APAgingSummaryTableDataDto,
 } from '../../dtos/FinancialReportResponse.dto';
+
+export class APAgingSummaryTableColumnDto extends FinancialTableColumnDto {
+  @ApiProperty({
+    description: 'Column key',
+    enum: Object.values(AGING_SUMMARY_COLUMN_KEYS),
+  })
+  key: AgingSummaryColumnKey;
+}
+
+export class APAgingSummaryTableDataDto extends FinancialTableDataDto {
+  @ApiProperty({
+    description: 'Table column definitions',
+    type: [APAgingSummaryTableColumnDto],
+  })
+  columns: APAgingSummaryTableColumnDto[];
+}
 
 export class APAgingSummaryTableResponseDto {
   @ApiProperty({
     description: 'Table data structure',
-    type: () => FinancialTableDataDto,
+    type: () => APAgingSummaryTableDataDto,
   })
-  table: FinancialTableDataDto;
+  table: APAgingSummaryTableDataDto;
 
   @ApiProperty({
     description: 'Query parameters used to generate the report',

--- a/packages/server/src/modules/FinancialStatements/modules/APAgingSummary/APAgingSummaryTable.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/APAgingSummary/APAgingSummaryTable.ts
@@ -5,6 +5,7 @@ import { ITableColumnAccessor } from '../../types/Table.types';
 import { IAgingSummaryQuery } from '../AgingSummary/AgingSummary.types';
 import { ITableColumn } from '../../types/Table.types';
 import { ITableRow } from '../../types/Table.types';
+import { AGING_SUMMARY_COLUMN_KEYS } from '../../common/constants/tableColumnKeys';
 
 export class APAgingSummaryTable extends AgingSummaryTable {
   readonly report: IAPAgingSummaryData;
@@ -36,7 +37,10 @@ export class APAgingSummaryTable extends AgingSummaryTable {
    * @returns {ITableColumnAccessor}
    */
   get contactNameNodeAccessor(): ITableColumnAccessor {
-    return { key: 'vendor_name', accessor: 'vendorName' };
+    return {
+      key: AGING_SUMMARY_COLUMN_KEYS.VENDOR_NAME,
+      accessor: 'vendorName',
+    };
   }
 
   /**
@@ -44,6 +48,6 @@ export class APAgingSummaryTable extends AgingSummaryTable {
    * @returns {ITableColumn}
    */
   contactNameTableColumn = (): ITableColumn => {
-    return { label: 'Vendor name', key: 'vendor_name' };
+    return { label: 'Vendor name', key: AGING_SUMMARY_COLUMN_KEYS.VENDOR_NAME };
   };
 }

--- a/packages/server/src/modules/FinancialStatements/modules/ARAgingSummary/ARAgingSummaryResponse.dto.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/ARAgingSummary/ARAgingSummaryResponse.dto.ts
@@ -1,10 +1,15 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { NumberFormatQueryDto } from '@/modules/BankingTransactions/dtos/NumberFormatQuery.dto';
 import {
+  FinancialTableColumnDto,
   FinancialReportTotalDto,
   FinancialReportMetaDto,
   FinancialTableDataDto,
 } from '../../dtos/FinancialReportResponse.dto';
+import {
+  AGING_SUMMARY_COLUMN_KEYS,
+  AgingSummaryColumnKey,
+} from '../../common/constants/tableColumnKeys';
 
 export class ARAgingPeriodDto {
   @ApiProperty({ description: 'From period date' })
@@ -117,16 +122,30 @@ export class ARAgingSummaryResponseDto {
 export {
   FinancialTableCellDto as ARAgingSummaryTableCellDto,
   FinancialTableRowDto as ARAgingSummaryTableRowDto,
-  FinancialTableColumnDto as ARAgingSummaryTableColumnDto,
-  FinancialTableDataDto as ARAgingSummaryTableDataDto,
 } from '../../dtos/FinancialReportResponse.dto';
+
+export class ARAgingSummaryTableColumnDto extends FinancialTableColumnDto {
+  @ApiProperty({
+    description: 'Column key',
+    enum: Object.values(AGING_SUMMARY_COLUMN_KEYS),
+  })
+  key: AgingSummaryColumnKey;
+}
+
+export class ARAgingSummaryTableDataDto extends FinancialTableDataDto {
+  @ApiProperty({
+    description: 'Table column definitions',
+    type: [ARAgingSummaryTableColumnDto],
+  })
+  columns: ARAgingSummaryTableColumnDto[];
+}
 
 export class ARAgingSummaryTableResponseDto {
   @ApiProperty({
     description: 'Table data structure',
-    type: () => FinancialTableDataDto,
+    type: () => ARAgingSummaryTableDataDto,
   })
-  table: FinancialTableDataDto;
+  table: ARAgingSummaryTableDataDto;
 
   @ApiProperty({
     description: 'Query parameters used to generate the report',

--- a/packages/server/src/modules/FinancialStatements/modules/AgingSummary/AgingSummaryTable.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/AgingSummary/AgingSummaryTable.ts
@@ -17,6 +17,7 @@ import {
   ITableRow,
 } from '../../types/Table.types';
 import { tableRowMapper } from '../../utils/Table.utils';
+import { AGING_SUMMARY_COLUMN_KEYS } from '../../common/constants/tableColumnKeys';
 
 export abstract class AgingSummaryTable extends R.pipe(
   FinancialSheetStructure,
@@ -63,7 +64,7 @@ export abstract class AgingSummaryTable extends R.pipe(
     node: IAgingSummaryContact | IAgingSummaryTotal,
   ): ITableColumnAccessor[] => {
     return node.aging.map((aging, index) => ({
-      key: 'aging_period',
+      key: AGING_SUMMARY_COLUMN_KEYS.AGING_PERIOD,
       accessor: `aging[${index}].total.formattedAmount`,
     }));
   };
@@ -73,7 +74,10 @@ export abstract class AgingSummaryTable extends R.pipe(
    * @returns {ITableColumnAccessor}
    */
   protected get contactNameNodeAccessor(): ITableColumnAccessor {
-    return { key: 'customer_name', accessor: 'customerName' };
+    return {
+      key: AGING_SUMMARY_COLUMN_KEYS.CUSTOMER_NAME,
+      accessor: 'customerName',
+    };
   }
 
   /**
@@ -87,9 +91,15 @@ export abstract class AgingSummaryTable extends R.pipe(
     return R.compose(
       R.concat([
         this.contactNameNodeAccessor,
-        { key: 'current', accessor: 'current.formattedAmount' },
+        {
+          key: AGING_SUMMARY_COLUMN_KEYS.CURRENT,
+          accessor: 'current.formattedAmount',
+        },
         ...this.agingNodeAccessors(node),
-        { key: 'total', accessor: 'total.formattedAmount' },
+        {
+          key: AGING_SUMMARY_COLUMN_KEYS.TOTAL,
+          accessor: 'total.formattedAmount',
+        },
       ]),
     )([]);
   };
@@ -128,9 +138,15 @@ export abstract class AgingSummaryTable extends R.pipe(
     return R.compose(
       R.concat([
         { key: 'blank', value: '' },
-        { key: 'current', accessor: 'current.formattedAmount' },
+        {
+          key: AGING_SUMMARY_COLUMN_KEYS.CURRENT,
+          accessor: 'current.formattedAmount',
+        },
         ...this.agingNodeAccessors(node),
-        { key: 'total', accessor: 'total.formattedAmount' },
+        {
+          key: AGING_SUMMARY_COLUMN_KEYS.TOTAL,
+          accessor: 'total.formattedAmount',
+        },
       ]),
     )([]);
   };
@@ -191,7 +207,7 @@ export abstract class AgingSummaryTable extends R.pipe(
         label: `${agingPeriod.beforeDays} - ${
           agingPeriod.toDays || 'And Over'
         }`,
-        key: 'aging_period',
+        key: AGING_SUMMARY_COLUMN_KEYS.AGING_PERIOD,
       };
     });
   };

--- a/packages/server/src/modules/FinancialStatements/modules/BalanceSheet/BalanceSheetResponse.dto.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/BalanceSheet/BalanceSheetResponse.dto.ts
@@ -4,8 +4,13 @@ import {
   FinancialReportTotalDto,
   FinancialReportPercentageDto,
   FinancialReportMetaDto,
+  FinancialTableColumnDto,
   FinancialTableDataDto,
 } from '../../dtos/FinancialReportResponse.dto';
+import {
+  BALANCE_SHEET_COLUMN_KEYS,
+  BalanceSheetColumnKey,
+} from '../../common/constants/tableColumnKeys';
 
 export class BalanceSheetDataNodeDto {
   @ApiProperty({
@@ -192,16 +197,30 @@ export class BalanceSheetResponseDto {
 export {
   FinancialTableCellDto as BalanceSheetTableCellDto,
   FinancialTableRowDto as BalanceSheetTableRowDto,
-  FinancialTableColumnDto as BalanceSheetTableColumnDto,
-  FinancialTableDataDto as BalanceSheetTableDataDto,
 } from '../../dtos/FinancialReportResponse.dto';
+
+export class BalanceSheetTableColumnDto extends FinancialTableColumnDto {
+  @ApiProperty({
+    description: 'Column key',
+    enum: Object.values(BALANCE_SHEET_COLUMN_KEYS),
+  })
+  key: BalanceSheetColumnKey;
+}
+
+export class BalanceSheetTableDataDto extends FinancialTableDataDto {
+  @ApiProperty({
+    description: 'Table column definitions',
+    type: [BalanceSheetTableColumnDto],
+  })
+  columns: BalanceSheetTableColumnDto[];
+}
 
 export class BalanceSheetTableResponseDto {
   @ApiProperty({
     description: 'Table data structure',
-    type: () => FinancialTableDataDto,
+    type: () => BalanceSheetTableDataDto,
   })
-  table: FinancialTableDataDto;
+  table: BalanceSheetTableDataDto;
 
   @ApiProperty({
     description: 'Query parameters used to generate the report',

--- a/packages/server/src/modules/FinancialStatements/modules/BalanceSheet/BalanceSheetTable.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/BalanceSheet/BalanceSheetTable.ts
@@ -31,6 +31,7 @@ import { BalanceSheetTablePreviousPeriod } from './BalanceSheetTablePreviousPeri
 import { FinancialTable } from '../../common/FinancialTable';
 import { BalanceSheetQuery } from './BalanceSheetQuery';
 import { BalanceSheetTableDatePeriods } from './BalanceSheetTableDatePeriods';
+import { BALANCE_SHEET_COLUMN_KEYS } from '../../common/constants/tableColumnKeys';
 
 export class BalanceSheetTable extends R.pipe(
   BalanceSheetBase,
@@ -96,7 +97,7 @@ export class BalanceSheetTable extends R.pipe(
    */
   public commonColumnsAccessors = (): ITableColumnAccessor[] => {
     return R.compose(
-      R.concat([{ key: 'name', accessor: 'name' }]),
+      R.concat([{ key: BALANCE_SHEET_COLUMN_KEYS.NAME, accessor: 'name' }]),
       R.ifElse(
         R.always(this.isDisplayColumnsBy(DISPLAY_COLUMNS_BY.DATE_PERIODS)),
         R.concat(this.datePeriodsColumnsAccessors()),
@@ -114,7 +115,12 @@ export class BalanceSheetTable extends R.pipe(
       R.concat(this.previousPeriodColumnAccessor()),
       R.concat(this.previousYearColumnAccessor()),
       R.concat(this.percentageColumnsAccessor()),
-      R.concat([{ key: 'total', accessor: 'total.formattedAmount' }]),
+      R.concat([
+        {
+          key: BALANCE_SHEET_COLUMN_KEYS.TOTAL,
+          accessor: 'total.formattedAmount',
+        },
+      ]),
     )([]);
   };
 
@@ -228,7 +234,12 @@ export class BalanceSheetTable extends R.pipe(
     return R.compose(
       R.unless(
         R.isEmpty,
-        R.concat([{ key: 'total', label: this.i18n.t('balance_sheet.total') }]),
+        R.concat([
+          {
+            key: BALANCE_SHEET_COLUMN_KEYS.TOTAL,
+            label: this.i18n.t('balance_sheet.total'),
+          },
+        ]),
       ),
       R.concat(this.percentageColumns()),
       R.concat(this.getPreviousYearColumns()),
@@ -243,7 +254,7 @@ export class BalanceSheetTable extends R.pipe(
   public totalColumn = (): ITableColumn[] => {
     return [
       {
-        key: 'total',
+        key: BALANCE_SHEET_COLUMN_KEYS.TOTAL,
         label: this.i18n.t('balance_sheet.total'),
         children: this.totalColumnChildren(),
       },
@@ -272,7 +283,10 @@ export class BalanceSheetTable extends R.pipe(
     return R.compose(
       this.tableColumnsCellIndexing,
       R.concat([
-        { key: 'name', label: this.i18n.t('balance_sheet.account_name') },
+        {
+          key: BALANCE_SHEET_COLUMN_KEYS.NAME,
+          label: this.i18n.t('balance_sheet.account_name'),
+        },
       ]),
       R.ifElse(
         this.query.isDatePeriodsColumnsType,

--- a/packages/server/src/modules/FinancialStatements/modules/BalanceSheet/BalanceSheetTableDatePeriods.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/BalanceSheet/BalanceSheetTableDatePeriods.ts
@@ -6,6 +6,7 @@ import { FinancialDatePeriods } from '../../common/FinancialDatePeriods';
 import { IDateRange } from '../CashFlow/Cashflow.types';
 import { GConstructor } from '@/common/types/Constructor';
 import { FinancialSheet } from '../../common/FinancialSheet';
+import { BALANCE_SHEET_COLUMN_KEYS } from '../../common/constants/tableColumnKeys';
 
 export const BalanceSheetTableDatePeriods = <
   T extends GConstructor<FinancialSheet>,
@@ -106,7 +107,10 @@ export const BalanceSheetTableDatePeriods = <
         R.unless(
           R.isEmpty,
           R.concat([
-            { key: `total`, label: this.i18n.t('balance_sheet.total') },
+            {
+              key: BALANCE_SHEET_COLUMN_KEYS.TOTAL,
+              label: this.i18n.t('balance_sheet.total'),
+            },
           ]),
         ),
         R.concat(this.percentageColumns()),

--- a/packages/server/src/modules/FinancialStatements/modules/BalanceSheet/BalanceSheetTablePercentage.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/BalanceSheet/BalanceSheetTablePercentage.ts
@@ -5,6 +5,7 @@ import { ITableColumn } from '../../types/Table.types';
 import { GConstructor } from '@/common/types/Constructor';
 import { BalanceSheetQuery } from './BalanceSheetQuery';
 import { FinancialSheet } from '../../common/FinancialSheet';
+import { BALANCE_SHEET_COLUMN_KEYS } from '../../common/constants/tableColumnKeys';
 
 export const BalanceSheetTablePercentage = <
   T extends GConstructor<FinancialSheet>,
@@ -27,14 +28,14 @@ export const BalanceSheetTablePercentage = <
         R.when(
           this.query.isColumnsPercentageActive,
           R.append({
-            key: 'percentage_of_column',
+            key: BALANCE_SHEET_COLUMN_KEYS.PERCENTAGE_OF_COLUMN,
             label: this.i18n.t('balance_sheet.percentage_of_column'),
           }),
         ),
         R.when(
           this.query.isRowsPercentageActive,
           R.append({
-            key: 'percentage_of_row',
+            key: BALANCE_SHEET_COLUMN_KEYS.PERCENTAGE_OF_ROW,
             label: this.i18n.t('balance_sheet.percentage_of_row'),
           }),
         ),
@@ -53,14 +54,14 @@ export const BalanceSheetTablePercentage = <
         R.when(
           this.query.isColumnsPercentageActive,
           R.append({
-            key: 'percentage_of_column',
+            key: BALANCE_SHEET_COLUMN_KEYS.PERCENTAGE_OF_COLUMN,
             accessor: 'percentageColumn.formattedAmount',
           }),
         ),
         R.when(
           this.query.isRowsPercentageActive,
           R.append({
-            key: 'percentage_of_row',
+            key: BALANCE_SHEET_COLUMN_KEYS.PERCENTAGE_OF_ROW,
             accessor: 'percentageRow.formattedAmount',
           }),
         ),

--- a/packages/server/src/modules/FinancialStatements/modules/CashFlowStatement/CashFlowTable.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/CashFlowStatement/CashFlowTable.ts
@@ -13,6 +13,7 @@ import { ITableRow, ITableColumn } from '../../types/Table.types';
 import { dateRangeFromToCollection } from '@/utils/date-range-collection';
 import { tableRowMapper } from '../../utils/Table.utils';
 import { mapValuesDeep } from '@/utils/deepdash';
+import { CASH_FLOW_COLUMN_KEYS } from '../../common/constants/tableColumnKeys';
 
 enum IROW_TYPE {
   AGGREGATE = 'AGGREGATE',
@@ -69,7 +70,9 @@ export class CashFlowTable {
    * Retrieve the total column accessor.
    */
   private totalColumnAccessor = () => {
-    return [{ key: 'total', accessor: 'total.formattedAmount' }];
+    return [
+      { key: CASH_FLOW_COLUMN_KEYS.TOTAL, accessor: 'total.formattedAmount' },
+    ];
   };
 
   /**
@@ -77,7 +80,7 @@ export class CashFlowTable {
    */
   private commonColumns = () => {
     return R.compose(
-      R.concat([{ key: 'name', accessor: 'label' }]),
+      R.concat([{ key: CASH_FLOW_COLUMN_KEYS.NAME, accessor: 'label' }]),
       R.when(
         R.always(this.isDisplayColumnsBy(DISPLAY_COLUMNS_BY.DATE_PERIODS)),
         R.concat(this.datePeriodsColumnsAccessors()),
@@ -302,7 +305,12 @@ export class CashFlowTable {
    * @returns {ITableColumn}
    */
   private totalColumns = (): ITableColumn[] => {
-    return [{ key: 'total', label: this.i18n.t('cash_flow_statement.total') }];
+    return [
+      {
+        key: CASH_FLOW_COLUMN_KEYS.TOTAL,
+        label: this.i18n.t('cash_flow_statement.total'),
+      },
+    ];
   };
 
   /**
@@ -367,7 +375,10 @@ export class CashFlowTable {
   public tableColumns = (): ITableColumn[] => {
     return R.compose(
       R.concat([
-        { key: 'name', label: this.i18n.t('cash_flow_statement.account_name') },
+        {
+          key: CASH_FLOW_COLUMN_KEYS.NAME,
+          label: this.i18n.t('cash_flow_statement.account_name'),
+        },
       ]),
       R.when(
         R.always(this.isDisplayColumnsBy(DISPLAY_COLUMNS_BY.DATE_PERIODS)),

--- a/packages/server/src/modules/FinancialStatements/modules/CashFlowStatement/CashflowStatementResponse.dto.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/CashFlowStatement/CashflowStatementResponse.dto.ts
@@ -1,10 +1,15 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { NumberFormatQueryDto } from '@/modules/BankingTransactions/dtos/NumberFormatQuery.dto';
 import {
+  FinancialTableColumnDto,
   FinancialReportTotalDto,
   FinancialReportMetaDto,
   FinancialTableDataDto,
 } from '../../dtos/FinancialReportResponse.dto';
+import {
+  CASH_FLOW_COLUMN_KEYS,
+  CashFlowColumnKey,
+} from '../../common/constants/tableColumnKeys';
 
 export class CashflowStatementDataNodeDto {
   @ApiProperty({
@@ -122,16 +127,30 @@ export class CashflowStatementResponseDto {
 export {
   FinancialTableCellDto as CashflowStatementTableCellDto,
   FinancialTableRowDto as CashflowStatementTableRowDto,
-  FinancialTableColumnDto as CashflowStatementTableColumnDto,
-  FinancialTableDataDto as CashflowStatementTableDataDto,
 } from '../../dtos/FinancialReportResponse.dto';
+
+export class CashflowStatementTableColumnDto extends FinancialTableColumnDto {
+  @ApiProperty({
+    description: 'Column key',
+    enum: Object.values(CASH_FLOW_COLUMN_KEYS),
+  })
+  key: CashFlowColumnKey;
+}
+
+export class CashflowStatementTableDataDto extends FinancialTableDataDto {
+  @ApiProperty({
+    description: 'Table column definitions',
+    type: [CashflowStatementTableColumnDto],
+  })
+  columns: CashflowStatementTableColumnDto[];
+}
 
 export class CashflowStatementTableResponseDto {
   @ApiProperty({
     description: 'Table data structure',
-    type: () => FinancialTableDataDto,
+    type: () => CashflowStatementTableDataDto,
   })
-  table: FinancialTableDataDto;
+  table: CashflowStatementTableDataDto;
 
   @ApiProperty({
     description: 'Query parameters used to generate the report',

--- a/packages/server/src/modules/FinancialStatements/modules/CustomerBalanceSummary/CustomerBalanceSummaryResponse.dto.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/CustomerBalanceSummary/CustomerBalanceSummaryResponse.dto.ts
@@ -1,10 +1,15 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { NumberFormatQueryDto } from '@/modules/BankingTransactions/dtos/NumberFormatQuery.dto';
 import {
+  FinancialTableColumnDto,
   FinancialReportTotalDto,
   FinancialReportMetaDto,
   FinancialTableDataDto,
 } from '../../dtos/FinancialReportResponse.dto';
+import {
+  CONTACT_BALANCE_COLUMN_KEYS,
+  CustomersBalanceColumnKey,
+} from '../../common/constants/tableColumnKeys';
 
 export class CustomerBalanceDto {
   @ApiProperty({ description: 'Customer ID', type: Number })
@@ -87,16 +92,30 @@ export class CustomerBalanceSummaryResponseDto {
 export {
   FinancialTableCellDto as CustomerBalanceSummaryTableCellDto,
   FinancialTableRowDto as CustomerBalanceSummaryTableRowDto,
-  FinancialTableColumnDto as CustomerBalanceSummaryTableColumnDto,
-  FinancialTableDataDto as CustomerBalanceSummaryTableDataDto,
 } from '../../dtos/FinancialReportResponse.dto';
+
+export class CustomerBalanceSummaryTableColumnDto extends FinancialTableColumnDto {
+  @ApiProperty({
+    description: 'Column key',
+    enum: Object.values(CONTACT_BALANCE_COLUMN_KEYS),
+  })
+  key: CustomersBalanceColumnKey;
+}
+
+export class CustomerBalanceSummaryTableDataDto extends FinancialTableDataDto {
+  @ApiProperty({
+    description: 'Table column definitions',
+    type: [CustomerBalanceSummaryTableColumnDto],
+  })
+  columns: CustomerBalanceSummaryTableColumnDto[];
+}
 
 export class CustomerBalanceSummaryTableResponseDto {
   @ApiProperty({
     description: 'Table data structure',
-    type: () => FinancialTableDataDto,
+    type: () => CustomerBalanceSummaryTableDataDto,
   })
-  table: FinancialTableDataDto;
+  table: CustomerBalanceSummaryTableDataDto;
 
   @ApiProperty({
     description: 'Query parameters used to generate the report',

--- a/packages/server/src/modules/FinancialStatements/modules/CustomerBalanceSummary/CustomerBalanceSummaryTableRows.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/CustomerBalanceSummary/CustomerBalanceSummaryTableRows.ts
@@ -12,6 +12,7 @@ import {
   ITableRow,
 } from '../../types/Table.types';
 import { tableMapper, tableRowMapper } from '../../utils/Table.utils';
+import { CONTACT_BALANCE_COLUMN_KEYS } from '../../common/constants/tableColumnKeys';
 
 enum TABLE_ROWS_TYPES {
   CUSTOMER = 'CUSTOMER',
@@ -58,8 +59,11 @@ export class CustomerBalanceSummaryTable {
    */
   private getCustomerColumnsAccessor = (): IColumnMapperMeta[] => {
     const columns = [
-      { key: 'name', accessor: 'customerName' },
-      { key: 'total', accessor: 'total.formattedAmount' },
+      { key: CONTACT_BALANCE_COLUMN_KEYS.NAME, accessor: 'customerName' },
+      {
+        key: CONTACT_BALANCE_COLUMN_KEYS.TOTAL,
+        accessor: 'total.formattedAmount',
+      },
     ];
     return R.compose(
       R.concat(columns),
@@ -91,8 +95,14 @@ export class CustomerBalanceSummaryTable {
    */
   private getTotalColumnsAccessor = (): IColumnMapperMeta[] => {
     const columns = [
-      { key: 'name', value: this.i18n.t('contact_summary_balance.total') },
-      { key: 'total', accessor: 'total.formattedAmount' },
+      {
+        key: CONTACT_BALANCE_COLUMN_KEYS.NAME,
+        value: this.i18n.t('contact_summary_balance.total'),
+      },
+      {
+        key: CONTACT_BALANCE_COLUMN_KEYS.TOTAL,
+        accessor: 'total.formattedAmount',
+      },
     ];
     // @ts-ignore
     return R.compose(
@@ -136,21 +146,24 @@ export class CustomerBalanceSummaryTable {
    * @returns {ITableColumn[]}
    */
   public tableColumns = (): ITableColumn[] => {
-    const columns = [
+    const columns: ITableColumn[] = [
       {
-        key: 'name',
+        key: CONTACT_BALANCE_COLUMN_KEYS.NAME,
         label: this.i18n.t('contact_summary_balance.account_name'),
       },
-      { key: 'total', label: this.i18n.t('contact_summary_balance.total') },
+      {
+        key: CONTACT_BALANCE_COLUMN_KEYS.TOTAL,
+        label: this.i18n.t('contact_summary_balance.total'),
+      },
     ];
     // @ts-ignore
     return R.compose(
       R.when(
         R.always(this.query.percentageColumn),
         R.append({
-          key: 'percentage_of_column',
+          key: CONTACT_BALANCE_COLUMN_KEYS.PERCENTAGE_OF_COLUMN,
           label: this.i18n.t('contact_summary_balance.percentage_column'),
-        }),
+        } as ITableColumn),
       ),
       R.concat(columns),
     )([]);

--- a/packages/server/src/modules/FinancialStatements/modules/GeneralLedger/GeneralLedgerResponse.dto.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/GeneralLedger/GeneralLedgerResponse.dto.ts
@@ -1,10 +1,15 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { NumberFormatQueryDto } from '@/modules/BankingTransactions/dtos/NumberFormatQuery.dto';
 import {
+  FinancialTableColumnDto,
   FinancialReportTotalDto,
   FinancialReportMetaDto,
   FinancialTableDataDto,
 } from '../../dtos/FinancialReportResponse.dto';
+import {
+  GENERAL_LEDGER_COLUMN_KEYS,
+  GeneralLedgerColumnKey,
+} from '../../common/constants/tableColumnKeys';
 
 export class GeneralLedgerTransactionDto {
   @ApiProperty({ description: 'Transaction date' })
@@ -158,16 +163,30 @@ export class GeneralLedgerResponseDto {
 export {
   FinancialTableCellDto as GeneralLedgerTableCellDto,
   FinancialTableRowDto as GeneralLedgerTableRowDto,
-  FinancialTableColumnDto as GeneralLedgerTableColumnDto,
-  FinancialTableDataDto as GeneralLedgerTableDataDto,
 } from '../../dtos/FinancialReportResponse.dto';
+
+export class GeneralLedgerTableColumnDto extends FinancialTableColumnDto {
+  @ApiProperty({
+    description: 'Column key',
+    enum: Object.values(GENERAL_LEDGER_COLUMN_KEYS),
+  })
+  key: GeneralLedgerColumnKey;
+}
+
+export class GeneralLedgerTableDataDto extends FinancialTableDataDto {
+  @ApiProperty({
+    description: 'Table column definitions',
+    type: [GeneralLedgerTableColumnDto],
+  })
+  columns: GeneralLedgerTableColumnDto[];
+}
 
 export class GeneralLedgerTableResponseDto {
   @ApiProperty({
     description: 'Table data structure',
-    type: () => FinancialTableDataDto,
+    type: () => GeneralLedgerTableDataDto,
   })
-  table: FinancialTableDataDto;
+  table: GeneralLedgerTableDataDto;
 
   @ApiProperty({
     description: 'Query parameters used to generate the report',

--- a/packages/server/src/modules/FinancialStatements/modules/GeneralLedger/GeneralLedgerTable.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/GeneralLedger/GeneralLedgerTable.ts
@@ -17,6 +17,7 @@ import {
   ITableRow,
 } from '../../types/Table.types';
 import { tableRowMapper } from '../../utils/Table.utils';
+import { GENERAL_LEDGER_COLUMN_KEYS } from '../../common/constants/tableColumnKeys';
 
 export class GeneralLedgerTable extends R.compose(
   FinancialTable,
@@ -49,15 +50,21 @@ export class GeneralLedgerTable extends R.compose(
    */
   private accountColumnsAccessors(): ITableColumnAccessor[] {
     return [
-      { key: 'date', accessor: 'name' },
-      { key: 'account_name', accessor: '_empty_' },
-      { key: 'reference_type', accessor: '_empty_' },
-      { key: 'reference_number', accessor: '_empty_' },
-      { key: 'description', accessor: 'description' },
-      { key: 'credit', accessor: '_empty_' },
-      { key: 'debit', accessor: '_empty_' },
-      { key: 'amount', accessor: 'amount.formattedAmount' },
-      { key: 'running_balance', accessor: 'closingBalance.formattedAmount' },
+      { key: GENERAL_LEDGER_COLUMN_KEYS.DATE, accessor: 'name' },
+      { key: GENERAL_LEDGER_COLUMN_KEYS.ACCOUNT_NAME, accessor: '_empty_' },
+      { key: GENERAL_LEDGER_COLUMN_KEYS.REFERENCE_TYPE, accessor: '_empty_' },
+      { key: GENERAL_LEDGER_COLUMN_KEYS.REFERENCE_NUMBER, accessor: '_empty_' },
+      { key: GENERAL_LEDGER_COLUMN_KEYS.DESCRIPTION, accessor: 'description' },
+      { key: GENERAL_LEDGER_COLUMN_KEYS.CREDIT, accessor: '_empty_' },
+      { key: GENERAL_LEDGER_COLUMN_KEYS.DEBIT, accessor: '_empty_' },
+      {
+        key: GENERAL_LEDGER_COLUMN_KEYS.AMOUNT,
+        accessor: 'amount.formattedAmount',
+      },
+      {
+        key: GENERAL_LEDGER_COLUMN_KEYS.RUNNING_BALANCE,
+        accessor: 'closingBalance.formattedAmount',
+      },
     ];
   }
 
@@ -67,15 +74,27 @@ export class GeneralLedgerTable extends R.compose(
    */
   private transactionColumnAccessors(): ITableColumnAccessor[] {
     return [
-      { key: 'date', accessor: 'dateFormatted' },
-      { key: 'account_name', accessor: 'account.name' },
-      { key: 'reference_type', accessor: 'transactionTypeFormatted' },
-      { key: 'reference_number', accessor: 'transactionNumber' },
-      { key: 'description', accessor: 'note' },
-      { key: 'credit', accessor: 'formattedCredit' },
-      { key: 'debit', accessor: 'formattedDebit' },
-      { key: 'amount', accessor: 'formattedAmount' },
-      { key: 'running_balance', accessor: 'formattedRunningBalance' },
+      { key: GENERAL_LEDGER_COLUMN_KEYS.DATE, accessor: 'dateFormatted' },
+      {
+        key: GENERAL_LEDGER_COLUMN_KEYS.ACCOUNT_NAME,
+        accessor: 'account.name',
+      },
+      {
+        key: GENERAL_LEDGER_COLUMN_KEYS.REFERENCE_TYPE,
+        accessor: 'transactionTypeFormatted',
+      },
+      {
+        key: GENERAL_LEDGER_COLUMN_KEYS.REFERENCE_NUMBER,
+        accessor: 'transactionNumber',
+      },
+      { key: GENERAL_LEDGER_COLUMN_KEYS.DESCRIPTION, accessor: 'note' },
+      { key: GENERAL_LEDGER_COLUMN_KEYS.CREDIT, accessor: 'formattedCredit' },
+      { key: GENERAL_LEDGER_COLUMN_KEYS.DEBIT, accessor: 'formattedDebit' },
+      { key: GENERAL_LEDGER_COLUMN_KEYS.AMOUNT, accessor: 'formattedAmount' },
+      {
+        key: GENERAL_LEDGER_COLUMN_KEYS.RUNNING_BALANCE,
+        accessor: 'formattedRunningBalance',
+      },
     ];
   }
 
@@ -85,15 +104,21 @@ export class GeneralLedgerTable extends R.compose(
    */
   private openingBalanceColumnsAccessors(): IColumnMapperMeta[] {
     return [
-      { key: 'date', value: 'Opening Balance' },
-      { key: 'account_name', value: '' },
-      { key: 'reference_type', accessor: '_empty_' },
-      { key: 'reference_number', accessor: '_empty_' },
-      { key: 'description', accessor: 'description' },
-      { key: 'credit', accessor: '_empty_' },
-      { key: 'debit', accessor: '_empty_' },
-      { key: 'amount', accessor: 'openingBalance.formattedAmount' },
-      { key: 'running_balance', accessor: 'openingBalance.formattedAmount' },
+      { key: GENERAL_LEDGER_COLUMN_KEYS.DATE, value: 'Opening Balance' },
+      { key: GENERAL_LEDGER_COLUMN_KEYS.ACCOUNT_NAME, value: '' },
+      { key: GENERAL_LEDGER_COLUMN_KEYS.REFERENCE_TYPE, accessor: '_empty_' },
+      { key: GENERAL_LEDGER_COLUMN_KEYS.REFERENCE_NUMBER, accessor: '_empty_' },
+      { key: GENERAL_LEDGER_COLUMN_KEYS.DESCRIPTION, accessor: 'description' },
+      { key: GENERAL_LEDGER_COLUMN_KEYS.CREDIT, accessor: '_empty_' },
+      { key: GENERAL_LEDGER_COLUMN_KEYS.DEBIT, accessor: '_empty_' },
+      {
+        key: GENERAL_LEDGER_COLUMN_KEYS.AMOUNT,
+        accessor: 'openingBalance.formattedAmount',
+      },
+      {
+        key: GENERAL_LEDGER_COLUMN_KEYS.RUNNING_BALANCE,
+        accessor: 'openingBalance.formattedAmount',
+      },
     ];
   }
 
@@ -106,15 +131,24 @@ export class GeneralLedgerTable extends R.compose(
     account: IGeneralLedgerSheetAccount,
   ): IColumnMapperMeta[] {
     return [
-      { key: 'date', value: `Closing balance for ${account.name}` },
-      { key: 'account_name', value: `` },
-      { key: 'reference_type', accessor: '_empty_' },
-      { key: 'reference_number', accessor: '_empty_' },
-      { key: 'description', accessor: '_empty_' },
-      { key: 'credit', accessor: '_empty_' },
-      { key: 'debit', accessor: '_empty_' },
-      { key: 'amount', accessor: 'closingBalance.formattedAmount' },
-      { key: 'running_balance', accessor: 'closingBalance.formattedAmount' },
+      {
+        key: GENERAL_LEDGER_COLUMN_KEYS.DATE,
+        value: `Closing balance for ${account.name}`,
+      },
+      { key: GENERAL_LEDGER_COLUMN_KEYS.ACCOUNT_NAME, value: `` },
+      { key: GENERAL_LEDGER_COLUMN_KEYS.REFERENCE_TYPE, accessor: '_empty_' },
+      { key: GENERAL_LEDGER_COLUMN_KEYS.REFERENCE_NUMBER, accessor: '_empty_' },
+      { key: GENERAL_LEDGER_COLUMN_KEYS.DESCRIPTION, accessor: '_empty_' },
+      { key: GENERAL_LEDGER_COLUMN_KEYS.CREDIT, accessor: '_empty_' },
+      { key: GENERAL_LEDGER_COLUMN_KEYS.DEBIT, accessor: '_empty_' },
+      {
+        key: GENERAL_LEDGER_COLUMN_KEYS.AMOUNT,
+        accessor: 'closingBalance.formattedAmount',
+      },
+      {
+        key: GENERAL_LEDGER_COLUMN_KEYS.RUNNING_BALANCE,
+        accessor: 'closingBalance.formattedAmount',
+      },
     ];
   }
 
@@ -128,21 +162,24 @@ export class GeneralLedgerTable extends R.compose(
   ): IColumnMapperMeta[] {
     return [
       {
-        key: 'date',
+        key: GENERAL_LEDGER_COLUMN_KEYS.DATE,
         value: `Closing Balance for ${account.name} with sub-accounts`,
       },
       {
-        key: 'account_name',
+        key: GENERAL_LEDGER_COLUMN_KEYS.ACCOUNT_NAME,
         value: ``,
       },
-      { key: 'reference_type', accessor: '_empty_' },
-      { key: 'reference_number', accessor: '_empty_' },
-      { key: 'description', accessor: '_empty_' },
-      { key: 'credit', accessor: '_empty_' },
-      { key: 'debit', accessor: '_empty_' },
-      { key: 'amount', accessor: 'closingBalanceSubaccounts.formattedAmount' },
+      { key: GENERAL_LEDGER_COLUMN_KEYS.REFERENCE_TYPE, accessor: '_empty_' },
+      { key: GENERAL_LEDGER_COLUMN_KEYS.REFERENCE_NUMBER, accessor: '_empty_' },
+      { key: GENERAL_LEDGER_COLUMN_KEYS.DESCRIPTION, accessor: '_empty_' },
+      { key: GENERAL_LEDGER_COLUMN_KEYS.CREDIT, accessor: '_empty_' },
+      { key: GENERAL_LEDGER_COLUMN_KEYS.DEBIT, accessor: '_empty_' },
       {
-        key: 'running_balance',
+        key: GENERAL_LEDGER_COLUMN_KEYS.AMOUNT,
+        accessor: 'closingBalanceSubaccounts.formattedAmount',
+      },
+      {
+        key: GENERAL_LEDGER_COLUMN_KEYS.RUNNING_BALANCE,
         accessor: 'closingBalanceSubaccounts.formattedAmount',
       },
     ];
@@ -154,15 +191,24 @@ export class GeneralLedgerTable extends R.compose(
    */
   private commonColumns(): ITableColumn[] {
     return [
-      { key: 'date', label: 'Date' },
-      { key: 'account_name', label: 'Account Name' },
-      { key: 'reference_type', label: 'Transaction Type' },
-      { key: 'reference_number', label: 'Transaction #' },
-      { key: 'description', label: 'Description' },
-      { key: 'credit', label: 'Credit' },
-      { key: 'debit', label: 'Debit' },
-      { key: 'amount', label: 'Amount' },
-      { key: 'running_balance', label: 'Running Balance' },
+      { key: GENERAL_LEDGER_COLUMN_KEYS.DATE, label: 'Date' },
+      { key: GENERAL_LEDGER_COLUMN_KEYS.ACCOUNT_NAME, label: 'Account Name' },
+      {
+        key: GENERAL_LEDGER_COLUMN_KEYS.REFERENCE_TYPE,
+        label: 'Transaction Type',
+      },
+      {
+        key: GENERAL_LEDGER_COLUMN_KEYS.REFERENCE_NUMBER,
+        label: 'Transaction #',
+      },
+      { key: GENERAL_LEDGER_COLUMN_KEYS.DESCRIPTION, label: 'Description' },
+      { key: GENERAL_LEDGER_COLUMN_KEYS.CREDIT, label: 'Credit' },
+      { key: GENERAL_LEDGER_COLUMN_KEYS.DEBIT, label: 'Debit' },
+      { key: GENERAL_LEDGER_COLUMN_KEYS.AMOUNT, label: 'Amount' },
+      {
+        key: GENERAL_LEDGER_COLUMN_KEYS.RUNNING_BALANCE,
+        label: 'Running Balance',
+      },
     ];
   }
 

--- a/packages/server/src/modules/FinancialStatements/modules/InventoryItemDetails/InventoryItemDetailsResponse.dto.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/InventoryItemDetails/InventoryItemDetailsResponse.dto.ts
@@ -1,10 +1,15 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { NumberFormatQueryDto } from '@/modules/BankingTransactions/dtos/NumberFormatQuery.dto';
 import {
+  FinancialTableColumnDto,
   FinancialReportTotalDto,
   FinancialReportMetaDto,
   FinancialTableDataDto,
 } from '../../dtos/FinancialReportResponse.dto';
+import {
+  INVENTORY_ITEM_DETAILS_COLUMN_KEYS,
+  InventoryItemDetailsColumnKey,
+} from '../../common/constants/tableColumnKeys';
 
 export class InventoryItemTransactionDto {
   @ApiProperty({ description: 'Transaction date' })
@@ -113,16 +118,30 @@ export class InventoryItemDetailsResponseDto {
 export {
   FinancialTableCellDto as InventoryItemDetailsTableCellDto,
   FinancialTableRowDto as InventoryItemDetailsTableRowDto,
-  FinancialTableColumnDto as InventoryItemDetailsTableColumnDto,
-  FinancialTableDataDto as InventoryItemDetailsTableDataDto,
 } from '../../dtos/FinancialReportResponse.dto';
+
+export class InventoryItemDetailsTableColumnDto extends FinancialTableColumnDto {
+  @ApiProperty({
+    description: 'Column key',
+    enum: Object.values(INVENTORY_ITEM_DETAILS_COLUMN_KEYS),
+  })
+  key: InventoryItemDetailsColumnKey;
+}
+
+export class InventoryItemDetailsTableDataDto extends FinancialTableDataDto {
+  @ApiProperty({
+    description: 'Table column definitions',
+    type: [InventoryItemDetailsTableColumnDto],
+  })
+  columns: InventoryItemDetailsTableColumnDto[];
+}
 
 export class InventoryItemDetailsTableResponseDto {
   @ApiProperty({
     description: 'Table data structure',
-    type: () => FinancialTableDataDto,
+    type: () => InventoryItemDetailsTableDataDto,
   })
-  table: FinancialTableDataDto;
+  table: InventoryItemDetailsTableDataDto;
 
   @ApiProperty({
     description: 'Query parameters used to generate the report',

--- a/packages/server/src/modules/FinancialStatements/modules/InventoryItemDetails/InventoryItemDetailsTable.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/InventoryItemDetails/InventoryItemDetailsTable.ts
@@ -16,6 +16,7 @@ import {
   ITableRow,
 } from '../../types/Table.types';
 import { mapValuesDeep } from '@/utils/deepdash';
+import { INVENTORY_ITEM_DETAILS_COLUMN_KEYS } from '../../common/constants/tableColumnKeys';
 
 enum IROW_TYPE {
   ITEM = 'ITEM',
@@ -61,18 +62,42 @@ export class InventoryItemDetailsTable {
     transaction: IInventoryDetailsItemTransaction,
   ) => {
     const columns = [
-      { key: 'date', accessor: 'date.formattedDate' },
-      { key: 'transaction_type', accessor: 'transactionType' },
-      { key: 'transaction_id', accessor: 'transactionNumber' },
+      {
+        key: INVENTORY_ITEM_DETAILS_COLUMN_KEYS.DATE,
+        accessor: 'date.formattedDate',
+      },
+      {
+        key: INVENTORY_ITEM_DETAILS_COLUMN_KEYS.TRANSACTION_TYPE,
+        accessor: 'transactionType',
+      },
+      {
+        key: INVENTORY_ITEM_DETAILS_COLUMN_KEYS.TRANSACTION_ID,
+        accessor: 'transactionNumber',
+      },
       {
         key: 'quantity_movement',
         accessor: 'quantityMovement.formattedNumber',
       },
-      { key: 'rate', accessor: 'rate.formattedNumber' },
-      { key: 'total', accessor: 'total.formattedNumber' },
-      { key: 'value', accessor: 'valueMovement.formattedNumber' },
-      { key: 'profit_margin', accessor: 'profitMargin.formattedNumber' },
-      { key: 'running_quantity', accessor: 'runningQuantity.formattedNumber' },
+      {
+        key: INVENTORY_ITEM_DETAILS_COLUMN_KEYS.RATE,
+        accessor: 'rate.formattedNumber',
+      },
+      {
+        key: INVENTORY_ITEM_DETAILS_COLUMN_KEYS.TOTAL,
+        accessor: 'total.formattedNumber',
+      },
+      {
+        key: INVENTORY_ITEM_DETAILS_COLUMN_KEYS.VALUE,
+        accessor: 'valueMovement.formattedNumber',
+      },
+      {
+        key: INVENTORY_ITEM_DETAILS_COLUMN_KEYS.PROFIT_MARGIN,
+        accessor: 'profitMargin.formattedNumber',
+      },
+      {
+        key: INVENTORY_ITEM_DETAILS_COLUMN_KEYS.RUNNING_QUANTITY,
+        accessor: 'runningQuantity.formattedNumber',
+      },
       {
         key: 'running_valuation',
         accessor: 'runningValuation.formattedNumber',
@@ -92,16 +117,25 @@ export class InventoryItemDetailsTable {
     transaction: IInventoryDetailsOpening,
   ): ITableRow => {
     const columns: Array<IColumnMapperMeta> = [
-      { key: 'date', accessor: 'date.formattedDate' },
+      {
+        key: INVENTORY_ITEM_DETAILS_COLUMN_KEYS.DATE,
+        accessor: 'date.formattedDate',
+      },
       {
         key: 'closing',
         value: this.i18n.t('inventory_item_details.opening_balance'),
       },
       { key: 'empty', value: '' },
-      { key: 'quantity', accessor: 'quantity.formattedNumber' },
+      {
+        key: INVENTORY_ITEM_DETAILS_COLUMN_KEYS.QUANTITY,
+        accessor: 'quantity.formattedNumber',
+      },
       { key: 'empty', value: '' },
       { key: 'empty', value: '' },
-      { key: 'value', accessor: 'value.formattedNumber' },
+      {
+        key: INVENTORY_ITEM_DETAILS_COLUMN_KEYS.VALUE,
+        accessor: 'value.formattedNumber',
+      },
     ];
     return tableRowMapper(transaction, columns, {
       rowTypes: [IROW_TYPE.OPENING_ENTRY],
@@ -117,16 +151,25 @@ export class InventoryItemDetailsTable {
     transaction: IInventoryDetailsClosing,
   ): ITableRow => {
     const columns: Array<IColumnMapperMeta> = [
-      { key: 'date', accessor: 'date.formattedDate' },
+      {
+        key: INVENTORY_ITEM_DETAILS_COLUMN_KEYS.DATE,
+        accessor: 'date.formattedDate',
+      },
       {
         key: 'closing',
         value: this.i18n.t('inventory_item_details.closing_balance'),
       },
       { key: 'empty', value: '' },
-      { key: 'quantity', accessor: 'quantity.formattedNumber' },
+      {
+        key: INVENTORY_ITEM_DETAILS_COLUMN_KEYS.QUANTITY,
+        accessor: 'quantity.formattedNumber',
+      },
       { key: 'empty', value: '' },
       { key: 'empty', value: '' },
-      { key: 'value', accessor: 'value.formattedNumber' },
+      {
+        key: INVENTORY_ITEM_DETAILS_COLUMN_KEYS.VALUE,
+        accessor: 'value.formattedNumber',
+      },
       { key: 'profitMargin', accessor: 'profitMargin.formattedNumber' },
     ];
     return tableRowMapper(transaction, columns, {
@@ -199,32 +242,44 @@ export class InventoryItemDetailsTable {
    */
   public tableColumns = (): ITableColumn[] => {
     return [
-      { key: 'date', label: this.i18n.t('inventory_item_details.date') },
       {
-        key: 'transaction_type',
+        key: INVENTORY_ITEM_DETAILS_COLUMN_KEYS.DATE,
+        label: this.i18n.t('inventory_item_details.date'),
+      },
+      {
+        key: INVENTORY_ITEM_DETAILS_COLUMN_KEYS.TRANSACTION_TYPE,
         label: this.i18n.t('inventory_item_details.transaction_type'),
       },
       {
-        key: 'transaction_id',
+        key: INVENTORY_ITEM_DETAILS_COLUMN_KEYS.TRANSACTION_ID,
         label: this.i18n.t('inventory_item_details.transaction_number'),
       },
       {
-        key: 'quantity',
+        key: INVENTORY_ITEM_DETAILS_COLUMN_KEYS.QUANTITY,
         label: this.i18n.t('inventory_item_details.quantity'),
       },
-      { key: 'rate', label: this.i18n.t('inventory_item_details.rate') },
-      { key: 'total', label: this.i18n.t('inventory_item_details.total') },
-      { key: 'value', label: this.i18n.t('inventory_item_details.value') },
       {
-        key: 'profit_margin',
+        key: INVENTORY_ITEM_DETAILS_COLUMN_KEYS.RATE,
+        label: this.i18n.t('inventory_item_details.rate'),
+      },
+      {
+        key: INVENTORY_ITEM_DETAILS_COLUMN_KEYS.TOTAL,
+        label: this.i18n.t('inventory_item_details.total'),
+      },
+      {
+        key: INVENTORY_ITEM_DETAILS_COLUMN_KEYS.VALUE,
+        label: this.i18n.t('inventory_item_details.value'),
+      },
+      {
+        key: INVENTORY_ITEM_DETAILS_COLUMN_KEYS.PROFIT_MARGIN,
         label: this.i18n.t('inventory_item_details.profit_margin'),
       },
       {
-        key: 'running_quantity',
+        key: INVENTORY_ITEM_DETAILS_COLUMN_KEYS.RUNNING_QUANTITY,
         label: this.i18n.t('inventory_item_details.running_quantity'),
       },
       {
-        key: 'running_value',
+        key: INVENTORY_ITEM_DETAILS_COLUMN_KEYS.RUNNING_VALUE,
         label: this.i18n.t('inventory_item_details.running_value'),
       },
     ];

--- a/packages/server/src/modules/FinancialStatements/modules/InventoryValuationSheet/InventoryValuationResponse.dto.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/InventoryValuationSheet/InventoryValuationResponse.dto.ts
@@ -1,10 +1,15 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { NumberFormatQueryDto } from '@/modules/BankingTransactions/dtos/NumberFormatQuery.dto';
 import {
+  FinancialTableColumnDto,
   FinancialReportTotalDto,
   FinancialReportMetaDto,
   FinancialTableDataDto,
 } from '../../dtos/FinancialReportResponse.dto';
+import {
+  INVENTORY_VALUATION_COLUMN_KEYS,
+  InventoryValuationColumnKey,
+} from '../../common/constants/tableColumnKeys';
 
 export class InventoryValuationItemDto {
   @ApiProperty({ description: 'Item ID', type: Number })
@@ -87,16 +92,30 @@ export class InventoryValuationResponseDto {
 export {
   FinancialTableCellDto as InventoryValuationTableCellDto,
   FinancialTableRowDto as InventoryValuationTableRowDto,
-  FinancialTableColumnDto as InventoryValuationTableColumnDto,
-  FinancialTableDataDto as InventoryValuationTableDataDto,
 } from '../../dtos/FinancialReportResponse.dto';
+
+export class InventoryValuationTableColumnDto extends FinancialTableColumnDto {
+  @ApiProperty({
+    description: 'Column key',
+    enum: Object.values(INVENTORY_VALUATION_COLUMN_KEYS),
+  })
+  key: InventoryValuationColumnKey;
+}
+
+export class InventoryValuationTableDataDto extends FinancialTableDataDto {
+  @ApiProperty({
+    description: 'Table column definitions',
+    type: [InventoryValuationTableColumnDto],
+  })
+  columns: InventoryValuationTableColumnDto[];
+}
 
 export class InventoryValuationTableResponseDto {
   @ApiProperty({
     description: 'Table data structure',
-    type: () => FinancialTableDataDto,
+    type: () => InventoryValuationTableDataDto,
   })
-  table: FinancialTableDataDto;
+  table: InventoryValuationTableDataDto;
 
   @ApiProperty({
     description: 'Query parameters used to generate the report',

--- a/packages/server/src/modules/FinancialStatements/modules/InventoryValuationSheet/InventoryValuationSheetTable.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/InventoryValuationSheet/InventoryValuationSheetTable.ts
@@ -14,6 +14,7 @@ import {
   ITableRow,
 } from '../../types/Table.types';
 import { tableRowMapper } from '../../utils/Table.utils';
+import { INVENTORY_VALUATION_COLUMN_KEYS } from '../../common/constants/tableColumnKeys';
 
 export class InventoryValuationSheetTable extends R.pipe(
   FinancialTable,
@@ -36,10 +37,19 @@ export class InventoryValuationSheetTable extends R.pipe(
    */
   private commonColumnsAccessors(): ITableColumnAccessor[] {
     return [
-      { key: 'item_name', accessor: 'name' },
-      { key: 'quantity', accessor: 'quantityFormatted' },
-      { key: 'valuation', accessor: 'valuationFormatted' },
-      { key: 'average', accessor: 'averageFormatted' },
+      { key: INVENTORY_VALUATION_COLUMN_KEYS.ITEM_NAME, accessor: 'name' },
+      {
+        key: INVENTORY_VALUATION_COLUMN_KEYS.QUANTITY,
+        accessor: 'quantityFormatted',
+      },
+      {
+        key: INVENTORY_VALUATION_COLUMN_KEYS.VALUATION,
+        accessor: 'valuationFormatted',
+      },
+      {
+        key: INVENTORY_VALUATION_COLUMN_KEYS.AVERAGE,
+        accessor: 'averageFormatted',
+      },
     ];
   }
 
@@ -97,10 +107,10 @@ export class InventoryValuationSheetTable extends R.pipe(
    */
   public tableColumns(): ITableColumn[] {
     const columns = [
-      { key: 'item_name', label: 'Item Name' },
-      { key: 'quantity', label: 'Quantity' },
-      { key: 'valuation', label: 'Valuation' },
-      { key: 'average', label: 'Average' },
+      { key: INVENTORY_VALUATION_COLUMN_KEYS.ITEM_NAME, label: 'Item Name' },
+      { key: INVENTORY_VALUATION_COLUMN_KEYS.QUANTITY, label: 'Quantity' },
+      { key: INVENTORY_VALUATION_COLUMN_KEYS.VALUATION, label: 'Valuation' },
+      { key: INVENTORY_VALUATION_COLUMN_KEYS.AVERAGE, label: 'Average' },
     ];
     return R.compose(this.tableColumnsCellIndexing)(columns);
   }

--- a/packages/server/src/modules/FinancialStatements/modules/JournalSheet/JournalSheetResponse.dto.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/JournalSheet/JournalSheetResponse.dto.ts
@@ -1,8 +1,13 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import {
+  FinancialTableColumnDto,
   FinancialReportMetaDto,
   FinancialTableDataDto,
 } from '../../dtos/FinancialReportResponse.dto';
+import {
+  JOURNAL_COLUMN_KEYS,
+  JournalColumnKey,
+} from '../../common/constants/tableColumnKeys';
 import { NumberFormatQueryDto } from '@/modules/BankingTransactions/dtos/NumberFormatQuery.dto';
 
 export class JournalEntryDto {
@@ -127,16 +132,30 @@ export class JournalSheetResponseDto {
 export {
   FinancialTableCellDto as JournalSheetTableCellDto,
   FinancialTableRowDto as JournalSheetTableRowDto,
-  FinancialTableColumnDto as JournalSheetTableColumnDto,
-  FinancialTableDataDto as JournalSheetTableDataDto,
 } from '../../dtos/FinancialReportResponse.dto';
+
+export class JournalSheetTableColumnDto extends FinancialTableColumnDto {
+  @ApiProperty({
+    description: 'Column key',
+    enum: Object.values(JOURNAL_COLUMN_KEYS),
+  })
+  key: JournalColumnKey;
+}
+
+export class JournalSheetTableDataDto extends FinancialTableDataDto {
+  @ApiProperty({
+    description: 'Table column definitions',
+    type: [JournalSheetTableColumnDto],
+  })
+  columns: JournalSheetTableColumnDto[];
+}
 
 export class JournalSheetTableResponseDto {
   @ApiProperty({
     description: 'Table data structure',
-    type: () => FinancialTableDataDto,
+    type: () => JournalSheetTableDataDto,
   })
-  table: FinancialTableDataDto;
+  table: JournalSheetTableDataDto;
 
   @ApiProperty({
     description: 'Query parameters used to generate the report',

--- a/packages/server/src/modules/FinancialStatements/modules/JournalSheet/JournalSheetTable.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/JournalSheet/JournalSheetTable.ts
@@ -19,6 +19,7 @@ import {
 } from '../../types/Table.types';
 import { tableRowMapper } from '../../utils/Table.utils';
 import { ILedgerEntry } from '@/modules/Ledger/types/Ledger.types';
+import { JOURNAL_COLUMN_KEYS } from '../../common/constants/tableColumnKeys';
 
 export class JournalSheetTable extends R.pipe(
   FinancialTable,
@@ -52,14 +53,20 @@ export class JournalSheetTable extends R.pipe(
    */
   private groupColumnsAccessors = (): ITableColumnAccessor[] => {
     return [
-      { key: 'date', accessor: 'dateFormatted' },
-      { key: 'transaction_type', accessor: 'referenceTypeFormatted' },
-      { key: 'transaction_number', accessor: 'entry.transactionNumber' },
-      { key: 'description', accessor: 'entry.note' },
-      { key: 'account_code', accessor: 'entry.accountCode' },
-      { key: 'account_name', accessor: 'entry.accountName' },
-      { key: 'debit', accessor: 'entry.formattedDebit' },
-      { key: 'credit', accessor: 'entry.formattedCredit' },
+      { key: JOURNAL_COLUMN_KEYS.DATE, accessor: 'dateFormatted' },
+      {
+        key: JOURNAL_COLUMN_KEYS.TRANSACTION_TYPE,
+        accessor: 'referenceTypeFormatted',
+      },
+      {
+        key: JOURNAL_COLUMN_KEYS.TRANSACTION_NUMBER,
+        accessor: 'entry.transactionNumber',
+      },
+      { key: JOURNAL_COLUMN_KEYS.DESCRIPTION, accessor: 'entry.note' },
+      { key: JOURNAL_COLUMN_KEYS.ACCOUNT_CODE, accessor: 'entry.accountCode' },
+      { key: JOURNAL_COLUMN_KEYS.ACCOUNT_NAME, accessor: 'entry.accountName' },
+      { key: JOURNAL_COLUMN_KEYS.DEBIT, accessor: 'entry.formattedDebit' },
+      { key: JOURNAL_COLUMN_KEYS.CREDIT, accessor: 'entry.formattedCredit' },
     ];
   };
 
@@ -69,14 +76,17 @@ export class JournalSheetTable extends R.pipe(
    */
   private entryColumnsAccessors = (): ITableColumnAccessor[] => {
     return [
-      { key: 'date', accessor: '_empty_' },
-      { key: 'transaction_type', accessor: '_empty_' },
-      { key: 'transaction_number', accessor: 'transactionNumber' },
-      { key: 'description', accessor: 'note' },
-      { key: 'account_code', accessor: 'accountCode' },
-      { key: 'account_name', accessor: 'accountName' },
-      { key: 'debit', accessor: 'formattedDebit' },
-      { key: 'credit', accessor: 'formattedCredit' },
+      { key: JOURNAL_COLUMN_KEYS.DATE, accessor: '_empty_' },
+      { key: JOURNAL_COLUMN_KEYS.TRANSACTION_TYPE, accessor: '_empty_' },
+      {
+        key: JOURNAL_COLUMN_KEYS.TRANSACTION_NUMBER,
+        accessor: 'transactionNumber',
+      },
+      { key: JOURNAL_COLUMN_KEYS.DESCRIPTION, accessor: 'note' },
+      { key: JOURNAL_COLUMN_KEYS.ACCOUNT_CODE, accessor: 'accountCode' },
+      { key: JOURNAL_COLUMN_KEYS.ACCOUNT_NAME, accessor: 'accountName' },
+      { key: JOURNAL_COLUMN_KEYS.DEBIT, accessor: 'formattedDebit' },
+      { key: JOURNAL_COLUMN_KEYS.CREDIT, accessor: 'formattedCredit' },
     ];
   };
 
@@ -86,14 +96,14 @@ export class JournalSheetTable extends R.pipe(
    */
   private totalEntryColumnAccessors = (): ITableColumnAccessor[] => {
     return [
-      { key: 'date', accessor: '_empty_' },
-      { key: 'transaction_type', accessor: '_empty_' },
-      { key: 'transaction_number', accessor: '_empty_' },
-      { key: 'description', accessor: '_empty_' },
-      { key: 'account_code', accessor: '_empty_' },
-      { key: 'account_name', accessor: '_empty_' },
-      { key: 'debit', accessor: 'formattedDebit' },
-      { key: 'credit', accessor: 'formattedCredit' },
+      { key: JOURNAL_COLUMN_KEYS.DATE, accessor: '_empty_' },
+      { key: JOURNAL_COLUMN_KEYS.TRANSACTION_TYPE, accessor: '_empty_' },
+      { key: JOURNAL_COLUMN_KEYS.TRANSACTION_NUMBER, accessor: '_empty_' },
+      { key: JOURNAL_COLUMN_KEYS.DESCRIPTION, accessor: '_empty_' },
+      { key: JOURNAL_COLUMN_KEYS.ACCOUNT_CODE, accessor: '_empty_' },
+      { key: JOURNAL_COLUMN_KEYS.ACCOUNT_NAME, accessor: '_empty_' },
+      { key: JOURNAL_COLUMN_KEYS.DEBIT, accessor: 'formattedDebit' },
+      { key: JOURNAL_COLUMN_KEYS.CREDIT, accessor: 'formattedCredit' },
     ];
   };
 
@@ -103,14 +113,14 @@ export class JournalSheetTable extends R.pipe(
    */
   private blankEnrtyColumnAccessors = (): IColumnMapperMeta[] => {
     return [
-      { key: 'date', value: '' },
-      { key: 'transaction_type', value: '' },
-      { key: 'transaction_number', value: '' },
-      { key: 'description', value: '' },
-      { key: 'account_code', value: '' },
-      { key: 'account_name', value: '' },
-      { key: 'debit', value: '' },
-      { key: 'credit', value: '' },
+      { key: JOURNAL_COLUMN_KEYS.DATE, value: '' },
+      { key: JOURNAL_COLUMN_KEYS.TRANSACTION_TYPE, value: '' },
+      { key: JOURNAL_COLUMN_KEYS.TRANSACTION_NUMBER, value: '' },
+      { key: JOURNAL_COLUMN_KEYS.DESCRIPTION, value: '' },
+      { key: JOURNAL_COLUMN_KEYS.ACCOUNT_CODE, value: '' },
+      { key: JOURNAL_COLUMN_KEYS.ACCOUNT_NAME, value: '' },
+      { key: JOURNAL_COLUMN_KEYS.DEBIT, value: '' },
+      { key: JOURNAL_COLUMN_KEYS.CREDIT, value: '' },
     ];
   };
 
@@ -120,14 +130,14 @@ export class JournalSheetTable extends R.pipe(
    */
   private commonColumns(): ITableColumn[] {
     return [
-      { key: 'date', label: 'Date' },
-      { key: 'transaction_type', label: 'Transaction Type' },
-      { key: 'transaction_number', label: 'Num.' },
-      { key: 'description', label: 'Description' },
-      { key: 'account_code', label: 'Acc. Code' },
-      { key: 'account_name', label: 'Account' },
-      { key: 'debit', label: 'Debit' },
-      { key: 'credit', label: 'Credit' },
+      { key: JOURNAL_COLUMN_KEYS.DATE, label: 'Date' },
+      { key: JOURNAL_COLUMN_KEYS.TRANSACTION_TYPE, label: 'Transaction Type' },
+      { key: JOURNAL_COLUMN_KEYS.TRANSACTION_NUMBER, label: 'Num.' },
+      { key: JOURNAL_COLUMN_KEYS.DESCRIPTION, label: 'Description' },
+      { key: JOURNAL_COLUMN_KEYS.ACCOUNT_CODE, label: 'Acc. Code' },
+      { key: JOURNAL_COLUMN_KEYS.ACCOUNT_NAME, label: 'Account' },
+      { key: JOURNAL_COLUMN_KEYS.DEBIT, label: 'Debit' },
+      { key: JOURNAL_COLUMN_KEYS.CREDIT, label: 'Credit' },
     ];
   }
 

--- a/packages/server/src/modules/FinancialStatements/modules/ProfitLossSheet/ProfitLossSheetResponse.dto.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/ProfitLossSheet/ProfitLossSheetResponse.dto.ts
@@ -1,11 +1,16 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { NumberFormatQueryDto } from '@/modules/BankingTransactions/dtos/NumberFormatQuery.dto';
 import {
+  FinancialTableColumnDto,
   FinancialReportTotalDto,
   FinancialReportPercentageDto,
   FinancialReportMetaDto,
   FinancialTableDataDto,
 } from '../../dtos/FinancialReportResponse.dto';
+import {
+  PROFIT_LOSS_COLUMN_KEYS,
+  ProfitLossColumnKey,
+} from '../../common/constants/tableColumnKeys';
 
 export class ProfitLossSheetDataNodeDto {
   @ApiProperty({
@@ -210,16 +215,30 @@ export class ProfitLossSheetResponseDto {
 export {
   FinancialTableCellDto as ProfitLossSheetTableCellDto,
   FinancialTableRowDto as ProfitLossSheetTableRowDto,
-  FinancialTableColumnDto as ProfitLossSheetTableColumnDto,
-  FinancialTableDataDto as ProfitLossSheetTableDataDto,
 } from '../../dtos/FinancialReportResponse.dto';
+
+export class ProfitLossSheetTableColumnDto extends FinancialTableColumnDto {
+  @ApiProperty({
+    description: 'Column key',
+    enum: Object.values(PROFIT_LOSS_COLUMN_KEYS),
+  })
+  key: ProfitLossColumnKey;
+}
+
+export class ProfitLossSheetTableDataDto extends FinancialTableDataDto {
+  @ApiProperty({
+    description: 'Table column definitions',
+    type: [ProfitLossSheetTableColumnDto],
+  })
+  columns: ProfitLossSheetTableColumnDto[];
+}
 
 export class ProfitLossSheetTableResponseDto {
   @ApiProperty({
     description: 'Table data structure',
-    type: () => FinancialTableDataDto,
+    type: () => ProfitLossSheetTableDataDto,
   })
-  table: FinancialTableDataDto;
+  table: ProfitLossSheetTableDataDto;
 
   @ApiProperty({
     description: 'Query parameters used to generate the report',

--- a/packages/server/src/modules/FinancialStatements/modules/ProfitLossSheet/ProfitLossSheetTable.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/ProfitLossSheet/ProfitLossSheetTable.ts
@@ -24,6 +24,7 @@ import { I18nService } from 'nestjs-i18n';
 import { FinancialSheetStructure } from '../../common/FinancialSheetStructure';
 import { FinancialTable } from '../../common/FinancialTable';
 import { tableRowMapper } from '../../utils/Table.utils';
+import { PROFIT_LOSS_COLUMN_KEYS } from '../../common/constants/tableColumnKeys';
 
 export class ProfitLossSheetTable extends R.pipe(
   ProfitLossTablePreviousPeriod,
@@ -68,7 +69,12 @@ export class ProfitLossSheetTable extends R.pipe(
         R.concat(this.previousYearColumnAccessor()),
       ),
       R.concat(this.percentageColumnsAccessor()),
-      R.concat([{ key: 'total', accessor: 'total.formattedAmount' }]),
+      R.concat([
+        {
+          key: PROFIT_LOSS_COLUMN_KEYS.TOTAL,
+          accessor: 'total.formattedAmount',
+        },
+      ]),
     )([]);
   };
 
@@ -78,7 +84,7 @@ export class ProfitLossSheetTable extends R.pipe(
    */
   private commonColumnsAccessors = (): ITableColumnAccessor[] => {
     return R.compose(
-      R.concat([{ key: 'name', accessor: 'name' }]),
+      R.concat([{ key: PROFIT_LOSS_COLUMN_KEYS.NAME, accessor: 'name' }]),
       R.ifElse(
         this.query.isDatePeriodsColumnsType,
         R.concat(this.datePeriodsColumnsAccessors()),
@@ -189,7 +195,10 @@ export class ProfitLossSheetTable extends R.pipe(
       R.unless(
         R.isEmpty,
         R.concat([
-          { key: 'total', label: this.i18n.t('profit_loss_sheet.total') },
+          {
+            key: PROFIT_LOSS_COLUMN_KEYS.TOTAL,
+            label: this.i18n.t('profit_loss_sheet.total'),
+          },
         ]),
       ),
       R.concat(this.percentageColumns()),
@@ -211,7 +220,7 @@ export class ProfitLossSheetTable extends R.pipe(
   private totalColumn = (): ITableColumn[] => {
     return [
       {
-        key: 'total',
+        key: PROFIT_LOSS_COLUMN_KEYS.TOTAL,
         label: this.i18n.t('profit_loss_sheet.total'),
         children: this.tableColumnChildren(),
       },
@@ -226,7 +235,10 @@ export class ProfitLossSheetTable extends R.pipe(
     return R.compose(
       this.tableColumnsCellIndexing,
       R.concat([
-        { key: 'name', label: this.i18n.t('profit_loss_sheet.account_name') },
+        {
+          key: PROFIT_LOSS_COLUMN_KEYS.NAME,
+          label: this.i18n.t('profit_loss_sheet.account_name'),
+        },
       ]),
       R.ifElse(
         this.query.isDatePeriodsColumnsType,

--- a/packages/server/src/modules/FinancialStatements/modules/ProfitLossSheet/ProfitLossSheetTableDatePeriods.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/ProfitLossSheet/ProfitLossSheetTableDatePeriods.ts
@@ -8,6 +8,7 @@ import { FinancialDatePeriods } from '../../common/FinancialDatePeriods';
 import { GConstructor } from '@/common/types/Constructor';
 import { FinancialSheet } from '../../common/FinancialSheet';
 import { IDateRange } from '../../types/Report.types';
+import { PROFIT_LOSS_COLUMN_KEYS } from '../../common/constants/tableColumnKeys';
 
 export const ProfitLossSheetTableDatePeriods = <
   T extends GConstructor<FinancialSheet>,
@@ -116,7 +117,10 @@ export const ProfitLossSheetTableDatePeriods = <
         R.unless(
           R.isEmpty,
           R.concat([
-            { key: `total`, label: this.i18n.t('profit_loss_sheet.total') },
+            {
+              key: PROFIT_LOSS_COLUMN_KEYS.TOTAL,
+              label: this.i18n.t('profit_loss_sheet.total'),
+            },
           ]),
         ),
         R.concat(this.percentageColumns()),

--- a/packages/server/src/modules/FinancialStatements/modules/ProfitLossSheet/ProfitLossSheetTablePercentage.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/ProfitLossSheet/ProfitLossSheetTablePercentage.ts
@@ -5,6 +5,7 @@ import { I18nService } from 'nestjs-i18n';
 import { GConstructor } from '@/common/types/Constructor';
 import { FinancialSheet } from '../../common/FinancialSheet';
 import { ITableColumn, ITableColumnAccessor } from '../../types/Table.types';
+import { PROFIT_LOSS_COLUMN_KEYS } from '../../common/constants/tableColumnKeys';
 
 export const ProfitLossSheetTablePercentage = <
   T extends GConstructor<FinancialSheet>,
@@ -31,28 +32,28 @@ export const ProfitLossSheetTablePercentage = <
         R.when(
           this.query.isIncomePercentage,
           R.append({
-            key: 'percentage_income',
+            key: PROFIT_LOSS_COLUMN_KEYS.PERCENTAGE_OF_INCOME,
             label: this.i18n.t('profit_loss_sheet.percentage_of_income'),
           }),
         ),
         R.when(
           this.query.isExpensesPercentage,
           R.append({
-            key: 'percentage_expenses',
+            key: PROFIT_LOSS_COLUMN_KEYS.PERCENTAGE_OF_EXPENSES,
             label: this.i18n.t('profit_loss_sheet.percentage_of_expenses'),
           }),
         ),
         R.when(
           this.query.isColumnPercentage,
           R.append({
-            key: 'percentage_column',
+            key: PROFIT_LOSS_COLUMN_KEYS.PERCENTAGE_OF_COLUMN,
             label: this.i18n.t('profit_loss_sheet.percentage_of_column'),
           }),
         ),
         R.when(
           this.query.isRowPercentage,
           R.append({
-            key: 'percentage_row',
+            key: PROFIT_LOSS_COLUMN_KEYS.PERCENTAGE_OF_ROW,
             label: this.i18n.t('profit_loss_sheet.percentage_of_row'),
           }),
         ),
@@ -71,7 +72,7 @@ export const ProfitLossSheetTablePercentage = <
         R.when(
           this.query.isIncomePercentage,
           R.append({
-            key: 'percentage_income',
+            key: PROFIT_LOSS_COLUMN_KEYS.PERCENTAGE_OF_INCOME,
             accessor: 'percentageIncome.formattedAmount',
           }),
         ),
@@ -85,14 +86,14 @@ export const ProfitLossSheetTablePercentage = <
         R.when(
           this.query.isColumnPercentage,
           R.append({
-            key: 'percentage_column',
+            key: PROFIT_LOSS_COLUMN_KEYS.PERCENTAGE_OF_COLUMN,
             accessor: 'percentageColumn.formattedAmount',
           }),
         ),
         R.when(
           this.query.isRowPercentage,
           R.append({
-            key: 'percentage_row',
+            key: PROFIT_LOSS_COLUMN_KEYS.PERCENTAGE_OF_ROW,
             accessor: 'percentageRow.formattedAmount',
           }),
         ),

--- a/packages/server/src/modules/FinancialStatements/modules/PurchasesByItems/PurchasesByItemsResponse.dto.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/PurchasesByItems/PurchasesByItemsResponse.dto.ts
@@ -1,10 +1,15 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { NumberFormatQueryDto } from '@/modules/BankingTransactions/dtos/NumberFormatQuery.dto';
 import {
+  FinancialTableColumnDto,
   FinancialReportTotalDto,
   FinancialReportMetaDto,
   FinancialTableDataDto,
 } from '../../dtos/FinancialReportResponse.dto';
+import {
+  PURCHASES_BY_ITEMS_COLUMN_KEYS,
+  PurchasesByItemsColumnKey,
+} from '../../common/constants/tableColumnKeys';
 
 export class PurchasesByItemDto {
   @ApiProperty({ description: 'Item ID', type: Number })
@@ -87,16 +92,30 @@ export class PurchasesByItemsResponseDto {
 export {
   FinancialTableCellDto as PurchasesByItemsTableCellDto,
   FinancialTableRowDto as PurchasesByItemsTableRowDto,
-  FinancialTableColumnDto as PurchasesByItemsTableColumnDto,
-  FinancialTableDataDto as PurchasesByItemsTableDataDto,
 } from '../../dtos/FinancialReportResponse.dto';
+
+export class PurchasesByItemsTableColumnDto extends FinancialTableColumnDto {
+  @ApiProperty({
+    description: 'Column key',
+    enum: Object.values(PURCHASES_BY_ITEMS_COLUMN_KEYS),
+  })
+  key: PurchasesByItemsColumnKey;
+}
+
+export class PurchasesByItemsTableDataDto extends FinancialTableDataDto {
+  @ApiProperty({
+    description: 'Table column definitions',
+    type: [PurchasesByItemsTableColumnDto],
+  })
+  columns: PurchasesByItemsTableColumnDto[];
+}
 
 export class PurchasesByItemsTableResponseDto {
   @ApiProperty({
     description: 'Table data structure',
-    type: () => FinancialTableDataDto,
+    type: () => PurchasesByItemsTableDataDto,
   })
-  table: FinancialTableDataDto;
+  table: PurchasesByItemsTableDataDto;
 
   @ApiProperty({
     description: 'Query parameters used to generate the report',

--- a/packages/server/src/modules/FinancialStatements/modules/PurchasesByItems/PurchasesByItemsTable.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/PurchasesByItems/PurchasesByItemsTable.ts
@@ -14,6 +14,7 @@ import { FinancialTable } from '../../common/FinancialTable';
 import { FinancialSheetStructure } from '../../common/FinancialSheetStructure';
 import { FinancialSheet } from '../../common/FinancialSheet';
 import { tableRowMapper } from '../../utils/Table.utils';
+import { PURCHASES_BY_ITEMS_COLUMN_KEYS } from '../../common/constants/tableColumnKeys';
 
 export class PurchasesByItemsTable extends R.compose(
   FinancialTable,
@@ -36,10 +37,19 @@ export class PurchasesByItemsTable extends R.compose(
    */
   private commonTableAccessors(): ITableColumnAccessor[] {
     return [
-      { key: 'item_name', accessor: 'name' },
-      { key: 'quantity_purchases', accessor: 'quantityPurchasedFormatted' },
-      { key: 'purchase_amount', accessor: 'purchaseCostFormatted' },
-      { key: 'average_cost', accessor: 'averageCostPriceFormatted' },
+      { key: PURCHASES_BY_ITEMS_COLUMN_KEYS.ITEM_NAME, accessor: 'name' },
+      {
+        key: PURCHASES_BY_ITEMS_COLUMN_KEYS.QUANTITY_PURCHASES,
+        accessor: 'quantityPurchasedFormatted',
+      },
+      {
+        key: PURCHASES_BY_ITEMS_COLUMN_KEYS.PURCHASE_AMOUNT,
+        accessor: 'purchaseCostFormatted',
+      },
+      {
+        key: PURCHASES_BY_ITEMS_COLUMN_KEYS.AVERAGE_COST,
+        accessor: 'averageCostPriceFormatted',
+      },
     ];
   }
 
@@ -49,10 +59,19 @@ export class PurchasesByItemsTable extends R.compose(
    */
   private commonTableColumns(): ITableColumn[] {
     return [
-      { label: 'Item name', key: 'item_name' },
-      { label: 'Quantity Purchased', key: 'quantity_purchases' },
-      { label: 'Purchase Amount', key: 'purchase_amount' },
-      { label: 'Average Price', key: 'average_cost' },
+      { label: 'Item name', key: PURCHASES_BY_ITEMS_COLUMN_KEYS.ITEM_NAME },
+      {
+        label: 'Quantity Purchased',
+        key: PURCHASES_BY_ITEMS_COLUMN_KEYS.QUANTITY_PURCHASES,
+      },
+      {
+        label: 'Purchase Amount',
+        key: PURCHASES_BY_ITEMS_COLUMN_KEYS.PURCHASE_AMOUNT,
+      },
+      {
+        label: 'Average Price',
+        key: PURCHASES_BY_ITEMS_COLUMN_KEYS.AVERAGE_COST,
+      },
     ];
   }
 

--- a/packages/server/src/modules/FinancialStatements/modules/SalesByItems/SalesByItemsResponse.dto.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/SalesByItems/SalesByItemsResponse.dto.ts
@@ -1,10 +1,15 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { NumberFormatQueryDto } from '@/modules/BankingTransactions/dtos/NumberFormatQuery.dto';
 import {
+  FinancialTableColumnDto,
   FinancialReportTotalDto,
   FinancialReportMetaDto,
   FinancialTableDataDto,
 } from '../../dtos/FinancialReportResponse.dto';
+import {
+  SALES_BY_ITEMS_COLUMN_KEYS,
+  SalesByItemsColumnKey,
+} from '../../common/constants/tableColumnKeys';
 
 export class SalesByItemDto {
   @ApiProperty({ description: 'Item ID', type: Number })
@@ -90,16 +95,30 @@ export class SalesByItemsResponseDto {
 export {
   FinancialTableCellDto as SalesByItemsTableCellDto,
   FinancialTableRowDto as SalesByItemsTableRowDto,
-  FinancialTableColumnDto as SalesByItemsTableColumnDto,
-  FinancialTableDataDto as SalesByItemsTableDataDto,
 } from '../../dtos/FinancialReportResponse.dto';
+
+export class SalesByItemsTableColumnDto extends FinancialTableColumnDto {
+  @ApiProperty({
+    description: 'Column key',
+    enum: Object.values(SALES_BY_ITEMS_COLUMN_KEYS),
+  })
+  key: SalesByItemsColumnKey;
+}
+
+export class SalesByItemsTableDataDto extends FinancialTableDataDto {
+  @ApiProperty({
+    description: 'Table column definitions',
+    type: [SalesByItemsTableColumnDto],
+  })
+  columns: SalesByItemsTableColumnDto[];
+}
 
 export class SalesByItemsTableResponseDto {
   @ApiProperty({
     description: 'Table data structure',
-    type: () => FinancialTableDataDto,
+    type: () => SalesByItemsTableDataDto,
   })
-  table: FinancialTableDataDto;
+  table: SalesByItemsTableDataDto;
 
   @ApiProperty({
     description: 'Query parameters used to generate the report',

--- a/packages/server/src/modules/FinancialStatements/modules/SalesByItems/SalesByItemsTable.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/SalesByItems/SalesByItemsTable.ts
@@ -10,6 +10,7 @@ import { FinancialSheetStructure } from '../../common/FinancialSheetStructure';
 import { FinancialSheet } from '../../common/FinancialSheet';
 import { ITableColumn, ITableRow } from '../../types/Table.types';
 import { tableRowMapper } from '../../utils/Table.utils';
+import { SALES_BY_ITEMS_COLUMN_KEYS } from '../../common/constants/tableColumnKeys';
 
 export class SalesByItemsTable extends R.pipe(
   FinancialTable,
@@ -32,10 +33,19 @@ export class SalesByItemsTable extends R.pipe(
    */
   private commonTableAccessors() {
     return [
-      { key: 'item_name', accessor: 'name' },
-      { key: 'sold_quantity', accessor: 'quantitySoldFormatted' },
-      { key: 'sold_amount', accessor: 'soldCostFormatted' },
-      { key: 'average_price', accessor: 'averageSellPriceFormatted' },
+      { key: SALES_BY_ITEMS_COLUMN_KEYS.ITEM_NAME, accessor: 'name' },
+      {
+        key: SALES_BY_ITEMS_COLUMN_KEYS.SOLD_QUANTITY,
+        accessor: 'quantitySoldFormatted',
+      },
+      {
+        key: SALES_BY_ITEMS_COLUMN_KEYS.SOLD_AMOUNT,
+        accessor: 'soldCostFormatted',
+      },
+      {
+        key: SALES_BY_ITEMS_COLUMN_KEYS.AVERAGE_PRICE,
+        accessor: 'averageSellPriceFormatted',
+      },
     ];
   }
 
@@ -93,10 +103,10 @@ export class SalesByItemsTable extends R.pipe(
    */
   public tableColumns(): ITableColumn[] {
     const columns = [
-      { key: 'item_name', label: 'Item name' },
-      { key: 'sold_quantity', label: 'Sold quantity' },
-      { key: 'sold_amount', label: 'Sold amount' },
-      { key: 'average_price', label: 'Average price' },
+      { key: SALES_BY_ITEMS_COLUMN_KEYS.ITEM_NAME, label: 'Item name' },
+      { key: SALES_BY_ITEMS_COLUMN_KEYS.SOLD_QUANTITY, label: 'Sold quantity' },
+      { key: SALES_BY_ITEMS_COLUMN_KEYS.SOLD_AMOUNT, label: 'Sold amount' },
+      { key: SALES_BY_ITEMS_COLUMN_KEYS.AVERAGE_PRICE, label: 'Average price' },
     ];
     return R.compose(this.tableColumnsCellIndexing)(columns);
   }

--- a/packages/server/src/modules/FinancialStatements/modules/SalesTaxLiabilitySummary/SalesTaxLiabilitySummaryResponse.dto.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/SalesTaxLiabilitySummary/SalesTaxLiabilitySummaryResponse.dto.ts
@@ -1,10 +1,15 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { NumberFormatQueryDto } from '@/modules/BankingTransactions/dtos/NumberFormatQuery.dto';
 import {
+  FinancialTableColumnDto,
   FinancialReportTotalDto,
   FinancialReportMetaDto,
   FinancialTableDataDto,
 } from '../../dtos/FinancialReportResponse.dto';
+import {
+  SALES_TAX_LIABILITY_COLUMN_KEYS,
+  SalesTaxLiabilityColumnKey,
+} from '../../common/constants/tableColumnKeys';
 
 export class TaxRateSummaryDto {
   @ApiProperty({ description: 'Tax rate ID', type: Number })
@@ -78,16 +83,30 @@ export class SalesTaxLiabilitySummaryResponseDto {
 export {
   FinancialTableCellDto as SalesTaxLiabilitySummaryTableCellDto,
   FinancialTableRowDto as SalesTaxLiabilitySummaryTableRowDto,
-  FinancialTableColumnDto as SalesTaxLiabilitySummaryTableColumnDto,
-  FinancialTableDataDto as SalesTaxLiabilitySummaryTableDataDto,
 } from '../../dtos/FinancialReportResponse.dto';
+
+export class SalesTaxLiabilitySummaryTableColumnDto extends FinancialTableColumnDto {
+  @ApiProperty({
+    description: 'Column key',
+    enum: Object.values(SALES_TAX_LIABILITY_COLUMN_KEYS),
+  })
+  key: SalesTaxLiabilityColumnKey;
+}
+
+export class SalesTaxLiabilitySummaryTableDataDto extends FinancialTableDataDto {
+  @ApiProperty({
+    description: 'Table column definitions',
+    type: [SalesTaxLiabilitySummaryTableColumnDto],
+  })
+  columns: SalesTaxLiabilitySummaryTableColumnDto[];
+}
 
 export class SalesTaxLiabilitySummaryTableResponseDto {
   @ApiProperty({
     description: 'Table data structure',
-    type: () => FinancialTableDataDto,
+    type: () => SalesTaxLiabilitySummaryTableDataDto,
   })
-  table: FinancialTableDataDto;
+  table: SalesTaxLiabilitySummaryTableDataDto;
 
   @ApiProperty({
     description: 'Query parameters used to generate the report',

--- a/packages/server/src/modules/FinancialStatements/modules/SalesTaxLiabilitySummary/SalesTaxLiabilitySummaryTable.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/SalesTaxLiabilitySummary/SalesTaxLiabilitySummaryTable.ts
@@ -12,6 +12,7 @@ import { FinancialSheetStructure } from '../../common/FinancialSheetStructure';
 import { ITableRow } from '../../types/Table.types';
 import { ITableColumn } from '../../types/Table.types';
 import { tableRowMapper } from '../../utils/Table.utils';
+import { SALES_TAX_LIABILITY_COLUMN_KEYS } from '../../common/constants/tableColumnKeys';
 
 export class SalesTaxLiabilitySummaryTable extends R.pipe(
   FinancialTable,
@@ -41,10 +42,19 @@ export class SalesTaxLiabilitySummaryTable extends R.pipe(
    */
   private get taxRateRowAccessor() {
     return [
-      { key: 'taxName', accessor: 'taxName' },
-      { key: 'taxPercentage', accessor: 'taxPercentage.formattedAmount' },
-      { key: 'taxableAmount', accessor: 'taxableAmount.formattedAmount' },
-      { key: 'collectedTax', accessor: 'collectedTaxAmount.formattedAmount' },
+      { key: SALES_TAX_LIABILITY_COLUMN_KEYS.TAX_NAME, accessor: 'taxName' },
+      {
+        key: SALES_TAX_LIABILITY_COLUMN_KEYS.TAX_PERCENTAGE,
+        accessor: 'taxPercentage.formattedAmount',
+      },
+      {
+        key: SALES_TAX_LIABILITY_COLUMN_KEYS.TAXABLE_AMOUNT,
+        accessor: 'taxableAmount.formattedAmount',
+      },
+      {
+        key: SALES_TAX_LIABILITY_COLUMN_KEYS.COLLECTED_TAX,
+        accessor: 'collectedTaxAmount.formattedAmount',
+      },
       { key: 'taxAmount', accessor: 'taxAmount.formattedAmount' },
     ];
   }
@@ -55,10 +65,16 @@ export class SalesTaxLiabilitySummaryTable extends R.pipe(
    */
   private get taxRateTotalRowAccessors() {
     return [
-      { key: 'taxName', value: 'Total' },
-      { key: 'taxPercentage', value: '' },
-      { key: 'taxableAmount', accessor: 'taxableAmount.formattedAmount' },
-      { key: 'collectedTax', accessor: 'collectedTaxAmount.formattedAmount' },
+      { key: SALES_TAX_LIABILITY_COLUMN_KEYS.TAX_NAME, value: 'Total' },
+      { key: SALES_TAX_LIABILITY_COLUMN_KEYS.TAX_PERCENTAGE, value: '' },
+      {
+        key: SALES_TAX_LIABILITY_COLUMN_KEYS.TAXABLE_AMOUNT,
+        accessor: 'taxableAmount.formattedAmount',
+      },
+      {
+        key: SALES_TAX_LIABILITY_COLUMN_KEYS.COLLECTED_TAX,
+        accessor: 'collectedTaxAmount.formattedAmount',
+      },
       { key: 'taxAmount', accessor: 'taxAmount.formattedAmount' },
     ];
   }
@@ -138,23 +154,23 @@ export class SalesTaxLiabilitySummaryTable extends R.pipe(
     return R.compose(this.tableColumnsCellIndexing)([
       {
         label: 'Tax Name',
-        key: 'taxName',
+        key: SALES_TAX_LIABILITY_COLUMN_KEYS.TAX_NAME,
       },
       {
         label: 'Tax Percentage',
-        key: 'taxPercentage',
+        key: SALES_TAX_LIABILITY_COLUMN_KEYS.TAX_PERCENTAGE,
       },
       {
         label: 'Taxable Amount',
-        key: 'taxableAmount',
+        key: SALES_TAX_LIABILITY_COLUMN_KEYS.TAXABLE_AMOUNT,
       },
       {
         label: 'Collected Tax',
-        key: 'collectedTax',
+        key: SALES_TAX_LIABILITY_COLUMN_KEYS.COLLECTED_TAX,
       },
       {
         label: 'Tax Amount',
-        key: 'taxRate',
+        key: SALES_TAX_LIABILITY_COLUMN_KEYS.TAX_RATE,
       },
     ]);
   }

--- a/packages/server/src/modules/FinancialStatements/modules/TrialBalanceSheet/TrialBalanceSheetResponse.dto.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/TrialBalanceSheet/TrialBalanceSheetResponse.dto.ts
@@ -1,9 +1,14 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import {
+  FinancialTableColumnDto,
   FinancialReportTotalDto,
   FinancialReportMetaDto,
   FinancialTableDataDto,
 } from '../../dtos/FinancialReportResponse.dto';
+import {
+  TRIAL_BALANCE_COLUMN_KEYS,
+  TrialBalanceColumnKey,
+} from '../../common/constants/tableColumnKeys';
 import { NumberFormatQueryDto } from '@/modules/BankingTransactions/dtos/NumberFormatQuery.dto';
 
 export class TrialBalanceSheetAccountDto {
@@ -153,16 +158,30 @@ export class TrialBalanceSheetResponseDto {
 export {
   FinancialTableCellDto as TrialBalanceSheetTableCellDto,
   FinancialTableRowDto as TrialBalanceSheetTableRowDto,
-  FinancialTableColumnDto as TrialBalanceSheetTableColumnDto,
-  FinancialTableDataDto as TrialBalanceSheetTableDataDto,
 } from '../../dtos/FinancialReportResponse.dto';
+
+export class TrialBalanceSheetTableColumnDto extends FinancialTableColumnDto {
+  @ApiProperty({
+    description: 'Column key',
+    enum: Object.values(TRIAL_BALANCE_COLUMN_KEYS),
+  })
+  key: TrialBalanceColumnKey;
+}
+
+export class TrialBalanceSheetTableDataDto extends FinancialTableDataDto {
+  @ApiProperty({
+    description: 'Table column definitions',
+    type: [TrialBalanceSheetTableColumnDto],
+  })
+  columns: TrialBalanceSheetTableColumnDto[];
+}
 
 export class TrialBalanceSheetTableResponseDto {
   @ApiProperty({
     description: 'Table data structure',
-    type: () => FinancialTableDataDto,
+    type: () => TrialBalanceSheetTableDataDto,
   })
-  table: FinancialTableDataDto;
+  table: TrialBalanceSheetTableDataDto;
 
   @ApiProperty({
     description: 'Query parameters used to generate the report',

--- a/packages/server/src/modules/FinancialStatements/modules/TrialBalanceSheet/TrialBalanceSheetTable.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/TrialBalanceSheet/TrialBalanceSheetTable.ts
@@ -16,6 +16,7 @@ import { FinancialSheetStructure } from '../../common/FinancialSheetStructure';
 import { I18nService } from 'nestjs-i18n';
 import { tableRowMapper } from '../../utils/Table.utils';
 import { IROW_TYPE } from './_constants';
+import { TRIAL_BALANCE_COLUMN_KEYS } from '../../common/constants/tableColumnKeys';
 
 export class TrialBalanceSheetTable extends R.compose(
   FinancialTable,
@@ -58,10 +59,10 @@ export class TrialBalanceSheetTable extends R.compose(
    */
   private commonColumnsAccessors = (): ITableColumnAccessor[] => {
     return [
-      { key: 'account', accessor: 'formattedName' },
-      { key: 'debit', accessor: 'formattedDebit' },
-      { key: 'credit', accessor: 'formattedCredit' },
-      { key: 'total', accessor: 'formattedBalance' },
+      { key: TRIAL_BALANCE_COLUMN_KEYS.ACCOUNT, accessor: 'formattedName' },
+      { key: TRIAL_BALANCE_COLUMN_KEYS.DEBIT, accessor: 'formattedDebit' },
+      { key: TRIAL_BALANCE_COLUMN_KEYS.CREDIT, accessor: 'formattedCredit' },
+      { key: TRIAL_BALANCE_COLUMN_KEYS.TOTAL, accessor: 'formattedBalance' },
     ];
   };
 
@@ -141,10 +142,22 @@ export class TrialBalanceSheetTable extends R.compose(
     return R.compose(
       this.tableColumnsCellIndexing,
       R.concat([
-        { key: 'account', label: this.i18n.t('trial_balance_sheet.account') },
-        { key: 'debit', label: this.i18n.t('trial_balance_sheet.debit') },
-        { key: 'credit', label: this.i18n.t('trial_balance_sheet.credit') },
-        { key: 'total', label: this.i18n.t('trial_balance_sheet.total') },
+        {
+          key: TRIAL_BALANCE_COLUMN_KEYS.ACCOUNT,
+          label: this.i18n.t('trial_balance_sheet.account'),
+        },
+        {
+          key: TRIAL_BALANCE_COLUMN_KEYS.DEBIT,
+          label: this.i18n.t('trial_balance_sheet.debit'),
+        },
+        {
+          key: TRIAL_BALANCE_COLUMN_KEYS.CREDIT,
+          label: this.i18n.t('trial_balance_sheet.credit'),
+        },
+        {
+          key: TRIAL_BALANCE_COLUMN_KEYS.TOTAL,
+          label: this.i18n.t('trial_balance_sheet.total'),
+        },
       ]),
     )([]);
   };

--- a/packages/server/src/modules/FinancialStatements/modules/VendorBalanceSummary/VendorBalanceSummaryResponse.dto.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/VendorBalanceSummary/VendorBalanceSummaryResponse.dto.ts
@@ -1,10 +1,15 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { NumberFormatQueryDto } from '@/modules/BankingTransactions/dtos/NumberFormatQuery.dto';
 import {
+  FinancialTableColumnDto,
   FinancialReportTotalDto,
   FinancialReportMetaDto,
   FinancialTableDataDto,
 } from '../../dtos/FinancialReportResponse.dto';
+import {
+  CONTACT_BALANCE_COLUMN_KEYS,
+  VendorsBalanceColumnKey,
+} from '../../common/constants/tableColumnKeys';
 
 export class VendorBalanceDto {
   @ApiProperty({ description: 'Vendor ID', type: Number })
@@ -87,16 +92,30 @@ export class VendorBalanceSummaryResponseDto {
 export {
   FinancialTableCellDto as VendorBalanceSummaryTableCellDto,
   FinancialTableRowDto as VendorBalanceSummaryTableRowDto,
-  FinancialTableColumnDto as VendorBalanceSummaryTableColumnDto,
-  FinancialTableDataDto as VendorBalanceSummaryTableDataDto,
 } from '../../dtos/FinancialReportResponse.dto';
+
+export class VendorBalanceSummaryTableColumnDto extends FinancialTableColumnDto {
+  @ApiProperty({
+    description: 'Column key',
+    enum: Object.values(CONTACT_BALANCE_COLUMN_KEYS),
+  })
+  key: VendorsBalanceColumnKey;
+}
+
+export class VendorBalanceSummaryTableDataDto extends FinancialTableDataDto {
+  @ApiProperty({
+    description: 'Table column definitions',
+    type: [VendorBalanceSummaryTableColumnDto],
+  })
+  columns: VendorBalanceSummaryTableColumnDto[];
+}
 
 export class VendorBalanceSummaryTableResponseDto {
   @ApiProperty({
     description: 'Table data structure',
-    type: () => FinancialTableDataDto,
+    type: () => VendorBalanceSummaryTableDataDto,
   })
-  table: FinancialTableDataDto;
+  table: VendorBalanceSummaryTableDataDto;
 
   @ApiProperty({
     description: 'Query parameters used to generate the report',

--- a/packages/server/src/modules/FinancialStatements/modules/VendorBalanceSummary/VendorBalanceSummaryTableRows.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/VendorBalanceSummary/VendorBalanceSummaryTableRows.ts
@@ -12,6 +12,7 @@ import {
   IColumnMapperMeta,
 } from '../../types/Table.types';
 import { tableMapper, tableRowMapper } from '../../utils/Table.utils';
+import { CONTACT_BALANCE_COLUMN_KEYS } from '../../common/constants/tableColumnKeys';
 
 enum TABLE_ROWS_TYPES {
   VENDOR = 'VENDOR',
@@ -58,8 +59,11 @@ export class VendorBalanceSummaryTable {
    */
   private getVendorColumnsAccessor = (): IColumnMapperMeta[] => {
     const columns = [
-      { key: 'name', accessor: 'vendorName' },
-      { key: 'total', accessor: 'total.formattedAmount' },
+      { key: CONTACT_BALANCE_COLUMN_KEYS.NAME, accessor: 'vendorName' },
+      {
+        key: CONTACT_BALANCE_COLUMN_KEYS.TOTAL,
+        accessor: 'total.formattedAmount',
+      },
     ];
     return R.compose(
       R.concat(columns),
@@ -91,8 +95,14 @@ export class VendorBalanceSummaryTable {
    */
   private getTotalColumnsAccessor = (): IColumnMapperMeta[] => {
     const columns = [
-      { key: 'name', value: this.i18n.t('contact_summary_balance.total') },
-      { key: 'total', accessor: 'total.formattedAmount' },
+      {
+        key: CONTACT_BALANCE_COLUMN_KEYS.NAME,
+        value: this.i18n.t('contact_summary_balance.total'),
+      },
+      {
+        key: CONTACT_BALANCE_COLUMN_KEYS.TOTAL,
+        accessor: 'total.formattedAmount',
+      },
     ];
     return R.compose(
       R.concat(columns),
@@ -133,20 +143,23 @@ export class VendorBalanceSummaryTable {
    * @returns {ITableColumn[]}
    */
   public tableColumns = (): ITableColumn[] => {
-    const columns = [
+    const columns: ITableColumn[] = [
       {
-        key: 'name',
+        key: CONTACT_BALANCE_COLUMN_KEYS.NAME,
         label: this.i18n.t('contact_summary_balance.account_name'),
       },
-      { key: 'total', label: this.i18n.t('contact_summary_balance.total') },
+      {
+        key: CONTACT_BALANCE_COLUMN_KEYS.TOTAL,
+        label: this.i18n.t('contact_summary_balance.total'),
+      },
     ];
     return R.compose(
       R.when(
         () => this.query.percentageColumn,
         R.append({
-          key: 'percentage_of_column',
+          key: CONTACT_BALANCE_COLUMN_KEYS.PERCENTAGE_OF_COLUMN,
           label: this.i18n.t('contact_summary_balance.percentage_column'),
-        }),
+        } as ITableColumn),
       ),
       R.concat(columns),
     )([]) as ITableColumn[];

--- a/packages/webapp/src/containers/FinancialStatements/AgingSummary/dynamicColumns.ts
+++ b/packages/webapp/src/containers/FinancialStatements/AgingSummary/dynamicColumns.ts
@@ -1,6 +1,9 @@
 import * as R from 'ramda';
+import type { AgingSummaryColumnKey } from '@bigcapital/sdk-ts';
 import { Align } from '@/constants';
 import { getColumnWidth } from '@/utils';
+
+const isColumnKey = (key: AgingSummaryColumnKey) => R.pathEq(['key'], key);
 
 interface AgingSummaryColumn {
   key: string;
@@ -75,11 +78,11 @@ const dynamicColumnMapper = R.curry(
     const agingPeriodAccessorColumn = agingPeriodAccessor(data);
 
     return R.compose(
-      R.when(R.pathEq(['key'], 'total'), totalAccessorColumn),
-      R.when(R.pathEq(['key'], 'current'), currentAccessorColumn),
-      R.when(R.pathEq(['key'], 'customer_name'), customerNameAccessorColumn),
-      R.when(R.pathEq(['key'], 'vendor_name'), customerNameAccessorColumn),
-      R.when(R.pathEq(['key'], 'aging_period'), agingPeriodAccessorColumn),
+      R.when(isColumnKey('total'), totalAccessorColumn),
+      R.when(isColumnKey('current'), currentAccessorColumn),
+      R.when(isColumnKey('customer_name'), customerNameAccessorColumn),
+      R.when(isColumnKey('vendor_name'), customerNameAccessorColumn),
+      R.when(isColumnKey('aging_period'), agingPeriodAccessorColumn),
     )(column);
   },
 );

--- a/packages/webapp/src/containers/FinancialStatements/BalanceSheet/dynamicColumns.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/BalanceSheet/dynamicColumns.tsx
@@ -1,5 +1,6 @@
 import { isEmpty } from 'lodash';
 import * as R from 'ramda';
+import type { BalanceSheetColumnKey } from '@bigcapital/sdk-ts';
 import { Align } from '@/constants';
 import { getColumnWidth } from '@/utils';
 
@@ -25,6 +26,8 @@ interface TableColumn {
 }
 
 const getTableCellValueAccessor = (index: number) => `cells[${index}].value`;
+
+const isColumnKey = (key: BalanceSheetColumnKey) => R.pathEq(['key'], key);
 
 const getReportColWidth = (
   data: unknown[],
@@ -286,34 +289,31 @@ const previousPeriodPercentageAccessor = R.curry(
 const totalColumnsMapper = R.curry(
   (data: unknown[], column: ReportTableColumn): TableColumn => {
     return R.compose(
-      R.when(R.pathEq(['key'], 'total'), totalMapper(data)),
+      R.when(isColumnKey('total'), totalMapper(data)),
       // Percetage of column/row.
       R.when(
-        R.pathEq(['key'], 'percentageOfColumn'),
+        isColumnKey('percentage_of_column'),
         percentageOfColumnAccessor(data),
       ),
-      R.when(
-        R.pathEq(['key'], 'percentageOfRow'),
-        percentageOfRowAccessor(data),
-      ),
+      R.when(isColumnKey('percentage_of_row'), percentageOfRowAccessor(data)),
       // Previous year.
-      R.when(R.pathEq(['key'], 'previousYear'), previousYearAccessor(data)),
+      R.when(isColumnKey('previous_year'), previousYearAccessor(data)),
       R.when(
-        R.pathEq(['key'], 'previousYearChange'),
+        isColumnKey('previous_year_change'),
         previousYearChangeAccessor(data),
       ),
       R.when(
-        R.pathEq(['key'], 'previousYearPercentage'),
+        isColumnKey('previous_year_percentage'),
         previousYearPercentageAccessor(data),
       ),
       // Pervious period.
-      R.when(R.pathEq(['key'], 'previousPeriod'), previousPeriodAccessor(data)),
+      R.when(isColumnKey('previous_period'), previousPeriodAccessor(data)),
       R.when(
-        R.pathEq(['key'], 'previousPeriodChange'),
+        isColumnKey('previous_period_change'),
         previousPeriodChangeAccessor(data),
       ),
       R.when(
-        R.pathEq(['key'], 'previousPeriodPercentage'),
+        isColumnKey('previous_period_percentage'),
         previousPeriodPercentageAccessor(data),
       ),
     )(column);
@@ -391,8 +391,8 @@ const dynamicColumnMapper = R.curry(
         R.pathSatisfies(isMatchesDateRange, ['key']),
         indexDatePeriodMapper,
       ),
-      R.when(R.pathEq(['key'], 'name'), indexAccountNameMapper),
-      R.when(R.pathEq(['key'], 'total'), indexTotalMapper),
+      R.when(isColumnKey('name'), indexAccountNameMapper),
+      R.when(isColumnKey('total'), indexTotalMapper),
     )(column);
   },
 );

--- a/packages/webapp/src/containers/FinancialStatements/CashFlowStatement/dynamicColumns.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/CashFlowStatement/dynamicColumns.tsx
@@ -1,8 +1,11 @@
 import * as R from 'ramda';
 import intl from 'react-intl-universal';
+import type { CashFlowColumnKey } from '@bigcapital/sdk-ts';
 import { CellTextSpan } from '@/components/Datatable/Cells';
 import { Align } from '@/constants';
 import { getColumnWidth } from '@/utils';
+
+const isColumnKey = (key: CashFlowColumnKey) => R.pathEq(['key'], key);
 
 interface ReportTableColumn {
   key: string;
@@ -75,8 +78,8 @@ export const dynamicColumns = (
         R.pathSatisfies(isMatchesDateRange, ['key']),
         R.curry(dateRangeMapper)(data, index),
       ),
-      R.when(R.pathEq(['key'], 'name'), accountNameMapper),
-      R.when(R.pathEq(['key'], 'total'), R.curry(totalMapper)(data, index)),
+      R.when(isColumnKey('name'), accountNameMapper),
+      R.when(isColumnKey('total'), R.curry(totalMapper)(data, index)),
     )(column);
   };
   return columns.map(mapper);

--- a/packages/webapp/src/containers/FinancialStatements/CustomersBalanceSummary/components.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/CustomersBalanceSummary/components.tsx
@@ -12,6 +12,7 @@ import React from 'react';
 import intl from 'react-intl-universal';
 import { FinancialLoadingBar } from '../FinancialLoadingBar';
 import { useCustomersBalanceSummaryContext } from './CustomersBalanceSummaryProvider';
+import type { CustomersBalanceColumnKey } from '@bigcapital/sdk-ts';
 import type {
   CustomerBalanceXlsxQuery,
   CustomerBalanceCsvQuery,
@@ -68,15 +69,14 @@ const percentageColumnAccessor = () => ({
   align: Align.Right,
 });
 
+const isColumnKey = (key: CustomersBalanceColumnKey) => R.pathEq(['key'], key);
+
 const dynamicColumns = (columns) => {
   return R.map(
     R.compose(
-      R.when(R.pathEq(['key'], 'name'), accountNameColumnAccessor),
-      R.when(R.pathEq(['key'], 'total'), totalColumnAccessor),
-      R.when(
-        R.pathEq(['key'], 'percentage_of_column'),
-        percentageColumnAccessor,
-      ),
+      R.when(isColumnKey('name'), accountNameColumnAccessor),
+      R.when(isColumnKey('total'), totalColumnAccessor),
+      R.when(isColumnKey('percentage_of_column'), percentageColumnAccessor),
     ),
   )(columns);
 };

--- a/packages/webapp/src/containers/FinancialStatements/GeneralLedger/dynamicColumns.ts
+++ b/packages/webapp/src/containers/FinancialStatements/GeneralLedger/dynamicColumns.ts
@@ -1,6 +1,7 @@
 import * as R from 'ramda';
 import React from 'react';
 import { useGeneralLedgerContext } from './GeneralLedgerProvider';
+import type { GeneralLedgerColumnKey } from '@bigcapital/sdk-ts';
 import { Align, CLASSES } from '@/constants';
 import { getColumnWidth } from '@/utils';
 
@@ -27,6 +28,8 @@ function DescriptionCell({ cell: { value } }: CellProps) {
 }
 
 const getTableCellValueAccessor = (index: number) => `cells[${index}].value`;
+
+const isColumnKey = (key: GeneralLedgerColumnKey) => R.pathEq(['key'], key);
 
 const getReportColWidth = (
   data: unknown[],
@@ -115,14 +118,14 @@ const dynamiColumnMapper = R.curry((data: unknown[], column: ColumnDef) => {
   const _numericColumnAccessor = numericColumnAccessor(data);
 
   return R.compose(
-    R.when(R.pathEq(['key'], 'date'), dateColumnAccessor),
-    R.when(R.pathEq(['key'], 'referenceType'), transactionTypeColumnAccessor),
-    R.when(R.pathEq(['key'], 'referenceNumber'), transactionIdColumnAccessor),
-    R.when(R.pathEq(['key'], 'description'), descriptionColumnAccessor),
-    R.when(R.pathEq(['key'], 'credit'), _numericColumnAccessor),
-    R.when(R.pathEq(['key'], 'debit'), _numericColumnAccessor),
-    R.when(R.pathEq(['key'], 'amount'), _numericColumnAccessor),
-    R.when(R.pathEq(['key'], 'runningBalance'), _numericColumnAccessor),
+    R.when(isColumnKey('date'), dateColumnAccessor),
+    R.when(isColumnKey('reference_type'), transactionTypeColumnAccessor),
+    R.when(isColumnKey('reference_number'), transactionIdColumnAccessor),
+    R.when(isColumnKey('description'), descriptionColumnAccessor),
+    R.when(isColumnKey('credit'), _numericColumnAccessor),
+    R.when(isColumnKey('debit'), _numericColumnAccessor),
+    R.when(isColumnKey('amount'), _numericColumnAccessor),
+    R.when(isColumnKey('running_balance'), _numericColumnAccessor),
     commonColumnMapper(data),
   )(column);
 });

--- a/packages/webapp/src/containers/FinancialStatements/InventoryItemDetails/utils.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/InventoryItemDetails/utils.tsx
@@ -1,6 +1,10 @@
 import * as R from 'ramda';
+import type { InventoryItemDetailsColumnKey } from '@bigcapital/sdk-ts';
 import { Align } from '@/constants';
 import { getColumnWidth } from '@/utils';
+
+const isColumnKey = (key: InventoryItemDetailsColumnKey) =>
+  R.pathEq(['key'], key);
 
 const itemNameOrDateColumn = R.curry(
   (data: unknown[], index: number, column: Record<string, any>) => ({
@@ -60,14 +64,14 @@ export const dynamicColumns = (
   const mapper = (column: Record<string, any>, index: number) => {
     return R.compose(
       R.cond([
-        [R.pathEq(['key'], 'date'), itemNameOrDateColumn(data, index)],
-        [R.pathEq(['key'], 'runningQuantity'), numericColumn(data, index)],
-        [R.pathEq(['key'], 'profitMargin'), numericColumn(data, index)],
-        [R.pathEq(['key'], 'runningValue'), numericColumn(data, index)],
-        [R.pathEq(['key'], 'quantity'), numericColumn(data, index)],
-        [R.pathEq(['key'], 'rate'), numericColumn(data, index)],
-        [R.pathEq(['key'], 'total'), numericColumn(data, index)],
-        [R.pathEq(['key'], 'value'), numericColumn(data, index)],
+        [isColumnKey('date'), itemNameOrDateColumn(data, index)],
+        [isColumnKey('running_quantity'), numericColumn(data, index)],
+        [isColumnKey('profit_margin'), numericColumn(data, index)],
+        [isColumnKey('running_value'), numericColumn(data, index)],
+        [isColumnKey('quantity'), numericColumn(data, index)],
+        [isColumnKey('rate'), numericColumn(data, index)],
+        [isColumnKey('total'), numericColumn(data, index)],
+        [isColumnKey('value'), numericColumn(data, index)],
         [R.T, columnsMapper(data, index)],
       ]),
     )(column);

--- a/packages/webapp/src/containers/FinancialStatements/InventoryValuation/dynamicColumns.ts
+++ b/packages/webapp/src/containers/FinancialStatements/InventoryValuation/dynamicColumns.ts
@@ -1,9 +1,13 @@
 import * as R from 'ramda';
 import { useInventoryValuationContext } from './InventoryValuationProvider';
+import type { InventoryValuationColumnKey } from '@bigcapital/sdk-ts';
 import { Align } from '@/constants';
 import { getColumnWidth } from '@/utils';
 
 const getTableCellValueAccessor = (index: number) => `cells[${index}].value`;
+
+const isColumnKey = (key: InventoryValuationColumnKey) =>
+  R.pathEq(['key'], key);
 
 const getReportColWidth = (
   data: unknown[],
@@ -75,10 +79,10 @@ const dynamicColumnMapper = R.curry(
     const _itemNameColumnAccessor = itemNameColumnAccessor(data);
 
     return R.compose(
-      R.when(R.pathEq(['key'], 'itemName'), _itemNameColumnAccessor),
-      R.when(R.pathEq(['key'], 'quantity'), _numericColumnAccessor),
-      R.when(R.pathEq(['key'], 'valuation'), _numericColumnAccessor),
-      R.when(R.pathEq(['key'], 'average'), _numericColumnAccessor),
+      R.when(isColumnKey('item_name'), _itemNameColumnAccessor),
+      R.when(isColumnKey('quantity'), _numericColumnAccessor),
+      R.when(isColumnKey('valuation'), _numericColumnAccessor),
+      R.when(isColumnKey('average'), _numericColumnAccessor),
       _commonAccessor,
     )(column);
   },

--- a/packages/webapp/src/containers/FinancialStatements/Journal/dynamicColumns.ts
+++ b/packages/webapp/src/containers/FinancialStatements/Journal/dynamicColumns.ts
@@ -1,8 +1,11 @@
 import * as R from 'ramda';
 import React from 'react';
 import { useJournalSheetContext } from './JournalProvider';
+import type { JournalColumnKey } from '@bigcapital/sdk-ts';
 import { Align, CLASSES } from '@/constants';
 import { getColumnWidth } from '@/utils';
+
+const isColumnKey = (key: JournalColumnKey) => R.pathEq(['key'], key);
 
 interface DescriptionCellProps {
   cell: { value: string };
@@ -133,19 +136,16 @@ const dynamicColumnMapper = R.curry(
     const _numericColumnAccessor = numericColumnAccessor(data);
 
     return R.compose(
-      R.when(R.pathEq(['key'], 'date'), dateColumnAccessor),
+      R.when(isColumnKey('date'), dateColumnAccessor),
+      R.when(isColumnKey('transaction_type'), transactionTypeColumnAccessor),
       R.when(
-        R.pathEq(['key'], 'transaction_type'),
-        transactionTypeColumnAccessor,
-      ),
-      R.when(
-        R.pathEq(['key'], 'transaction_number'),
+        isColumnKey('transaction_number'),
         transactionNumberColumnAccessor,
       ),
-      R.when(R.pathEq(['key'], 'description'), descriptionColumnAccessor),
-      R.when(R.pathEq(['key'], 'account_code'), accountCodeColumnAccessor),
-      R.when(R.pathEq(['key'], 'credit'), _numericColumnAccessor),
-      R.when(R.pathEq(['key'], 'debit'), _numericColumnAccessor),
+      R.when(isColumnKey('description'), descriptionColumnAccessor),
+      R.when(isColumnKey('account_code'), accountCodeColumnAccessor),
+      R.when(isColumnKey('credit'), _numericColumnAccessor),
+      R.when(isColumnKey('debit'), _numericColumnAccessor),
       _commonAccessor,
     )(column);
   },

--- a/packages/webapp/src/containers/FinancialStatements/ProfitLossSheet/dynamicColumns.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/ProfitLossSheet/dynamicColumns.tsx
@@ -1,5 +1,6 @@
 import { isEmpty } from 'lodash';
 import * as R from 'ramda';
+import type { ProfitLossColumnKey } from '@bigcapital/sdk-ts';
 import { Align } from '@/constants';
 import { getColumnWidth } from '@/utils';
 
@@ -11,6 +12,8 @@ interface ReportTableColumn {
 }
 
 const getTableCellValueAccessor = (index: number) => `cells[${index}].value`;
+
+const isColumnKey = (key: ProfitLossColumnKey) => R.pathEq(['key'], key);
 
 const getReportColWidth = (
   data: unknown[],
@@ -225,39 +228,33 @@ const previousPeriodPercentageAccessor = R.curry((data, column) => {
  */
 const totalColumnsMapper = R.curry((data, column) => {
   return R.compose(
-    R.when(R.pathEq(['key'], 'total'), totalColumn(data)),
+    R.when(isColumnKey('total'), totalColumn(data)),
     // Percetage of column/row.
+    R.when(isColumnKey('percentage_column'), percentageOfColumnAccessor(data)),
+    R.when(isColumnKey('percentage_row'), percentageOfRowAccessor(data)),
+    R.when(isColumnKey('percentage_income'), percentageOfIncomeAccessor(data)),
     R.when(
-      R.pathEq(['key'], 'percentageColumn'),
-      percentageOfColumnAccessor(data),
-    ),
-    R.when(R.pathEq(['key'], 'percentageRow'), percentageOfRowAccessor(data)),
-    R.when(
-      R.pathEq(['key'], 'percentageIncome'),
-      percentageOfIncomeAccessor(data),
-    ),
-    R.when(
-      R.pathEq(['key'], 'percentageExpenses'),
+      isColumnKey('percentage_expenses'),
       percentageOfExpenseAccessor(data),
     ),
     // Previous year.
-    R.when(R.pathEq(['key'], 'previousYear'), previousYearAccessor(data)),
+    R.when(isColumnKey('previous_year'), previousYearAccessor(data)),
     R.when(
-      R.pathEq(['key'], 'previousYearChange'),
+      isColumnKey('previous_year_change'),
       previousYearChangeAccessor(data),
     ),
     R.when(
-      R.pathEq(['key'], 'previousYearPercentage'),
+      isColumnKey('previous_year_percentage'),
       previousYearPercentageAccessor(data),
     ),
     // Pervious period.
-    R.when(R.pathEq(['key'], 'previousPeriod'), previousPeriodAccessor(data)),
+    R.when(isColumnKey('previous_period'), previousPeriodAccessor(data)),
     R.when(
-      R.pathEq(['key'], 'previousPeriodChange'),
+      isColumnKey('previous_period_change'),
       previousPeriodChangeAccessor(data),
     ),
     R.when(
-      R.pathEq(['key'], 'previousPeriodPercentage'),
+      isColumnKey('previous_period_percentage'),
       previousPeriodPercentageAccessor(data),
     ),
   )(column);
@@ -387,8 +384,8 @@ const dynamicColumnMapper = R.curry((data, column) => {
 
   return R.compose(
     R.when(R.pathSatisfies(isMatchesDateRange, ['key']), indexDatePeriodMapper),
-    R.when(R.pathEq(['key'], 'name'), indexAccountNameColumn),
-    R.when(R.pathEq(['key'], 'total'), indexTotalColumn),
+    R.when(isColumnKey('name'), indexAccountNameColumn),
+    R.when(isColumnKey('total'), indexTotalColumn),
   )(column);
 });
 

--- a/packages/webapp/src/containers/FinancialStatements/PurchasesByItems/dynamicColumns.ts
+++ b/packages/webapp/src/containers/FinancialStatements/PurchasesByItems/dynamicColumns.ts
@@ -1,9 +1,12 @@
 import * as R from 'ramda';
 import { usePurchaseByItemsContext } from './PurchasesByItemsProvider';
+import type { PurchasesByItemsColumnKey } from '@bigcapital/sdk-ts';
 import { Align } from '@/constants';
 import { getColumnWidth } from '@/utils';
 
 const getTableCellValueAccessor = (index: number) => `cells[${index}].value`;
+
+const isColumnKey = (key: PurchasesByItemsColumnKey) => R.pathEq(['key'], key);
 
 const getReportColWidth = (
   data: any[],
@@ -70,10 +73,10 @@ const dynamicColumnMapper = R.curry(
     const _itemNameColumnAccessor = itemNameColumnAccessor(data);
 
     return R.compose(
-      R.when(R.pathEq(['key'], 'itemName'), _itemNameColumnAccessor),
-      R.when(R.pathEq(['key'], 'quantityPurchases'), _numericColumnAccessor),
-      R.when(R.pathEq(['key'], 'purchaseAmount'), _numericColumnAccessor),
-      R.when(R.pathEq(['key'], 'averageCost'), _numericColumnAccessor),
+      R.when(isColumnKey('item_name'), _itemNameColumnAccessor),
+      R.when(isColumnKey('quantity_purchases'), _numericColumnAccessor),
+      R.when(isColumnKey('purchase_amount'), _numericColumnAccessor),
+      R.when(isColumnKey('average_cost'), _numericColumnAccessor),
       commonColumnMapper(data),
     )(column);
   },

--- a/packages/webapp/src/containers/FinancialStatements/SalesByItems/dynamicColumns.ts
+++ b/packages/webapp/src/containers/FinancialStatements/SalesByItems/dynamicColumns.ts
@@ -1,9 +1,12 @@
 import * as R from 'ramda';
 import { useSalesByItemsContext } from './SalesByItemProvider';
+import type { SalesByItemsColumnKey } from '@bigcapital/sdk-ts';
 import { Align } from '@/constants';
 import { getColumnWidth } from '@/utils';
 
 const getTableCellValueAccessor = (index: number) => `cells[${index}].value`;
+
+const isColumnKey = (key: SalesByItemsColumnKey) => R.pathEq(['key'], key);
 
 const getReportColWidth = (
   data: any[],
@@ -70,10 +73,10 @@ const dynamicColumnMapper = R.curry(
     const _itemNameColumnAccessor = itemNameColumnAccessor(data);
 
     return R.compose(
-      R.when(R.pathEq(['key'], 'itemName'), _itemNameColumnAccessor),
-      R.when(R.pathEq(['key'], 'soldQuantity'), _numericColumnAccessor),
-      R.when(R.pathEq(['key'], 'soldAmount'), _numericColumnAccessor),
-      R.when(R.pathEq(['key'], 'averagePrice'), _numericColumnAccessor),
+      R.when(isColumnKey('item_name'), _itemNameColumnAccessor),
+      R.when(isColumnKey('sold_quantity'), _numericColumnAccessor),
+      R.when(isColumnKey('sold_amount'), _numericColumnAccessor),
+      R.when(isColumnKey('average_price'), _numericColumnAccessor),
       commonColumnMapper(data),
     )(column);
   },

--- a/packages/webapp/src/containers/FinancialStatements/SalesTaxLiabilitySummary/dynamicColumns.ts
+++ b/packages/webapp/src/containers/FinancialStatements/SalesTaxLiabilitySummary/dynamicColumns.ts
@@ -1,6 +1,9 @@
 import * as R from 'ramda';
+import type { SalesTaxLiabilityColumnKey } from '@bigcapital/sdk-ts';
 import { Align } from '@/constants';
 import { getColumnWidth } from '@/utils';
+
+const isColumnKey = (key: SalesTaxLiabilityColumnKey) => R.pathEq(['key'], key);
 
 const getTableCellValueAccessor = (index: number) => `cells[${index}].value`;
 
@@ -36,11 +39,11 @@ const dynamicColumnMapper = R.curry(
     const taxableAmountColumn = taxableAmountAccessor(data);
 
     return R.compose(
-      R.when(R.pathEq(['key'], 'taxName'), taxNameAccessorColumn),
-      R.when(R.pathEq(['key'], 'taxableAmount'), taxableAmountColumn),
-      R.when(R.pathEq(['key'], 'taxRate'), taxableAmountColumn),
-      R.when(R.pathEq(['key'], 'taxPercentage'), taxableAmountColumn),
-      R.when(R.pathEq(['key'], 'collectedTax'), taxableAmountColumn),
+      R.when(isColumnKey('taxName'), taxNameAccessorColumn),
+      R.when(isColumnKey('taxableAmount'), taxableAmountColumn),
+      R.when(isColumnKey('taxRate'), taxableAmountColumn),
+      R.when(isColumnKey('taxPercentage'), taxableAmountColumn),
+      R.when(isColumnKey('collectedTax'), taxableAmountColumn),
     )(column);
   },
 );

--- a/packages/webapp/src/containers/FinancialStatements/TrialBalanceSheet/dynamicColumns.ts
+++ b/packages/webapp/src/containers/FinancialStatements/TrialBalanceSheet/dynamicColumns.ts
@@ -1,6 +1,9 @@
 import * as R from 'ramda';
+import type { TrialBalanceColumnKey } from '@bigcapital/sdk-ts';
 import { Align } from '@/constants';
 import { getColumnWidth } from '@/utils';
+
+const isColumnKey = (key: TrialBalanceColumnKey) => R.pathEq(['key'], key);
 
 const ACCOUNT_NAME_COLUMN_WIDTH = 320;
 const AMOUNT_COLUMNS_MIN_WIDTH = 120;
@@ -44,10 +47,10 @@ const dynamicColumnMapper = R.curry((data: any, column: any) => {
   const totalColumn = amountAccessor(data);
 
   return R.compose(
-    R.when(R.pathEq(['key'], 'account'), accountNameColumn),
-    R.when(R.pathEq(['key'], 'credit'), creditColumn),
-    R.when(R.pathEq(['key'], 'debit'), debitColumn),
-    R.when(R.pathEq(['key'], 'total'), totalColumn),
+    R.when(isColumnKey('account'), accountNameColumn),
+    R.when(isColumnKey('credit'), creditColumn),
+    R.when(isColumnKey('debit'), debitColumn),
+    R.when(isColumnKey('total'), totalColumn),
   )(column);
 });
 

--- a/packages/webapp/src/containers/FinancialStatements/VendorsBalanceSummary/components.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/VendorsBalanceSummary/components.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import intl from 'react-intl-universal';
 import { FinancialLoadingBar } from '../FinancialLoadingBar';
 import { useVendorsBalanceSummaryContext } from './VendorsBalanceSummaryProvider';
+import type { VendorsBalanceColumnKey } from '@bigcapital/sdk-ts';
 import { AppToaster, If, Stack } from '@/components';
 import { Align, CLASSES } from '@/constants';
 import {
@@ -67,18 +68,17 @@ const totalColumnAccessor = () => ({
   money: true,
 });
 
+const isColumnKey = (key: VendorsBalanceColumnKey) => R.pathEq(['key'], key);
+
 /**
  * Composes the response columns to table component columns.
  */
 const dynamicColumns = (columns: ColumnDef[]) => {
   return R.map(
     R.compose(
-      R.when(R.pathEq(['key'], 'name'), vendorColumnAccessor),
-      R.when(R.pathEq(['key'], 'total'), totalColumnAccessor),
-      R.when(
-        R.pathEq(['key'], 'percentage_of_column'),
-        percentageColumnAccessor,
-      ),
+      R.when(isColumnKey('name'), vendorColumnAccessor),
+      R.when(isColumnKey('total'), totalColumnAccessor),
+      R.when(isColumnKey('percentage_of_column'), percentageColumnAccessor),
     ),
   )(columns);
 };

--- a/shared/sdk-ts/openapi.json
+++ b/shared/sdk-ts/openapi.json
@@ -38042,6 +38042,46 @@
           "label"
         ]
       },
+      "BalanceSheetTableColumnDto": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "Column key",
+            "enum": [
+              "name",
+              "total",
+              "previous_period",
+              "previous_period_change",
+              "previous_period_percentage",
+              "previous_year",
+              "previous_year_change",
+              "previous_year_percentage",
+              "percentage_of_column",
+              "percentage_of_row"
+            ]
+          },
+          "label": {
+            "type": "string",
+            "description": "Column header label"
+          },
+          "cellIndex": {
+            "type": "number",
+            "description": "Cell position index"
+          },
+          "children": {
+            "description": "Nested column definitions",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FinancialTableColumnDto"
+            }
+          }
+        },
+        "required": [
+          "key",
+          "label"
+        ]
+      },
       "FinancialTableCellDto": {
         "type": "object",
         "properties": {
@@ -38094,14 +38134,14 @@
           "id"
         ]
       },
-      "FinancialTableDataDto": {
+      "BalanceSheetTableDataDto": {
         "type": "object",
         "properties": {
           "columns": {
             "description": "Table column definitions",
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/FinancialTableColumnDto"
+              "$ref": "#/components/schemas/BalanceSheetTableColumnDto"
             }
           },
           "rows": {
@@ -38124,7 +38164,7 @@
             "description": "Table data structure",
             "allOf": [
               {
-                "$ref": "#/components/schemas/FinancialTableDataDto"
+                "$ref": "#/components/schemas/BalanceSheetTableDataDto"
               }
             ]
           },
@@ -38318,6 +38358,63 @@
           "meta"
         ]
       },
+      "PurchasesByItemsTableColumnDto": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "Column key",
+            "enum": [
+              "item_name",
+              "quantity_purchases",
+              "purchase_amount",
+              "average_cost"
+            ]
+          },
+          "label": {
+            "type": "string",
+            "description": "Column header label"
+          },
+          "cellIndex": {
+            "type": "number",
+            "description": "Cell position index"
+          },
+          "children": {
+            "description": "Nested column definitions",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FinancialTableColumnDto"
+            }
+          }
+        },
+        "required": [
+          "key",
+          "label"
+        ]
+      },
+      "PurchasesByItemsTableDataDto": {
+        "type": "object",
+        "properties": {
+          "columns": {
+            "description": "Table column definitions",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PurchasesByItemsTableColumnDto"
+            }
+          },
+          "rows": {
+            "description": "Table row data",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FinancialTableRowDto"
+            }
+          }
+        },
+        "required": [
+          "columns",
+          "rows"
+        ]
+      },
       "PurchasesByItemsTableResponseDto": {
         "type": "object",
         "properties": {
@@ -38325,7 +38422,7 @@
             "description": "Table data structure",
             "allOf": [
               {
-                "$ref": "#/components/schemas/FinancialTableDataDto"
+                "$ref": "#/components/schemas/PurchasesByItemsTableDataDto"
               }
             ]
           },
@@ -38516,6 +38613,62 @@
           "meta"
         ]
       },
+      "CustomerBalanceSummaryTableColumnDto": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "Column key",
+            "enum": [
+              "name",
+              "total",
+              "percentage_of_column"
+            ]
+          },
+          "label": {
+            "type": "string",
+            "description": "Column header label"
+          },
+          "cellIndex": {
+            "type": "number",
+            "description": "Cell position index"
+          },
+          "children": {
+            "description": "Nested column definitions",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FinancialTableColumnDto"
+            }
+          }
+        },
+        "required": [
+          "key",
+          "label"
+        ]
+      },
+      "CustomerBalanceSummaryTableDataDto": {
+        "type": "object",
+        "properties": {
+          "columns": {
+            "description": "Table column definitions",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CustomerBalanceSummaryTableColumnDto"
+            }
+          },
+          "rows": {
+            "description": "Table row data",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FinancialTableRowDto"
+            }
+          }
+        },
+        "required": [
+          "columns",
+          "rows"
+        ]
+      },
       "CustomerBalanceSummaryTableResponseDto": {
         "type": "object",
         "properties": {
@@ -38523,7 +38676,7 @@
             "description": "Table data structure",
             "allOf": [
               {
-                "$ref": "#/components/schemas/FinancialTableDataDto"
+                "$ref": "#/components/schemas/CustomerBalanceSummaryTableDataDto"
               }
             ]
           },
@@ -38714,6 +38867,62 @@
           "meta"
         ]
       },
+      "VendorBalanceSummaryTableColumnDto": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "Column key",
+            "enum": [
+              "name",
+              "total",
+              "percentage_of_column"
+            ]
+          },
+          "label": {
+            "type": "string",
+            "description": "Column header label"
+          },
+          "cellIndex": {
+            "type": "number",
+            "description": "Cell position index"
+          },
+          "children": {
+            "description": "Nested column definitions",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FinancialTableColumnDto"
+            }
+          }
+        },
+        "required": [
+          "key",
+          "label"
+        ]
+      },
+      "VendorBalanceSummaryTableDataDto": {
+        "type": "object",
+        "properties": {
+          "columns": {
+            "description": "Table column definitions",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VendorBalanceSummaryTableColumnDto"
+            }
+          },
+          "rows": {
+            "description": "Table row data",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FinancialTableRowDto"
+            }
+          }
+        },
+        "required": [
+          "columns",
+          "rows"
+        ]
+      },
       "VendorBalanceSummaryTableResponseDto": {
         "type": "object",
         "properties": {
@@ -38721,7 +38930,7 @@
             "description": "Table data structure",
             "allOf": [
               {
-                "$ref": "#/components/schemas/FinancialTableDataDto"
+                "$ref": "#/components/schemas/VendorBalanceSummaryTableDataDto"
               }
             ]
           },
@@ -38935,6 +39144,63 @@
           "meta"
         ]
       },
+      "SalesByItemsTableColumnDto": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "Column key",
+            "enum": [
+              "item_name",
+              "sold_quantity",
+              "sold_amount",
+              "average_price"
+            ]
+          },
+          "label": {
+            "type": "string",
+            "description": "Column header label"
+          },
+          "cellIndex": {
+            "type": "number",
+            "description": "Cell position index"
+          },
+          "children": {
+            "description": "Nested column definitions",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FinancialTableColumnDto"
+            }
+          }
+        },
+        "required": [
+          "key",
+          "label"
+        ]
+      },
+      "SalesByItemsTableDataDto": {
+        "type": "object",
+        "properties": {
+          "columns": {
+            "description": "Table column definitions",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SalesByItemsTableColumnDto"
+            }
+          },
+          "rows": {
+            "description": "Table row data",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FinancialTableRowDto"
+            }
+          }
+        },
+        "required": [
+          "columns",
+          "rows"
+        ]
+      },
       "SalesByItemsTableResponseDto": {
         "type": "object",
         "properties": {
@@ -38942,7 +39208,7 @@
             "description": "Table data structure",
             "allOf": [
               {
-                "$ref": "#/components/schemas/FinancialTableDataDto"
+                "$ref": "#/components/schemas/SalesByItemsTableDataDto"
               }
             ]
           },
@@ -39259,6 +39525,68 @@
           "meta"
         ]
       },
+      "GeneralLedgerTableColumnDto": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "Column key",
+            "enum": [
+              "date",
+              "account_name",
+              "reference_type",
+              "reference_number",
+              "description",
+              "credit",
+              "debit",
+              "amount",
+              "running_balance"
+            ]
+          },
+          "label": {
+            "type": "string",
+            "description": "Column header label"
+          },
+          "cellIndex": {
+            "type": "number",
+            "description": "Cell position index"
+          },
+          "children": {
+            "description": "Nested column definitions",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FinancialTableColumnDto"
+            }
+          }
+        },
+        "required": [
+          "key",
+          "label"
+        ]
+      },
+      "GeneralLedgerTableDataDto": {
+        "type": "object",
+        "properties": {
+          "columns": {
+            "description": "Table column definitions",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GeneralLedgerTableColumnDto"
+            }
+          },
+          "rows": {
+            "description": "Table row data",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FinancialTableRowDto"
+            }
+          }
+        },
+        "required": [
+          "columns",
+          "rows"
+        ]
+      },
       "GeneralLedgerTableResponseDto": {
         "type": "object",
         "properties": {
@@ -39266,7 +39594,7 @@
             "description": "Table data structure",
             "allOf": [
               {
-                "$ref": "#/components/schemas/FinancialTableDataDto"
+                "$ref": "#/components/schemas/GeneralLedgerTableDataDto"
               }
             ]
           },
@@ -39554,6 +39882,63 @@
           "meta"
         ]
       },
+      "TrialBalanceSheetTableColumnDto": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "Column key",
+            "enum": [
+              "account",
+              "debit",
+              "credit",
+              "total"
+            ]
+          },
+          "label": {
+            "type": "string",
+            "description": "Column header label"
+          },
+          "cellIndex": {
+            "type": "number",
+            "description": "Cell position index"
+          },
+          "children": {
+            "description": "Nested column definitions",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FinancialTableColumnDto"
+            }
+          }
+        },
+        "required": [
+          "key",
+          "label"
+        ]
+      },
+      "TrialBalanceSheetTableDataDto": {
+        "type": "object",
+        "properties": {
+          "columns": {
+            "description": "Table column definitions",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TrialBalanceSheetTableColumnDto"
+            }
+          },
+          "rows": {
+            "description": "Table row data",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FinancialTableRowDto"
+            }
+          }
+        },
+        "required": [
+          "columns",
+          "rows"
+        ]
+      },
       "TrialBalanceSheetTableResponseDto": {
         "type": "object",
         "properties": {
@@ -39561,7 +39946,7 @@
             "description": "Table data structure",
             "allOf": [
               {
-                "$ref": "#/components/schemas/FinancialTableDataDto"
+                "$ref": "#/components/schemas/TrialBalanceSheetTableDataDto"
               }
             ]
           },
@@ -39820,6 +40205,29 @@
           "query",
           "data",
           "meta"
+        ]
+      },
+      "FinancialTableDataDto": {
+        "type": "object",
+        "properties": {
+          "columns": {
+            "description": "Table column definitions",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FinancialTableColumnDto"
+            }
+          },
+          "rows": {
+            "description": "Table row data",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FinancialTableRowDto"
+            }
+          }
+        },
+        "required": [
+          "columns",
+          "rows"
         ]
       },
       "TransactionsByVendorTableResponseDto": {
@@ -40505,6 +40913,64 @@
           "meta"
         ]
       },
+      "ARAgingSummaryTableColumnDto": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "Column key",
+            "enum": [
+              "customer_name",
+              "vendor_name",
+              "current",
+              "total",
+              "aging_period"
+            ]
+          },
+          "label": {
+            "type": "string",
+            "description": "Column header label"
+          },
+          "cellIndex": {
+            "type": "number",
+            "description": "Cell position index"
+          },
+          "children": {
+            "description": "Nested column definitions",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FinancialTableColumnDto"
+            }
+          }
+        },
+        "required": [
+          "key",
+          "label"
+        ]
+      },
+      "ARAgingSummaryTableDataDto": {
+        "type": "object",
+        "properties": {
+          "columns": {
+            "description": "Table column definitions",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ARAgingSummaryTableColumnDto"
+            }
+          },
+          "rows": {
+            "description": "Table row data",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FinancialTableRowDto"
+            }
+          }
+        },
+        "required": [
+          "columns",
+          "rows"
+        ]
+      },
       "ARAgingSummaryTableResponseDto": {
         "type": "object",
         "properties": {
@@ -40512,7 +40978,7 @@
             "description": "Table data structure",
             "allOf": [
               {
-                "$ref": "#/components/schemas/FinancialTableDataDto"
+                "$ref": "#/components/schemas/ARAgingSummaryTableDataDto"
               }
             ]
           },
@@ -40714,6 +41180,64 @@
           "meta"
         ]
       },
+      "APAgingSummaryTableColumnDto": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "Column key",
+            "enum": [
+              "customer_name",
+              "vendor_name",
+              "current",
+              "total",
+              "aging_period"
+            ]
+          },
+          "label": {
+            "type": "string",
+            "description": "Column header label"
+          },
+          "cellIndex": {
+            "type": "number",
+            "description": "Cell position index"
+          },
+          "children": {
+            "description": "Nested column definitions",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FinancialTableColumnDto"
+            }
+          }
+        },
+        "required": [
+          "key",
+          "label"
+        ]
+      },
+      "APAgingSummaryTableDataDto": {
+        "type": "object",
+        "properties": {
+          "columns": {
+            "description": "Table column definitions",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/APAgingSummaryTableColumnDto"
+            }
+          },
+          "rows": {
+            "description": "Table row data",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FinancialTableRowDto"
+            }
+          }
+        },
+        "required": [
+          "columns",
+          "rows"
+        ]
+      },
       "APAgingSummaryQueryResponseDto": {
         "type": "object",
         "properties": {
@@ -40773,7 +41297,7 @@
             "description": "Table data structure",
             "allOf": [
               {
-                "$ref": "#/components/schemas/FinancialTableDataDto"
+                "$ref": "#/components/schemas/APAgingSummaryTableDataDto"
               }
             ]
           },
@@ -41014,6 +41538,69 @@
           "meta"
         ]
       },
+      "InventoryItemDetailsTableColumnDto": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "Column key",
+            "enum": [
+              "date",
+              "transaction_type",
+              "transaction_id",
+              "quantity",
+              "rate",
+              "total",
+              "value",
+              "profit_margin",
+              "running_quantity",
+              "running_value"
+            ]
+          },
+          "label": {
+            "type": "string",
+            "description": "Column header label"
+          },
+          "cellIndex": {
+            "type": "number",
+            "description": "Cell position index"
+          },
+          "children": {
+            "description": "Nested column definitions",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FinancialTableColumnDto"
+            }
+          }
+        },
+        "required": [
+          "key",
+          "label"
+        ]
+      },
+      "InventoryItemDetailsTableDataDto": {
+        "type": "object",
+        "properties": {
+          "columns": {
+            "description": "Table column definitions",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/InventoryItemDetailsTableColumnDto"
+            }
+          },
+          "rows": {
+            "description": "Table row data",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FinancialTableRowDto"
+            }
+          }
+        },
+        "required": [
+          "columns",
+          "rows"
+        ]
+      },
       "InventoryItemDetailsTableResponseDto": {
         "type": "object",
         "properties": {
@@ -41021,7 +41608,7 @@
             "description": "Table data structure",
             "allOf": [
               {
-                "$ref": "#/components/schemas/FinancialTableDataDto"
+                "$ref": "#/components/schemas/InventoryItemDetailsTableDataDto"
               }
             ]
           },
@@ -41208,6 +41795,63 @@
           "meta"
         ]
       },
+      "InventoryValuationTableColumnDto": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "Column key",
+            "enum": [
+              "item_name",
+              "quantity",
+              "valuation",
+              "average"
+            ]
+          },
+          "label": {
+            "type": "string",
+            "description": "Column header label"
+          },
+          "cellIndex": {
+            "type": "number",
+            "description": "Cell position index"
+          },
+          "children": {
+            "description": "Nested column definitions",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FinancialTableColumnDto"
+            }
+          }
+        },
+        "required": [
+          "key",
+          "label"
+        ]
+      },
+      "InventoryValuationTableDataDto": {
+        "type": "object",
+        "properties": {
+          "columns": {
+            "description": "Table column definitions",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/InventoryValuationTableColumnDto"
+            }
+          },
+          "rows": {
+            "description": "Table row data",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FinancialTableRowDto"
+            }
+          }
+        },
+        "required": [
+          "columns",
+          "rows"
+        ]
+      },
       "InventoryValuationTableResponseDto": {
         "type": "object",
         "properties": {
@@ -41215,7 +41859,7 @@
             "description": "Table data structure",
             "allOf": [
               {
-                "$ref": "#/components/schemas/FinancialTableDataDto"
+                "$ref": "#/components/schemas/InventoryValuationTableDataDto"
               }
             ]
           },
@@ -41397,6 +42041,64 @@
           "meta"
         ]
       },
+      "SalesTaxLiabilitySummaryTableColumnDto": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "Column key",
+            "enum": [
+              "taxName",
+              "taxPercentage",
+              "taxableAmount",
+              "collectedTax",
+              "taxRate"
+            ]
+          },
+          "label": {
+            "type": "string",
+            "description": "Column header label"
+          },
+          "cellIndex": {
+            "type": "number",
+            "description": "Cell position index"
+          },
+          "children": {
+            "description": "Nested column definitions",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FinancialTableColumnDto"
+            }
+          }
+        },
+        "required": [
+          "key",
+          "label"
+        ]
+      },
+      "SalesTaxLiabilitySummaryTableDataDto": {
+        "type": "object",
+        "properties": {
+          "columns": {
+            "description": "Table column definitions",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SalesTaxLiabilitySummaryTableColumnDto"
+            }
+          },
+          "rows": {
+            "description": "Table row data",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FinancialTableRowDto"
+            }
+          }
+        },
+        "required": [
+          "columns",
+          "rows"
+        ]
+      },
       "SalesTaxLiabilitySummaryTableResponseDto": {
         "type": "object",
         "properties": {
@@ -41404,7 +42106,7 @@
             "description": "Table data structure",
             "allOf": [
               {
-                "$ref": "#/components/schemas/FinancialTableDataDto"
+                "$ref": "#/components/schemas/SalesTaxLiabilitySummaryTableDataDto"
               }
             ]
           },
@@ -41671,6 +42373,67 @@
           "meta"
         ]
       },
+      "JournalSheetTableColumnDto": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "Column key",
+            "enum": [
+              "date",
+              "transaction_type",
+              "transaction_number",
+              "description",
+              "account_code",
+              "account_name",
+              "debit",
+              "credit"
+            ]
+          },
+          "label": {
+            "type": "string",
+            "description": "Column header label"
+          },
+          "cellIndex": {
+            "type": "number",
+            "description": "Cell position index"
+          },
+          "children": {
+            "description": "Nested column definitions",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FinancialTableColumnDto"
+            }
+          }
+        },
+        "required": [
+          "key",
+          "label"
+        ]
+      },
+      "JournalSheetTableDataDto": {
+        "type": "object",
+        "properties": {
+          "columns": {
+            "description": "Table column definitions",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/JournalSheetTableColumnDto"
+            }
+          },
+          "rows": {
+            "description": "Table row data",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FinancialTableRowDto"
+            }
+          }
+        },
+        "required": [
+          "columns",
+          "rows"
+        ]
+      },
       "JournalSheetTableResponseDto": {
         "type": "object",
         "properties": {
@@ -41678,7 +42441,7 @@
             "description": "Table data structure",
             "allOf": [
               {
-                "$ref": "#/components/schemas/FinancialTableDataDto"
+                "$ref": "#/components/schemas/JournalSheetTableDataDto"
               }
             ]
           },
@@ -42051,6 +42814,71 @@
           "meta"
         ]
       },
+      "ProfitLossSheetTableColumnDto": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "Column key",
+            "enum": [
+              "name",
+              "total",
+              "previous_period",
+              "previous_period_change",
+              "previous_period_percentage",
+              "previous_year",
+              "previous_year_change",
+              "previous_year_percentage",
+              "percentage_income",
+              "percentage_expenses",
+              "percentage_column",
+              "percentage_row"
+            ]
+          },
+          "label": {
+            "type": "string",
+            "description": "Column header label"
+          },
+          "cellIndex": {
+            "type": "number",
+            "description": "Cell position index"
+          },
+          "children": {
+            "description": "Nested column definitions",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FinancialTableColumnDto"
+            }
+          }
+        },
+        "required": [
+          "key",
+          "label"
+        ]
+      },
+      "ProfitLossSheetTableDataDto": {
+        "type": "object",
+        "properties": {
+          "columns": {
+            "description": "Table column definitions",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProfitLossSheetTableColumnDto"
+            }
+          },
+          "rows": {
+            "description": "Table row data",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FinancialTableRowDto"
+            }
+          }
+        },
+        "required": [
+          "columns",
+          "rows"
+        ]
+      },
       "ProfitLossSheetTableResponseDto": {
         "type": "object",
         "properties": {
@@ -42058,7 +42886,7 @@
             "description": "Table data structure",
             "allOf": [
               {
-                "$ref": "#/components/schemas/FinancialTableDataDto"
+                "$ref": "#/components/schemas/ProfitLossSheetTableDataDto"
               }
             ]
           },
@@ -42301,6 +43129,61 @@
           "meta"
         ]
       },
+      "CashflowStatementTableColumnDto": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "Column key",
+            "enum": [
+              "name",
+              "total"
+            ]
+          },
+          "label": {
+            "type": "string",
+            "description": "Column header label"
+          },
+          "cellIndex": {
+            "type": "number",
+            "description": "Cell position index"
+          },
+          "children": {
+            "description": "Nested column definitions",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FinancialTableColumnDto"
+            }
+          }
+        },
+        "required": [
+          "key",
+          "label"
+        ]
+      },
+      "CashflowStatementTableDataDto": {
+        "type": "object",
+        "properties": {
+          "columns": {
+            "description": "Table column definitions",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CashflowStatementTableColumnDto"
+            }
+          },
+          "rows": {
+            "description": "Table row data",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FinancialTableRowDto"
+            }
+          }
+        },
+        "required": [
+          "columns",
+          "rows"
+        ]
+      },
       "CashflowStatementTableResponseDto": {
         "type": "object",
         "properties": {
@@ -42308,7 +43191,7 @@
             "description": "Table data structure",
             "allOf": [
               {
-                "$ref": "#/components/schemas/FinancialTableDataDto"
+                "$ref": "#/components/schemas/CashflowStatementTableDataDto"
               }
             ]
           },

--- a/shared/sdk-ts/src/reports/index.ts
+++ b/shared/sdk-ts/src/reports/index.ts
@@ -17,3 +17,4 @@ export * from './inventory-valuation';
 export * from './inventory-details';
 export * from './sales-tax-liability';
 export * from './transactions-reference';
+export * from './table-column-keys';

--- a/shared/sdk-ts/src/reports/table-column-keys.ts
+++ b/shared/sdk-ts/src/reports/table-column-keys.ts
@@ -1,0 +1,51 @@
+import type { components } from '../schema';
+
+/**
+ * Per-report table column key types, derived from the server OpenAPI spec.
+ *
+ * These unions are the single source of truth for the `key` values emitted by
+ * each financial statement table. The webapp column mappers reference them so
+ * any key change on the server (after regenerating the SDK) surfaces as a
+ * type error in the webapp instead of a runtime crash / mis-styled column.
+ */
+export type BalanceSheetColumnKey =
+  components['schemas']['BalanceSheetTableColumnDto']['key'];
+
+export type ProfitLossColumnKey =
+  components['schemas']['ProfitLossSheetTableColumnDto']['key'];
+
+export type TrialBalanceColumnKey =
+  components['schemas']['TrialBalanceSheetTableColumnDto']['key'];
+
+export type CashFlowColumnKey =
+  components['schemas']['CashflowStatementTableColumnDto']['key'];
+
+export type AgingSummaryColumnKey =
+  components['schemas']['ARAgingSummaryTableColumnDto']['key'];
+
+export type GeneralLedgerColumnKey =
+  components['schemas']['GeneralLedgerTableColumnDto']['key'];
+
+export type JournalColumnKey =
+  components['schemas']['JournalSheetTableColumnDto']['key'];
+
+export type CustomersBalanceColumnKey =
+  components['schemas']['CustomerBalanceSummaryTableColumnDto']['key'];
+
+export type VendorsBalanceColumnKey =
+  components['schemas']['VendorBalanceSummaryTableColumnDto']['key'];
+
+export type SalesByItemsColumnKey =
+  components['schemas']['SalesByItemsTableColumnDto']['key'];
+
+export type PurchasesByItemsColumnKey =
+  components['schemas']['PurchasesByItemsTableColumnDto']['key'];
+
+export type InventoryValuationColumnKey =
+  components['schemas']['InventoryValuationTableColumnDto']['key'];
+
+export type InventoryItemDetailsColumnKey =
+  components['schemas']['InventoryItemDetailsTableColumnDto']['key'];
+
+export type SalesTaxLiabilityColumnKey =
+  components['schemas']['SalesTaxLiabilitySummaryTableColumnDto']['key'];

--- a/shared/sdk-ts/src/schema.ts
+++ b/shared/sdk-ts/src/schema.ts
@@ -14278,6 +14278,19 @@ export interface components {
             /** @description Nested column definitions */
             children?: components["schemas"]["FinancialTableColumnDto"][];
         };
+        BalanceSheetTableColumnDto: {
+            /**
+             * @description Column key
+             * @enum {string}
+             */
+            key: "name" | "total" | "previous_period" | "previous_period_change" | "previous_period_percentage" | "previous_year" | "previous_year_change" | "previous_year_percentage" | "percentage_of_column" | "percentage_of_row";
+            /** @description Column header label */
+            label: string;
+            /** @description Cell position index */
+            cellIndex?: number;
+            /** @description Nested column definitions */
+            children?: components["schemas"]["FinancialTableColumnDto"][];
+        };
         FinancialTableCellDto: {
             /** @description Cell key */
             key: string;
@@ -14294,15 +14307,15 @@ export interface components {
             /** @description Child rows */
             children?: components["schemas"]["FinancialTableRowDto"][];
         };
-        FinancialTableDataDto: {
+        BalanceSheetTableDataDto: {
             /** @description Table column definitions */
-            columns: components["schemas"]["FinancialTableColumnDto"][];
+            columns: components["schemas"]["BalanceSheetTableColumnDto"][];
             /** @description Table row data */
             rows: components["schemas"]["FinancialTableRowDto"][];
         };
         BalanceSheetTableResponseDto: {
             /** @description Table data structure */
-            table: components["schemas"]["FinancialTableDataDto"];
+            table: components["schemas"]["BalanceSheetTableDataDto"];
             /** @description Query parameters used to generate the report */
             query: components["schemas"]["BalanceSheetQueryResponseDto"];
             /** @description Report metadata */
@@ -14362,9 +14375,28 @@ export interface components {
             /** @description Report metadata */
             meta: components["schemas"]["PurchasesByItemsMetaDto"];
         };
+        PurchasesByItemsTableColumnDto: {
+            /**
+             * @description Column key
+             * @enum {string}
+             */
+            key: "item_name" | "quantity_purchases" | "purchase_amount" | "average_cost";
+            /** @description Column header label */
+            label: string;
+            /** @description Cell position index */
+            cellIndex?: number;
+            /** @description Nested column definitions */
+            children?: components["schemas"]["FinancialTableColumnDto"][];
+        };
+        PurchasesByItemsTableDataDto: {
+            /** @description Table column definitions */
+            columns: components["schemas"]["PurchasesByItemsTableColumnDto"][];
+            /** @description Table row data */
+            rows: components["schemas"]["FinancialTableRowDto"][];
+        };
         PurchasesByItemsTableResponseDto: {
             /** @description Table data structure */
-            table: components["schemas"]["FinancialTableDataDto"];
+            table: components["schemas"]["PurchasesByItemsTableDataDto"];
             /** @description Query parameters used to generate the report */
             query: components["schemas"]["PurchasesByItemsQueryResponseDto"];
             /** @description Report metadata */
@@ -14420,9 +14452,28 @@ export interface components {
             /** @description Report metadata */
             meta: components["schemas"]["CustomerBalanceSummaryMetaDto"];
         };
+        CustomerBalanceSummaryTableColumnDto: {
+            /**
+             * @description Column key
+             * @enum {string}
+             */
+            key: "name" | "total" | "percentage_of_column";
+            /** @description Column header label */
+            label: string;
+            /** @description Cell position index */
+            cellIndex?: number;
+            /** @description Nested column definitions */
+            children?: components["schemas"]["FinancialTableColumnDto"][];
+        };
+        CustomerBalanceSummaryTableDataDto: {
+            /** @description Table column definitions */
+            columns: components["schemas"]["CustomerBalanceSummaryTableColumnDto"][];
+            /** @description Table row data */
+            rows: components["schemas"]["FinancialTableRowDto"][];
+        };
         CustomerBalanceSummaryTableResponseDto: {
             /** @description Table data structure */
-            table: components["schemas"]["FinancialTableDataDto"];
+            table: components["schemas"]["CustomerBalanceSummaryTableDataDto"];
             /** @description Query parameters used to generate the report */
             query: components["schemas"]["CustomerBalanceSummaryQueryResponseDto"];
             /** @description Report metadata */
@@ -14478,9 +14529,28 @@ export interface components {
             /** @description Report metadata */
             meta: components["schemas"]["VendorBalanceSummaryMetaDto"];
         };
+        VendorBalanceSummaryTableColumnDto: {
+            /**
+             * @description Column key
+             * @enum {string}
+             */
+            key: "name" | "total" | "percentage_of_column";
+            /** @description Column header label */
+            label: string;
+            /** @description Cell position index */
+            cellIndex?: number;
+            /** @description Nested column definitions */
+            children?: components["schemas"]["FinancialTableColumnDto"][];
+        };
+        VendorBalanceSummaryTableDataDto: {
+            /** @description Table column definitions */
+            columns: components["schemas"]["VendorBalanceSummaryTableColumnDto"][];
+            /** @description Table row data */
+            rows: components["schemas"]["FinancialTableRowDto"][];
+        };
         VendorBalanceSummaryTableResponseDto: {
             /** @description Table data structure */
-            table: components["schemas"]["FinancialTableDataDto"];
+            table: components["schemas"]["VendorBalanceSummaryTableDataDto"];
             /** @description Query parameters used to generate the report */
             query: components["schemas"]["VendorBalanceSummaryQueryResponseDto"];
             /** @description Report metadata */
@@ -14546,9 +14616,28 @@ export interface components {
             /** @description Report metadata */
             meta: components["schemas"]["SalesByItemsMetaDto"];
         };
+        SalesByItemsTableColumnDto: {
+            /**
+             * @description Column key
+             * @enum {string}
+             */
+            key: "item_name" | "sold_quantity" | "sold_amount" | "average_price";
+            /** @description Column header label */
+            label: string;
+            /** @description Cell position index */
+            cellIndex?: number;
+            /** @description Nested column definitions */
+            children?: components["schemas"]["FinancialTableColumnDto"][];
+        };
+        SalesByItemsTableDataDto: {
+            /** @description Table column definitions */
+            columns: components["schemas"]["SalesByItemsTableColumnDto"][];
+            /** @description Table row data */
+            rows: components["schemas"]["FinancialTableRowDto"][];
+        };
         SalesByItemsTableResponseDto: {
             /** @description Table data structure */
-            table: components["schemas"]["FinancialTableDataDto"];
+            table: components["schemas"]["SalesByItemsTableDataDto"];
             /** @description Query parameters used to generate the report */
             query: components["schemas"]["SalesByItemsQueryResponseDto"];
             /** @description Report metadata */
@@ -14657,9 +14746,28 @@ export interface components {
             /** @description Report metadata */
             meta: components["schemas"]["GeneralLedgerMetaDto"];
         };
+        GeneralLedgerTableColumnDto: {
+            /**
+             * @description Column key
+             * @enum {string}
+             */
+            key: "date" | "account_name" | "reference_type" | "reference_number" | "description" | "credit" | "debit" | "amount" | "running_balance";
+            /** @description Column header label */
+            label: string;
+            /** @description Cell position index */
+            cellIndex?: number;
+            /** @description Nested column definitions */
+            children?: components["schemas"]["FinancialTableColumnDto"][];
+        };
+        GeneralLedgerTableDataDto: {
+            /** @description Table column definitions */
+            columns: components["schemas"]["GeneralLedgerTableColumnDto"][];
+            /** @description Table row data */
+            rows: components["schemas"]["FinancialTableRowDto"][];
+        };
         GeneralLedgerTableResponseDto: {
             /** @description Table data structure */
-            table: components["schemas"]["FinancialTableDataDto"];
+            table: components["schemas"]["GeneralLedgerTableDataDto"];
             /** @description Query parameters used to generate the report */
             query: components["schemas"]["GeneralLedgerQueryResponseDto"];
             /** @description Report metadata */
@@ -14763,9 +14871,28 @@ export interface components {
             /** @description Report metadata */
             meta: components["schemas"]["TrialBalanceSheetMetaDto"];
         };
+        TrialBalanceSheetTableColumnDto: {
+            /**
+             * @description Column key
+             * @enum {string}
+             */
+            key: "account" | "debit" | "credit" | "total";
+            /** @description Column header label */
+            label: string;
+            /** @description Cell position index */
+            cellIndex?: number;
+            /** @description Nested column definitions */
+            children?: components["schemas"]["FinancialTableColumnDto"][];
+        };
+        TrialBalanceSheetTableDataDto: {
+            /** @description Table column definitions */
+            columns: components["schemas"]["TrialBalanceSheetTableColumnDto"][];
+            /** @description Table row data */
+            rows: components["schemas"]["FinancialTableRowDto"][];
+        };
         TrialBalanceSheetTableResponseDto: {
             /** @description Table data structure */
-            table: components["schemas"]["FinancialTableDataDto"];
+            table: components["schemas"]["TrialBalanceSheetTableDataDto"];
             /** @description Query parameters used to generate the report */
             query: components["schemas"]["TrialBalanceSheetQueryResponseDto"];
             /** @description Report metadata */
@@ -14844,6 +14971,12 @@ export interface components {
             data: components["schemas"]["VendorWithTransactionsDto"][];
             /** @description Report metadata */
             meta: components["schemas"]["TransactionsByVendorMetaDto"];
+        };
+        FinancialTableDataDto: {
+            /** @description Table column definitions */
+            columns: components["schemas"]["FinancialTableColumnDto"][];
+            /** @description Table row data */
+            rows: components["schemas"]["FinancialTableRowDto"][];
         };
         TransactionsByVendorTableResponseDto: {
             /** @description Table data structure */
@@ -15056,9 +15189,28 @@ export interface components {
             /** @description Report metadata */
             meta: components["schemas"]["ARAgingSummaryMetaDto"];
         };
+        ARAgingSummaryTableColumnDto: {
+            /**
+             * @description Column key
+             * @enum {string}
+             */
+            key: "customer_name" | "vendor_name" | "current" | "total" | "aging_period";
+            /** @description Column header label */
+            label: string;
+            /** @description Cell position index */
+            cellIndex?: number;
+            /** @description Nested column definitions */
+            children?: components["schemas"]["FinancialTableColumnDto"][];
+        };
+        ARAgingSummaryTableDataDto: {
+            /** @description Table column definitions */
+            columns: components["schemas"]["ARAgingSummaryTableColumnDto"][];
+            /** @description Table row data */
+            rows: components["schemas"]["FinancialTableRowDto"][];
+        };
         ARAgingSummaryTableResponseDto: {
             /** @description Table data structure */
-            table: components["schemas"]["FinancialTableDataDto"];
+            table: components["schemas"]["ARAgingSummaryTableDataDto"];
             /** @description Query parameters used to generate the report */
             query: components["schemas"]["ARAgingSummaryQueryResponseDto"];
             /** @description Report metadata */
@@ -15116,6 +15268,25 @@ export interface components {
             /** @description Report metadata */
             meta: components["schemas"]["APAgingSummaryMetaDto"];
         };
+        APAgingSummaryTableColumnDto: {
+            /**
+             * @description Column key
+             * @enum {string}
+             */
+            key: "customer_name" | "vendor_name" | "current" | "total" | "aging_period";
+            /** @description Column header label */
+            label: string;
+            /** @description Cell position index */
+            cellIndex?: number;
+            /** @description Nested column definitions */
+            children?: components["schemas"]["FinancialTableColumnDto"][];
+        };
+        APAgingSummaryTableDataDto: {
+            /** @description Table column definitions */
+            columns: components["schemas"]["APAgingSummaryTableColumnDto"][];
+            /** @description Table row data */
+            rows: components["schemas"]["FinancialTableRowDto"][];
+        };
         APAgingSummaryQueryResponseDto: {
             /** @description As-of date */
             asDate: string;
@@ -15134,7 +15305,7 @@ export interface components {
         };
         APAgingSummaryTableResponseDto: {
             /** @description Table data structure */
-            table: components["schemas"]["FinancialTableDataDto"];
+            table: components["schemas"]["APAgingSummaryTableDataDto"];
             /** @description Query parameters used to generate the report */
             query: components["schemas"]["APAgingSummaryQueryResponseDto"];
             /** @description Report metadata */
@@ -15212,9 +15383,28 @@ export interface components {
             /** @description Report metadata */
             meta: components["schemas"]["InventoryItemDetailsMetaDto"];
         };
+        InventoryItemDetailsTableColumnDto: {
+            /**
+             * @description Column key
+             * @enum {string}
+             */
+            key: "date" | "transaction_type" | "transaction_id" | "quantity" | "rate" | "total" | "value" | "profit_margin" | "running_quantity" | "running_value";
+            /** @description Column header label */
+            label: string;
+            /** @description Cell position index */
+            cellIndex?: number;
+            /** @description Nested column definitions */
+            children?: components["schemas"]["FinancialTableColumnDto"][];
+        };
+        InventoryItemDetailsTableDataDto: {
+            /** @description Table column definitions */
+            columns: components["schemas"]["InventoryItemDetailsTableColumnDto"][];
+            /** @description Table row data */
+            rows: components["schemas"]["FinancialTableRowDto"][];
+        };
         InventoryItemDetailsTableResponseDto: {
             /** @description Table data structure */
-            table: components["schemas"]["FinancialTableDataDto"];
+            table: components["schemas"]["InventoryItemDetailsTableDataDto"];
             /** @description Query parameters used to generate the report */
             query: components["schemas"]["InventoryItemDetailsQueryResponseDto"];
             /** @description Report metadata */
@@ -15274,9 +15464,28 @@ export interface components {
             /** @description Report metadata */
             meta: components["schemas"]["InventoryValuationMetaDto"];
         };
+        InventoryValuationTableColumnDto: {
+            /**
+             * @description Column key
+             * @enum {string}
+             */
+            key: "item_name" | "quantity" | "valuation" | "average";
+            /** @description Column header label */
+            label: string;
+            /** @description Cell position index */
+            cellIndex?: number;
+            /** @description Nested column definitions */
+            children?: components["schemas"]["FinancialTableColumnDto"][];
+        };
+        InventoryValuationTableDataDto: {
+            /** @description Table column definitions */
+            columns: components["schemas"]["InventoryValuationTableColumnDto"][];
+            /** @description Table row data */
+            rows: components["schemas"]["FinancialTableRowDto"][];
+        };
         InventoryValuationTableResponseDto: {
             /** @description Table data structure */
-            table: components["schemas"]["FinancialTableDataDto"];
+            table: components["schemas"]["InventoryValuationTableDataDto"];
             /** @description Query parameters used to generate the report */
             query: components["schemas"]["InventoryValuationQueryResponseDto"];
             /** @description Report metadata */
@@ -15330,9 +15539,28 @@ export interface components {
             /** @description Report metadata */
             meta: components["schemas"]["SalesTaxLiabilitySummaryMetaDto"];
         };
+        SalesTaxLiabilitySummaryTableColumnDto: {
+            /**
+             * @description Column key
+             * @enum {string}
+             */
+            key: "taxName" | "taxPercentage" | "taxableAmount" | "collectedTax" | "taxRate";
+            /** @description Column header label */
+            label: string;
+            /** @description Cell position index */
+            cellIndex?: number;
+            /** @description Nested column definitions */
+            children?: components["schemas"]["FinancialTableColumnDto"][];
+        };
+        SalesTaxLiabilitySummaryTableDataDto: {
+            /** @description Table column definitions */
+            columns: components["schemas"]["SalesTaxLiabilitySummaryTableColumnDto"][];
+            /** @description Table row data */
+            rows: components["schemas"]["FinancialTableRowDto"][];
+        };
         SalesTaxLiabilitySummaryTableResponseDto: {
             /** @description Table data structure */
-            table: components["schemas"]["FinancialTableDataDto"];
+            table: components["schemas"]["SalesTaxLiabilitySummaryTableDataDto"];
             /** @description Query parameters used to generate the report */
             query: components["schemas"]["SalesTaxLiabilitySummaryQueryResponseDto"];
             /** @description Report metadata */
@@ -15424,9 +15652,28 @@ export interface components {
             /** @description Report metadata */
             meta: components["schemas"]["JournalSheetMetaDto"];
         };
+        JournalSheetTableColumnDto: {
+            /**
+             * @description Column key
+             * @enum {string}
+             */
+            key: "date" | "transaction_type" | "transaction_number" | "description" | "account_code" | "account_name" | "debit" | "credit";
+            /** @description Column header label */
+            label: string;
+            /** @description Cell position index */
+            cellIndex?: number;
+            /** @description Nested column definitions */
+            children?: components["schemas"]["FinancialTableColumnDto"][];
+        };
+        JournalSheetTableDataDto: {
+            /** @description Table column definitions */
+            columns: components["schemas"]["JournalSheetTableColumnDto"][];
+            /** @description Table row data */
+            rows: components["schemas"]["FinancialTableRowDto"][];
+        };
         JournalSheetTableResponseDto: {
             /** @description Table data structure */
-            table: components["schemas"]["FinancialTableDataDto"];
+            table: components["schemas"]["JournalSheetTableDataDto"];
             /** @description Query parameters used to generate the report */
             query: components["schemas"]["JournalSheetQueryResponseDto"];
             /** @description Report metadata */
@@ -15550,9 +15797,28 @@ export interface components {
             /** @description Report metadata */
             meta: components["schemas"]["ProfitLossSheetMetaDto"];
         };
+        ProfitLossSheetTableColumnDto: {
+            /**
+             * @description Column key
+             * @enum {string}
+             */
+            key: "name" | "total" | "previous_period" | "previous_period_change" | "previous_period_percentage" | "previous_year" | "previous_year_change" | "previous_year_percentage" | "percentage_income" | "percentage_expenses" | "percentage_column" | "percentage_row";
+            /** @description Column header label */
+            label: string;
+            /** @description Cell position index */
+            cellIndex?: number;
+            /** @description Nested column definitions */
+            children?: components["schemas"]["FinancialTableColumnDto"][];
+        };
+        ProfitLossSheetTableDataDto: {
+            /** @description Table column definitions */
+            columns: components["schemas"]["ProfitLossSheetTableColumnDto"][];
+            /** @description Table row data */
+            rows: components["schemas"]["FinancialTableRowDto"][];
+        };
         ProfitLossSheetTableResponseDto: {
             /** @description Table data structure */
-            table: components["schemas"]["FinancialTableDataDto"];
+            table: components["schemas"]["ProfitLossSheetTableDataDto"];
             /** @description Query parameters used to generate the report */
             query: components["schemas"]["ProfitLossSheetQueryResponseDto"];
             /** @description Report metadata */
@@ -15636,9 +15902,28 @@ export interface components {
             /** @description Report metadata */
             meta: components["schemas"]["CashflowStatementMetaDto"];
         };
+        CashflowStatementTableColumnDto: {
+            /**
+             * @description Column key
+             * @enum {string}
+             */
+            key: "name" | "total";
+            /** @description Column header label */
+            label: string;
+            /** @description Cell position index */
+            cellIndex?: number;
+            /** @description Nested column definitions */
+            children?: components["schemas"]["FinancialTableColumnDto"][];
+        };
+        CashflowStatementTableDataDto: {
+            /** @description Table column definitions */
+            columns: components["schemas"]["CashflowStatementTableColumnDto"][];
+            /** @description Table row data */
+            rows: components["schemas"]["FinancialTableRowDto"][];
+        };
         CashflowStatementTableResponseDto: {
             /** @description Table data structure */
-            table: components["schemas"]["FinancialTableDataDto"];
+            table: components["schemas"]["CashflowStatementTableDataDto"];
             /** @description Query parameters used to generate the report */
             query: components["schemas"]["CashflowStatementQueryResponseDto"];
             /** @description Report metadata */


### PR DESCRIPTION
## Description

The balance sheet (and other financial statements) crashed when enabling the previous period / previous year / percentage columns:

```
Uncaught Error: A column ID (or string accessor) is required!
```

The webapp column mappers hardcoded key predicates (e.g. `previous_year`) while the server emitted the same values as plain strings, so any mismatch either mis-styled columns or crashed react-table. This change makes the column `key` values a single source of truth shared between the server and the webapp through sdk-ts, so a typo or a server-side key change now fails the typecheck instead of failing at runtime.

- Added per-report table column key consts + types on the server (`FinancialStatements/common/constants/tableColumnKeys.ts`) and refactored all financial statement table builders to emit keys from them.
- Exposed the keys as OpenAPI enums via per-report column DTOs (each report response now carries its own `*TableColumnDto` with an enum `key`).
- Regenerated `openapi.json` / `schema.ts` and exported the per-report key union types from sdk-ts.
- Updated all webapp `dynamicColumns` mappers to use a typed `isColumnKey()` helper (e.g. `BalanceSheetColumnKey`), replacing raw `R.pathEq(['key'], '...')` predicates.

No new dependencies.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- `npx tsc --noEmit` in `packages/server` — clean.
- `yarn typecheck` + `yarn build` in `shared/sdk-ts` — clean.
- `yarn typecheck` in `packages/webapp` — no new errors versus the pre-existing baseline (36 files already failed on `develop`; unchanged).
- `npx eslint` on the changed webapp files — 0 errors (2 pre-existing warnings).
- Verified via `openapi:export` that all 15 per-report column DTOs now carry the correct key enums in the generated spec.

Manual verification steps:
1. Run the server (`packages/server`) and webapp (`packages/webapp`, `yarn dev`).
2. Open Balance Sheet and enable Previous Period + Previous Year + percentage columns.
3. Confirm the report renders (previously it crashed).
4. Spot-check General Ledger, Sales/Purchases by Items, Inventory Valuation, and Inventory Item Details styling.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>
