### PR TITLE
test(webapp): add e2e CRUD tests for bills

### DIFF
--- a/e2e/_bills.ts
+++ b/e2e/_bills.ts
@@ -1,0 +1,191 @@
+import { expect, type Locator, type Page } from '@playwright/test';
+
+/**
+ * Waits until the bills list page is loaded.
+ */
+export async function waitForBillsList(page: Page) {
+  await expect(page.getByTestId('dashboard-topbar').locator('h1')).toHaveText(
+    'Bills List',
+    { timeout: 30_000 },
+  );
+  await expect(
+    page.getByRole('button', { name: 'New Bill' }).first(),
+  ).toBeVisible({ timeout: 30_000 });
+}
+
+/**
+ * Waits until the bill form page is loaded for the given title
+ * (New Bill or Edit Bill).
+ */
+export async function waitForBillForm(page: Page, title: string) {
+  await expect(page.getByTestId('dashboard-topbar').locator('h1')).toHaveText(
+    title,
+    { timeout: 30_000 },
+  );
+  await expect(page.getByTestId('bill-vendor-select')).toBeVisible({
+    timeout: 30_000,
+  });
+}
+
+/**
+ * Selects the given vendor inside the bill form.
+ *
+ * The vendor Select popover cannot be opened reliably with a plain mouse
+ * click, so it is retried the same way the customer select does: focus the
+ * trigger, press Enter to open the popover, then immediately click the
+ * matching menu item before the popover collapses.
+ */
+export async function selectVendor(page: Page, displayName: string) {
+  const button = page.getByTestId('bill-vendor-select');
+
+  for (let attempt = 0; attempt < 8; attempt++) {
+    await button.focus();
+    await page.keyboard.press('Enter');
+
+    const clicked = await page.evaluate((name) => {
+      const items = Array.from(document.querySelectorAll('[role="menuitem"]'));
+      const item = items.find((el) =>
+        (el as HTMLElement).innerText.trim().includes(name),
+      );
+      if (item) {
+        (item as HTMLElement).click();
+        return true;
+      }
+      return false;
+    }, displayName);
+
+    if (clicked) {
+      await expect(button).toContainText(displayName, { timeout: 5_000 });
+      return;
+    }
+    await page.keyboard.press('Escape');
+  }
+  throw new Error(`Failed to select the "${displayName}" vendor.`);
+}
+
+/**
+ * Selects the given item inside the first entries table row.
+ *
+ * Once the item is selected the row is auto-filled with the purchase price,
+ * unit quantity and description, and a new empty line is appended. Waiting
+ * for the second item input ensures the fetched values were committed before
+ * saving.
+ */
+export async function selectEntryItem(page: Page, itemName: string) {
+  const input = page.getByPlaceholder('Enter an item...').first();
+  await input.click();
+  await input.pressSequentially(itemName);
+
+  // The item suggestion popover opens asynchronously after typing and can
+  // re-render its menu items while waiting, so the click scans the live DOM
+  // in a polling loop instead of holding a possibly-stale locator.
+  let clicked = false;
+  for (let attempt = 0; attempt < 12 && !clicked; attempt++) {
+    clicked = await page.evaluate((name) => {
+      const items = Array.from(document.querySelectorAll('[role="menuitem"]'));
+      const item = items.find((el) =>
+        (el as HTMLElement).innerText.trim().includes(name),
+      );
+      if (item) {
+        (item as HTMLElement).click();
+        return true;
+      }
+      return false;
+    }, itemName);
+
+    if (!clicked) {
+      await page.waitForTimeout(250);
+    }
+  }
+
+  if (!clicked) {
+    throw new Error(`Failed to select the "${itemName}" item.`);
+  }
+
+  await expect(page.getByPlaceholder('Enter an item...')).toHaveCount(2, {
+    timeout: 10_000,
+  });
+
+  // Close any lingering select popover before interacting with the footer.
+  await page.keyboard.press('Escape');
+}
+
+/**
+ * Creates a bill through the UI as a draft and expects the redirect back to
+ * the bills list page. The bill number is filled explicitly (bills are not
+ * auto-numbered by default), so the returned value is the one that was set.
+ */
+export async function createBill(
+  page: Page,
+  {
+    vendorName,
+    itemName,
+    billNumber,
+  }: {
+    vendorName: string;
+    itemName: string;
+    billNumber?: string;
+  },
+): Promise<string> {
+  await page.goto('/bills/new');
+  await waitForBillForm(page, 'New Bill');
+
+  await selectVendor(page, vendorName);
+  await selectEntryItem(page, itemName);
+
+  const number =
+    billNumber ??
+    `BILL-${Date.now()}-${Math.floor(Math.random() * 1000)}`;
+  await page.getByTestId('bill-number-input').fill(number);
+
+  await page.getByRole('button', { name: 'Save as Draft' }).click();
+
+  // A successful save redirects back to the bills list page.
+  await waitForBillsList(page);
+
+  return String(number);
+}
+
+/**
+ * Filters the bills table by the given bill number and returns the matching
+ * row locator. The bill number is unique per test, so the filtered table
+ * holds a single row.
+ */
+export async function filterBillsByNumber(
+  page: Page,
+  billNumber: string,
+): Promise<Locator> {
+  await page.getByRole('button', { name: /filter|filters applied/i }).click();
+  await page.getByPlaceholder('Value').first().fill(billNumber);
+
+  const row = page
+    .getByTestId('bill-row')
+    .filter({ hasText: billNumber })
+    .first();
+  await expect(row).toBeVisible({ timeout: 30_000 });
+
+  // Close the filter popover before interacting with the table.
+  await page.keyboard.press('Escape');
+
+  return row;
+}
+
+/**
+ * Deletes the given bill row through the context menu and expects the success
+ * toast.
+ */
+export async function deleteBillViaRow(page: Page, row: Locator) {
+  await row.click({ button: 'right' });
+  await page.getByRole('menuitem', { name: 'Delete Bill' }).click();
+
+  await expect(page.getByTestId('bill-delete-alert')).toBeVisible();
+  await page
+    .getByRole('dialog')
+    .filter({ has: page.getByTestId('bill-delete-alert') })
+    .getByRole('button', { name: 'Delete' })
+    .click();
+
+  await expect(
+    page.getByText('The bill has been deleted successfully.'),
+  ).toBeVisible({ timeout: 15_000 });
+}

