### PR TITLE
feat(webapp): implement remember me on sign-in

### DIFF
--- a/packages/server/src/modules/Auth/Auth.controller.ts
+++ b/packages/server/src/modules/Auth/Auth.controller.ts
@@ -68,7 +68,7 @@ export class AuthController {
     }
 
     return {
-      accessToken: this.authSignin.signToken(user),
+      accessToken: this.authSignin.signToken(user, signinDto?.rememberMe),
       organizationId: tenant.organizationId,
       tenantId: tenant.id,
       userId: user.id,

--- a/packages/server/src/modules/Auth/commands/AuthSignin.service.ts
+++ b/packages/server/src/modules/Auth/commands/AuthSignin.service.ts
@@ -125,12 +125,14 @@ export class AuthSigninService {
   /**
    *
    * @param {SystemUser} user
+   * @param {boolean} rememberMe - Extends the token lifetime when the user opted to stay signed in.
    * @returns {string}
    */
-  signToken(user: SystemUser): string {
+  signToken(user: SystemUser, rememberMe = false): string {
     const payload = {
       sub: user.email,
     };
-    return this.jwtService.sign(payload);
+    const expiresIn = rememberMe ? '30d' : '1d';
+    return this.jwtService.sign(payload, { expiresIn });
   }
 }

--- a/packages/server/src/modules/Auth/dtos/AuthSignin.dto.ts
+++ b/packages/server/src/modules/Auth/dtos/AuthSignin.dto.ts
@@ -1,4 +1,4 @@
-import { IsNotEmpty, IsString } from 'class-validator';
+import { IsBoolean, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class AuthSigninDto {
@@ -14,4 +14,14 @@ export class AuthSigninDto {
   @IsNotEmpty()
   @IsString()
   email: string;
+
+  @ApiProperty({
+    example: true,
+    description:
+      'Whether to keep the user signed in for a longer period (remember me).',
+    required: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  rememberMe?: boolean;
 }

--- a/packages/webapp/src/containers/Authentication/Login.tsx
+++ b/packages/webapp/src/containers/Authentication/Login.tsx
@@ -36,6 +36,7 @@ export function Login() {
     loginMutate({
       email: values.crediential,
       password: values.password,
+      rememberMe: values.keepLoggedIn,
     }).catch((response: ApiError) => {
       const toastMessages = transformLoginErrorsToToasts(response.data);
 

--- a/packages/webapp/src/hooks/query/authentication/queries.ts
+++ b/packages/webapp/src/hooks/query/authentication/queries.ts
@@ -33,15 +33,19 @@ import { authenticationKeys } from './query-keys';
 /**
  * Saves the response data to cookies.
  */
-export function setAuthLoginCookies(data: AuthSigninResponse): void {
+export function setAuthLoginCookies(
+  data: AuthSigninResponse,
+  rememberMe = false,
+): void {
+  const expiry = rememberMe ? 30 : 1;
   // @ts-ignore
-  setCookie('token', data.access_token ?? '');
+  setCookie('token', data.access_token ?? '', expiry);
   // @ts-ignore
-  setCookie('authenticated_user_id', String(data.user_id ?? ''));
+  setCookie('authenticated_user_id', String(data.user_id ?? ''), expiry);
   // @ts-ignore
-  setCookie('organization_id', data.organization_id ?? '');
+  setCookie('organization_id', data.organization_id ?? '', expiry);
   // @ts-ignore
-  setCookie('tenant_id', String(data.tenant_id ?? ''));
+  setCookie('tenant_id', String(data.tenant_id ?? ''), expiry);
 }
 
 export function useAuthLogin(
@@ -56,7 +60,7 @@ export function useAuthLogin(
     ...props,
     mutationFn: (values: AuthSigninBody) => signin(fetcher, values),
     onSuccess: (data, variables, context, mutation) => {
-      setAuthLoginCookies(data);
+      setAuthLoginCookies(data, variables?.rememberMe);
       batch(() => {
         // @ts-ignore
         setAuthToken(data.access_token ?? '');

--- a/shared/sdk-ts/openapi.json
+++ b/shared/sdk-ts/openapi.json
@@ -24374,6 +24374,11 @@
             "type": "string",
             "example": "user@example.com",
             "description": "User email address"
+          },
+          "rememberMe": {
+            "type": "boolean",
+            "example": true,
+            "description": "Whether to keep the user signed in for a longer period (remember me)."
           }
         },
         "required": [

--- a/shared/sdk-ts/src/schema.ts
+++ b/shared/sdk-ts/src/schema.ts
@@ -4968,6 +4968,11 @@ export interface components {
              * @example user@example.com
              */
             email: string;
+            /**
+             * @description Whether to keep the user signed in for a longer period (remember me).
+             * @example true
+             */
+            rememberMe?: boolean;
         };
         AuthSignupDto: {
             /**


### PR DESCRIPTION
## Description

The "Keep me logged in" checkbox on the sign-in page was rendered but non-functional: the form captured the value, yet it was never sent to the API. Sign-in always issued a short-lived (1-day) JWT with 365-day cookies, so the checkbox had no effect and the cookie lifetime was misleading.

This change wires the checkbox end-to-end so checking it extends the session:
- The sign-in request body now includes the `rememberMe` flag.
- The backend signs the JWT with a 30-day expiry when remembered, otherwise the existing 1-day expiry.
- The frontend sets the auth cookies with a matching 30-day (remembered) / 1-day (default) expiry.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Verified the request body now carries `rememberMe` based on the checkbox state and that the backend issues a token with `30d` vs `1d` expiry accordingly. Regenerated and rebuilt the shared SDK types (`@bigcapital/sdk-ts`) so `AuthSigninBody` includes the new field.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>
