### PR TITLE
fix(server): localize resource meta fields in API response

### DIFF
--- a/packages/server/src/i18n/en/bill_payment.json
+++ b/packages/server/src/i18n/en/bill_payment.json
@@ -9,6 +9,11 @@
   "field.entries": "Entries",
   "field.entries.bill": "Bill",
   "field.entries.payment_amount": "Payment Amount",
+  "field.amount": "Amount",
+  "field.due_amount": "Due Amount",
+  "field.reference_no": "Reference No.",
+  "field.description": "Description",
+  "field.created_at": "Created At",
   "field.payment_number_hint": "The payment number should be unique.",
   "field.bill_hint": "Matches the bill number."
 }

--- a/packages/server/src/i18n/en/credit_note.json
+++ b/packages/server/src/i18n/en/credit_note.json
@@ -16,6 +16,14 @@
   "field.item": "Item",
   "field.rate": "Rate",
   "field.quantity": "Quantity",
-  "field.description": "Description"
+  "field.description": "Description",
+  "field.amount": "Amount",
+  "field.currency_code": "Currency Code",
+  "field.status": "Status",
+  "field.status.draft": "Draft",
+  "field.status.published": "Published",
+  "field.status.open": "Open",
+  "field.status.closed": "Closed",
+  "field.created_at": "Created At"
 }
 

--- a/packages/server/src/i18n/en/inventory_adjustment.json
+++ b/packages/server/src/i18n/en/inventory_adjustment.json
@@ -1,4 +1,15 @@
 {
   "decrement": "Decrement",
-  "increment": "Increment"
+  "increment": "Increment",
+
+  "field.date": "Adjustment Date",
+  "field.type": "Adjustment Type",
+  "field.type.increment": "Increment",
+  "field.type.decrement": "Decrement",
+  "field.adjustment_account": "Adjustment Account",
+  "field.reason": "Reason",
+  "field.reference_no": "Reference No.",
+  "field.description": "Description",
+  "field.published_at": "Published At",
+  "field.created_at": "Created At"
 }

--- a/packages/server/src/i18n/en/vendor.json
+++ b/packages/server/src/i18n/en/vendor.json
@@ -9,5 +9,11 @@
   "field.website": "Website",
   "field.opening_balance": "Opening balance",
   "field.opening_balance_at": "Opening balance at",
-  "field.currency": "Currency"
+  "field.currency": "Currency",
+  "field.created_at": "Created At",
+  "field.balance": "Balance",
+  "field.note": "Note",
+  "field.status": "Status",
+  "field.status.overdue": "Overdue",
+  "field.status.unpaid": "Unpaid"
 }

--- a/packages/server/src/i18n/en/vendor_credit.json
+++ b/packages/server/src/i18n/en/vendor_credit.json
@@ -15,5 +15,15 @@
   "field.item": "Item",
   "field.rate": "Rate",
   "field.quantity": "Quantity",
-  "field.description": "Description"
+  "field.description": "Description",
+  "field.amount": "Amount",
+  "field.created_at": "Created At",
+  "field.credit_date": "Credit Date",
+  "field.credit_number": "Credit Number",
+  "field.currency_code": "Currency Code",
+  "field.status": "Status",
+  "field.status.draft": "Draft",
+  "field.status.published": "Published",
+  "field.status.open": "Open",
+  "field.status.closed": "Closed"
 }

--- a/packages/server/src/i18n/en/warehouse_transfer.json
+++ b/packages/server/src/i18n/en/warehouse_transfer.json
@@ -1,0 +1,6 @@
+{
+  "field.date": "Transfer Date",
+  "field.transaction_number": "Transaction No.",
+  "field.status": "Status",
+  "field.created_at": "Created At"
+}

