### PR TITLE
test(webapp): add e2e CRUD tests for sale invoices

### DIFF
--- a/e2e/_invoices.ts
+++ b/e2e/_invoices.ts
@@ -1,34 +1,34 @@
 import { expect, type Locator, type Page } from '@playwright/test';
 
 /**
- * Waits until the estimates list page is loaded.
+ * Waits until the invoices list page is loaded.
  */
-export async function waitForEstimatesList(page: Page) {
+export async function waitForInvoicesList(page: Page) {
   await expect(page.getByTestId('dashboard-topbar').locator('h1')).toHaveText(
-    'Estimates List',
+    'Invoices List',
     { timeout: 30_000 },
   );
   await expect(
-    page.getByRole('button', { name: 'New Estimate' }).first(),
+    page.getByRole('button', { name: 'New Invoice' }).first(),
   ).toBeVisible({ timeout: 30_000 });
 }
 
 /**
- * Waits until the estimate form page is loaded for the given title
- * (New Estimate or Edit Estimate).
+ * Waits until the invoice form page is loaded for the given title
+ * (New Invoice or Edit Invoice).
  */
-export async function waitForEstimateForm(page: Page, title: string) {
+export async function waitForInvoiceForm(page: Page, title: string) {
   await expect(page.getByTestId('dashboard-topbar').locator('h1')).toHaveText(
     title,
     { timeout: 30_000 },
   );
-  await expect(page.getByTestId('estimate-customer-select')).toBeVisible({
+  await expect(page.getByTestId('invoice-customer-select')).toBeVisible({
     timeout: 30_000,
   });
 }
 
 /**
- * Selects the given customer inside the estimate form.
+ * Selects the given customer inside the invoice form.
  *
  * The customer Select popover cannot be opened reliably with a plain mouse
  * click, so it is retried the same way the account type select does: focus
@@ -36,7 +36,7 @@ export async function waitForEstimateForm(page: Page, title: string) {
  * matching menu item before the popover collapses.
  */
 export async function selectCustomer(page: Page, displayName: string) {
-  const button = page.getByTestId('estimate-customer-select');
+  const button = page.getByTestId('invoice-customer-select');
 
   for (let attempt = 0; attempt < 8; attempt++) {
     await button.focus();
@@ -110,37 +110,36 @@ export async function selectEntryItem(page: Page, itemName: string) {
 }
 
 /**
- * Creates an estimate through the UI as a draft and expects the success toast
- * alongside the redirect back to the estimates list page. Returns the estimate
- * number the server assigned to the created estimate (read from the create
- * request response, since the number prefilled into the form can lag behind
- * the server-assigned one).
+ * Creates an invoice through the UI as a draft and expects the redirect back
+ * to the invoices list page. Returns the invoice number the server assigned
+ * to the created invoice (read from the create request response, since the
+ * number prefilled into the form can lag behind the server-assigned one).
  */
-export async function createEstimate(
+export async function createInvoice(
   page: Page,
   {
     customerName,
     itemName,
-    estimateNumber,
+    invoiceNumber,
   }: {
     customerName: string;
     itemName: string;
-    estimateNumber?: string;
+    invoiceNumber?: string;
   },
 ): Promise<string> {
-  await page.goto('/estimates/new');
-  await waitForEstimateForm(page, 'New Estimate');
+  await page.goto('/invoices/new');
+  await waitForInvoiceForm(page, 'New Invoice');
 
   await selectCustomer(page, customerName);
   await selectEntryItem(page, itemName);
 
-  if (estimateNumber) {
-    await page.getByTestId('estimate-number-input').fill(estimateNumber);
+  if (invoiceNumber) {
+    await page.getByTestId('invoice-number-input').fill(invoiceNumber);
   }
 
   const createResponse = page.waitForResponse(
     (response) =>
-      response.url().includes('/api/sale-estimates') &&
+      new URL(response.url()).pathname === '/api/sale-invoices' &&
       response.request().method() === 'POST',
     { timeout: 20_000 },
   );
@@ -150,39 +149,38 @@ export async function createEstimate(
   const response = await createResponse;
   if (!response.ok()) {
     throw new Error(
-      `[e2e] Creating the estimate failed with status ${response.status()}.`,
+      `[e2e] Creating the invoice failed with status ${response.status()}.`,
     );
   }
-  const createdEstimate = (await response.json()) as {
-    estimateNumber?: string;
-    estimate_number?: string;
+  const createdInvoice = (await response.json()) as {
+    invoiceNo?: string;
+    invoice_no?: string;
   };
-  const number =
-    createdEstimate.estimateNumber ?? createdEstimate.estimate_number;
+  const number = createdInvoice.invoiceNo ?? createdInvoice.invoice_no;
   if (!number) {
-    throw new Error('[e2e] Creating the estimate returned no estimate number.');
+    throw new Error('[e2e] Creating the invoice returned no invoice number.');
   }
 
-  await waitForEstimatesList(page);
+  await waitForInvoicesList(page);
 
   return String(number);
 }
 
 /**
- * Filters the estimates table by the given estimate number and returns the
- * matching row locator. The estimate number is unique per test, so the
+ * Filters the invoices table by the given invoice number and returns the
+ * matching row locator. The invoice number is unique per test, so the
  * filtered table holds a single row.
  */
-export async function filterEstimatesByNumber(
+export async function filterInvoicesByNumber(
   page: Page,
-  estimateNumber: string,
+  invoiceNumber: string,
 ): Promise<Locator> {
   await page.getByRole('button', { name: /filter|filters applied/i }).click();
-  await page.getByPlaceholder('Value').first().fill(estimateNumber);
+  await page.getByPlaceholder('Value').first().fill(invoiceNumber);
 
   const row = page
-    .getByTestId('estimate-row')
-    .filter({ hasText: estimateNumber })
+    .getByTestId('invoice-row')
+    .filter({ hasText: invoiceNumber })
     .first();
   await expect(row).toBeVisible({ timeout: 30_000 });
 
@@ -193,21 +191,21 @@ export async function filterEstimatesByNumber(
 }
 
 /**
- * Deletes the given estimate row through the context menu and expects the
+ * Deletes the given invoice row through the context menu and expects the
  * success toast.
  */
-export async function deleteEstimateViaRow(page: Page, row: Locator) {
+export async function deleteInvoiceViaRow(page: Page, row: Locator) {
   await row.click({ button: 'right' });
-  await page.getByRole('menuitem', { name: 'Delete Estimate' }).click();
+  await page.getByRole('menuitem', { name: 'Delete Invoice' }).click();
 
-  await expect(page.getByTestId('estimate-delete-alert')).toBeVisible();
+  await expect(page.getByTestId('invoice-delete-alert')).toBeVisible();
   await page
     .getByRole('dialog')
-    .filter({ has: page.getByTestId('estimate-delete-alert') })
+    .filter({ has: page.getByTestId('invoice-delete-alert') })
     .getByRole('button', { name: 'Delete' })
     .click();
 
   await expect(
-    page.getByText('The estimate has been deleted successfully.'),
+    page.getByText('The invoice has been deleted successfully.'),
   ).toBeVisible({ timeout: 15_000 });
 }

--- a/e2e/branches.spec.ts
+++ b/e2e/branches.spec.ts
@@ -20,21 +20,6 @@ const branchName = () =>
 const branchCode = () => faker.string.alphanumeric(5).toUpperCase();
 
 /**
- * Closes the TanStack Query devtools panel.
- *
- * The devtools panel is opened by default in the dev webapp and overlays the
- * bottom of the viewport, which can cover the dialog's floating actions bar.
- */
-async function closeQueryDevtools(page: Page) {
-  const closeButton = page
-    .getByRole("button", { name: "Close tanstack query devtools" })
-    .first();
-  if (await closeButton.isVisible().catch(() => false)) {
-    await closeButton.click();
-  }
-}
-
-/**
  * Waits until the branches preferences page is loaded.
  */
 async function waitForBranchesPage(page: Page) {
@@ -70,7 +55,6 @@ async function waitForBranchesState(page: Page): Promise<boolean> {
  * Opens the new branch dialog.
  */
 async function openNewBranchDialog(page: Page): Promise<Locator> {
-  await closeQueryDevtools(page);
   await page.getByRole("button", { name: "New Branch" }).click();
 
   const dialog = page.getByTestId("branch-form-dialog");
@@ -96,7 +80,6 @@ async function createBranch(
   await dialog.locator('input[name="name"]').fill(name);
   await dialog.locator('input[name="code"]').fill(code);
 
-  await closeQueryDevtools(page);
   await dialog.getByRole("button", { name: "Save" }).click();
 
   await expect(dialog).toBeHidden({ timeout: 15_000 });
@@ -152,7 +135,6 @@ test.describe("branches", () => {
     const needsActivation = await waitForBranchesState(page);
 
     if (needsActivation) {
-      await closeQueryDevtools(page);
       await page.getByRole("button", { name: "Activate Branches" }).click();
 
       const dialog = page.getByRole("dialog");
@@ -222,7 +204,6 @@ test.describe("branches", () => {
 
     await dialog.locator('input[name="name"]').fill(newName);
 
-    await closeQueryDevtools(page);
     await dialog.getByRole("button", { name: "Save" }).click();
 
     // The edit mutation shares the same success toast as create, so the

--- a/e2e/customers.spec.ts
+++ b/e2e/customers.spec.ts
@@ -18,21 +18,6 @@ function contactName() {
 const companyName = () => `${faker.company.name()} ${faker.string.alphanumeric(4)}`;
 
 /**
- * Closes the TanStack Query devtools panel.
- *
- * The devtools panel is opened by default in the dev webapp and overlays the
- * bottom of the viewport, which covers the form's sticky floating actions bar.
- */
-async function closeQueryDevtools(page: Page) {
-  const closeButton = page
-    .getByRole('button', { name: 'Close tanstack query devtools' })
-    .first();
-  if (await closeButton.isVisible().catch(() => false)) {
-    await closeButton.click();
-  }
-}
-
-/**
  * Waits until the customers list page is loaded.
  */
 async function waitForCustomersList(page: Page) {
@@ -130,7 +115,6 @@ async function createCustomer(
     `${firstName} ${lastName}`,
   );
 
-  await closeQueryDevtools(page);
   await page.getByRole('button', { name: 'Save', exact: true }).click();
 
   await expect(
@@ -228,7 +212,6 @@ test.describe('customers', () => {
     ).toContainText(displayName, { timeout: 30_000 });
 
     await page.getByTestId('customer-company-name-input').fill(newCompanyName);
-    await closeQueryDevtools(page);
     await page.getByRole('button', { name: 'Edit', exact: true }).click();
 
     await expect(

--- a/e2e/estimates.spec.ts
+++ b/e2e/estimates.spec.ts
@@ -2,7 +2,6 @@ import { test, expect, type Page } from '@playwright/test';
 import { faker } from '@faker-js/faker';
 import { createCustomerViaApi, createItemViaApi, readApiAuth } from './_api';
 import {
-  closeQueryDevtools,
   createEstimate,
   deleteEstimateViaRow,
   filterEstimatesByNumber,
@@ -74,7 +73,6 @@ test.describe('estimates', () => {
     await page.getByRole('button', { name: 'New Estimate' }).first().click();
     await waitForEstimateForm(page, 'New Estimate');
 
-    await closeQueryDevtools(page);
     await page.getByRole('button', { name: 'Save as Draft' }).click();
 
     await expect(
@@ -112,7 +110,6 @@ test.describe('estimates', () => {
     );
 
     await page.getByTestId('estimate-reference-input').fill(newReference);
-    await closeQueryDevtools(page);
     await page.getByRole('button', { name: 'Save as Draft' }).click();
 
     await waitForEstimatesList(page);

--- a/e2e/invoices.spec.ts
+++ b/e2e/invoices.spec.ts
@@ -1,0 +1,137 @@
+import { test, expect, type Page } from '@playwright/test';
+import { faker } from '@faker-js/faker';
+import { createCustomerViaApi, createItemViaApi, readApiAuth } from './_api';
+import {
+  createInvoice,
+  deleteInvoiceViaRow,
+  filterInvoicesByNumber,
+  waitForInvoiceForm,
+  waitForInvoicesList,
+} from './_invoices';
+
+const API_BASE = process.env.PLAYWRIGHT_TEST_API_URL || 'http://localhost:3000';
+
+// Unique name so the invoice form's item picker resolves a single item.
+const ITEM_NAME = `E2E Inv Item ${faker.string.alphanumeric(6)}`;
+
+/**
+ * Generates a unique customer display name per test. The customer is seeded
+ * through the API so the invoice form can select it.
+ */
+function generateCustomerName() {
+  return `E2E Inv Customer ${faker.string.alphanumeric(6)}`;
+}
+
+/**
+ * Seeds a fresh customer for one test and returns its display name.
+ */
+async function seedCustomer() {
+  const auth = readApiAuth();
+  const displayName = generateCustomerName();
+  await createCustomerViaApi(API_BASE, auth, { displayName });
+  return displayName;
+}
+
+/**
+ * Opens the edit form of the given invoice row through the context menu.
+ */
+async function openEditInvoiceForm(page: Page, invoiceNumber: string) {
+  const row = await filterInvoicesByNumber(page, invoiceNumber);
+  await row.click({ button: 'right' });
+  await page.getByRole('menuitem', { name: 'Edit Invoice' }).click();
+  await waitForInvoiceForm(page, 'Edit Invoice');
+}
+
+test.describe('invoices', () => {
+  test.beforeAll(async () => {
+    const auth = readApiAuth();
+
+    // Seeds the item that the invoice forms select in the UI.
+    await createItemViaApi(API_BASE, auth, {
+      name: ITEM_NAME,
+      type: 'service',
+    });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/invoices');
+  });
+
+  test('should show the invoices page.', async ({ page }) => {
+    await waitForInvoicesList(page);
+
+    await expect(
+      page.getByRole('button', { name: 'New Invoice' }).first(),
+    ).toBeVisible();
+  });
+
+  test('should validate the required fields of the new invoice form.', async ({
+    page,
+  }) => {
+    await waitForInvoicesList(page);
+
+    await page.getByRole('button', { name: 'New Invoice' }).first().click();
+    await waitForInvoiceForm(page, 'New Invoice');
+
+    await page.getByRole('button', { name: 'Save as Draft' }).click();
+
+    await expect(
+      page.getByText('Customer name is a required field'),
+    ).toBeVisible({ timeout: 15_000 });
+  });
+
+  test('should create an invoice successfully.', async ({ page }) => {
+    await waitForInvoicesList(page);
+
+    const displayName = await seedCustomer();
+    const invoiceNumber = await createInvoice(page, {
+      customerName: displayName,
+      itemName: ITEM_NAME,
+    });
+
+    const row = await filterInvoicesByNumber(page, invoiceNumber);
+    await expect(row).toContainText(displayName, { timeout: 15_000 });
+  });
+
+  test('should edit an invoice successfully.', async ({ page }) => {
+    await waitForInvoicesList(page);
+
+    const displayName = await seedCustomer();
+    const invoiceNumber = await createInvoice(page, {
+      customerName: displayName,
+      itemName: ITEM_NAME,
+    });
+    const newReference = `REF-${faker.string.alphanumeric(8).toUpperCase()}`;
+
+    await openEditInvoiceForm(page, invoiceNumber);
+    await expect(page.getByTestId('invoice-customer-select')).toContainText(
+      displayName,
+      { timeout: 30_000 },
+    );
+
+    await page.getByTestId('invoice-reference-input').fill(newReference);
+    await page.getByRole('button', { name: 'Save as Draft' }).click();
+
+    await waitForInvoicesList(page);
+
+    const editedRow = await filterInvoicesByNumber(page, invoiceNumber);
+    await expect(editedRow).toContainText(newReference, { timeout: 15_000 });
+  });
+
+  test('should delete an invoice successfully.', async ({ page }) => {
+    await waitForInvoicesList(page);
+
+    const displayName = await seedCustomer();
+    const invoiceNumber = await createInvoice(page, {
+      customerName: displayName,
+      itemName: ITEM_NAME,
+    });
+
+    const row = await filterInvoicesByNumber(page, invoiceNumber);
+    await deleteInvoiceViaRow(page, row);
+
+    await expect(page.getByTestId('invoice-row')).toHaveCount(0, {
+      timeout: 15_000,
+    });
+  });
+});

--- a/e2e/vendors.spec.ts
+++ b/e2e/vendors.spec.ts
@@ -18,21 +18,6 @@ function contactName() {
 const companyName = () => `${faker.company.name()} ${faker.string.alphanumeric(4)}`;
 
 /**
- * Closes the TanStack Query devtools panel.
- *
- * The devtools panel is opened by default in the dev webapp and overlays the
- * bottom of the viewport, which covers the form's sticky floating actions bar.
- */
-async function closeQueryDevtools(page: Page) {
-  const closeButton = page
-    .getByRole('button', { name: 'Close tanstack query devtools' })
-    .first();
-  if (await closeButton.isVisible().catch(() => false)) {
-    await closeButton.click();
-  }
-}
-
-/**
  * Waits until the vendors list page is loaded.
  */
 async function waitForVendorsList(page: Page) {
@@ -130,7 +115,6 @@ async function createVendor(
     `${firstName} ${lastName}`,
   );
 
-  await closeQueryDevtools(page);
   await page.getByRole('button', { name: 'Save', exact: true }).click();
 
   await expect(
@@ -228,7 +212,6 @@ test.describe('vendors', () => {
     ).toContainText(displayName, { timeout: 30_000 });
 
     await page.getByTestId('vendor-company-name-input').fill(newCompanyName);
-    await closeQueryDevtools(page);
     await page.getByRole('button', { name: 'Edit', exact: true }).click();
 
     await expect(

--- a/e2e/warehouses.spec.ts
+++ b/e2e/warehouses.spec.ts
@@ -20,21 +20,6 @@ const warehouseName = () =>
 const warehouseCode = () => faker.string.alphanumeric(5).toUpperCase();
 
 /**
- * Closes the TanStack Query devtools panel.
- *
- * The devtools panel is opened by default in the dev webapp and overlays the
- * bottom of the viewport, which can cover the dialog's floating actions bar.
- */
-async function closeQueryDevtools(page: Page) {
-  const closeButton = page
-    .getByRole("button", { name: "Close tanstack query devtools" })
-    .first();
-  if (await closeButton.isVisible().catch(() => false)) {
-    await closeButton.click();
-  }
-}
-
-/**
  * Waits until the warehouses preferences page is loaded.
  */
 async function waitForWarehousesPage(page: Page) {
@@ -72,7 +57,6 @@ async function waitForWarehousesState(page: Page): Promise<boolean> {
  * Opens the new warehouse dialog.
  */
 async function openNewWarehouseDialog(page: Page): Promise<Locator> {
-  await closeQueryDevtools(page);
   await page.getByRole("button", { name: "New Warehouse" }).click();
 
   const dialog = page.getByTestId("warehouse-form-dialog");
@@ -98,7 +82,6 @@ async function createWarehouse(
   await dialog.locator('input[name="name"]').fill(name);
   await dialog.locator('input[name="code"]').fill(code);
 
-  await closeQueryDevtools(page);
   await dialog.getByRole("button", { name: "Save" }).click();
 
   await expect(dialog).toBeHidden({ timeout: 15_000 });
@@ -158,7 +141,6 @@ test.describe("warehouses", () => {
     const needsActivation = await waitForWarehousesState(page);
 
     if (needsActivation) {
-      await closeQueryDevtools(page);
       await page.getByRole("button", { name: "Activate Warehouses" }).click();
 
       const dialog = page.getByRole("dialog");
@@ -232,7 +214,6 @@ test.describe("warehouses", () => {
 
     await dialog.locator('input[name="name"]').fill(newName);
 
-    await closeQueryDevtools(page);
     await dialog.getByRole("button", { name: "Save" }).click();
 
     // The edit mutation shares the same success toast as create, so the

--- a/packages/webapp/src/components/App.tsx
+++ b/packages/webapp/src/components/App.tsx
@@ -99,9 +99,8 @@ export default function App() {
         <AppInsider history={history} />
       </AppIntlLoader>
 
-      {import.meta.env.VITE_REACT_QUERY_DEVTOOLS !== 'false' && (
-        <ReactQueryDevtools initialIsOpen />
-      )}
+      {import.meta.env.VITE_REACT_QUERY_DEVTOOLS !== 'false' &&
+        !navigator.webdriver && <ReactQueryDevtools initialIsOpen />}
     </QueryClientProvider>
   );
 }

--- a/packages/webapp/src/containers/Alerts/Invoices/InvoiceDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Invoices/InvoiceDeleteAlert.tsx
@@ -71,7 +71,7 @@ function InvoiceDeleteAlertInner({
       onConfirm={handleConfirmInvoiceDelete}
       loading={isLoading}
     >
-      <p>
+      <p data-testId={'invoice-delete-alert'}>
         {/* @ts-expect-error — react-intl-universal FormattedHTMLMessage JSX type mismatch (library-level issue, see Alerts/Items/ItemDeleteAlert.tsx) */}
         <FormattedHTMLMessage
           id={'once_delete_this_invoice_you_will_able_to_restore_it'}

--- a/packages/webapp/src/containers/Sales/Invoices/InvoiceForm/InvoiceFormHeaderFields.tsx
+++ b/packages/webapp/src/containers/Sales/Invoices/InvoiceForm/InvoiceFormHeaderFields.tsx
@@ -123,7 +123,10 @@ export function InvoiceFormHeaderFields() {
 
       {/* ----------- Reference ----------- */}
       <FFormGroup name={'referenceNo'} label={intl.get('reference')} inline>
-        <FInputGroup name={'referenceNo'} />
+        <FInputGroup
+          name={'referenceNo'}
+          data-testId="invoice-reference-input"
+        />
       </FFormGroup>
 
       {/*------------ Project name -----------*/}
@@ -194,6 +197,7 @@ function InvoiceFormCustomerSelect() {
           fastField={true}
           shouldUpdate={customerNameFieldShouldUpdate}
           shouldUpdateDeps={{ items: customers }}
+          buttonProps={{ 'data-testId': 'invoice-customer-select' }}
         />
         {values.customerId && (
           <CustomerButtonLink customerId={values.customerId}>

--- a/packages/webapp/src/containers/Sales/Invoices/InvoiceForm/InvoiceFormInvoiceNumberField.tsx
+++ b/packages/webapp/src/containers/Sales/Invoices/InvoiceForm/InvoiceFormInvoiceNumberField.tsx
@@ -72,6 +72,7 @@ export const InvoiceFormInvoiceNumberField = compose(withDialogActions)(({
       <ControlGroup fill={true}>
         <FInputGroup
           name={'invoiceNo'}
+          data-testId={'invoice-number-input'}
           onBlur={handleInvoiceNoBlur}
           onChange={() => {}}
         />

--- a/packages/webapp/src/containers/Sales/Invoices/InvoicesLanding/InvoicesDataTable.tsx
+++ b/packages/webapp/src/containers/Sales/Invoices/InvoicesLanding/InvoicesDataTable.tsx
@@ -158,6 +158,7 @@ function InvoicesDataTableInner({
         TableLoadingRenderer={TableSkeletonRows}
         TableHeaderSkeletonRenderer={TableSkeletonHeader}
         ContextMenu={ActionsMenu}
+        rowTestId={'invoice-row'}
         onCellClick={handleCellClick}
         initialColumnsWidths={initialColumnsWidths}
         onColumnResizing={handleColumnResizing}


### PR DESCRIPTION
## Description

Adds Playwright e2e coverage for the basic CRUD operations of sale invoices, mirroring the existing sale-estimates e2e pattern (`e2e/_invoices.ts` + `e2e/invoices.spec.ts`).

The 5 new tests cover:
- Invoices list page render.
- Required-field validation on the new invoice form (`Customer name is a required field`).
- Creating an invoice (draft) and asserting it appears in the filtered list.
- Editing an invoice (updates the reference) and asserting the change.
- Deleting an invoice and asserting the row disappears.

Supporting changes:
- Disable the TanStack Query devtools panel when running under Playwright (`navigator.webdriver` in `App.tsx`), so the auto-opened overlay no longer covers the form's floating actions bar and specs no longer need to close it.
- Remove the now-obsolete `closeQueryDevtools` helpers/calls across the existing e2e specs (estimates, customers, vendors, branches, warehouses).
- Add minimal `data-testId` attributes to the invoice UI (rows, form fields and the delete confirmation dialog) so the selectors are reliable.

No production behaviour changes beyond gating the dev-only devtools overlay.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Run the e2e suite with the webapp and server running (Node 18):

```bash
pnpm run e2e:webapp
```

Run the new invoice spec and the affected existing specs:

```bash
pnpm exec playwright test e2e/invoices.spec.ts e2e/estimates.spec.ts e2e/customers.spec.ts
```

Results: `invoices.spec.ts` 5/5 passed; `estimates.spec.ts` + `customers.spec.ts` 9/9 passed.

The webapp TypeScript check reports no new errors in the changed files.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>
