### PR TITLE
fix(webapp): boolean field checkbox state in advanced filter

### DIFF
--- a/packages/webapp/src/components/AdvancedFilter/AdvancedFilterDropdown.tsx
+++ b/packages/webapp/src/components/AdvancedFilter/AdvancedFilterDropdown.tsx
@@ -252,7 +252,7 @@ function FilterValueField(): JSX.Element | null {
         <FFormGroup className={'form-group--value'} name={valueFieldPath}>
           <AdvancedFilterValueField
             isFocus={conditionIndex === 0}
-            value={typeof field.value === 'string' ? field.value : ''}
+            value={field.value as string | boolean | undefined}
             key={'name'}
             label={fieldName}
             fieldType={fieldType}

--- a/packages/webapp/src/components/AdvancedFilter/AdvancedFilterValueField.tsx
+++ b/packages/webapp/src/components/AdvancedFilter/AdvancedFilterValueField.tsx
@@ -129,14 +129,7 @@ export default function AdvancedFilterValueField({
       </Choose.When>
 
       <Choose.When condition={fieldType === IFieldType.BOOLEAN}>
-        <Checkbox
-          value={
-            typeof localValue === 'string'
-              ? localValue
-              : String(localValue ?? '')
-          }
-          onChange={handleInputChange}
-        />
+        <Checkbox checked={localValue === true} onChange={handleInputChange} />
       </Choose.When>
 
       <Choose.Otherwise>

--- a/packages/webapp/src/style/pages/Dashboard/Dashboard.scss
+++ b/packages/webapp/src/style/pages/Dashboard/Dashboard.scss
@@ -240,7 +240,10 @@ $dashboard-views-bar-height: 44px;
           &,
           &.bp4-active,
           &:active {
-            background: #eafbe4;
+            background: var(--color-dark-gray1);
+          }
+          .bp4-dark & {
+            background: rgba(52, 152, 219, 0.1);
           }
         }
 


### PR DESCRIPTION
## Description

Fixes the boolean field checkbox not reflecting the selected value in the advanced filter. The boolean filter condition now binds the checkbox `checked` state directly to the formula field's value, and the dropdown passes `boolean | string | undefined` values through instead of coercing them to a string.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Verified locally that toggling a boolean filter condition in the advanced filter dropdown updates and persists the checked state, and that the active filter chip renders the correct styling in both light and dark themes.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>