### PR TITLE
test(webapp): add e2e CRUD tests for sale estimates

### DIFF
--- a/e2e/_estimates.ts
+++ b/e2e/_estimates.ts
@@ -1,0 +1,233 @@
+import { expect, type Locator, type Page } from '@playwright/test';
+
+/**
+ * Waits until the estimates list page is loaded.
+ */
+export async function waitForEstimatesList(page: Page) {
+  await expect(page.getByTestId('dashboard-topbar').locator('h1')).toHaveText(
+    'Estimates List',
+    { timeout: 30_000 },
+  );
+  await expect(
+    page.getByRole('button', { name: 'New Estimate' }).first(),
+  ).toBeVisible({ timeout: 30_000 });
+}
+
+/**
+ * Waits until the estimate form page is loaded for the given title
+ * (New Estimate or Edit Estimate).
+ */
+export async function waitForEstimateForm(page: Page, title: string) {
+  await expect(page.getByTestId('dashboard-topbar').locator('h1')).toHaveText(
+    title,
+    { timeout: 30_000 },
+  );
+  await expect(page.getByTestId('estimate-customer-select')).toBeVisible({
+    timeout: 30_000,
+  });
+}
+
+/**
+ * Closes the TanStack Query devtools panel.
+ *
+ * The devtools panel is opened by default in the dev webapp and overlays the
+ * bottom of the viewport, which covers the form's sticky floating actions bar.
+ */
+export async function closeQueryDevtools(page: Page) {
+  const closeButton = page
+    .getByRole('button', { name: 'Close tanstack query devtools' })
+    .first();
+  if (await closeButton.isVisible().catch(() => false)) {
+    await closeButton.click();
+  }
+}
+
+/**
+ * Selects the given customer inside the estimate form.
+ *
+ * The customer Select popover cannot be opened reliably with a plain mouse
+ * click, so it is retried the same way the account type select does: focus
+ * the trigger, press Enter to open the popover, then immediately click the
+ * matching menu item before the popover collapses.
+ */
+export async function selectCustomer(page: Page, displayName: string) {
+  const button = page.getByTestId('estimate-customer-select');
+
+  for (let attempt = 0; attempt < 8; attempt++) {
+    await button.focus();
+    await page.keyboard.press('Enter');
+
+    const clicked = await page.evaluate((name) => {
+      const items = Array.from(document.querySelectorAll('[role="menuitem"]'));
+      const item = items.find((el) =>
+        (el as HTMLElement).innerText.trim().includes(name),
+      );
+      if (item) {
+        (item as HTMLElement).click();
+        return true;
+      }
+      return false;
+    }, displayName);
+
+    if (clicked) {
+      await expect(button).toContainText(displayName, { timeout: 5_000 });
+      return;
+    }
+    await page.keyboard.press('Escape');
+  }
+  throw new Error(`Failed to select the "${displayName}" customer.`);
+}
+
+/**
+ * Selects the given item inside the first entries table row.
+ *
+ * Once the item is selected the row is auto-filled with the sell price, unit
+ * quantity and description, and a new empty line is appended. Waiting for the
+ * second item input ensures the fetched values were committed before saving.
+ */
+export async function selectEntryItem(page: Page, itemName: string) {
+  const input = page.getByPlaceholder('Enter an item...').first();
+  await input.click();
+  await input.pressSequentially(itemName);
+
+  // The item suggestion popover opens asynchronously after typing and can
+  // re-render its menu items while waiting, so the click scans the live DOM
+  // in a polling loop instead of holding a possibly-stale locator.
+  let clicked = false;
+  for (let attempt = 0; attempt < 12 && !clicked; attempt++) {
+    clicked = await page.evaluate((name) => {
+      const items = Array.from(document.querySelectorAll('[role="menuitem"]'));
+      const item = items.find((el) =>
+        (el as HTMLElement).innerText.trim().includes(name),
+      );
+      if (item) {
+        (item as HTMLElement).click();
+        return true;
+      }
+      return false;
+    }, itemName);
+
+    if (!clicked) {
+      await page.waitForTimeout(250);
+    }
+  }
+
+  if (!clicked) {
+    throw new Error(`Failed to select the "${itemName}" item.`);
+  }
+
+  await expect(page.getByPlaceholder('Enter an item...')).toHaveCount(2, {
+    timeout: 10_000,
+  });
+
+  // Close any lingering select popover before interacting with the footer.
+  await page.keyboard.press('Escape');
+}
+
+/**
+ * Creates an estimate through the UI as a draft and expects the success toast
+ * alongside the redirect back to the estimates list page. Returns the estimate
+ * number the server assigned to the created estimate (read from the create
+ * request response, since the number prefilled into the form can lag behind
+ * the server-assigned one).
+ */
+export async function createEstimate(
+  page: Page,
+  {
+    customerName,
+    itemName,
+    estimateNumber,
+  }: {
+    customerName: string;
+    itemName: string;
+    estimateNumber?: string;
+  },
+): Promise<string> {
+  await page.goto('/estimates/new');
+  await waitForEstimateForm(page, 'New Estimate');
+
+  // Close the devtools panel early so it does not overlay the entries table
+  // or the floating actions bar during the rest of the flow.
+  await closeQueryDevtools(page);
+
+  await selectCustomer(page, customerName);
+  await selectEntryItem(page, itemName);
+
+  if (estimateNumber) {
+    await page.getByTestId('estimate-number-input').fill(estimateNumber);
+  }
+
+  const createResponse = page.waitForResponse(
+    (response) =>
+      response.url().includes('/api/sale-estimates') &&
+      response.request().method() === 'POST',
+    { timeout: 20_000 },
+  );
+
+  await closeQueryDevtools(page);
+  await page.getByRole('button', { name: 'Save as Draft' }).click();
+
+  const response = await createResponse;
+  if (!response.ok()) {
+    throw new Error(
+      `[e2e] Creating the estimate failed with status ${response.status()}.`,
+    );
+  }
+  const createdEstimate = (await response.json()) as {
+    estimateNumber?: string;
+    estimate_number?: string;
+  };
+  const number =
+    createdEstimate.estimateNumber ?? createdEstimate.estimate_number;
+  if (!number) {
+    throw new Error('[e2e] Creating the estimate returned no estimate number.');
+  }
+
+  await waitForEstimatesList(page);
+
+  return String(number);
+}
+
+/**
+ * Filters the estimates table by the given estimate number and returns the
+ * matching row locator. The estimate number is unique per test, so the
+ * filtered table holds a single row.
+ */
+export async function filterEstimatesByNumber(
+  page: Page,
+  estimateNumber: string,
+): Promise<Locator> {
+  await page.getByRole('button', { name: /filter|filters applied/i }).click();
+  await page.getByPlaceholder('Value').first().fill(estimateNumber);
+
+  const row = page
+    .getByTestId('estimate-row')
+    .filter({ hasText: estimateNumber })
+    .first();
+  await expect(row).toBeVisible({ timeout: 30_000 });
+
+  // Close the filter popover before interacting with the table.
+  await page.keyboard.press('Escape');
+
+  return row;
+}
+
+/**
+ * Deletes the given estimate row through the context menu and expects the
+ * success toast.
+ */
+export async function deleteEstimateViaRow(page: Page, row: Locator) {
+  await row.click({ button: 'right' });
+  await page.getByRole('menuitem', { name: 'Delete Estimate' }).click();
+
+  await expect(page.getByTestId('estimate-delete-alert')).toBeVisible();
+  await page
+    .getByRole('dialog')
+    .filter({ has: page.getByTestId('estimate-delete-alert') })
+    .getByRole('button', { name: 'Delete' })
+    .click();
+
+  await expect(
+    page.getByText('The estimate has been deleted successfully.'),
+  ).toBeVisible({ timeout: 15_000 });
+}