--- a/e2e/bills.spec.ts
+++ b/e2e/bills.spec.ts
@@ -1,0 +1,137 @@
+import { test, expect, type Page } from '@playwright/test';
+import { faker } from '@faker-js/faker';
+import { createItemViaApi, createVendorViaApi, readApiAuth } from './_api';
+import {
+  createBill,
+  deleteBillViaRow,
+  filterBillsByNumber,
+  waitForBillForm,
+  waitForBillsList,
+} from './_bills';
+
+const API_BASE = process.env.PLAYWRIGHT_TEST_API_URL || 'http://localhost:3000';
+
+// Unique name so the bill form's item picker resolves a single item.
+const ITEM_NAME = `E2E Bill Item ${faker.string.alphanumeric(6)}`;
+
+/**
+ * Generates a unique vendor display name per test. The vendor is seeded
+ * through the API so the bill form can select it.
+ */
+function generateVendorName() {
+  return `E2E Bill Vendor ${faker.string.alphanumeric(6)}`;
+}
+
+/**
+ * Seeds a fresh vendor for one test and returns its display name.
+ */
+async function seedVendor() {
+  const auth = readApiAuth();
+  const displayName = generateVendorName();
+  await createVendorViaApi(API_BASE, auth, { displayName });
+  return displayName;
+}
+
+/**
+ * Opens the edit form of the given bill row through the context menu.
+ */
+async function openEditBillForm(page: Page, billNumber: string) {
+  const row = await filterBillsByNumber(page, billNumber);
+  await row.click({ button: 'right' });
+  await page.getByRole('menuitem', { name: 'Edit Bill' }).click();
+  await waitForBillForm(page, 'Edit Bill');
+}
+
+test.describe('bills', () => {
+  test.beforeAll(async () => {
+    const auth = readApiAuth();
+
+    // Seeds the item that the bill forms select in the UI.
+    await createItemViaApi(API_BASE, auth, {
+      name: ITEM_NAME,
+      type: 'service',
+    });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/bills');
+  });
+
+  test('should show the bills page.', async ({ page }) => {
+    await waitForBillsList(page);
+
+    await expect(
+      page.getByRole('button', { name: 'New Bill' }).first(),
+    ).toBeVisible();
+  });
+
+  test('should validate the required fields of the new bill form.', async ({
+    page,
+  }) => {
+    await waitForBillsList(page);
+
+    await page.getByRole('button', { name: 'New Bill' }).first().click();
+    await waitForBillForm(page, 'New Bill');
+
+    await page.getByRole('button', { name: 'Save as Draft' }).click();
+
+    await expect(
+      page.getByText('Vendor name is a required field'),
+    ).toBeVisible({ timeout: 15_000 });
+  });
+
+  test('should create a bill successfully.', async ({ page }) => {
+    await waitForBillsList(page);
+
+    const displayName = await seedVendor();
+    const billNumber = await createBill(page, {
+      vendorName: displayName,
+      itemName: ITEM_NAME,
+    });
+
+    const row = await filterBillsByNumber(page, billNumber);
+    await expect(row).toContainText(displayName, { timeout: 15_000 });
+  });
+
+  test('should edit a bill successfully.', async ({ page }) => {
+    await waitForBillsList(page);
+
+    const displayName = await seedVendor();
+    const billNumber = await createBill(page, {
+      vendorName: displayName,
+      itemName: ITEM_NAME,
+    });
+    const newReference = `REF-${faker.string.alphanumeric(8).toUpperCase()}`;
+
+    await openEditBillForm(page, billNumber);
+    await expect(page.getByTestId('bill-vendor-select')).toContainText(
+      displayName,
+      { timeout: 30_000 },
+    );
+
+    await page.getByTestId('bill-reference-input').fill(newReference);
+    await page.getByRole('button', { name: 'Save as Draft' }).click();
+
+    await waitForBillsList(page);
+
+    const editedRow = await filterBillsByNumber(page, billNumber);
+    await expect(editedRow).toContainText(newReference, { timeout: 15_000 });
+  });
+
+  test('should delete a bill successfully.', async ({ page }) => {
+    await waitForBillsList(page);
+
+    const displayName = await seedVendor();
+    const billNumber = await createBill(page, {
+      vendorName: displayName,
+      itemName: ITEM_NAME,
+    });
+
+    const row = await filterBillsByNumber(page, billNumber);
+    await deleteBillViaRow(page, row);
+
+    await expect(page.getByTestId('bill-row')).toHaveCount(0, {
+      timeout: 15_000,
+    });
+  });
+});

