### PR TITLE
feat(server): add XCD currency to seeded currencies list

### DIFF
--- a/packages/server/src/modules/Currencies/Currencies.constants.ts
+++ b/packages/server/src/modules/Currencies/Currencies.constants.ts
@@ -7,6 +7,7 @@ export const InitialCurrencies = [
   'CNY',
   'AUD',
   'INR',
+  'XCD',
 ];
 
 export const ERRORS = {

--- a/packages/server/src/modules/Currencies/commands/InitialCurrenciesSeed.service.spec.ts
+++ b/packages/server/src/modules/Currencies/commands/InitialCurrenciesSeed.service.spec.ts
@@ -1,0 +1,75 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import * as Currencies from 'js-money/lib/currency';
+import { InitialCurrenciesSeedService } from './InitialCurrenciesSeed.service';
+
+describe('InitialCurrenciesSeedService', () => {
+  let service: InitialCurrenciesSeedService;
+
+  const inserted: any[] = [];
+  const findOne = jest.fn<Promise<any>, []>().mockResolvedValue(null);
+  const insert = jest.fn((row: any) => {
+    inserted.push(row);
+    return Promise.resolve(row);
+  });
+  // The service receives a callable tenant-model proxy:
+  // this.currencyModel() returns the model, whose static .query()
+  // yields the objection.js query builder.
+  const currencyModel = jest.fn(() => ({
+    query: () => ({ findOne, insert }),
+  }));
+
+  beforeEach(async () => {
+    inserted.length = 0;
+    findOne.mockResolvedValue(null);
+    insert.mockClear();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        InitialCurrenciesSeedService,
+        {
+          // Matches @Inject(Currency.name) in the service constructor.
+          provide: 'Currency',
+          useValue: currencyModel,
+        },
+      ],
+    }).compile();
+
+    service = module.get<InitialCurrenciesSeedService>(
+      InitialCurrenciesSeedService,
+    );
+  });
+
+  it('seeds a currency from js-money metadata', async () => {
+    await service.seedCurrencyByCode('AUD');
+
+    expect(inserted).toEqual([
+      {
+        currencyCode: 'AUD',
+        currencyName: (Currencies as any).AUD.name,
+        currencySign: (Currencies as any).AUD.symbol,
+      },
+    ]);
+  });
+
+  it('seeds XCD even though js-money has no metadata for it', async () => {
+    expect((Currencies as any).XCD).toBeUndefined();
+
+    await service.seedCurrencyByCode('XCD');
+
+    expect(inserted).toEqual([
+      {
+        currencyCode: 'XCD',
+        currencyName: 'East Caribbean Dollar',
+        currencySign: 'EC$',
+      },
+    ]);
+  });
+
+  it('does not insert when the currency already exists', async () => {
+    findOne.mockResolvedValue({ id: 1 });
+
+    await service.seedCurrencyByCode('USD');
+
+    expect(inserted).toHaveLength(0);
+  });
+});

--- a/packages/server/src/modules/Currencies/commands/InitialCurrenciesSeed.service.ts
+++ b/packages/server/src/modules/Currencies/commands/InitialCurrenciesSeed.service.ts
@@ -5,6 +5,22 @@ import { InitialCurrencies } from '../Currencies.constants';
 import { TenantModelProxy } from '../../System/models/TenantBaseModel';
 import { Currency } from '../models/Currency.model';
 
+/**
+ * Metadata for ISO 4217 currencies that the js-money library does not
+ * carry. Used when seeding so a currency outside js-money's list seeds
+ * instead of crashing on an undefined lookup.
+ */
+const ExtraCurrencyMeta: Record<
+  string,
+  { code: string; name: string; symbol: string }
+> = {
+  XCD: {
+    code: 'XCD',
+    name: 'East Caribbean Dollar',
+    symbol: 'EC$',
+  },
+};
+
 @Injectable()
 export class InitialCurrenciesSeedService {
   constructor(
@@ -17,7 +33,8 @@ export class InitialCurrenciesSeedService {
    * @param {string} baseCurrency - Base currency code.
    */
   public async seedCurrencyByCode(currencyCode: string): Promise<void> {
-    const currencyMeta = Currencies[currencyCode];
+    const currencyMeta =
+      Currencies[currencyCode] ?? ExtraCurrencyMeta[currencyCode];
 
     const foundBaseCurrency = await this.currencyModel()
       .query()


### PR DESCRIPTION
Closes #313.

## What

Adds the East Caribbean Dollar (`XCD`) to `InitialCurrencies` so new organisations seed it alongside USD, CAD, EUR, LYD, GBP, CNY, AUD and INR.

## Why the change is slightly bigger than one array entry

js-money has **no metadata for XCD**, and `InitialCurrenciesSeedService.seedCurrencyByCode` reads `Currencies[code].code/.name/.symbol` directly. Seeding XCD without any other change crashes tenant seeding with:

```
TypeError: Cannot read properties of undefined (reading 'code')
    at InitialCurrenciesSeedService.seedCurrencyByCode
```

So this PR adds a small `ExtraCurrencyMeta` fallback map in the seed service for ISO 4217 currencies js-money does not carry, with XCD as its first entry:

| code | name | symbol |
|---|---|---|
| XCD | East Caribbean Dollar | EC$ |

The lookup becomes `Currencies[code] ?? ExtraCurrencyMeta[code]`. Codes present in js-money are unaffected; future additions outside js-money only need a map entry plus the code in `InitialCurrencies`.

## Verification

New spec `InitialCurrenciesSeed.service.spec.ts`, 3 cases passing:

- seeds from js-money metadata (AUD) with exact inserted row asserted
- seeds XCD via the fallback map (asserts js-money really has no XCD first)
- does not insert when the currency already exists

`pnpm exec jest InitialCurrenciesSeed`: 3 passed. Prettier clean on touched files. Full-package typecheck has pre-existing failures from unbuilt sibling packages (`@bigcapital/pdf-templates` etc.) on a fresh clone; none reference the Currencies module.