--- a/e2e/estimates.spec.ts
+++ b/e2e/estimates.spec.ts
@@ -1,0 +1,140 @@
+import { test, expect, type Page } from '@playwright/test';
+import { faker } from '@faker-js/faker';
+import { createCustomerViaApi, createItemViaApi, readApiAuth } from './_api';
+import {
+  closeQueryDevtools,
+  createEstimate,
+  deleteEstimateViaRow,
+  filterEstimatesByNumber,
+  waitForEstimateForm,
+  waitForEstimatesList,
+} from './_estimates';
+
+const API_BASE = process.env.PLAYWRIGHT_TEST_API_URL || 'http://localhost:3000';
+
+// Unique name so the estimate form's item picker resolves a single item.
+const ITEM_NAME = `E2E Est Item ${faker.string.alphanumeric(6)}`;
+
+/**
+ * Generates a unique customer display name per test. The customer is seeded
+ * through the API so the estimate form can select it.
+ */
+function generateCustomerName() {
+  return `E2E Est Customer ${faker.string.alphanumeric(6)}`;
+}
+
+/**
+ * Seeds a fresh customer for one test and returns its display name.
+ */
+async function seedCustomer() {
+  const auth = readApiAuth();
+  const displayName = generateCustomerName();
+  await createCustomerViaApi(API_BASE, auth, { displayName });
+  return displayName;
+}
+
+/**
+ * Opens the edit form of the given estimate row through the context menu.
+ */
+async function openEditEstimateForm(page: Page, estimateNumber: string) {
+  const row = await filterEstimatesByNumber(page, estimateNumber);
+  await row.click({ button: 'right' });
+  await page.getByRole('menuitem', { name: 'Edit Estimate' }).click();
+  await waitForEstimateForm(page, 'Edit Estimate');
+}
+
+test.describe('estimates', () => {
+  test.beforeAll(async () => {
+    const auth = readApiAuth();
+
+    // Seeds the item that the estimate forms select in the UI.
+    await createItemViaApi(API_BASE, auth, {
+      name: ITEM_NAME,
+      type: 'service',
+    });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/estimates');
+  });
+
+  test('should show the estimates page.', async ({ page }) => {
+    await waitForEstimatesList(page);
+
+    await expect(
+      page.getByRole('button', { name: 'New Estimate' }).first(),
+    ).toBeVisible();
+  });
+
+  test('should validate the required fields of the new estimate form.', async ({
+    page,
+  }) => {
+    await waitForEstimatesList(page);
+
+    await page.getByRole('button', { name: 'New Estimate' }).first().click();
+    await waitForEstimateForm(page, 'New Estimate');
+
+    await closeQueryDevtools(page);
+    await page.getByRole('button', { name: 'Save as Draft' }).click();
+
+    await expect(
+      page.getByText('Customer name is a required field'),
+    ).toBeVisible({ timeout: 15_000 });
+  });
+
+  test('should create an estimate successfully.', async ({ page }) => {
+    await waitForEstimatesList(page);
+
+    const displayName = await seedCustomer();
+    const estimateNumber = await createEstimate(page, {
+      customerName: displayName,
+      itemName: ITEM_NAME,
+    });
+
+    const row = await filterEstimatesByNumber(page, estimateNumber);
+    await expect(row).toContainText(displayName, { timeout: 15_000 });
+  });
+
+  test('should edit an estimate successfully.', async ({ page }) => {
+    await waitForEstimatesList(page);
+
+    const displayName = await seedCustomer();
+    const estimateNumber = await createEstimate(page, {
+      customerName: displayName,
+      itemName: ITEM_NAME,
+    });
+    const newReference = `REF-${faker.string.alphanumeric(8).toUpperCase()}`;
+
+    await openEditEstimateForm(page, estimateNumber);
+    await expect(page.getByTestId('estimate-customer-select')).toContainText(
+      displayName,
+      { timeout: 30_000 },
+    );
+
+    await page.getByTestId('estimate-reference-input').fill(newReference);
+    await closeQueryDevtools(page);
+    await page.getByRole('button', { name: 'Save as Draft' }).click();
+
+    await waitForEstimatesList(page);
+
+    const editedRow = await filterEstimatesByNumber(page, estimateNumber);
+    await expect(editedRow).toContainText(newReference, { timeout: 15_000 });
+  });
+
+  test('should delete an estimate successfully.', async ({ page }) => {
+    await waitForEstimatesList(page);
+
+    const displayName = await seedCustomer();
+    const estimateNumber = await createEstimate(page, {
+      customerName: displayName,
+      itemName: ITEM_NAME,
+    });
+
+    const row = await filterEstimatesByNumber(page, estimateNumber);
+    await deleteEstimateViaRow(page, row);
+
+    await expect(page.getByTestId('estimate-row')).toHaveCount(0, {
+      timeout: 15_000,
+    });
+  });
+});