--- a/e2e/number-format.spec.ts
+++ b/e2e/number-format.spec.ts
@@ -406,22 +406,17 @@ test.describe('number format', () => {
       });
 
       if (cell) {
-        // Wait for the report to re-render with the divided amounts.
         const cellLocator = moneyCellLocator(page, cell);
-        await expect(cellLocator).not.toHaveText(cell.text, {
-          timeout: 30_000,
-        });
 
-        // The amount was divided by 1000 (allow 2-decimal rounding error).
-        // Poll until the divided value is actually rendered, since the report
-        // passes through an empty loading state on refetch that would otherwise
-        // be read as zero.
+        // The report clears its rows while it refetches after the
+        // number-format change, so wait until the money cell is back in the
+        // DOM and reflects the divided amount (allow 2-decimal rounding error).
         await expect
           .poll(
             async () => {
-              const after = parseFormattedAmount(
-                (await cellLocator.textContent()) ?? '',
-              );
+              const text = await cellLocator.textContent();
+              // Missing/empty cell: keep polling instead of parsing as 0.
+              const after = text === null ? NaN : parseFormattedAmount(text);
               return Math.abs(after * 1000 - before);
             },
             { timeout: 30_000 },

--- a/e2e/number-format.spec.ts
+++ b/e2e/number-format.spec.ts
@@ -412,11 +412,21 @@ test.describe('number format', () => {
           timeout: 30_000,
         });
 
-        const after = parseFormattedAmount(
-          (await cellLocator.textContent()) ?? '',
-        );
         // The amount was divided by 1000 (allow 2-decimal rounding error).
-        expect(Math.abs(after * 1000 - before)).toBeLessThan(10);
+        // Poll until the divided value is actually rendered, since the report
+        // passes through an empty loading state on refetch that would otherwise
+        // be read as zero.
+        await expect
+          .poll(
+            async () => {
+              const after = parseFormattedAmount(
+                (await cellLocator.textContent()) ?? '',
+              );
+              return Math.abs(after * 1000 - before);
+            },
+            { timeout: 30_000 },
+          )
+          .toBeLessThan(10);
       }
     });
   }

