### PR TITLE
fix(server): rename sale receipt closed property to isClosed

### DIFF
--- a/packages/server/src/modules/SaleReceipts/dtos/SaleReceiptResponse.dto.ts
+++ b/packages/server/src/modules/SaleReceipts/dtos/SaleReceiptResponse.dto.ts
@@ -79,8 +79,18 @@ export class SaleReceiptResponseDto {
   })
   statement?: string;
 
-  @ApiProperty({ description: 'Whether the receipt is closed', example: false })
-  closed: boolean;
+  @ApiProperty({
+    description: 'Whether the sale receipt is closed',
+    example: false,
+  })
+  isClosed: boolean;
+
+  @ApiProperty({
+    description: 'Whether the sale receipt is draft',
+    example: false,
+    required: false,
+  })
+  isDraft?: boolean;
 
   @ApiProperty({
     description: 'The date when the receipt was closed',

--- a/packages/webapp/src/containers/Drawers/ReceiptDetailDrawer/components.tsx
+++ b/packages/webapp/src/containers/Drawers/ReceiptDetailDrawer/components.tsx
@@ -30,7 +30,7 @@ interface ReceiptMoreMenuItemsProps {
 export function ReceiptDetailsStatus({ receipt }: ReceiptDetailsStatusProps) {
   return (
     <Choose>
-      <Choose.When condition={receipt.closed}>
+      <Choose.When condition={receipt.isClosed}>
         <Tag round={true} intent={Intent.SUCCESS}>
           <T id={'closed'} />
         </Tag>

--- a/packages/webapp/src/containers/Sales/Receipts/ReceiptForm/ReceiptFormFloatingActions.tsx
+++ b/packages/webapp/src/containers/Sales/Receipts/ReceiptForm/ReceiptFormFloatingActions.tsx
@@ -99,7 +99,7 @@ export function ReceiptFormFloatingActions() {
     <PageForm.FooterActions spacing={10} position="apart">
       <Group spacing={10}>
         {/* ----------- Save And Close ----------- */}
-        <If condition={!receipt || !receipt?.closed}>
+        <If condition={!receipt || !receipt?.isClosed}>
           <ButtonGroup>
             <Button
               disabled={isSubmitting}
@@ -167,7 +167,7 @@ export function ReceiptFormFloatingActions() {
         </If>
 
         {/* ----------- Save and New ----------- */}
-        <If condition={Boolean(receipt && receipt?.closed)}>
+        <If condition={Boolean(receipt && receipt?.isClosed)}>
           <ButtonGroup>
             <Button
               disabled={isSubmitting}

--- a/shared/sdk-ts/openapi.json
+++ b/shared/sdk-ts/openapi.json
@@ -32392,9 +32392,14 @@
             "description": "The statement on the receipt",
             "example": "Paid in full"
           },
-          "closed": {
+          "isClosed": {
             "type": "boolean",
-            "description": "Whether the receipt is closed",
+            "description": "Whether the sale receipt is closed",
+            "example": false
+          },
+          "isDraft": {
+            "type": "boolean",
+            "description": "Whether the sale receipt is draft",
             "example": false
           },
           "closedAt": {
@@ -32567,7 +32572,7 @@
           "customer",
           "depositAccountId",
           "depositAccount",
-          "closed",
+          "isClosed",
           "entries",
           "subtotal",
           "subtotalLocal",

--- a/shared/sdk-ts/src/schema.ts
+++ b/shared/sdk-ts/src/schema.ts
@@ -10312,10 +10312,15 @@ export interface components {
              */
             statement?: string;
             /**
-             * @description Whether the receipt is closed
+             * @description Whether the sale receipt is closed
              * @example false
              */
-            closed: boolean;
+            isClosed: boolean;
+            /**
+             * @description Whether the sale receipt is draft
+             * @example false
+             */
+            isDraft?: boolean;
             /**
              * @description The date when the receipt was closed
              * @example 2024-01-02T00:00:00Z


### PR DESCRIPTION
## Description

Renames the `closed` property to `isClosed` on the sale receipt response DTO, aligning it with the boolean naming convention used across other document responses. Adds a new optional `isDraft` property to indicate draft receipts.

The webapp was already consuming `receipt.closed` from the API response, but the server exposed the property as part of the response schema. This change updates the server DTO, the regenerated OpenAPI spec, the TS SDK types, and all webapp usages to consistently use `isClosed`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Verified the shared SDK types compile against the updated OpenAPI spec.
- Confirmed webapp type references (`receipt.isClosed`) match the updated schema.
- Ran the repo-wide format hook locally without introducing formatting changes.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>