### PR TITLE
ci: publish docker images to GitHub Container Registry

### DIFF
--- a/.github/workflows/build-deploy-container.yml
+++ b/.github/workflows/build-deploy-container.yml
@@ -16,6 +16,9 @@ jobs:
     name: Build and deploy webapp container
     runs-on: ubuntu-latest
     environment: production
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Prepare
         run: |
@@ -35,6 +38,14 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      # Login to GitHub Container Registry.
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
@@ -51,7 +62,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           labels: ${{ steps.meta.outputs.labels }}
-          tags: bigcapitalhq/webapp:latest, bigcapitalhq/webapp:${{github.ref_name}}
+          tags: bigcapitalhq/webapp:latest, bigcapitalhq/webapp:${{github.ref_name}}, ghcr.io/bigcapitalhq/bigcapital/webapp:latest, ghcr.io/bigcapitalhq/bigcapital/webapp:${{github.ref_name}}
 
       - name: Export digest
         run: |
@@ -75,6 +86,9 @@ jobs:
   build-publish-server:
     name: Build and deploy server container
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Prepare
         run: |
@@ -94,6 +108,14 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      # Login to GitHub Container Registry.
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       # Builds and push the Docker image.
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
@@ -103,7 +125,7 @@ jobs:
           file: ./packages/server/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: bigcapitalhq/server:latest, bigcapitalhq/server:${{github.ref_name}}
+          tags: bigcapitalhq/server:latest, bigcapitalhq/server:${{github.ref_name}}, ghcr.io/bigcapitalhq/bigcapital/server:latest, ghcr.io/bigcapitalhq/bigcapital/server:${{github.ref_name}}
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Export digest

--- a/.github/workflows/build-deploy-develop-container.yaml
+++ b/.github/workflows/build-deploy-develop-container.yaml
@@ -16,6 +16,9 @@ jobs:
     name: Build and deploy webapp container
     runs-on: ubuntu-latest
     environment: production
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Prepare
         run: |
@@ -35,6 +38,14 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      # Login to GitHub Container Registry.
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
@@ -51,7 +62,7 @@ jobs:
           platforms: linux/amd64
           push: true
           labels: ${{ steps.meta.outputs.labels }}
-          tags: bigcapitalhq/webapp:develop
+          tags: bigcapitalhq/webapp:develop, ghcr.io/bigcapitalhq/bigcapital/webapp:develop
 
       - name: Export digest
         run: |
@@ -75,6 +86,9 @@ jobs:
   build-publish-server:
     name: Build and deploy server container
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Prepare
         run: |
@@ -94,6 +108,14 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      # Login to GitHub Container Registry.
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       # Builds and push the Docker image.
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
@@ -103,7 +125,7 @@ jobs:
           file: ./packages/server/Dockerfile
           platforms: linux/amd64
           push: true
-          tags: bigcapitalhq/server:develop
+          tags: bigcapitalhq/server:develop, ghcr.io/bigcapitalhq/bigcapital/server:develop
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Export digest


### PR DESCRIPTION
## Description

Adds GitHub Container Registry (GHCR) publishing for the `webapp` and `server` Docker images, alongside the existing Docker Hub pushes. The release workflow (`build-deploy-container.yml`) now also pushes `ghcr.io/bigcapitalhq/bigcapital/webapp|server:latest` and `:<release_tag>`, and the develop workflow (`build-deploy-develop-container.yaml`) now also pushes `ghcr.io/bigcapitalhq/bigcapital/webapp|server:develop` on merges to develop.

Each job gains a `packages: write` permission so the built-in `GITHUB_TOKEN` can push to GHCR, plus a `docker/login-action` step authenticating to `ghcr.io`. No new secrets are required.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

CI configuration change. Verified the YAML is valid and the tags/permissions are correctly structured; the actual image publication will be exercised by the GitHub Actions runs after the workflow is merged.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>