--- a/packages/webapp/src/containers/Alerts/Bills/BillDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Bills/BillDeleteAlert.tsx
@@ -71,7 +71,7 @@ function BillDeleteAlertInner({
       onConfirm={handleConfirmBillDelete}
       loading={isLoading}
     >
-      <p>
+      <p data-testId={'bill-delete-alert'}>
         <T id={'once_delete_this_bill_you_will_able_to_restore_it'} />
       </p>
     </Alert>

--- a/packages/webapp/src/containers/Purchases/Bills/BillForm/BillFormHeaderFields.tsx
+++ b/packages/webapp/src/containers/Purchases/Bills/BillForm/BillFormHeaderFields.tsx
@@ -111,7 +111,7 @@ function BillFormHeader() {
         inline
         fastField
       >
-        <FInputGroup name={'billNumber'} />
+        <FInputGroup name={'billNumber'} data-testId={'bill-number-input'} />
       </FFormGroup>
 
       {/* ------- Reference ------- */}
@@ -121,7 +121,7 @@ function BillFormHeader() {
         inline={true}
         fastField
       >
-        <FInputGroup name={'referenceNo'} />
+        <FInputGroup name={'referenceNo'} data-testId="bill-reference-input" />
       </FFormGroup>
 
       {/*------------ Project name -----------*/}
@@ -175,6 +175,7 @@ function BillFormVendorField() {
           fastField={true}
           shouldUpdate={vendorsFieldShouldUpdate}
           shouldUpdateDeps={{ items: vendors }}
+          buttonProps={{ 'data-testId': 'bill-vendor-select' }}
         />
         {values.vendorId && (
           <VendorButtonLink vendorId={Number(values.vendorId)}>

--- a/packages/webapp/src/containers/Purchases/Bills/BillsLanding/BillsTable.tsx
+++ b/packages/webapp/src/containers/Purchases/Bills/BillsLanding/BillsTable.tsx
@@ -142,6 +142,7 @@ function BillsDataTable({
         TableLoadingRenderer={TableSkeletonRows}
         TableHeaderSkeletonRenderer={TableSkeletonHeader}
         ContextMenu={ActionsMenu}
+        rowTestId={'bill-row'}
         onCellClick={handleCellClick}
         initialColumnsWidths={initialColumnsWidths}
         onColumnResizing={handleColumnResizing}


### PR DESCRIPTION
## Description

Adds Playwright e2e coverage for the basic CRUD operations of bills, mirroring the existing sale-invoices / sale-estimates e2e pattern (`e2e/_bills.ts` + `e2e/bills.spec.ts`).

The 5 new tests cover:
- Bills list page render.
- Required-field validation on the new bill form (`Vendor name is a required field`).
- Creating a bill (draft) and asserting it appears in the filtered list.
- Editing a bill (updates the reference) and asserting the change.
- Deleting a bill and asserting the row disappears.

Notable details:
- Bills are not auto-numbered by default, so the create helper fills a unique bill number explicitly and treats the redirect back to the list as the success signal (rather than reading a number from the create response).
- Add minimal `data-testId` attributes to the bill UI (rows, form fields and the delete confirmation dialog) so the selectors are reliable.

No production behaviour changes; this is test coverage only.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Run the e2e suite with the webapp and server running (Node 18):

```bash
pnpm run e2e:webapp
```

Run the new bill spec specifically:

```bash
pnpm exec playwright test e2e/bills.spec.ts
```

Results: all 5 tests pass (list render, required-field validation, create, edit, delete).

The webapp TypeScript check reports no new errors in the changed files.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>
