### PR TITLE
fix(webapp): selected field not displaying in advanced filter dropdown

### DIFF
--- a/packages/webapp/src/components/AdvancedFilter/AdvancedFilterDropdown.tsx
+++ b/packages/webapp/src/components/AdvancedFilter/AdvancedFilterDropdown.tsx
@@ -1,6 +1,5 @@
 import { Button, Classes, InputGroup, MenuItem } from '@blueprintjs/core';
 import { Formik, FastField, FieldArray, useFormikContext } from 'formik';
-import type { FieldInputProps, FormikContextType, ArrayHelpers } from 'formik';
 import { get, first, defaultTo, isEqual, isEmpty } from 'lodash';
 import React from 'react';
 import intl from 'react-intl-universal';
@@ -32,6 +31,7 @@ import type {
   IResourceField,
   IResourceFieldType,
 } from './interfaces';
+import type { FieldInputProps, FormikContextType, ArrayHelpers } from 'formik';
 import {
   Choose,
   Icon,
@@ -194,6 +194,7 @@ function FilterFieldsField(): JSX.Element {
       }) => (
         <FFormGroup className={'form-group--fieldKey'} name={fieldPath}>
           <FSelect
+            name={fieldPath}
             selectedItem={field.value}
             textAccessor={'label'}
             valueAccessor={'value'}

--- a/packages/webapp/src/components/AdvancedFilter/AdvancedFilterValueField.tsx
+++ b/packages/webapp/src/components/AdvancedFilter/AdvancedFilterValueField.tsx
@@ -4,20 +4,20 @@ import { isUndefined } from 'lodash';
 import moment from 'moment';
 import React from 'react';
 import intl from 'react-intl-universal';
-import { Choose } from '@/components';
-import { Select } from '@/components/Forms';
-import { useAutofocus } from '@/hooks';
-import { momentFormatter } from '@/utils';
 import {
   IFieldType,
   type IFilterOption,
   type IAdvancedFilterValueField,
 } from './interfaces';
+import { Choose } from '@/components';
+import { Select } from '@/components/Forms';
+import { useAutofocus } from '@/hooks';
+import { momentFormatter } from '@/utils';
 
 function AdvancedFilterEnumerationField({
   options,
   value,
-  ...rest
+  onItemSelect,
 }: {
   options: IFilterOption[];
   value?: string | boolean;
@@ -26,6 +26,7 @@ function AdvancedFilterEnumerationField({
   return (
     <Select
       items={options}
+      selectedValue={typeof value === 'string' ? value : undefined}
       popoverProps={{
         fill: true,
         minimal: true,
@@ -34,7 +35,7 @@ function AdvancedFilterEnumerationField({
       placeholder={intl.get('filter.select_option')}
       textAccessor={'label'}
       valueAccessor={'key'}
-      {...rest}
+      onItemChange={(option: IFilterOption) => onItemSelect?.(option)}
     />
   );
 }


### PR DESCRIPTION
## Description

Fixes the advanced filter dropdown where selecting a field name from the dropdown did not display the selected field and the selection appeared not to stick.

The `FSelect` component in `FilterFieldsField` was used without the `name` prop, so the Formik-bound value that drives the button label (`selectedValue`) was always `undefined`. The button therefore always rendered the placeholder. Additionally, the enumeration value select used the deprecated `value`/`onItemSelect` props that `@blueprintjs-formik/select` v0.4.9 ignores, so enumeration option values were not displayed either.

Changes:
- `AdvancedFilterDropdown.tsx`: bind the field `FSelect` to Formik by passing `name={fieldPath}` so the selected field name displays and stays selected.
- `AdvancedFilterValueField.tsx`: use `selectedValue` + `onItemChange` in `AdvancedFilterEnumerationField` so the chosen enumeration option label displays.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Ran `eslint` on the modified files (clean after applying the `import/order` autofix).
- Ran `pnpm --filter webapp typecheck`; no errors are reported in the AdvancedFilter files (pre-existing unrelated errors remain elsewhere).
- Manual verification: open the advanced filter dropdown, select a field name — the name appears in the select button and the selection persists; selecting an enumeration-type field shows the chosen option label.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>