--- a/packages/server/src/modules/Customers/models/Customer.meta.ts
+++ b/packages/server/src/modules/Customers/models/Customer.meta.ts
@@ -36,7 +36,7 @@ export const CustomerMeta = {
       fieldType: 'text',
     },
     personal_phone: {
-      name: 'vendor.field.personal_pone',
+      name: 'vendor.field.personal_phone',
       column: 'personal_phone',
       fieldType: 'text',
     },

--- a/packages/server/src/modules/Resource/Resource.controller.ts
+++ b/packages/server/src/modules/Resource/Resource.controller.ts
@@ -36,6 +36,8 @@ export class ResourceController {
   ): ResourceMetaResponseDto {
     const resourceMeta = this.resourcesService.getResourceMeta(resourceModel);
 
-    return resourceMeta as ResourceMetaResponseDto;
+    return this.resourcesService.localizeResourceMeta(
+      resourceMeta,
+    ) as ResourceMetaResponseDto;
   }
 }

--- a/packages/server/src/modules/Resource/ResourceService.ts
+++ b/packages/server/src/modules/Resource/ResourceService.ts
@@ -98,30 +98,42 @@ export class ResourceService {
   };
 
   /**
-   * Localizes a single field by translating its name and importHint.
+   * Localizes a single field by translating its name, importHint and the
+   * enumeration options labels.
    * @param {IModelMetaField2} field - The field to localize.
    * @returns {IModelMetaField2} - The localized field.
    */
   private localizeField(field: IModelMetaField2): IModelMetaField2 {
-    const localizedField = {
+    return {
       ...field,
       name: this.i18nService.t(field.name, { defaultValue: field.name }),
+      ...(field.importHint
+        ? {
+            importHint: this.i18nService.t(field.importHint, {
+              defaultValue: field.importHint,
+            }),
+          }
+        : {}),
+      // Localize the enumeration options labels.
+      ...(field.fieldType === 'enumeration' && field.options
+        ? {
+            options: field.options.map((option) => ({
+              ...option,
+              label: this.i18nService.t(option.label, {
+                defaultValue: option.label,
+              }),
+            })),
+          }
+        : {}),
+      // Recursively localize nested fields (for collection types)
+      ...(field.fields
+        ? {
+            fields: this.localizeFields(
+              field.fields as unknown as Record<string, IModelMetaField2>,
+            ) as unknown as typeof field.fields,
+          }
+        : {}),
     } as IModelMetaField2;
-
-    if (field.importHint) {
-      localizedField.importHint = this.i18nService.t(field.importHint, {
-        defaultValue: field.importHint,
-      });
-    }
-
-    // Recursively localize nested fields (for collection types)
-    if (field.fields) {
-      localizedField.fields = this.localizeFields(
-        field.fields as unknown as Record<string, IModelMetaField2>,
-      ) as unknown as typeof field.fields;
-    }
-
-    return localizedField;
   }
 
   /**
@@ -133,6 +145,55 @@ export class ResourceService {
     fields: Record<string, IModelMetaField2>,
   ): Record<string, IModelMetaField2> {
     return mapValues(fields, (field) => this.localizeField(field));
+  }
+
+  /**
+   * Localizes a single column by translating its name.
+   * @param {IModelMetaColumn} column - The column to localize.
+   * @returns {IModelMetaColumn} - The localized column.
+   */
+  private localizeColumn(column: IModelMetaColumn): IModelMetaColumn {
+    return {
+      ...column,
+      name: this.i18nService.t(column.name, { defaultValue: column.name }),
+      // Recursively localize nested columns (for collection types)
+      ...('columns' in column
+        ? {
+            columns: mapValues(
+              column.columns as Record<string, IModelMetaColumn>,
+              (nestedColumn) => this.localizeColumn(nestedColumn),
+            ),
+          }
+        : {}),
+    } as IModelMetaColumn;
+  }
+
+  /**
+   * Localizes the columns of the given columns map.
+   * @param {Record<string, IModelMetaColumn>} columns - The columns to localize.
+   * @returns {Record<string, IModelMetaColumn>} - The localized columns.
+   */
+  private localizeColumns(
+    columns: Record<string, IModelMetaColumn>,
+  ): Record<string, IModelMetaColumn> {
+    return mapValues(columns, (column) => this.localizeColumn(column));
+  }
+
+  /**
+   * Localizes the resource meta fields, fields2 and columns names and the
+   * enumeration options labels based on the current request language.
+   * @param {IModelMeta} meta - The resource meta to localize.
+   * @returns {IModelMeta} - The localized resource meta.
+   */
+  public localizeResourceMeta(meta: IModelMeta): IModelMeta {
+    return {
+      ...meta,
+      fields: this.localizeFields(
+        meta.fields as unknown as Record<string, IModelMetaField2>,
+      ) as Record<string, IModelMetaField>,
+      fields2: this.localizeFields(meta.fields2),
+      columns: this.localizeColumns(meta.columns),
+    };
   }
 
   /**
@@ -174,40 +235,4 @@ export class ResourceService {
 
     return pickBy(fields, (field) => field.importable);
   }
-
-  /**
-   * Retrieve the resource meta localized based on the current user language.
-   */
-  // public getResourceMetaLocalized(meta, tenantId) {
-  //   const $enumerationType = (field) =>
-  //     field.fieldType === 'enumeration' ? field : undefined;
-
-  //   const $hasFields = (field) =>
-  //     'undefined' !== typeof field.fields ? field : undefined;
-
-  //   const $ColumnHasColumns = (column) =>
-  //     'undefined' !== typeof column.columns ? column : undefined;
-
-  //   const $hasColumns = (columns) =>
-  //     'undefined' !== typeof columns ? columns : undefined;
-
-  //   const naviagations = [
-  //     ['fields', qim.$each, 'name'],
-  //     ['fields', qim.$each, $enumerationType, 'options', qim.$each, 'label'],
-  //     ['fields2', qim.$each, 'name'],
-  //     ['fields2', qim.$each, $enumerationType, 'options', qim.$each, 'label'],
-  //     ['fields2', qim.$each, $hasFields, 'fields', qim.$each, 'name'],
-  //     ['columns', $hasColumns, qim.$each, 'name'],
-  //     [
-  //       'columns',
-  //       $hasColumns,
-  //       qim.$each,
-  //       $ColumnHasColumns,
-  //       'columns',
-  //       qim.$each,
-  //       'name',
-  //     ],
-  //   ];
-  //   return this.i18nService.i18nApply(naviagations, meta, tenantId);
-  // }
 }


