### PR TITLE
fix(webapp): specific items multi-select empty in inventory reports

### DIFF
--- a/packages/webapp/src/containers/FinancialStatements/InventoryItemDetails/InventoryItemDetailsHeaderGeneralProvider.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/InventoryItemDetails/InventoryItemDetailsHeaderGeneralProvider.tsx
@@ -39,7 +39,7 @@ function InventoryItemDetailsHeaderGeneralProvider({
   const provider: InventoryItemDetailsHeaderGeneralContextValue = {
     isItemsFetching,
     isItemsLoading,
-    items: (itemsData as any)?.items,
+    items: (itemsData as any)?.data,
   };
   // Loading state.
   const loading = isItemsLoading;

--- a/packages/webapp/src/containers/FinancialStatements/InventoryValuation/InventoryValuationHeaderGeneralPanelProvider.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/InventoryValuation/InventoryValuationHeaderGeneralPanelProvider.tsx
@@ -35,7 +35,7 @@ function InventoryValuationGeneralPanelProvider({
 
   // Provider data.
   const provider: InventoryValuationGeneralPanelContextValue = {
-    items: (itemsData as any)?.items,
+    items: (itemsData as any)?.data,
     isItemsFetching,
     isItemsLoading,
   };


### PR DESCRIPTION
## Description

The "Specific items" multi-select in the **Inventory Item Details** and **Inventory Valuation** reports did not show any items.

The `GET /api/items` endpoint returns the item array under the `data` field (`{ data, pagination, filterMeta }`), but the header providers for both inventory reports read it from `itemsData.items`, which is always `undefined`. As a result, the multi-select fell back to an empty list. The Sales by Items and Purchases by Items reports were already fixed to read `itemsData.data`; this change applies the same fix to the two remaining inventory reports.

No backend changes are required — the report endpoints already accept and honor `itemsIds`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Verified the response shape returned by `GET /api/items` (`packages/server/src/modules/Items/GetItems.service.ts` returns `{ data, pagination, filterMeta }`) and confirmed the change matches the already-fixed patterns in the Sales by Items and Purchases by Items report providers. Ran ESLint on the two changed files (no errors).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>
