### PR TITLE
fix(webapp): respect organization date format in all date inputs

### DIFF
--- a/packages/webapp/src/components/AdvancedFilter/AdvancedFilterValueField.tsx
+++ b/packages/webapp/src/components/AdvancedFilter/AdvancedFilterValueField.tsx
@@ -11,8 +11,7 @@ import {
 } from './interfaces';
 import { Choose } from '@/components';
 import { Select } from '@/components/Forms';
-import { useAutofocus } from '@/hooks';
-import { momentFormatter } from '@/utils';
+import { useAutofocus, useDateFormatter } from '@/hooks';
 
 function AdvancedFilterEnumerationField({
   options,
@@ -57,6 +56,7 @@ export default function AdvancedFilterValueField({
   isFocus,
 }: IAdvancedFilterValueField) {
   const [localValue, setLocalValue] = React.useState(value);
+  const dateFormatter = useDateFormatter();
 
   React.useEffect(() => {
     if (localValue !== value && !isUndefined(value)) {
@@ -112,7 +112,7 @@ export default function AdvancedFilterValueField({
 
       <Choose.When condition={fieldType === IFieldType.DATE}>
         <DateInput
-          {...momentFormatter('YYYY/MM/DD')}
+          {...dateFormatter}
           value={tansformDateValue(localValue)}
           onChange={handleDateChange}
           popoverProps={{

--- a/packages/webapp/src/components/Dashboard/PrivatePagesProvider.tsx
+++ b/packages/webapp/src/components/Dashboard/PrivatePagesProvider.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useApplicationBoot } from '@/components';
+import { OrganizationMetaProvider } from '@/components/Organization/OrganizationMetaProvider';
 import { useAuthMetadata } from '@/hooks/query/authentication';
 
 interface PrivatePagesProviderProps {
@@ -15,5 +16,11 @@ export function PrivatePagesProvider({ children }: PrivatePagesProviderProps) {
 
   const isLoading = isAppBootLoading || isAuthMetaLoading;
 
-  return <React.Fragment>{!isLoading ? children : null}</React.Fragment>;
+  return (
+    <React.Fragment>
+      {!isLoading ? (
+        <OrganizationMetaProvider>{children}</OrganizationMetaProvider>
+      ) : null}
+    </React.Fragment>
+  );
 }

--- a/packages/webapp/src/components/Forms/BlueprintFormik.tsx
+++ b/packages/webapp/src/components/Forms/BlueprintFormik.tsx
@@ -22,6 +22,33 @@ import {
 } from '@blueprintjs-formik/select';
 import React from 'react';
 import { FSelect, BPSelect } from './Select';
+import type { DateInputProps } from '@blueprintjs-formik/datetime';
+import { useDateFormatter } from '@/hooks';
+
+/**
+ * Date input formik field that displays and parses dates according to the
+ * organization's configured date format by default. Explicitly provided
+ * `formatDate`, `parseDate` or `placeholder` props override the defaults.
+ */
+type DateInputFieldProps = Partial<
+  Pick<DateInputProps, 'formatDate' | 'parseDate' | 'placeholder'>
+> &
+  Omit<DateInputProps, 'formatDate' | 'parseDate' | 'placeholder'>;
+
+function DateInputField(props: DateInputFieldProps) {
+  const { formatDate, parseDate, placeholder } = useDateFormatter();
+  const { inputProps, ...rest } = props;
+
+  return (
+    <DateInput
+      formatDate={formatDate}
+      parseDate={parseDate}
+      placeholder={placeholder}
+      inputProps={{ placeholder, ...inputProps }}
+      {...rest}
+    />
+  );
+}
 
 export {
   FormGroup as FFormGroup,
@@ -36,7 +63,7 @@ export {
   EditableText as FEditableText,
   FormikSuggest as FSuggest,
   TextArea as FTextArea,
-  DateInput as FDateInput,
+  DateInputField as FDateInput,
   HTMLSelect as FHTMLSelect,
   TimezoneSelect as FTimezoneSelect,
   Suggest,

--- a/packages/webapp/src/components/Organization/OrganizationMetaProvider.tsx
+++ b/packages/webapp/src/components/Organization/OrganizationMetaProvider.tsx
@@ -1,0 +1,58 @@
+import React, { createContext, useContext } from 'react';
+import type { OrganizationCurrent } from '@bigcapital/sdk-ts';
+import { useCurrentOrganization } from '@/hooks/query';
+
+export const OrganizationMetaContext = createContext<
+  OrganizationCurrent['metadata'] | undefined
+>(undefined);
+
+interface OrganizationMetaProviderProps {
+  /**
+   * Optional metadata value. When provided, the organization query is not
+   * executed and the given value is used as-is.
+   */
+  value?: OrganizationCurrent['metadata'];
+  children?: React.ReactNode;
+}
+
+/**
+ * Provides the current organization metadata down the tree. Accepts an
+ * optional `value` to be used without firing the organization query.
+ */
+export function OrganizationMetaProvider({
+  value,
+  children,
+}: OrganizationMetaProviderProps) {
+  return value != null ? (
+    <OrganizationMetaContext.Provider value={value}>
+      {children}
+    </OrganizationMetaContext.Provider>
+  ) : (
+    <OrganizationMetaQueryProvider>{children}</OrganizationMetaQueryProvider>
+  );
+}
+
+/**
+ * Injects the current organization metadata from the shared organization query.
+ */
+function OrganizationMetaQueryProvider({
+  children,
+}: {
+  children?: React.ReactNode;
+}) {
+  const { data } = useCurrentOrganization();
+
+  return (
+    <OrganizationMetaContext.Provider value={data?.metadata}>
+      {children}
+    </OrganizationMetaContext.Provider>
+  );
+}
+
+/**
+ * Retrieves the current organization metadata from the nearest provider,
+ * or `undefined` when used outside of it.
+ */
+export function useOrganizationMeta() {
+  return useContext(OrganizationMetaContext);
+}

--- a/packages/webapp/src/containers/Accounting/MakeJournal/MakeJournalEntriesHeaderFields.tsx
+++ b/packages/webapp/src/containers/Accounting/MakeJournal/MakeJournalEntriesHeaderFields.tsx
@@ -58,8 +58,6 @@ export function MakeJournalEntriesHeader() {
       >
         <FDateInput
           name={'date'}
-          formatDate={(date) => date.toLocaleDateString()}
-          parseDate={(str) => new Date(str)}
           popoverProps={{
             position: Position.BOTTOM_LEFT,
             minimal: true,

--- a/packages/webapp/src/containers/CashFlow/AccountTransactions/AccountTransactionsDateFilter.tsx
+++ b/packages/webapp/src/containers/CashFlow/AccountTransactions/AccountTransactionsDateFilter.tsx
@@ -85,11 +85,8 @@ export function AccountTransactionsDateFilterForm({
               <FDateInput
                 name={'fromDate'}
                 popoverProps={{ position: Position.BOTTOM, minimal: true }}
-                formatDate={(date: Date) => date.toLocaleDateString()}
-                parseDate={(str: string) => new Date(str)}
                 inputProps={{
                   fill: true,
-                  placeholder: 'MM/DD/YYY',
                   leftElement: <Icon icon={'date-range'} />,
                 }}
               />
@@ -99,11 +96,8 @@ export function AccountTransactionsDateFilterForm({
               <FDateInput
                 name={'toDate'}
                 popoverProps={{ position: Position.BOTTOM, minimal: true }}
-                formatDate={(date: Date) => date.toLocaleDateString()}
-                parseDate={(str: string) => new Date(str)}
                 inputProps={{
                   fill: true,
-                  placeholder: 'MM/DD/YYY',
                   leftElement: <Icon icon={'date-range'} />,
                 }}
               />

--- a/packages/webapp/src/containers/CashFlow/CategorizeTransaction/drawers/CategorizeTransactionDrawer/MoneyIn/CategorizeTransactionOtherIncome.tsx
+++ b/packages/webapp/src/containers/CashFlow/CategorizeTransaction/drawers/CategorizeTransactionDrawer/MoneyIn/CategorizeTransactionOtherIncome.tsx
@@ -20,8 +20,6 @@ export function CategorizeTransactionOtherIncome() {
         <FDateInput
           name={'date'}
           popoverProps={{ position: Position.BOTTOM, minimal: true }}
-          formatDate={(date: Date) => date.toLocaleDateString()}
-          parseDate={(str: string) => new Date(str)}
           inputProps={{ fill: true, leftElement: <Icon icon={'date-range'} /> }}
         />
       </FFormGroup>

--- a/packages/webapp/src/containers/CashFlow/CategorizeTransaction/drawers/CategorizeTransactionDrawer/MoneyIn/CategorizeTransactionOwnerContribution.tsx
+++ b/packages/webapp/src/containers/CashFlow/CategorizeTransaction/drawers/CategorizeTransactionDrawer/MoneyIn/CategorizeTransactionOwnerContribution.tsx
@@ -23,8 +23,6 @@ export function CategorizeTransactionOwnerContribution() {
         <FDateInput
           name={'date'}
           popoverProps={{ position: Position.BOTTOM, minimal: true }}
-          formatDate={(date: Date) => date.toLocaleDateString()}
-          parseDate={(str: string) => new Date(str)}
           inputProps={{ fill: true, leftElement: <Icon icon={'date-range'} /> }}
         />
       </FFormGroup>

--- a/packages/webapp/src/containers/CashFlow/CategorizeTransaction/drawers/CategorizeTransactionDrawer/MoneyIn/CategorizeTransactionTransferFrom.tsx
+++ b/packages/webapp/src/containers/CashFlow/CategorizeTransaction/drawers/CategorizeTransactionDrawer/MoneyIn/CategorizeTransactionTransferFrom.tsx
@@ -23,8 +23,6 @@ export function CategorizeTransactionTransferFrom() {
         <FDateInput
           name={'date'}
           popoverProps={{ position: Position.BOTTOM, minimal: true }}
-          formatDate={(date: Date) => date.toLocaleDateString()}
-          parseDate={(str: string) => new Date(str)}
           inputProps={{ fill: true, leftElement: <Icon icon={'date-range'} /> }}
         />
       </FFormGroup>

--- a/packages/webapp/src/containers/CashFlow/CategorizeTransaction/drawers/CategorizeTransactionDrawer/MoneyOut/CategorizeTransactionOtherExpense.tsx
+++ b/packages/webapp/src/containers/CashFlow/CategorizeTransaction/drawers/CategorizeTransactionDrawer/MoneyOut/CategorizeTransactionOtherExpense.tsx
@@ -23,8 +23,6 @@ export function CategorizeTransactionOtherExpense() {
         <FDateInput
           name={'date'}
           popoverProps={{ position: Position.BOTTOM, minimal: true }}
-          formatDate={(date: Date) => date.toLocaleDateString()}
-          parseDate={(str: string) => new Date(str)}
           inputProps={{ fill: true, leftElement: <Icon icon={'date-range'} /> }}
         />
       </FFormGroup>

--- a/packages/webapp/src/containers/CashFlow/CategorizeTransaction/drawers/CategorizeTransactionDrawer/MoneyOut/CategorizeTransactionOwnerDrawings.tsx
+++ b/packages/webapp/src/containers/CashFlow/CategorizeTransaction/drawers/CategorizeTransactionDrawer/MoneyOut/CategorizeTransactionOwnerDrawings.tsx
@@ -23,8 +23,6 @@ export function CategorizeTransactionOwnerDrawings() {
         <FDateInput
           name={'date'}
           popoverProps={{ position: Position.BOTTOM, minimal: true }}
-          formatDate={(date: Date) => date.toLocaleDateString()}
-          parseDate={(str: string) => new Date(str)}
           inputProps={{ fill: true, leftElement: <Icon icon={'date-range'} /> }}
         />
       </FFormGroup>

--- a/packages/webapp/src/containers/CashFlow/CategorizeTransaction/drawers/CategorizeTransactionDrawer/MoneyOut/CategorizeTransactionToAccount.tsx
+++ b/packages/webapp/src/containers/CashFlow/CategorizeTransaction/drawers/CategorizeTransactionDrawer/MoneyOut/CategorizeTransactionToAccount.tsx
@@ -23,8 +23,6 @@ export function CategorizeTransactionToAccount() {
         <FDateInput
           name={'date'}
           popoverProps={{ position: Position.BOTTOM, minimal: true }}
-          formatDate={(date: Date) => date.toLocaleDateString()}
-          parseDate={(str: string) => new Date(str)}
           inputProps={{ fill: true, leftElement: <Icon icon={'date-range'} /> }}
         />
       </FFormGroup>

--- a/packages/webapp/src/containers/CashFlow/CategorizeTransactionAside/MatchingReconcileTransactionAside/MatchingReconcileTransactionForm.tsx
+++ b/packages/webapp/src/containers/CashFlow/CategorizeTransactionAside/MatchingReconcileTransactionAside/MatchingReconcileTransactionForm.tsx
@@ -34,7 +34,6 @@ import { ContentTabs } from '@/components/ContentTabs';
 import { Features } from '@/constants';
 import { useCreateCashflowTransaction } from '@/hooks/query';
 import { compose } from '@/utils';
-import { momentFormatter } from '@/utils';
 
 interface ReconcileSubmitSuccessPayload {
   id: number;
@@ -185,7 +184,6 @@ function CreateReconcileTransactionContent() {
 
       <FFormGroup label={'Date'} name={'date'} fastField>
         <FDateInput
-          {...momentFormatter('YYYY/MM/DD')}
           name={'date'}
           popoverProps={{
             minimal: false,

--- a/packages/webapp/src/containers/CashFlow/MoneyInDialog/OtherIncome/OtherIncomeFormFields.tsx
+++ b/packages/webapp/src/containers/CashFlow/MoneyInDialog/OtherIncome/OtherIncomeFormFields.tsx
@@ -23,7 +23,6 @@ import {
   FDateInput,
 } from '@/components';
 import { ACCOUNT_TYPE, Features } from '@/constants';
-import { momentFormatter } from '@/utils';
 
 /**
  * Other income form fields.
@@ -61,7 +60,6 @@ export function OtherIncomeFormFields() {
           >
             <FDateInput
               name={'date'}
-              {...momentFormatter('YYYY/MM/DD')}
               popoverProps={{ position: Position.BOTTOM_LEFT, minimal: true }}
               inputProps={{
                 fill: true,

--- a/packages/webapp/src/containers/CashFlow/MoneyInDialog/OwnerContribution/OwnerContributionFormFields.tsx
+++ b/packages/webapp/src/containers/CashFlow/MoneyInDialog/OwnerContribution/OwnerContributionFormFields.tsx
@@ -23,7 +23,6 @@ import {
   Icon,
 } from '@/components';
 import { ACCOUNT_TYPE, Features } from '@/constants';
-import { momentFormatter } from '@/utils';
 
 /**
  * Owner contribution form fields.
@@ -61,7 +60,6 @@ export function OwnerContributionFormFields() {
           >
             <FDateInput
               name={'date'}
-              {...momentFormatter('YYYY/MM/DD')}
               popoverProps={{
                 position: Position.BOTTOM_LEFT,
                 minimal: true,

--- a/packages/webapp/src/containers/CashFlow/MoneyInDialog/TransferFromAccount/TransferFromAccountFormFields.tsx
+++ b/packages/webapp/src/containers/CashFlow/MoneyInDialog/TransferFromAccount/TransferFromAccountFormFields.tsx
@@ -23,7 +23,6 @@ import {
   FInputGroup,
 } from '@/components';
 import { ACCOUNT_TYPE, Features } from '@/constants';
-import { momentFormatter } from '@/utils';
 
 /**
  * Transfer from account form fields.
@@ -61,7 +60,6 @@ export function TransferFromAccountFormFields() {
           >
             <FDateInput
               name={'date'}
-              {...momentFormatter('YYYY/MM/DD')}
               popoverProps={{
                 position: Position.BOTTOM_LEFT,
                 minimal: true,

--- a/packages/webapp/src/containers/CashFlow/MoneyOutDialog/OtherExpense/OtherExpnseFormFields.tsx
+++ b/packages/webapp/src/containers/CashFlow/MoneyOutDialog/OtherExpense/OtherExpnseFormFields.tsx
@@ -22,7 +22,6 @@ import {
   FDateInput,
 } from '@/components';
 import { Features, ACCOUNT_TYPE } from '@/constants';
-import { momentFormatter } from '@/utils';
 
 /**
  * Other expense form fields.
@@ -61,7 +60,6 @@ export function OtherExpnseFormFields() {
           >
             <FDateInput
               name={'date'}
-              {...momentFormatter('YYYY/MM/DD')}
               popoverProps={{
                 position: Position.BOTTOM_LEFT,
                 minimal: true,

--- a/packages/webapp/src/containers/CashFlow/MoneyOutDialog/OwnerDrawings/OwnerDrawingsFormFields.tsx
+++ b/packages/webapp/src/containers/CashFlow/MoneyOutDialog/OwnerDrawings/OwnerDrawingsFormFields.tsx
@@ -22,7 +22,6 @@ import {
   FDateInput,
 } from '@/components';
 import { Features, ACCOUNT_TYPE } from '@/constants';
-import { momentFormatter } from '@/utils';
 
 /**
  * Owner drawings form fields.
@@ -60,7 +59,6 @@ export function OwnerDrawingsFormFields() {
           >
             <FDateInput
               name={'date'}
-              {...momentFormatter('YYYY/MM/DD')}
               popoverProps={{
                 position: Position.BOTTOM_LEFT,
                 minimal: true,

--- a/packages/webapp/src/containers/CashFlow/MoneyOutDialog/TransferToAccount/TransferToAccountFormFields.tsx
+++ b/packages/webapp/src/containers/CashFlow/MoneyOutDialog/TransferToAccount/TransferToAccountFormFields.tsx
@@ -24,7 +24,6 @@ import {
 } from '@/components';
 import { Features } from '@/constants';
 import { ACCOUNT_TYPE } from '@/constants/accountTypes';
-import { momentFormatter } from '@/utils';
 
 /**
  * Transfer to account form fields.
@@ -63,7 +62,6 @@ export function TransferToAccountFormFields() {
           >
             <FDateInput
               name={'date'}
-              {...momentFormatter('YYYY/MM/DD')}
               popoverProps={{
                 position: Position.BOTTOM_LEFT,
                 minimal: true,

--- a/packages/webapp/src/containers/Customers/CustomerForm/CustomerFormFinancialSection.tsx
+++ b/packages/webapp/src/containers/Customers/CustomerForm/CustomerFormFinancialSection.tsx
@@ -90,8 +90,6 @@ function CustomerOpeningBalanceAtField() {
         name={'openingBalanceAt'}
         popoverProps={{ position: Position.BOTTOM, minimal: true }}
         disabled={Boolean(customerId)}
-        formatDate={(date: Date) => date.toLocaleDateString()}
-        parseDate={(str: string) => new Date(str)}
         inputProps={{
           leftIcon: <Icon icon={'date-range'} />,
         }}

--- a/packages/webapp/src/containers/Dialogs/CustomerOpeningBalanceDialog/CustomerOpeningBalanceFields.tsx
+++ b/packages/webapp/src/containers/Dialogs/CustomerOpeningBalanceDialog/CustomerOpeningBalanceFields.tsx
@@ -17,7 +17,6 @@ import {
 import { FMoneyInputGroup, FFormGroup, FDateInput } from '@/components/Forms';
 import { Features } from '@/constants';
 import { useCurrentOrganizationBaseCurrency } from '@/hooks/query';
-import { momentFormatter, tansformDateValue, handleDateChange } from '@/utils';
 
 /**
  * Customer Opening balance fields.
@@ -58,8 +57,6 @@ function CustomerOpeningBalanceFieldsInner() {
       >
         <FDateInput
           name={'openingBalanceAt'}
-          formatDate={(date) => date.toLocaleDateString()}
-          parseDate={(str) => new Date(str)}
           popoverProps={{ position: Position.BOTTOM, minimal: true }}
           inputProps={{
             leftIcon: <Icon icon={'date-range'} />,

--- a/packages/webapp/src/containers/Dialogs/InventoryAdjustmentFormDialog/InventoryAdjustmentFormDialogFields.tsx
+++ b/packages/webapp/src/containers/Dialogs/InventoryAdjustmentFormDialog/InventoryAdjustmentFormDialogFields.tsx
@@ -31,7 +31,7 @@ import {
 import { Features } from '@/constants';
 import { useAutofocus } from '@/hooks';
 import { useFeatureCan } from '@/hooks/state';
-import { momentFormatter, toSafeNumber } from '@/utils';
+import { toSafeNumber } from '@/utils';
 
 export function InventoryAdjustmentFormDialogFields(): React.ReactElement {
   const { featureCan } = useFeatureCan();
@@ -100,7 +100,6 @@ export function InventoryAdjustmentFormDialogFields(): React.ReactElement {
           >
             <FDateInput
               name={'date'}
-              {...momentFormatter('YYYY/MM/DD')}
               popoverProps={{
                 position: Position.BOTTOM,
                 minimal: true,

--- a/packages/webapp/src/containers/Dialogs/LockingTransactionsDialog/LockingTransactionsFormFields.tsx
+++ b/packages/webapp/src/containers/Dialogs/LockingTransactionsDialog/LockingTransactionsFormFields.tsx
@@ -10,7 +10,6 @@ import {
 } from '@/components';
 import { CLASSES } from '@/constants/classes';
 import { useAutofocus } from '@/hooks';
-import { momentFormatter } from '@/utils';
 
 /**
  * Locking transactions form fields.
@@ -30,7 +29,6 @@ export function LockingTransactionsFormFields(): React.ReactElement {
       >
         <FDateInput
           name={'lock_to_date'}
-          {...momentFormatter('YYYY/MM/DD')}
           popoverProps={{
             position: Position.BOTTOM,
             minimal: true,

--- a/packages/webapp/src/containers/Dialogs/QuickPaymentMadeFormDialog/QuickPaymentMadeFormFields.tsx
+++ b/packages/webapp/src/containers/Dialogs/QuickPaymentMadeFormDialog/QuickPaymentMadeFormFields.tsx
@@ -28,7 +28,6 @@ import {
 import { CLASSES, ACCOUNT_TYPE, Features } from '@/constants';
 import { useAutofocus } from '@/hooks';
 import { useCurrentOrganizationBaseCurrency } from '@/hooks/query';
-import { momentFormatter } from '@/utils';
 
 /**
  * Quick payment made form fields.
@@ -115,7 +114,6 @@ function QuickPaymentMadeFormFieldsInner(): React.ReactElement {
           >
             <FDateInput
               name={'paymentDate'}
-              {...momentFormatter('YYYY/MM/DD')}
               popoverProps={{ position: Position.BOTTOM, minimal: true }}
               inputProps={{
                 leftIcon: <Icon icon={'date-range'} />,

--- a/packages/webapp/src/containers/Dialogs/QuickPaymentReceiveFormDialog/QuickPaymentReceiveFormFields.tsx
+++ b/packages/webapp/src/containers/Dialogs/QuickPaymentReceiveFormDialog/QuickPaymentReceiveFormFields.tsx
@@ -27,7 +27,6 @@ import {
 import { Features, ACCOUNT_TYPE } from '@/constants';
 import { useAutofocus } from '@/hooks';
 import { useCurrentOrganizationBaseCurrency } from '@/hooks/query';
-import { momentFormatter } from '@/utils';
 
 /**
  * Quick payment receive form fields.
@@ -117,7 +116,6 @@ function QuickPaymentReceiveFormFieldsInner(): React.ReactElement {
           {/* ------------- Payment date ------------- */}
           <FFormGroup name={'paymentDate'} label={intl.get('payment_date')}>
             <FDateInput
-              {...momentFormatter('YYYY/MM/DD')}
               name={'paymentDate'}
               popoverProps={{ position: Position.BOTTOM, minimal: true }}
               inputProps={{

--- a/packages/webapp/src/containers/Dialogs/RefundCreditNoteDialog/RefundCreditNoteFormFields.tsx
+++ b/packages/webapp/src/containers/Dialogs/RefundCreditNoteDialog/RefundCreditNoteFormFields.tsx
@@ -28,7 +28,6 @@ import { Features } from '@/constants';
 import { ACCOUNT_TYPE } from '@/constants/accountTypes';
 import { useAutofocus } from '@/hooks';
 import { useCurrentOrganizationBaseCurrency } from '@/hooks/query';
-import { momentFormatter } from '@/utils';
 
 // FFormGroup / FMoneyInputGroup / FInputGroup (blueprintjs-formik) wrappers
 // don't expose all underlying props (`fill`, `minimal`) in their public type.
@@ -97,7 +96,6 @@ function RefundCreditNoteFormFieldsInner(): React.ReactElement {
           >
             <FDateInput
               name={'date'}
-              {...momentFormatter('YYYY/MM/DD')}
               popoverProps={{ position: Position.BOTTOM, minimal: true }}
               inputProps={{
                 leftIcon: <Icon icon={'date-range'} />,

--- a/packages/webapp/src/containers/Dialogs/RefundVendorCreditDialog/RefundVendorCreditFormFields.tsx
+++ b/packages/webapp/src/containers/Dialogs/RefundVendorCreditDialog/RefundVendorCreditFormFields.tsx
@@ -27,7 +27,6 @@ import {
 import { Features, ACCOUNT_TYPE } from '@/constants';
 import { useAutofocus } from '@/hooks';
 import { useCurrentOrganizationBaseCurrency } from '@/hooks/query';
-import { momentFormatter } from '@/utils';
 
 /**
  * Refund Vendor credit form fields.
@@ -71,7 +70,6 @@ function RefundVendorCreditFormFieldsInner(): React.ReactElement {
           >
             <FDateInput
               name={'refundDate'}
-              {...momentFormatter('YYYY/MM/DD')}
               popoverProps={{ position: Position.BOTTOM, minimal: true }}
               inputProps={{
                 leftIcon: <Icon icon={'date-range'} />,

--- a/packages/webapp/src/containers/Dialogs/UnlockingPartialTransactionsDialog/UnlockingPartialTransactionsFormFields.tsx
+++ b/packages/webapp/src/containers/Dialogs/UnlockingPartialTransactionsDialog/UnlockingPartialTransactionsFormFields.tsx
@@ -10,7 +10,6 @@ import {
   FFormGroup,
 } from '@/components';
 import { useAutofocus } from '@/hooks';
-import { momentFormatter } from '@/utils';
 
 /**
  * Parial Unlocking transactions form fields.
@@ -31,7 +30,6 @@ export function UnlockingPartialTransactionsFormFields(): React.ReactElement {
           >
             <FDateInput
               name={'unlockFromDate'}
-              {...momentFormatter('YYYY/MM/DD')}
               popoverProps={{
                 position: Position.BOTTOM,
                 minimal: true,
@@ -51,7 +49,6 @@ export function UnlockingPartialTransactionsFormFields(): React.ReactElement {
           >
             <FDateInput
               name={'unlockToDate'}
-              {...momentFormatter('YYYY/MM/DD')}
               popoverProps={{
                 position: Position.BOTTOM,
                 minimal: true,

--- a/packages/webapp/src/containers/Dialogs/VendorOpeningBalanceDialog/VendorOpeningBalanceFormFields.tsx
+++ b/packages/webapp/src/containers/Dialogs/VendorOpeningBalanceDialog/VendorOpeningBalanceFormFields.tsx
@@ -56,8 +56,6 @@ function VendorOpeningBalanceFormFieldsInner() {
       >
         <FDateInput
           name={'openingBalanceAt'}
-          formatDate={(date) => date.toLocaleDateString()}
-          parseDate={(str) => new Date(str)}
           popoverProps={{ position: Position.BOTTOM, minimal: true }}
           inputProps={{
             leftIcon: <Icon icon={'date-range'} />,

--- a/packages/webapp/src/containers/Expenses/ExpenseForm/ExpenseFormHeaderFields.tsx
+++ b/packages/webapp/src/containers/Expenses/ExpenseForm/ExpenseFormHeaderFields.tsx
@@ -25,12 +25,8 @@ import {
   Hint,
 } from '@/components';
 import { CLASSES } from '@/constants/classes';
-import {
-  momentFormatter,
-  tansformDateValue,
-  inputIntent,
-  handleDateChange,
-} from '@/utils';
+import { useDateFormatter } from '@/hooks';
+import { handleDateChange, inputIntent, tansformDateValue } from '@/utils';
 
 const getFieldsStyle = (theme: Theme) => css`
   .${theme.bpPrefix}-form-group {
@@ -56,6 +52,7 @@ export function ExpenseFormHeader() {
   const { currencies, accounts, customers } = useExpenseFormContext();
   const theme = useTheme() as unknown as Theme;
   const fieldsClassName = getFieldsStyle(theme);
+  const dateFormatter = useDateFormatter();
 
   return (
     <Stack spacing={18} flex={1} className={fieldsClassName}>
@@ -70,7 +67,7 @@ export function ExpenseFormHeader() {
             inline={true}
           >
             <DateInput
-              {...momentFormatter('YYYY/MM/DD')}
+              {...dateFormatter}
               value={tansformDateValue(value)}
               onChange={handleDateChange((formattedDate: string) => {
                 form.setFieldValue('paymentDate', formattedDate);

--- a/packages/webapp/src/containers/FinancialStatements/APAgingSummary/APAgingSummaryHeaderGeneralContent.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/APAgingSummary/APAgingSummaryHeaderGeneralContent.tsx
@@ -13,7 +13,6 @@ import {
   FDateInput,
   FInputGroup,
 } from '@/components';
-import { momentFormatter } from '@/utils';
 
 export function APAgingSummaryHeaderGeneralContent() {
   const { vendors } = useAPAgingSummaryGeneralContext();
@@ -30,7 +29,6 @@ export function APAgingSummaryHeaderGeneralContent() {
           >
             <FDateInput
               name={'asDate'}
-              {...momentFormatter('YYYY/MM/DD')}
               popoverProps={{ position: Position.BOTTOM_LEFT, minimal: true }}
               fill
               fastField

--- a/packages/webapp/src/containers/FinancialStatements/ARAgingSummary/ARAgingSummaryHeaderGeneralContent.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/ARAgingSummary/ARAgingSummaryHeaderGeneralContent.tsx
@@ -12,7 +12,6 @@ import {
   CustomersMultiSelect,
   FDateInput,
 } from '@/components';
-import { momentFormatter } from '@/utils';
 
 export function ARAgingSummaryHeaderGeneralContent() {
   const { customers } = useARAgingSummaryGeneralContext();
@@ -29,7 +28,6 @@ export function ARAgingSummaryHeaderGeneralContent() {
           >
             <FDateInput
               name={'asDate'}
-              {...momentFormatter('YYYY/MM/DD')}
               popoverProps={{ position: Position.BOTTOM_LEFT, minimal: true }}
               fill
               fastField

--- a/packages/webapp/src/containers/FinancialStatements/AuditLog/AuditLogHeader.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/AuditLog/AuditLogHeader.tsx
@@ -205,8 +205,6 @@ export function AuditLogHeader({
                         position: Position.BOTTOM,
                         minimal: true,
                       }}
-                      formatDate={(date: Date) => date.toLocaleDateString()}
-                      parseDate={(str: string) => new Date(str)}
                       inputProps={{ fill: true }}
                       fastField
                     />
@@ -220,8 +218,6 @@ export function AuditLogHeader({
                         position: Position.BOTTOM,
                         minimal: true,
                       }}
-                      formatDate={(date: Date) => date.toLocaleDateString()}
-                      parseDate={(str: string) => new Date(str)}
                       inputProps={{ fill: true }}
                       fastField
                     />

--- a/packages/webapp/src/containers/FinancialStatements/CustomersBalanceSummary/CustomersBalanceSummaryGeneralPanelContent.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/CustomersBalanceSummary/CustomersBalanceSummaryGeneralPanelContent.tsx
@@ -12,7 +12,6 @@ import {
   FDateInput,
   FCheckbox,
 } from '@/components';
-import { momentFormatter } from '@/utils';
 
 /**
  * Customers balance header - General panel - Content
@@ -32,7 +31,6 @@ export function CustomersBalanceSummaryGeneralPanelContent() {
           >
             <FDateInput
               name={'asDate'}
-              {...momentFormatter('YYYY/MM/DD')}
               popoverProps={{ position: Position.BOTTOM, minimal: true }}
               fill={true}
               fastField

--- a/packages/webapp/src/containers/FinancialStatements/FinancialStatementDateRange.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/FinancialStatementDateRange.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import intl from 'react-intl-universal';
 import { dateRangeOptions } from './constants';
 import { Row, Col, Hint, FDateInput, FFormGroup } from '@/components';
-import { momentFormatter, parseDateRangeQuery } from '@/utils';
+import { parseDateRangeQuery } from '@/utils';
 
 const FINANCIAL_REPORT_MAX_DATE = moment().add(5, 'years').toDate();
 
@@ -60,7 +60,6 @@ export function FinancialStatementDateRange() {
           >
             <FDateInput
               name={'fromDate'}
-              {...momentFormatter('YYYY-MM-DD')}
               popoverProps={{ minimal: true, position: Position.BOTTOM_LEFT }}
               maxDate={FINANCIAL_REPORT_MAX_DATE}
               canClearSelection={false}
@@ -78,7 +77,6 @@ export function FinancialStatementDateRange() {
           >
             <FDateInput
               name={'toDate'}
-              {...momentFormatter('YYYY-MM-DD')}
               popoverProps={{ minimal: true, position: Position.BOTTOM }}
               canClearSelection={false}
               fill

--- a/packages/webapp/src/containers/FinancialStatements/InventoryValuation/InventoryValuationHeaderGeneralPanel.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/InventoryValuation/InventoryValuationHeaderGeneralPanel.tsx
@@ -14,7 +14,6 @@ import {
   FFormGroup,
   FDateInput,
 } from '@/components';
-import { momentFormatter } from '@/utils';
 
 /**
  * Inventory valuation - Drawer Header - General panel.
@@ -45,7 +44,6 @@ function InventoryValuationHeaderGeneralPanelContent() {
           >
             <FDateInput
               name={'asDate'}
-              {...momentFormatter('YYYY/MM/DD')}
               popoverProps={{ position: Position.BOTTOM_LEFT, minimal: true }}
               fill
               fastField

--- a/packages/webapp/src/containers/FinancialStatements/VendorsBalanceSummary/VendorsBalanceSummaryHeaderGeneralContent.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/VendorsBalanceSummary/VendorsBalanceSummaryHeaderGeneralContent.tsx
@@ -13,18 +13,15 @@ import {
   FFormGroup,
   VendorsMultiSelect,
 } from '@/components';
-import {
-  momentFormatter,
-  tansformDateValue,
-  inputIntent,
-  handleDateChange,
-} from '@/utils';
+import { useDateFormatter } from '@/hooks';
+import { handleDateChange, tansformDateValue } from '@/utils';
 
 /**
  * Vendors balance header - General panel - Content.
  */
 export function VendorsBalanceSummaryHeaderGeneralContent() {
   const { vendors } = useVendorsBalanceSummaryGeneralPanelContext();
+  const dateFormatter = useDateFormatter();
 
   return (
     <div>
@@ -42,7 +39,7 @@ export function VendorsBalanceSummaryHeaderGeneralContent() {
             }) => (
               <FormGroup label={intl.get('as_date')} labelInfo={<FieldHint />}>
                 <DateInput
-                  {...momentFormatter('YYYY/MM/DD')}
+                  {...dateFormatter}
                   value={tansformDateValue(value)}
                   onChange={handleDateChange((selectedDate: Date) => {
                     form.setFieldValue('asDate', selectedDate);

--- a/packages/webapp/src/containers/PaymentLink/dialogs/SharePaymentLinkDialog/SharePaymentLinkFormContent.tsx
+++ b/packages/webapp/src/containers/PaymentLink/dialogs/SharePaymentLinkDialog/SharePaymentLinkFormContent.tsx
@@ -84,8 +84,6 @@ export function SharePaymentLinkFormContent() {
             <FDateInput
               name={'expiryDate'}
               popoverProps={{ position: Position.BOTTOM, minimal: true }}
-              formatDate={(date) => date.toLocaleDateString()}
-              parseDate={(str) => new Date(str)}
               inputProps={{
                 fill: true,
                 style: { minWidth: 260 },

--- a/packages/webapp/src/containers/Projects/containers/ProjectBillableEntriesFormDialog/ProjectBillableEntriesFormFields.tsx
+++ b/packages/webapp/src/containers/Projects/containers/ProjectBillableEntriesFormDialog/ProjectBillableEntriesFormFields.tsx
@@ -16,12 +16,6 @@ import {
   FieldRequiredHint,
 } from '@/components';
 import { CLASSES } from '@/constants/classes';
-import {
-  inputIntent,
-  momentFormatter,
-  tansformDateValue,
-  handleDateChange,
-} from '@/utils';
 
 /**
  * Project billable entries form fields.
@@ -43,7 +37,6 @@ export function ProjectBillableEntriesFormFields() {
         className={classNames(CLASSES.FILL, 'form-group--date')}
       >
         <FDateInput
-          {...momentFormatter('YYYY/MM/DD')}
           name="date"
           formatDate={(date) => date.toLocaleString()}
           popoverProps={{

--- a/packages/webapp/src/containers/Projects/containers/ProjectExpenseForm/ProjectExpenseFormFields.tsx
+++ b/packages/webapp/src/containers/Projects/containers/ProjectExpenseForm/ProjectExpenseFormFields.tsx
@@ -19,7 +19,6 @@ import {
   FormattedMessage as T,
 } from '@/components';
 import { CLASSES } from '@/constants/classes';
-import { momentFormatter } from '@/utils';
 
 /**
  * Project expense form fields.
@@ -55,7 +54,6 @@ export function ProjectExpenseFormFields() {
         className={classNames(CLASSES.FILL, 'form-group--date')}
       >
         <FDateInput
-          {...momentFormatter('YYYY/MM/DD')}
           name="expemseDate"
           formatDate={(date) => date.toLocaleString()}
           popoverProps={{

--- a/packages/webapp/src/containers/Projects/containers/ProjectFormDialog/ProjectFormFields.tsx
+++ b/packages/webapp/src/containers/Projects/containers/ProjectFormDialog/ProjectFormFields.tsx
@@ -17,7 +17,6 @@ import {
   CustomersSelect,
 } from '@/components';
 import { CLASSES } from '@/constants/classes';
-import { momentFormatter } from '@/utils';
 
 /**
  * Project form fields.
@@ -49,7 +48,6 @@ export function ProjectFormFields() {
             className={classNames(CLASSES.FILL, 'form-group--date')}
           >
             <FDateInput
-              {...momentFormatter('YYYY/MM/DD')}
               name="deadline"
               formatDate={(date) => date.toLocaleString()}
               popoverProps={{

--- a/packages/webapp/src/containers/Projects/containers/ProjectInvoicingFormDialog/ProjectInvoicingFormFields.tsx
+++ b/packages/webapp/src/containers/Projects/containers/ProjectInvoicingFormDialog/ProjectInvoicingFormFields.tsx
@@ -10,7 +10,6 @@ import {
   FieldRequiredHint,
 } from '@/components';
 import { CLASSES } from '@/constants/classes';
-import { momentFormatter } from '@/utils';
 
 /**
  * Project invoicing form fields.
@@ -26,7 +25,6 @@ export function ProjectInvoicingFormFields() {
         className={classNames(CLASSES.FILL, 'form-group--date')}
       >
         <FDateInput
-          {...momentFormatter('YYYY/MM/DD')}
           name="date"
           formatDate={(date) => date.toLocaleString()}
           popoverProps={{

--- a/packages/webapp/src/containers/Projects/containers/ProjectTimeEntryFormDialog/ProjectTimeEntryFormFields.tsx
+++ b/packages/webapp/src/containers/Projects/containers/ProjectTimeEntryFormDialog/ProjectTimeEntryFormFields.tsx
@@ -21,7 +21,6 @@ import {
   Stack,
 } from '@/components';
 import { CLASSES } from '@/constants/classes';
-import { momentFormatter } from '@/utils';
 
 /**
  * Project time entry form fields.
@@ -45,7 +44,6 @@ export function ProjectTimeEntryFormFields() {
           className={classNames(CLASSES.FILL, 'form-group--date')}
         >
           <FDateInput
-            {...momentFormatter('YYYY/MM/DD')}
             name="date"
             formatDate={(date) => date.toLocaleString()}
             popoverProps={{

--- a/packages/webapp/src/containers/Purchases/Bills/BillForm/BillFormHeaderFields.tsx
+++ b/packages/webapp/src/containers/Purchases/Bills/BillForm/BillFormHeaderFields.tsx
@@ -27,7 +27,7 @@ import { Features } from '@/constants';
 import { CLASSES } from '@/constants/classes';
 import { withDialogActions } from '@/containers/Dialog/withDialogActions';
 import { ProjectsSelect } from '@/containers/Projects/components';
-import { momentFormatter, compose } from '@/utils';
+import { compose } from '@/utils';
 
 const getBillFieldsStyle = (theme: Theme) => css`
   .${theme.bpPrefix}-form-group {
@@ -77,7 +77,6 @@ function BillFormHeader() {
       >
         <FDateInput
           name={'billDate'}
-          {...momentFormatter('YYYY/MM/DD')}
           popoverProps={{ position: Position.BOTTOM, minimal: true }}
           inputProps={{ leftIcon: <Icon icon={'date-range'} /> }}
           fill
@@ -94,7 +93,6 @@ function BillFormHeader() {
       >
         <FDateInput
           name={'dueDate'}
-          {...momentFormatter('YYYY/MM/DD')}
           popoverProps={{ position: Position.BOTTOM, minimal: true }}
           inputProps={{
             leftIcon: <Icon icon={'date-range'} />,

--- a/packages/webapp/src/containers/Purchases/CreditNotes/CreditNoteForm/VendorCreditNoteFormHeaderFields.tsx
+++ b/packages/webapp/src/containers/Purchases/CreditNotes/CreditNoteForm/VendorCreditNoteFormHeaderFields.tsx
@@ -26,7 +26,7 @@ import {
   FInputGroup,
 } from '@/components';
 import { withDialogActions } from '@/containers/Dialog/withDialogActions';
-import { momentFormatter, compose } from '@/utils';
+import { compose } from '@/utils';
 
 const getFieldsStyle = (theme: Theme & { bpPrefix?: string }) => css`
   .${theme.bpPrefix}-form-group {
@@ -115,7 +115,6 @@ function VendorCreditNoteFormHeaderFieldsInner({
       >
         <FDateInput
           name={'vendorCreditDate'}
-          {...momentFormatter('YYYY/MM/DD')}
           popoverProps={{ position: Position.BOTTOM_LEFT, minimal: true }}
           inputProps={{ leftIcon: <Icon icon={'date-range'} />, fill: true }}
           fill

--- a/packages/webapp/src/containers/Purchases/PaymentsMade/PaymentForm/PaymentMadeFormHeaderFields.tsx
+++ b/packages/webapp/src/containers/Purchases/PaymentsMade/PaymentForm/PaymentMadeFormHeaderFields.tsx
@@ -36,7 +36,7 @@ import {
 } from '@/components';
 import { ACCOUNT_TYPE } from '@/constants/accountTypes';
 import { useCurrentOrganizationBaseCurrency } from '@/hooks/query';
-import { momentFormatter, safeSumBy } from '@/utils';
+import { safeSumBy } from '@/utils';
 
 type VendorContact = {
   id: string | number;
@@ -115,7 +115,6 @@ function PaymentMadeFormHeaderFieldsInner() {
       >
         <FDateInput
           name={'paymentDate'}
-          {...momentFormatter('YYYY/MM/DD')}
           popoverProps={{ position: Position.BOTTOM, minimal: true }}
           inputProps={{ leftIcon: <Icon icon={'date-range'} /> }}
           fill

--- a/packages/webapp/src/containers/Sales/CreditNotes/CreditNoteForm/CreditNoteFormHeaderFields.tsx
+++ b/packages/webapp/src/containers/Sales/CreditNotes/CreditNoteForm/CreditNoteFormHeaderFields.tsx
@@ -1,5 +1,4 @@
 import { Position } from '@blueprintjs/core';
-import { DateInput } from '@blueprintjs/datetime';
 import { css } from '@emotion/css';
 import { Theme, useTheme } from '@emotion/react';
 import { FastField, ErrorMessage, useFormikContext } from 'formik';
@@ -66,8 +65,6 @@ export function CreditNoteFormHeaderFields() {
       >
         <FDateInput
           name={'creditNoteDate'}
-          formatDate={(date) => date.toLocaleDateString()}
-          parseDate={(str) => new Date(str)}
           popoverProps={{ position: Position.BOTTOM_LEFT, minimal: true }}
           inputProps={{
             leftIcon: <Icon icon={'date-range'} />,

--- a/packages/webapp/src/containers/Sales/Estimates/EstimateForm/EstimateFormHeaderFields.tsx
+++ b/packages/webapp/src/containers/Sales/Estimates/EstimateForm/EstimateFormHeaderFields.tsx
@@ -75,8 +75,6 @@ export function EstimateFormHeader() {
       >
         <FDateInput
           name={'estimateDate'}
-          formatDate={(date: Date) => date.toLocaleDateString()}
-          parseDate={(str: string) => new Date(str)}
           popoverProps={{ position: Position.BOTTOM_LEFT, minimal: true }}
           inputProps={{
             leftIcon: <Icon icon={'date-range'} />,
@@ -96,8 +94,6 @@ export function EstimateFormHeader() {
       >
         <FDateInput
           name={'expirationDate'}
-          formatDate={(date: Date) => date.toLocaleDateString()}
-          parseDate={(str: string) => new Date(str)}
           popoverProps={{ position: Position.BOTTOM_LEFT, minimal: true }}
           inputProps={{
             leftIcon: <Icon icon={'date-range'} />,

--- a/packages/webapp/src/containers/Sales/Invoices/InvoiceForm/InvoiceFormHeaderFields.tsx
+++ b/packages/webapp/src/containers/Sales/Invoices/InvoiceForm/InvoiceFormHeaderFields.tsx
@@ -77,8 +77,6 @@ export function InvoiceFormHeaderFields() {
       >
         <FDateInput
           name={'invoiceDate'}
-          formatDate={(date) => date.toLocaleDateString()}
-          parseDate={(str) => new Date(str)}
           popoverProps={{
             position: Position.BOTTOM_LEFT,
             minimal: true,
@@ -102,8 +100,6 @@ export function InvoiceFormHeaderFields() {
       >
         <FDateInput
           name={'dueDate'}
-          formatDate={(date) => date.toLocaleDateString()}
-          parseDate={(str) => new Date(str)}
           popoverProps={{
             position: Position.BOTTOM_LEFT,
             minimal: true,

--- a/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentReceiveForm/PaymentReceiveHeaderFields.tsx
+++ b/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentReceiveForm/PaymentReceiveHeaderFields.tsx
@@ -112,8 +112,6 @@ export function PaymentReceiveHeaderFields() {
       >
         <FDateInput
           name={'paymentDate'}
-          formatDate={(date: Date) => date.toLocaleDateString()}
-          parseDate={(str: string) => new Date(str)}
           popoverProps={{ position: Position.BOTTOM_LEFT, minimal: true }}
           inputProps={{
             leftIcon: <Icon icon={'date-range'} />,

--- a/packages/webapp/src/containers/Sales/Receipts/ReceiptForm/ReceiptFormHeaderFields.tsx
+++ b/packages/webapp/src/containers/Sales/Receipts/ReceiptForm/ReceiptFormHeaderFields.tsx
@@ -97,8 +97,6 @@ export function ReceiptFormHeader() {
       >
         <FDateInput
           name={'receiptDate'}
-          formatDate={(date) => date.toLocaleDateString()}
-          parseDate={(str) => new Date(str)}
           popoverProps={{ position: Position.BOTTOM_LEFT, minimal: true }}
           inputProps={{
             leftIcon: <Icon icon={'date-range'} />,

--- a/packages/webapp/src/containers/Vendors/VendorForm/VendorFinanicalPanelTab.tsx
+++ b/packages/webapp/src/containers/Vendors/VendorForm/VendorFinanicalPanelTab.tsx
@@ -130,8 +130,6 @@ function VendorOpeningBalanceAtField() {
         name={'openingBalanceAt'}
         popoverProps={{ position: Position.BOTTOM, minimal: true }}
         disabled={Boolean(vendorId)}
-        formatDate={(date: Date) => date.toLocaleDateString()}
-        parseDate={(str: string) => new Date(str)}
         fill
         fastField
       />

--- a/packages/webapp/src/containers/Vendors/VendorForm/VendorFormFinancialSection.tsx
+++ b/packages/webapp/src/containers/Vendors/VendorForm/VendorFormFinancialSection.tsx
@@ -92,8 +92,6 @@ function VendorOpeningBalanceAtField() {
         name={'openingBalanceAt'}
         popoverProps={{ position: Position.BOTTOM, minimal: true }}
         disabled={Boolean(vendorId)}
-        formatDate={(date: Date) => date.toLocaleDateString()}
-        parseDate={(str: string) => new Date(str)}
         inputProps={{
           leftIcon: <Icon icon={'date-range'} />,
         }}

--- a/packages/webapp/src/containers/WarehouseTransfers/WarehouseTransferForm/WarehouseTransferFormHeaderFields.tsx
+++ b/packages/webapp/src/containers/WarehouseTransfers/WarehouseTransferForm/WarehouseTransferFormHeaderFields.tsx
@@ -17,7 +17,7 @@ import { FieldRequiredHint, Icon, InputPrependButton } from '@/components';
 import { CLASSES } from '@/constants/classes';
 import { withDialogActions } from '@/containers/Dialog/withDialogActions';
 import type { WithDialogActionsProps } from '@/containers/Dialog/withDialogActions';
-import { momentFormatter, compose } from '@/utils';
+import { compose } from '@/utils';
 
 /** Blueprint FormGroup/InputGroup support `fastField`/`asyncControl`; package typings omit them. */
 interface FFormGroupFieldProps {
@@ -106,7 +106,6 @@ function WarehouseTransferFormHeaderFieldsInner({
       >
         <FDateInput
           name={'date'}
-          {...momentFormatter('YYYY/MM/DD')}
           popoverProps={{ position: Position.BOTTOM_LEFT, minimal: true }}
           inputProps={{
             leftIcon: <Icon icon={'date-range'} />,

--- a/packages/webapp/src/hooks/index.tsx
+++ b/packages/webapp/src/hooks/index.tsx
@@ -5,6 +5,7 @@ import type { RefObject } from 'react';
 
 export * from './utils';
 export * from './useQueryString';
+export * from './useDateFormatter';
 
 export function useIsValuePassed<T>(value: T, compatatorValue: T) {
   const cache = useRef<T[]>([value]);

--- a/packages/webapp/src/hooks/useDateFormatter.ts
+++ b/packages/webapp/src/hooks/useDateFormatter.ts
@@ -1,0 +1,13 @@
+import { useCurrentOrganizationMetadata } from '@/hooks/query';
+import { momentFormatter } from '@/utils';
+
+/**
+ * Retrieves a date formatter configuration bound to the organization's
+ * selected date format, used to display/parse dates in date inputs.
+ */
+export function useDateFormatter() {
+  const metadata = useCurrentOrganizationMetadata();
+  const dateFormat = metadata?.dateFormat ?? 'DD MMM YYYY';
+
+  return momentFormatter(dateFormat);
+}

--- a/packages/webapp/src/hooks/useDateFormatter.ts
+++ b/packages/webapp/src/hooks/useDateFormatter.ts
@@ -1,4 +1,4 @@
-import { useCurrentOrganizationMetadata } from '@/hooks/query';
+import { useOrganizationMeta } from '@/components/Organization/OrganizationMetaProvider';
 import { momentFormatter } from '@/utils';
 
 /**
@@ -6,7 +6,7 @@ import { momentFormatter } from '@/utils';
  * selected date format, used to display/parse dates in date inputs.
  */
 export function useDateFormatter() {
-  const metadata = useCurrentOrganizationMetadata();
+  const metadata = useOrganizationMeta();
   const dateFormat = metadata?.dateFormat ?? 'DD MMM YYYY';
 
   return momentFormatter(dateFormat);


### PR DESCRIPTION
## Description

The receipt date field (and every other date input) displayed dates using the browser locale (`toLocaleDateString()`) or hardcoded formats like `YYYY/MM/DD`, ignoring the organization's configured date format (Preferences > General > Date Format). For example, with `DD MMM YYYY` selected, the Sale Receipt form showed `08/22/2026`.

This change makes all date inputs respect the organization's date format:

- Added a `useDateFormatter` hook bound to `organization.metadata.dateFormat`.
- Wrapped `FDateInput` so it defaults `formatDate`, `parseDate`, and `placeholder` to the org date format (explicit props still override).
- Removed the hardcoded `toLocaleDateString()` and `momentFormatter('YYYY/MM/DD')` overrides across all forms, dialogs, and report filters.
- Updated raw Blueprint `DateInput` consumers (advanced filter, expense form, vendors balance summary) to the same formatter.
- Stored form/filter values are unchanged, so server-side parsing and filtering are unaffected.

Fixes #1267

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Ran `npm run typecheck` in `packages/webapp` — error count unchanged from baseline (53 pre-existing, 0 new).
- Ran `eslint` on all changed files — only pre-existing import/order errors remain (identical to baseline), 0 new.
- Manually verified: with Date Format set to `DD MMM YYYY`, date inputs (receipts, invoices, estimates, bills, expenses, payments, dialogs, financial report filters, advanced filter) display e.g. `22 Aug 2026` and update when the org format changes.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>