--- a/packages/webapp/src/containers/Alerts/Estimates/EstimateDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Estimates/EstimateDeleteAlert.tsx
@@ -83,7 +83,7 @@ function EstimateDeleteAlertInner({
       onCancel={handleAlertCancel}
       onConfirm={handleAlertConfirm}
     >
-      <p>
+      <p data-testId={'estimate-delete-alert'}>
         {/* @ts-expect-error — react-intl-universal FormattedHTMLMessage JSX type mismatch (library-level issue, see Alerts/Items/ItemDeleteAlert.tsx) */}
         <FormattedHTMLMessage
           id={'once_delete_this_estimate_you_will_able_to_restore_it'}

--- a/packages/webapp/src/containers/Sales/Estimates/EstimateForm/EstimateFormEstimateNumberField.tsx
+++ b/packages/webapp/src/containers/Sales/Estimates/EstimateForm/EstimateFormEstimateNumberField.tsx
@@ -65,6 +65,7 @@ export const EstimateFormEstimateNumberField = compose(withDialogActions)(({
       <ControlGroup fill={true}>
         <FInputGroup
           name={'estimateNumber'}
+          data-testId={'estimate-number-input'}
           asyncControl={true}
           onBlur={handleEstimateNoBlur}
           onChange={() => {}}

--- a/packages/webapp/src/containers/Sales/Estimates/EstimateForm/EstimateFormHeaderFields.tsx
+++ b/packages/webapp/src/containers/Sales/Estimates/EstimateForm/EstimateFormHeaderFields.tsx
@@ -113,7 +113,10 @@ export function EstimateFormHeader() {
 
       {/* ----------- Reference ----------- */}
       <FFormGroup name={'reference'} label={intl.get('reference')} inline>
-        <FInputGroup name={'reference'} />
+        <FInputGroup
+          name={'reference'}
+          data-testId="estimate-reference-input"
+        />
       </FFormGroup>
 
       {/*------------ Project name -----------*/}
@@ -172,6 +175,7 @@ function EstimateFormCustomerSelect() {
           fastField={true}
           shouldUpdate={customersFieldShouldUpdate}
           shouldUpdateDeps={{ items: customers }}
+          buttonProps={{ 'data-testId': 'estimate-customer-select' }}
         />
         {values.customerId && (
           <CustomerButtonLink customerId={values.customerId}>

--- a/packages/webapp/src/containers/Sales/Estimates/EstimatesLanding/EstimatesDataTable.tsx
+++ b/packages/webapp/src/containers/Sales/Estimates/EstimatesLanding/EstimatesDataTable.tsx
@@ -158,6 +158,7 @@ function EstimatesDataTableInner({
         TableLoadingRenderer={TableSkeletonRows}
         TableHeaderSkeletonRenderer={TableSkeletonHeader}
         ContextMenu={ActionsMenu}
+        rowTestId={'estimate-row'}
         onCellClick={handleCellClick}
         initialColumnsWidths={initialColumnsWidths}
         onColumnResizing={handleColumnResizing}


### PR DESCRIPTION
## Description

Adds a Playwright end-to-end spec covering the basic CRUD operations for sale estimates (list view, required-field validation, create, edit, and delete), alongside a shared helper module (`e2e/_estimates.ts`).

To make the selectors reliable, minimal `data-testId` attributes were added to the estimate UI (list row, customer select, estimate-number/reference inputs, and the delete confirmation dialog), mirroring the existing customers/expenses e2e patterns.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Ran the new spec against the local stack (webapp on :4000, API on :3000): `npx playwright test e2e/estimates.spec.ts`.
- Suite passes 5/5: page loads, required-field validation, create, edit, and delete.
- Confirmed no new lint/prettier issues in the touched webapp files.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>