### PR DESCRIPTION
## Description

The resource meta endpoint (`GET /resources/:resourceModel/meta`) returned raw i18n keys (e.g. `invoice.field.amount`, `receipt.field.status.draft`) for `fields[].name` and enumeration `options[].label`. The webapp's AdvancedFilter popover rendered those keys verbatim, so filter field names and enumeration option labels were not localized.

This PR localizes the resource meta response server-side by translating the `fields`, `fields2` and `columns` names and the enumeration option labels using the existing server i18n files (`src/i18n/en/*.json`), with a `defaultValue` fallback so hard-coded/missing labels pass through unchanged.

It also completes the missing English translations for the affected modules (`bill_payment`, `credit_note`, `inventory_adjustment`, `vendor`, `vendor_credit`) and adds the missing `warehouse_transfer` locale file, plus fixes the `vendor.field.personal_pone` typo in `Customer.meta.ts`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- `pnpm --filter @bigcapital/server build` passes (tsc via `nest build`).
- ESLint (with `ESLINT_USE_FLAT_CONFIG=false` to accommodate the repo's `.eslintrc.js`) and Prettier check pass on the changed files.
- Verified programmatically that every `field.name` / enumeration `options[].label` key referenced across all `*.meta.ts` files now resolves against the server `en` i18n files.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>
