### PR TITLE
fix(webapp): open customize drawer in inventory item details report

### DIFF
--- a/packages/webapp/src/containers/FinancialStatements/InventoryItemDetails/InventoryItemDetailsHeader.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/InventoryItemDetails/InventoryItemDetailsHeader.tsx
@@ -137,7 +137,7 @@ function InventoryItemDetailsHeaderInner({
 
 export const InventoryItemDetailsHeader = compose(
   withInventoryItemDetails(({ inventoryItemDetailDrawerFilter }) => ({
-    isFilterDrawerOpen: inventoryItemDetailDrawerFilter,
+    inventoryItemDetailDrawerFilter,
   })),
   withInventoryItemDetailsActions,
 )(InventoryItemDetailsHeaderInner);


### PR DESCRIPTION
## Description

The "Customize Report" button in the Inventory Item Details report toggled the filter drawer flag correctly (the button text changed to "Hide Customizer"), but the drawer never opened.

The header's Redux connector mapped the drawer flag to an `isFilterDrawerOpen` prop, while the header component reads it as `inventoryItemDetailDrawerFilter`. Since the injected prop name did not match the destructured prop name, the value was always `undefined` and `isOpen` was permanently `false`.

This change maps the flag under its actual prop name, matching the `inventoryItemDetailDrawerFilter` prop type and the pattern used by the other financial reports (e.g. `InventoryValuationHeader`).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Manually verified the fix by opening the Inventory Item Details report and clicking "Customize Report"; the customizer drawer now opens and the button text toggles between "Customize Report" and "Hide Customizer". Also ran ESLint on the changed file.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>