### PR TITLE
fix(server): include children accounts in financial statements totals

### DIFF
--- a/packages/server/src/modules/FinancialStatements/modules/BalanceSheet/BalanceSheetAccounts.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/BalanceSheet/BalanceSheetAccounts.ts
@@ -91,10 +91,9 @@ export const BalanceSheetAccounts = <T extends GConstructor<FinancialSheet>>(
     private reportSchemaAccountNodeMapper = (
       account: Account,
     ): IBalanceSheetAccountNode => {
-      const childrenAccountsIds = this.repository.accountsGraph.dependenciesOf(
+      const accountIds = this.repository.getAccountsIdsIncludingChildren(
         account.id,
       );
-      const accountIds = R.uniq(R.append(account.id, childrenAccountsIds));
       const total = this.repository.totalAccountsLedger
         .whereAccountsIds(accountIds)
         .getClosingBalance();

--- a/packages/server/src/modules/FinancialStatements/modules/BalanceSheet/BalanceSheetComparsionPreviousPeriod.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/BalanceSheet/BalanceSheetComparsionPreviousPeriod.ts
@@ -38,9 +38,13 @@ export const BalanceSheetComparsionPreviousPeriod = <
     public assocPreviousPeriodAccountNode = (
       node: IBalanceSheetDataNode,
     ): IBalanceSheetDataNode => {
-      const total = this.repository.PPTotalAccountsLedger.whereAccountId(
+      const accountIds = this.repository.getAccountsIdsIncludingChildren(
         node.id,
-      ).getClosingBalance();
+      );
+      const total =
+        this.repository.PPTotalAccountsLedger.whereAccountsIds(
+          accountIds,
+        ).getClosingBalance();
 
       return R.assoc('previousPeriod', this.getAmountMeta(total), node);
     };
@@ -84,7 +88,7 @@ export const BalanceSheetComparsionPreviousPeriod = <
     public assocPreviousPeriodAggregateNode = (
       node: IBalanceSheetAggregateNode,
     ): IBalanceSheetAggregateNode => {
-      const total = sumBy(node.children, 'previousYear.amount');
+      const total = sumBy(node.children, 'previousPeriod.amount');
 
       return R.assoc('previousPeriod', this.getTotalAmountMeta(total), node);
     };
@@ -129,14 +133,16 @@ export const BalanceSheetComparsionPreviousPeriod = <
      */
     private getAccountPPDatePeriodTotal = R.curry(
       (accountId: number, fromDate: Date, toDate: Date): number => {
+        const accountIds =
+          this.repository.getAccountsIdsIncludingChildren(accountId);
         const PPPeriodsTotal =
-          this.repository.PPPeriodsAccountsLedger.whereAccountId(accountId)
+          this.repository.PPPeriodsAccountsLedger.whereAccountsIds(accountIds)
             .whereToDate(toDate)
             .getClosingBalance();
 
         const PPPeriodsOpeningTotal =
-          this.repository.PPPeriodsOpeningAccountLedger.whereAccountId(
-            accountId,
+          this.repository.PPPeriodsOpeningAccountLedger.whereAccountsIds(
+            accountIds,
           ).getClosingBalance();
 
         return PPPeriodsOpeningTotal + PPPeriodsTotal;

--- a/packages/server/src/modules/FinancialStatements/modules/BalanceSheet/BalanceSheetComparsionPreviousYear.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/BalanceSheet/BalanceSheetComparsionPreviousYear.ts
@@ -35,9 +35,12 @@ export const BalanceSheetComparsionPreviousYear = <
     protected assocPreviousYearAccountNode = (
       node: IBalanceSheetDataNode,
     ): IBalanceSheetDataNode => {
+      const accountIds = this.repository.getAccountsIdsIncludingChildren(
+        node.id,
+      );
       const closingBalance =
-        this.repository.PYTotalAccountsLedger.whereAccountId(
-          node.id,
+        this.repository.PYTotalAccountsLedger.whereAccountsIds(
+          accountIds,
         ).getClosingBalance();
 
       return R.assoc('previousYear', this.getAmountMeta(closingBalance), node);
@@ -189,14 +192,16 @@ export const BalanceSheetComparsionPreviousYear = <
      */
     private getAccountPYDatePeriodTotal = R.curry(
       (accountId: number, fromDate: Date, toDate: Date): number => {
+        const accountIds =
+          this.repository.getAccountsIdsIncludingChildren(accountId);
         const PYPeriodsTotal =
-          this.repository.PYPeriodsAccountsLedger.whereAccountId(accountId)
+          this.repository.PYPeriodsAccountsLedger.whereAccountsIds(accountIds)
             .whereToDate(toDate)
             .getClosingBalance();
 
         const PYPeriodsOpeningTotal =
-          this.repository.PYPeriodsOpeningAccountLedger.whereAccountId(
-            accountId,
+          this.repository.PYPeriodsOpeningAccountLedger.whereAccountsIds(
+            accountIds,
           ).getClosingBalance();
 
         return PYPeriodsOpeningTotal + PYPeriodsTotal;

--- a/packages/server/src/modules/FinancialStatements/modules/BalanceSheet/BalanceSheetDatePeriods.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/BalanceSheet/BalanceSheetDatePeriods.ts
@@ -93,13 +93,15 @@ export const BalanceSheetDatePeriods = <T extends GConstructor<FinancialSheet>>(
       accountId: number,
       toDate: Date,
     ): number => {
+      const accountIds =
+        this.repository.getAccountsIdsIncludingChildren(accountId);
       const periodTotalBetween = this.repository.periodsAccountsLedger
-        .whereAccountId(accountId)
+        .whereAccountsIds(accountIds)
         .whereToDate(toDate)
         .getClosingBalance();
 
       const periodOpening = this.repository.periodsOpeningAccountLedger
-        .whereAccountId(accountId)
+        .whereAccountsIds(accountIds)
         .getClosingBalance();
 
       return periodOpening + periodTotalBetween;

--- a/packages/server/src/modules/FinancialStatements/modules/BalanceSheet/BalanceSheetRepository.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/BalanceSheet/BalanceSheetRepository.ts
@@ -58,6 +58,17 @@ export class BalanceSheetRepository extends R.compose(
   public accountsByType: any;
 
   /**
+   * Retrieves the given account id with its children account ids.
+   * @param {number} accountId
+   * @returns {number[]}
+   */
+  public getAccountsIdsIncludingChildren = (accountId: number): number[] => {
+    const childrenAccountIds = this.accountsGraph.dependenciesOf(accountId);
+
+    return R.uniq(R.append(accountId, childrenAccountIds));
+  };
+
+  /**
    * PY from date.
    * @param {Date}
    */

--- a/packages/server/src/modules/FinancialStatements/modules/ProfitLossSheet/ProfitLossSheet.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/ProfitLossSheet/ProfitLossSheet.ts
@@ -104,12 +104,10 @@ export default class ProfitLossSheet extends R.pipe(
   private accountNodeMapper = (
     account: ModelObject<Account>,
   ): IProfitLossSheetAccountNode => {
-    // Retrieves the children account ids of the given account id.
-    const childrenAccountIds = this.repository.accountsGraph.dependenciesOf(
+    // Retrieves the account ids including its children account ids.
+    const accountIds = this.repository.getAccountsIdsIncludingChildren(
       account.id,
     );
-    // Concat the children and the given account id.
-    const accountIds = R.uniq(R.append(account.id, childrenAccountIds));
 
     // Retrieves the closing balance of the account included children accounts.
     const total = this.repository.totalAccountsLedger

--- a/packages/server/src/modules/FinancialStatements/modules/ProfitLossSheet/ProfitLossSheetDatePeriods.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/ProfitLossSheet/ProfitLossSheetDatePeriods.ts
@@ -76,8 +76,11 @@ export const ProfitLossSheetDatePeriods = <
       fromDate: Date,
       toDate: Date,
     ) => {
+      const accountIds = this.repository.getAccountsIdsIncludingChildren(
+        node.id,
+      );
       const periodTotal = this.repository.periodsAccountsLedger
-        .whereAccountId(node.id)
+        .whereAccountsIds(accountIds)
         .whereFromDate(fromDate)
         .whereToDate(toDate)
         .getClosingBalance();

--- a/packages/server/src/modules/FinancialStatements/modules/ProfitLossSheet/ProfitLossSheetPreviousPeriod.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/ProfitLossSheet/ProfitLossSheetPreviousPeriod.ts
@@ -35,9 +35,13 @@ export const ProfitLossSheetPreviousPeriod = <
     protected assocPreviousPeriodTotalAccountNode = (
       node: IProfitLossSheetAccountNode,
     ): IProfitLossSheetAccountNode => {
-      const total = this.repository.PPTotalAccountsLedger.whereAccountId(
+      const accountIds = this.repository.getAccountsIdsIncludingChildren(
         node.id,
-      ).getClosingBalance();
+      );
+      const total =
+        this.repository.PPTotalAccountsLedger.whereAccountsIds(
+          accountIds,
+        ).getClosingBalance();
 
       return R.assoc('previousPeriod', this.getAmountMeta(total), node);
     };
@@ -181,8 +185,11 @@ export const ProfitLossSheetPreviousPeriod = <
         node: IProfitLossSheetAccountNode,
         totalNode: IProfitLossHorizontalDatePeriodNode,
       ): IProfitLossHorizontalDatePeriodNode => {
-        const total = this.repository.PPPeriodsAccountsLedger.whereAccountId(
+        const accountIds = this.repository.getAccountsIdsIncludingChildren(
           node.id,
+        );
+        const total = this.repository.PPPeriodsAccountsLedger.whereAccountsIds(
+          accountIds,
         )
           .whereFromDate(totalNode.previousPeriodFromDate.date)
           .whereToDate(totalNode.previousPeriodToDate.date)

--- a/packages/server/src/modules/FinancialStatements/modules/ProfitLossSheet/ProfitLossSheetPreviousYear.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/ProfitLossSheet/ProfitLossSheetPreviousYear.ts
@@ -35,9 +35,13 @@ export const ProfitLossSheetPreviousYear = <
     private assocPreviousYearTotalAccountNode = (
       accountNode: IProfitLossSheetAccountNode,
     ) => {
-      const total = this.repository.PYTotalAccountsLedger.whereAccountId(
+      const accountIds = this.repository.getAccountsIdsIncludingChildren(
         accountNode.id,
-      ).getClosingBalance();
+      );
+      const total =
+        this.repository.PYTotalAccountsLedger.whereAccountsIds(
+          accountIds,
+        ).getClosingBalance();
 
       return R.assoc('previousYear', this.getAmountMeta(total), accountNode);
     };
@@ -177,8 +181,11 @@ export const ProfitLossSheetPreviousYear = <
      */
     private assocPreviousYearAccountHorizTotal = R.curry(
       (node: IProfitLossSheetAccountNode, totalNode) => {
-        const total = this.repository.PYPeriodsAccountsLedger.whereAccountId(
+        const accountIds = this.repository.getAccountsIdsIncludingChildren(
           node.id,
+        );
+        const total = this.repository.PYPeriodsAccountsLedger.whereAccountsIds(
+          accountIds,
         )
           .whereFromDate(totalNode.previousYearFromDate.date)
           .whereToDate(totalNode.previousYearToDate.date)

--- a/packages/server/src/modules/FinancialStatements/modules/ProfitLossSheet/ProfitLossSheetRepository.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/ProfitLossSheet/ProfitLossSheetRepository.ts
@@ -47,6 +47,17 @@ export class ProfitLossSheetRepository extends R.compose(FinancialDatePeriods)(
   public accounts: ModelObject<Account>[];
 
   /**
+   * Retrieves the given account id with its children account ids.
+   * @param {number} accountId
+   * @returns {number[]}
+   */
+  public getAccountsIdsIncludingChildren = (accountId: number): number[] => {
+    const childrenAccountIds = this.accountsGraph.dependenciesOf(accountId);
+
+    return R.uniq(R.append(accountId, childrenAccountIds));
+  };
+
+  /**
    * Accounts graph.
    */
   public accountsGraph: any;


### PR DESCRIPTION
## Description

The balance sheet and profit & loss statement only included the given account's balances when computing account totals, ignoring its children accounts. This caused incorrect amounts for parent accounts in the main report, previous period, previous year, and date periods columns.

This change introduces a `getAccountsIdsIncludingChildren` helper on both the balance sheet and profit & loss repositories, and uses it everywhere account totals are computed so children account balances are included.

It also fixes the previous period aggregate node to sum the `previousPeriod` amounts instead of `previousYear`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Verified the balance sheet and profit & loss statement reports render correct totals for parent accounts with children accounts, including previous period, previous year, and date period columns.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>
