### PR TITLE
ci(server): add dedicated server tests GitHub Actions workflow

### DIFF
--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -163,11 +163,11 @@ jobs:
 
           API_URL=http://localhost:3000/api
 
-          curl -sf -X POST "$API_URL/auth/signup" \
+          curl --fail-with-body -sS -X POST "$API_URL/auth/signup" \
             -H 'Content-Type: application/json' \
             -d '{"firstName":"Test","lastName":"User","email":"kk@kk.com","password":"123123123"}'
 
-          SIGNIN=$(curl -sf -X POST "$API_URL/auth/signin" \
+          SIGNIN=$(curl --fail-with-body -sS -X POST "$API_URL/auth/signin" \
             -H 'Content-Type: application/json' \
             -d '{"email":"kk@kk.com","password":"123123123"}')
 
@@ -180,13 +180,13 @@ jobs:
             exit 1
           fi
 
-          BUILD=$(curl -sf -X POST "$API_URL/organization/build" \
+          BUILD=$(curl --fail-with-body -sS -X POST "$API_URL/organization/build" \
             -H 'Content-Type: application/json' \
             -H "Authorization: Bearer $TOKEN" \
             -H "organization-id: $ORG_ID" \
-            -d '{"name":"Test Organization","location":"US","baseCurrency":"USD","timezone":"America/New_York","fiscalYear":"January","language":"en-US"}')
+            -d '{"name":"Test Organization","location":"US","baseCurrency":"USD","timezone":"America/New_York","fiscalYear":"january","language":"en"}')
 
-          JOB_ID=$(printf '%s' "$BUILD" | jq -r '.data.jobId')
+          JOB_ID=$(printf '%s' "$BUILD" | jq -r '.data.job_id // .data.jobId')
 
           if [ -z "$JOB_ID" ] || [ "$JOB_ID" = "null" ]; then
             echo '::error::Organization build job was not queued.'
@@ -196,7 +196,7 @@ jobs:
 
           BUILD_COMPLETED=false
           for i in $(seq 1 60); do
-            JOB=$(curl -sf "$API_URL/organization/build/$JOB_ID" \
+            JOB=$(curl --fail-with-body -sS "$API_URL/organization/build/$JOB_ID" \
               -H "Authorization: Bearer $TOKEN" \
               -H "organization-id: $ORG_ID")
             STATE=$(printf '%s' "$JOB" | jq -r '.state')

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -1,0 +1,233 @@
+name: Server Tests
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - develop
+    paths:
+      - '**.ts'
+      - '**.tsx'
+      - '**/tsconfig.json'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/server-tests.yml'
+  pull_request:
+    paths:
+      - '**.ts'
+      - '**.tsx'
+      - '**/tsconfig.json'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/server-tests.yml'
+
+defaults:
+  run:
+    shell: 'bash'
+
+jobs:
+  test_server:
+    runs-on: ubuntu-latest
+    name: Jest e2e tests
+    timeout-minutes: 40
+
+    services:
+      mysql:
+        image: mariadb:10.6
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: bigcapital_system
+          MYSQL_USER: bigcapital
+          MYSQL_PASSWORD: bigcapital
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
+
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: --health-cmd="redis-cli ping" --health-interval=10s --health-timeout=5s --health-retries=5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18.16.1
+
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 9
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+        id: pnpm-cache
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build shared packages and server
+        run: pnpm build:server
+
+      - name: Create server .env file
+        run: |
+          cat > packages/server/.env << EOF
+          # Database
+          DB_HOST=127.0.0.1
+          DB_USER=bigcapital
+          DB_PASSWORD=bigcapital
+          DB_ROOT_PASSWORD=root
+          DB_CHARSET=utf8
+
+          # System database
+          SYSTEM_DB_NAME=bigcapital_system
+
+          # Tenant databases
+          TENANT_DB_NAME_PERFIX=bigcapital_tenant_
+
+          # Application
+          BASE_URL=http://localhost:3000
+          JWT_SECRET=test-jwt-secret-for-server-testing
+          APP_JWT_SECRET=test-app-jwt-secret
+
+          # Sign-up
+          SIGNUP_DISABLED=false
+          SIGNUP_EMAIL_CONFIRMATION=false
+
+          # API throttling
+          THROTTLE_GLOBAL_TTL=60000
+          THROTTLE_GLOBAL_LIMIT=300
+          THROTTLE_AUTH_TTL=60000
+          THROTTLE_AUTH_LIMIT=300
+
+          # Redis
+          REDIS_HOST=127.0.0.1
+          REDIS_PORT=6379
+
+          # S3 (placeholder values for testing)
+          S3_REGION=us-east-1
+          S3_ACCESS_KEY_ID=test-access-key
+          S3_SECRET_ACCESS_KEY=test-secret-key
+          S3_ENDPOINT=http://localhost:9000
+          S3_BUCKET=test-bucket
+
+          # Mail (placeholder values for testing)
+          MAIL_HOST=localhost
+          MAIL_PORT=1025
+          MAIL_FROM_NAME=Bigcapital
+          MAIL_FROM_ADDRESS=test@bigcapital.app
+          EOF
+
+      - name: Grant tenant database privileges
+        run: |
+          CID=$(docker ps -qf "ancestor=mariadb:10.6" | head -1)
+          docker exec "$CID" mysql -uroot -proot -e \
+            "GRANT ALL PRIVILEGES ON *.* TO 'bigcapital'@'%' WITH GRANT OPTION; FLUSH PRIVILEGES;"
+
+      - name: Run database migrations
+        run: pnpm system:migrate:latest
+
+      - name: Start server in background
+        run: |
+          cd packages/server && NODE_ENV=production node dist/main > /tmp/bigcapital-server.log 2>&1 &
+          echo $! > /tmp/bigcapital-server.pid
+
+          SERVER_READY=false
+          for i in $(seq 1 60); do
+            if curl -sf http://localhost:3000/api/auth/meta > /dev/null; then
+              SERVER_READY=true
+              break
+            fi
+            sleep 2
+          done
+
+          if [ "$SERVER_READY" != "true" ]; then
+            echo '::error::Server failed to become ready.'
+            tail -100 /tmp/bigcapital-server.log
+            exit 1
+          fi
+
+      - name: Seed test user and organization
+        run: |
+          set -euo pipefail
+
+          API_URL=http://localhost:3000/api
+
+          curl -sf -X POST "$API_URL/auth/signup" \
+            -H 'Content-Type: application/json' \
+            -d '{"firstName":"Test","lastName":"User","email":"kk@kk.com","password":"123123123"}'
+
+          SIGNIN=$(curl -sf -X POST "$API_URL/auth/signin" \
+            -H 'Content-Type: application/json' \
+            -d '{"email":"kk@kk.com","password":"123123123"}')
+
+          TOKEN=$(printf '%s' "$SIGNIN" | jq -r '.access_token')
+          ORG_ID=$(printf '%s' "$SIGNIN" | jq -r '.organization_id')
+
+          if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ] || [ -z "$ORG_ID" ] || [ "$ORG_ID" = "null" ]; then
+            echo '::error::Sign-in failed.'
+            printf '%s\n' "$SIGNIN"
+            exit 1
+          fi
+
+          BUILD=$(curl -sf -X POST "$API_URL/organization/build" \
+            -H 'Content-Type: application/json' \
+            -H "Authorization: Bearer $TOKEN" \
+            -H "organization-id: $ORG_ID" \
+            -d '{"name":"Test Organization","location":"US","baseCurrency":"USD","timezone":"America/New_York","fiscalYear":"January","language":"en-US"}')
+
+          JOB_ID=$(printf '%s' "$BUILD" | jq -r '.data.jobId')
+
+          if [ -z "$JOB_ID" ] || [ "$JOB_ID" = "null" ]; then
+            echo '::error::Organization build job was not queued.'
+            printf '%s\n' "$BUILD"
+            exit 1
+          fi
+
+          BUILD_COMPLETED=false
+          for i in $(seq 1 60); do
+            JOB=$(curl -sf "$API_URL/organization/build/$JOB_ID" \
+              -H "Authorization: Bearer $TOKEN" \
+              -H "organization-id: $ORG_ID")
+            STATE=$(printf '%s' "$JOB" | jq -r '.state')
+
+            if [ "$STATE" = "completed" ]; then
+              BUILD_COMPLETED=true
+              break
+            fi
+            if [ "$STATE" = "failed" ]; then
+              echo '::error::Organization build job failed.'
+              tail -100 /tmp/bigcapital-server.log
+              exit 1
+            fi
+            sleep 5
+          done
+
+          if [ "$BUILD_COMPLETED" != "true" ]; then
+            echo '::error::Timed out waiting for the organization build job to complete.'
+            tail -100 /tmp/bigcapital-server.log
+            exit 1
+          fi
+
+      - name: Stop server
+        run: |
+          kill "$(cat /tmp/bigcapital-server.pid)" 2>/dev/null || true
+          pkill -f 'packages/server/dist/main' 2>/dev/null || true
+          sleep 5
+
+      - name: Run server tests
+        run: pnpm --filter @bigcapital/server test:e2e
+
+      - name: Print server log on failure
+        if: failure()
+        run: tail -200 /tmp/bigcapital-server.log || true

--- a/packages/server/test/accounts.e2e-spec.ts
+++ b/packages/server/test/accounts.e2e-spec.ts
@@ -8,7 +8,7 @@ const makeAccountRequest = () => ({
   code: faker.string.alphanumeric({ length: 6 }).toUpperCase(),
 });
 
-describe.only('Accounts (e2e)', () => {
+describe('Accounts (e2e)', () => {
   it('/accounts (POST)', () => {
     return request(app.getHttpServer())
       .post('/accounts')

--- a/packages/server/test/init-app-test.ts
+++ b/packages/server/test/init-app-test.ts
@@ -5,7 +5,7 @@ import { AppModule } from '../src/modules/App/App.module';
 
 let app: INestApplication;
 
-const email = 'bigcapital@bigcapital.com';
+const email = 'kk@kk.com';
 const password = '123123123';
 
 let orgainzationId = '';

--- a/packages/server/test/jest-e2e.json
+++ b/packages/server/test/jest-e2e.json
@@ -2,7 +2,7 @@
   "moduleFileExtensions": ["js", "json", "ts"],
   "rootDir": ".",
   "testEnvironment": "node",
-  "testRegex": "auth.e2e-spec.ts$",
+  "testRegex": ".*\\.e2e-spec\\.ts$",
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
   },


### PR DESCRIPTION
## Description

This PR adds a dedicated GitHub Actions workflow (`server-tests.yml`) that runs the server jest e2e suite (`packages/server/test/*.e2e-spec.ts`) with its own isolated infrastructure, modeled after the existing E2E (Playwright) workflow.

The workflow provisions per-run service containers (MariaDB 10.6 and Redis 7), builds the server, applies system migrations, boots the production server build, seeds a test user (`kk@kk.com`) with a fully built organization via the public API (signup → signin → organization build → job polling), stops the server, and then runs the full jest suite via `pnpm --filter @bigcapital/server test:e2e`. The server log is attached on failure for debugging.

To make the full suite CI-runnable, this PR also:

- Restores the jest e2e config to run all `*.e2e-spec.ts` files instead of only the auth spec.
- Aligns the shared test bootstrap credentials (`init-app-test.ts`) with the user seeded by CI (`kk@kk.com`).
- Removes a leftover `describe.only` from the accounts spec so all cases execute.

No dependencies are required for this change.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Validated the workflow YAML parses correctly and all inline run scripts pass `bash -n` syntax checks.
- Verified the generated `.env` heredoc produces correct flush-left dotenv content by executing it against a simulated workspace root.
- Verified all `jq` extraction paths against realistic API response shapes for `/auth/signin`, `/organization/build`, and the build-job status endpoint.
- Confirmed endpoint paths/prefixes (`/api` global prefix) and required headers (`Authorization`, `organization-id`) against the server source code.
- The workflow itself will be exercised by the CI run triggered on this PR.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>
