### PR TITLE
fix(webapp): forward inactive filter query to bank accounts endpoint

### DIFF
--- a/packages/webapp/src/containers/CashFlow/CashFlowAccounts/utils.tsx
+++ b/packages/webapp/src/containers/CashFlow/CashFlowAccounts/utils.tsx
@@ -5,6 +5,6 @@ export const transformAccountsStateToQuery = (
 ) => {
   return {
     ...transformTableStateToQuery(tableState),
-    inactive_mode: tableState.inactiveMode,
+    inactiveMode: tableState.inactiveMode,
   };
 };

--- a/packages/webapp/src/hooks/query/cashflow-accounts/queries.ts
+++ b/packages/webapp/src/hooks/query/cashflow-accounts/queries.ts
@@ -32,6 +32,7 @@ import type {
   CreateCashflowTransactionBody,
   CashflowAccountTransactionsQuery,
   CashflowAccountUncategorizedTransactionsQuery,
+  GetBankingAccountsQuery,
   CategorizeTransactionBody,
   UncategorizedTransactionResponse,
 } from '@bigcapital/sdk-ts';
@@ -88,7 +89,8 @@ export function useCashflowAccounts(
   >({
     ...props,
     queryKey: cashflowAccountsKeys.list(query),
-    queryFn: () => fetchCashflowAccounts(fetcher),
+    queryFn: () =>
+      fetchCashflowAccounts(fetcher, query as GetBankingAccountsQuery),
   });
 }
 

--- a/shared/sdk-ts/src/cashflow-accounts.ts
+++ b/shared/sdk-ts/src/cashflow-accounts.ts
@@ -15,6 +15,11 @@ export const BANKING_ACCOUNTS_ROUTES = {
 
 export type BankingAccountsListResponse = OpResponseBody<OpForPath<typeof BANKING_ACCOUNTS_ROUTES.LIST, 'get'>>;
 
+/** Query params for GET /api/banking/accounts. */
+export type GetBankingAccountsQuery = OpQueryParams<
+  OpForPath<typeof BANKING_ACCOUNTS_ROUTES.LIST, 'get'>
+>;
+
 /** Response for GET /api/banking/transactions/{id}. */
 export type BankingTransactionResponse = OpResponseBody<
   OpForPath<typeof BANKING_ACCOUNTS_ROUTES.TRANSACTION_BY_ID, 'get'>
@@ -32,9 +37,12 @@ export interface BankingAccountSummaryResponse {
   totalRecognizedTransactions: number;
 }
 
-export async function fetchBankingAccounts(fetcher: ApiFetcher): Promise<BankingAccountsListResponse> {
+export async function fetchBankingAccounts(
+  fetcher: ApiFetcher,
+  query?: GetBankingAccountsQuery,
+): Promise<BankingAccountsListResponse> {
   const get = fetcher.path(BANKING_ACCOUNTS_ROUTES.LIST).method('get').create();
-  const { data } = await get({});
+  const { data } = await get(query ?? {});
   return data;
 }
 
@@ -160,8 +168,9 @@ export type CashflowAccountUncategorizedTransactionsQuery = GetUncategorizedTran
 /** Fetch cashflow accounts (alias for fetchBankingAccounts). */
 export async function fetchCashflowAccounts(
   fetcher: ApiFetcher,
+  query?: GetBankingAccountsQuery,
 ): Promise<BankingAccountsListResponse> {
-  return fetchBankingAccounts(fetcher);
+  return fetchBankingAccounts(fetcher, query);
 }
 
 /** Create a cashflow transaction (alias for createBankingTransaction). */


### PR DESCRIPTION
## Description

Fixes the "Inactive" toggle on the Bank Accounts (Cash Flow) page, which had no effect.

The filtered list query was only used as a React Query cache key and was never forwarded to the API: `useCashflowAccounts` called `fetchCashflowAccounts(fetcher)` without the query, and the SDK's `fetchBankingAccounts` sent no query params (`get({})`). Additionally, the frontend emitted the param as `inactive_mode` while the server's `BankAccountsQueryDto` (whitelist validation) only accepts `inactiveMode`.

Changes:
- `useCashflowAccounts` now forwards the query object to `fetchCashflowAccounts`.
- SDK `fetchBankingAccounts`/`fetchCashflowAccounts` now accept and forward the query params (`get(query ?? {})`), with a new `GetBankingAccountsQuery` type.
- `transformAccountsStateToQuery` emits `inactiveMode` to match the server DTO.

No new dependencies added.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Toggled the "Inactive" switch on the Bank Accounts page and confirmed the request to `/api/banking/accounts` now includes `inactiveMode=true`, and inactive bank/cash/credit-card accounts appear in the list.
- `shared/sdk-ts`: `npm run typecheck` passes.
- `packages/webapp`: `npm run typecheck` and eslint pass for the changed files (remaining webapp type errors are pre-existing in unrelated files).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>
