### PR TITLE
fix(webapp): make date inputs respect the organization date format

### DIFF
--- a/packages/webapp/src/components/AdvancedFilter/AdvancedFilterValueField.tsx
+++ b/packages/webapp/src/components/AdvancedFilter/AdvancedFilterValueField.tsx
@@ -11,8 +11,7 @@ import {
 } from './interfaces';
 import { Choose } from '@/components';
 import { Select } from '@/components/Forms';
-import { useAutofocus } from '@/hooks';
-import { momentFormatter } from '@/utils';
+import { useAutofocus, useDateInputFormatter } from '@/hooks';
 
 function AdvancedFilterEnumerationField({
   options,
@@ -57,6 +56,7 @@ export default function AdvancedFilterValueField({
   isFocus,
 }: IAdvancedFilterValueField) {
   const [localValue, setLocalValue] = React.useState(value);
+  const dateInputFormatter = useDateInputFormatter();
 
   React.useEffect(() => {
     if (localValue !== value && !isUndefined(value)) {
@@ -112,7 +112,7 @@ export default function AdvancedFilterValueField({
 
       <Choose.When condition={fieldType === IFieldType.DATE}>
         <DateInput
-          {...momentFormatter('YYYY/MM/DD')}
+          {...dateInputFormatter}
           value={tansformDateValue(localValue)}
           onChange={handleDateChange}
           popoverProps={{

--- a/packages/webapp/src/containers/Accounting/MakeJournal/MakeJournalEntriesHeaderFields.tsx
+++ b/packages/webapp/src/containers/Accounting/MakeJournal/MakeJournalEntriesHeaderFields.tsx
@@ -19,6 +19,7 @@ import {
   FDateInput,
   Stack,
 } from '@/components';
+import { useDateInputFormatter } from '@/hooks';
 
 const getFieldsStyle = (theme: Theme) => css`
   .${theme.bpPrefix}-form-group {
@@ -45,6 +46,7 @@ export function MakeJournalEntriesHeader() {
   const form = useFormikContext<MakeJournalFormValues>();
   const theme = useTheme();
   const fieldsClassName = getFieldsStyle(theme);
+  const dateInputFormatter = useDateInputFormatter();
 
   return (
     <Stack spacing={18} flex={1} className={fieldsClassName}>
@@ -58,8 +60,7 @@ export function MakeJournalEntriesHeader() {
       >
         <FDateInput
           name={'date'}
-          formatDate={(date) => date.toLocaleDateString()}
-          parseDate={(str) => new Date(str)}
+          {...dateInputFormatter}
           popoverProps={{
             position: Position.BOTTOM_LEFT,
             minimal: true,

--- a/packages/webapp/src/containers/CashFlow/AccountTransactions/AccountTransactionsDateFilter.tsx
+++ b/packages/webapp/src/containers/CashFlow/AccountTransactions/AccountTransactionsDateFilter.tsx
@@ -16,6 +16,7 @@ import {
   Icon,
   Stack,
 } from '@/components';
+import { useDateInputFormatter } from '@/hooks';
 
 export interface AccountTransactionsDateFilterFormValues {
   period: string;
@@ -54,6 +55,8 @@ export function AccountTransactionsDateFilterForm({
   initialValues = {},
   onSubmit,
 }: UncategorizedTransactionsDateFilterProps) {
+  const dateInputFormatter = useDateInputFormatter();
+
   const handleSubmit = (
     values: AccountTransactionsDateFilterFormValues,
     bag: FormikHelpers<AccountTransactionsDateFilterFormValues>,
@@ -85,8 +88,7 @@ export function AccountTransactionsDateFilterForm({
               <FDateInput
                 name={'fromDate'}
                 popoverProps={{ position: Position.BOTTOM, minimal: true }}
-                formatDate={(date: Date) => date.toLocaleDateString()}
-                parseDate={(str: string) => new Date(str)}
+                {...dateInputFormatter}
                 inputProps={{
                   fill: true,
                   placeholder: 'MM/DD/YYY',
@@ -99,8 +101,7 @@ export function AccountTransactionsDateFilterForm({
               <FDateInput
                 name={'toDate'}
                 popoverProps={{ position: Position.BOTTOM, minimal: true }}
-                formatDate={(date: Date) => date.toLocaleDateString()}
-                parseDate={(str: string) => new Date(str)}
+                {...dateInputFormatter}
                 inputProps={{
                   fill: true,
                   placeholder: 'MM/DD/YYY',

--- a/packages/webapp/src/containers/CashFlow/CategorizeTransaction/drawers/CategorizeTransactionDrawer/MoneyIn/CategorizeTransactionOtherIncome.tsx
+++ b/packages/webapp/src/containers/CashFlow/CategorizeTransaction/drawers/CategorizeTransactionDrawer/MoneyIn/CategorizeTransactionOtherIncome.tsx
@@ -10,9 +10,11 @@ import {
   FTextArea,
   Icon,
 } from '@/components';
+import { useDateInputFormatter } from '@/hooks';
 
 export function CategorizeTransactionOtherIncome() {
   const { accounts } = useCategorizeTransactionBoot();
+  const dateInputFormatter = useDateInputFormatter();
 
   return (
     <>
@@ -20,8 +22,7 @@ export function CategorizeTransactionOtherIncome() {
         <FDateInput
           name={'date'}
           popoverProps={{ position: Position.BOTTOM, minimal: true }}
-          formatDate={(date: Date) => date.toLocaleDateString()}
-          parseDate={(str: string) => new Date(str)}
+          {...dateInputFormatter}
           inputProps={{ fill: true, leftElement: <Icon icon={'date-range'} /> }}
         />
       </FFormGroup>

--- a/packages/webapp/src/containers/CashFlow/CategorizeTransaction/drawers/CategorizeTransactionDrawer/MoneyIn/CategorizeTransactionOwnerContribution.tsx
+++ b/packages/webapp/src/containers/CashFlow/CategorizeTransaction/drawers/CategorizeTransactionDrawer/MoneyIn/CategorizeTransactionOwnerContribution.tsx
@@ -10,9 +10,11 @@ import {
   FTextArea,
   Icon,
 } from '@/components';
+import { useDateInputFormatter } from '@/hooks';
 
 export function CategorizeTransactionOwnerContribution() {
   const { accounts } = useCategorizeTransactionBoot();
+  const dateInputFormatter = useDateInputFormatter();
 
   if (!accounts) {
     return null;
@@ -23,8 +25,7 @@ export function CategorizeTransactionOwnerContribution() {
         <FDateInput
           name={'date'}
           popoverProps={{ position: Position.BOTTOM, minimal: true }}
-          formatDate={(date: Date) => date.toLocaleDateString()}
-          parseDate={(str: string) => new Date(str)}
+          {...dateInputFormatter}
           inputProps={{ fill: true, leftElement: <Icon icon={'date-range'} /> }}
         />
       </FFormGroup>

--- a/packages/webapp/src/containers/CashFlow/CategorizeTransaction/drawers/CategorizeTransactionDrawer/MoneyIn/CategorizeTransactionTransferFrom.tsx
+++ b/packages/webapp/src/containers/CashFlow/CategorizeTransaction/drawers/CategorizeTransactionDrawer/MoneyIn/CategorizeTransactionTransferFrom.tsx
@@ -10,9 +10,11 @@ import {
   FTextArea,
   Icon,
 } from '@/components';
+import { useDateInputFormatter } from '@/hooks';
 
 export function CategorizeTransactionTransferFrom() {
   const { accounts } = useCategorizeTransactionBoot();
+  const dateInputFormatter = useDateInputFormatter();
 
   if (!accounts) {
     return null;
@@ -23,8 +25,7 @@ export function CategorizeTransactionTransferFrom() {
         <FDateInput
           name={'date'}
           popoverProps={{ position: Position.BOTTOM, minimal: true }}
-          formatDate={(date: Date) => date.toLocaleDateString()}
-          parseDate={(str: string) => new Date(str)}
+          {...dateInputFormatter}
           inputProps={{ fill: true, leftElement: <Icon icon={'date-range'} /> }}
         />
       </FFormGroup>

--- a/packages/webapp/src/containers/CashFlow/CategorizeTransaction/drawers/CategorizeTransactionDrawer/MoneyOut/CategorizeTransactionOtherExpense.tsx
+++ b/packages/webapp/src/containers/CashFlow/CategorizeTransaction/drawers/CategorizeTransactionDrawer/MoneyOut/CategorizeTransactionOtherExpense.tsx
@@ -10,9 +10,11 @@ import {
   FTextArea,
   Icon,
 } from '@/components';
+import { useDateInputFormatter } from '@/hooks';
 
 export function CategorizeTransactionOtherExpense() {
   const { accounts } = useCategorizeTransactionBoot();
+  const dateInputFormatter = useDateInputFormatter();
 
   if (!accounts) {
     return null;
@@ -23,8 +25,7 @@ export function CategorizeTransactionOtherExpense() {
         <FDateInput
           name={'date'}
           popoverProps={{ position: Position.BOTTOM, minimal: true }}
-          formatDate={(date: Date) => date.toLocaleDateString()}
-          parseDate={(str: string) => new Date(str)}
+          {...dateInputFormatter}
           inputProps={{ fill: true, leftElement: <Icon icon={'date-range'} /> }}
         />
       </FFormGroup>

--- a/packages/webapp/src/containers/CashFlow/CategorizeTransaction/drawers/CategorizeTransactionDrawer/MoneyOut/CategorizeTransactionOwnerDrawings.tsx
+++ b/packages/webapp/src/containers/CashFlow/CategorizeTransaction/drawers/CategorizeTransactionDrawer/MoneyOut/CategorizeTransactionOwnerDrawings.tsx
@@ -10,9 +10,11 @@ import {
   FTextArea,
   Icon,
 } from '@/components';
+import { useDateInputFormatter } from '@/hooks';
 
 export function CategorizeTransactionOwnerDrawings() {
   const { accounts } = useCategorizeTransactionBoot();
+  const dateInputFormatter = useDateInputFormatter();
 
   if (!accounts) {
     return null;
@@ -23,8 +25,7 @@ export function CategorizeTransactionOwnerDrawings() {
         <FDateInput
           name={'date'}
           popoverProps={{ position: Position.BOTTOM, minimal: true }}
-          formatDate={(date: Date) => date.toLocaleDateString()}
-          parseDate={(str: string) => new Date(str)}
+          {...dateInputFormatter}
           inputProps={{ fill: true, leftElement: <Icon icon={'date-range'} /> }}
         />
       </FFormGroup>

--- a/packages/webapp/src/containers/CashFlow/CategorizeTransaction/drawers/CategorizeTransactionDrawer/MoneyOut/CategorizeTransactionToAccount.tsx
+++ b/packages/webapp/src/containers/CashFlow/CategorizeTransaction/drawers/CategorizeTransactionDrawer/MoneyOut/CategorizeTransactionToAccount.tsx
@@ -10,9 +10,11 @@ import {
   FTextArea,
   Icon,
 } from '@/components';
+import { useDateInputFormatter } from '@/hooks';
 
 export function CategorizeTransactionToAccount() {
   const { accounts } = useCategorizeTransactionBoot();
+  const dateInputFormatter = useDateInputFormatter();
 
   if (!accounts) {
     return null;
@@ -23,8 +25,7 @@ export function CategorizeTransactionToAccount() {
         <FDateInput
           name={'date'}
           popoverProps={{ position: Position.BOTTOM, minimal: true }}
-          formatDate={(date: Date) => date.toLocaleDateString()}
-          parseDate={(str: string) => new Date(str)}
+          {...dateInputFormatter}
           inputProps={{ fill: true, leftElement: <Icon icon={'date-range'} /> }}
         />
       </FFormGroup>

--- a/packages/webapp/src/containers/CashFlow/CategorizeTransactionAside/MatchingReconcileTransactionAside/MatchingReconcileTransactionForm.tsx
+++ b/packages/webapp/src/containers/CashFlow/CategorizeTransactionAside/MatchingReconcileTransactionAside/MatchingReconcileTransactionForm.tsx
@@ -32,9 +32,9 @@ import {
 import { Aside } from '@/components/Aside/Aside';
 import { ContentTabs } from '@/components/ContentTabs';
 import { Features } from '@/constants';
+import { useDateInputFormatter } from '@/hooks';
 import { useCreateCashflowTransaction } from '@/hooks/query';
 import { compose } from '@/utils';
-import { momentFormatter } from '@/utils';
 
 interface ReconcileSubmitSuccessPayload {
   id: number;
@@ -178,6 +178,7 @@ function ReconcileMatchingType() {
 
 function CreateReconcileTransactionContent() {
   const { branches } = useMatchingReconcileTransactionBoot();
+  const dateInputFormatter = useDateInputFormatter();
 
   return (
     <Box className={styles.content}>
@@ -185,7 +186,7 @@ function CreateReconcileTransactionContent() {
 
       <FFormGroup label={'Date'} name={'date'} fastField>
         <FDateInput
-          {...momentFormatter('YYYY/MM/DD')}
+          {...dateInputFormatter}
           name={'date'}
           popoverProps={{
             minimal: false,

--- a/packages/webapp/src/containers/CashFlow/MoneyInDialog/OtherIncome/OtherIncomeFormFields.tsx
+++ b/packages/webapp/src/containers/CashFlow/MoneyInDialog/OtherIncome/OtherIncomeFormFields.tsx
@@ -23,7 +23,7 @@ import {
   FDateInput,
 } from '@/components';
 import { ACCOUNT_TYPE, Features } from '@/constants';
-import { momentFormatter } from '@/utils';
+import { useDateInputFormatter } from '@/hooks';
 
 /**
  * Other income form fields.
@@ -33,6 +33,7 @@ export function OtherIncomeFormFields() {
   const { account } = useMoneyInFieldsContext();
 
   useSetPrimaryBranchToForm();
+  const dateInputFormatter = useDateInputFormatter();
 
   return (
     <React.Fragment>
@@ -61,7 +62,7 @@ export function OtherIncomeFormFields() {
           >
             <FDateInput
               name={'date'}
-              {...momentFormatter('YYYY/MM/DD')}
+              {...dateInputFormatter}
               popoverProps={{ position: Position.BOTTOM_LEFT, minimal: true }}
               inputProps={{
                 fill: true,

--- a/packages/webapp/src/containers/CashFlow/MoneyInDialog/OwnerContribution/OwnerContributionFormFields.tsx
+++ b/packages/webapp/src/containers/CashFlow/MoneyInDialog/OwnerContribution/OwnerContributionFormFields.tsx
@@ -23,7 +23,7 @@ import {
   Icon,
 } from '@/components';
 import { ACCOUNT_TYPE, Features } from '@/constants';
-import { momentFormatter } from '@/utils';
+import { useDateInputFormatter } from '@/hooks';
 
 /**
  * Owner contribution form fields.
@@ -33,6 +33,7 @@ export function OwnerContributionFormFields() {
   const { account } = useMoneyInFieldsContext();
 
   useSetPrimaryBranchToForm();
+  const dateInputFormatter = useDateInputFormatter();
 
   return (
     <React.Fragment>
@@ -61,7 +62,7 @@ export function OwnerContributionFormFields() {
           >
             <FDateInput
               name={'date'}
-              {...momentFormatter('YYYY/MM/DD')}
+              {...dateInputFormatter}
               popoverProps={{
                 position: Position.BOTTOM_LEFT,
                 minimal: true,

--- a/packages/webapp/src/containers/CashFlow/MoneyInDialog/TransferFromAccount/TransferFromAccountFormFields.tsx
+++ b/packages/webapp/src/containers/CashFlow/MoneyInDialog/TransferFromAccount/TransferFromAccountFormFields.tsx
@@ -23,7 +23,7 @@ import {
   FInputGroup,
 } from '@/components';
 import { ACCOUNT_TYPE, Features } from '@/constants';
-import { momentFormatter } from '@/utils';
+import { useDateInputFormatter } from '@/hooks';
 
 /**
  * Transfer from account form fields.
@@ -33,6 +33,7 @@ export function TransferFromAccountFormFields() {
   const { account } = useMoneyInFieldsContext();
 
   useSetPrimaryBranchToForm();
+  const dateInputFormatter = useDateInputFormatter();
 
   return (
     <React.Fragment>
@@ -61,7 +62,7 @@ export function TransferFromAccountFormFields() {
           >
             <FDateInput
               name={'date'}
-              {...momentFormatter('YYYY/MM/DD')}
+              {...dateInputFormatter}
               popoverProps={{
                 position: Position.BOTTOM_LEFT,
                 minimal: true,

--- a/packages/webapp/src/containers/CashFlow/MoneyOutDialog/OtherExpense/OtherExpnseFormFields.tsx
+++ b/packages/webapp/src/containers/CashFlow/MoneyOutDialog/OtherExpense/OtherExpnseFormFields.tsx
@@ -22,7 +22,7 @@ import {
   FDateInput,
 } from '@/components';
 import { Features, ACCOUNT_TYPE } from '@/constants';
-import { momentFormatter } from '@/utils';
+import { useDateInputFormatter } from '@/hooks';
 
 /**
  * Other expense form fields.
@@ -32,6 +32,7 @@ export function OtherExpnseFormFields() {
   const { account } = useMoneyOutFieldsContext();
 
   useSetPrimaryBranchToForm();
+  const dateInputFormatter = useDateInputFormatter();
 
   return (
     <React.Fragment>
@@ -61,7 +62,7 @@ export function OtherExpnseFormFields() {
           >
             <FDateInput
               name={'date'}
-              {...momentFormatter('YYYY/MM/DD')}
+              {...dateInputFormatter}
               popoverProps={{
                 position: Position.BOTTOM_LEFT,
                 minimal: true,

--- a/packages/webapp/src/containers/CashFlow/MoneyOutDialog/OwnerDrawings/OwnerDrawingsFormFields.tsx
+++ b/packages/webapp/src/containers/CashFlow/MoneyOutDialog/OwnerDrawings/OwnerDrawingsFormFields.tsx
@@ -22,7 +22,7 @@ import {
   FDateInput,
 } from '@/components';
 import { Features, ACCOUNT_TYPE } from '@/constants';
-import { momentFormatter } from '@/utils';
+import { useDateInputFormatter } from '@/hooks';
 
 /**
  * Owner drawings form fields.
@@ -32,6 +32,7 @@ export function OwnerDrawingsFormFields() {
   const { account } = useMoneyOutFieldsContext();
 
   useSetPrimaryBranchToForm();
+  const dateInputFormatter = useDateInputFormatter();
 
   return (
     <React.Fragment>
@@ -60,7 +61,7 @@ export function OwnerDrawingsFormFields() {
           >
             <FDateInput
               name={'date'}
-              {...momentFormatter('YYYY/MM/DD')}
+              {...dateInputFormatter}
               popoverProps={{
                 position: Position.BOTTOM_LEFT,
                 minimal: true,

--- a/packages/webapp/src/containers/CashFlow/MoneyOutDialog/TransferToAccount/TransferToAccountFormFields.tsx
+++ b/packages/webapp/src/containers/CashFlow/MoneyOutDialog/TransferToAccount/TransferToAccountFormFields.tsx
@@ -24,7 +24,7 @@ import {
 } from '@/components';
 import { Features } from '@/constants';
 import { ACCOUNT_TYPE } from '@/constants/accountTypes';
-import { momentFormatter } from '@/utils';
+import { useDateInputFormatter } from '@/hooks';
 
 /**
  * Transfer to account form fields.
@@ -34,6 +34,7 @@ export function TransferToAccountFormFields() {
   const { account } = useMoneyOutFieldsContext();
 
   useSetPrimaryBranchToForm();
+  const dateInputFormatter = useDateInputFormatter();
 
   return (
     <React.Fragment>
@@ -63,7 +64,7 @@ export function TransferToAccountFormFields() {
           >
             <FDateInput
               name={'date'}
-              {...momentFormatter('YYYY/MM/DD')}
+              {...dateInputFormatter}
               popoverProps={{
                 position: Position.BOTTOM_LEFT,
                 minimal: true,

--- a/packages/webapp/src/containers/Customers/CustomerForm/CustomerFormFinancialSection.tsx
+++ b/packages/webapp/src/containers/Customers/CustomerForm/CustomerFormFinancialSection.tsx
@@ -24,6 +24,7 @@ import {
   Box,
 } from '@/components';
 import { Features } from '@/constants';
+import { useDateInputFormatter } from '@/hooks';
 import { useCurrentOrganizationBaseCurrency } from '@/hooks/query';
 
 export function CustomerFormFinancialSection() {
@@ -75,6 +76,7 @@ export function CustomerFormFinancialSection() {
 
 function CustomerOpeningBalanceAtField() {
   const { customerId } = useCustomerFormContext();
+  const dateInputFormatter = useDateInputFormatter();
 
   // Cannot continue if the customer id is defined.
   if (customerId) return null;
@@ -90,8 +92,7 @@ function CustomerOpeningBalanceAtField() {
         name={'openingBalanceAt'}
         popoverProps={{ position: Position.BOTTOM, minimal: true }}
         disabled={Boolean(customerId)}
-        formatDate={(date: Date) => date.toLocaleDateString()}
-        parseDate={(str: string) => new Date(str)}
+        {...dateInputFormatter}
         inputProps={{
           leftIcon: <Icon icon={'date-range'} />,
         }}

--- a/packages/webapp/src/containers/Dialogs/CustomerOpeningBalanceDialog/CustomerOpeningBalanceFields.tsx
+++ b/packages/webapp/src/containers/Dialogs/CustomerOpeningBalanceDialog/CustomerOpeningBalanceFields.tsx
@@ -16,8 +16,9 @@ import {
 } from '@/components';
 import { FMoneyInputGroup, FFormGroup, FDateInput } from '@/components/Forms';
 import { Features } from '@/constants';
+import { useDateInputFormatter } from '@/hooks';
 import { useCurrentOrganizationBaseCurrency } from '@/hooks/query';
-import { momentFormatter, tansformDateValue, handleDateChange } from '@/utils';
+import { tansformDateValue, handleDateChange } from '@/utils';
 
 /**
  * Customer Opening balance fields.
@@ -32,6 +33,7 @@ function CustomerOpeningBalanceFieldsInner() {
 
   // Sets the primary branch to form.
   useSetPrimaryBranchToForm();
+  const dateInputFormatter = useDateInputFormatter();
 
   return (
     <div className={Classes.DIALOG_BODY}>
@@ -58,8 +60,7 @@ function CustomerOpeningBalanceFieldsInner() {
       >
         <FDateInput
           name={'openingBalanceAt'}
-          formatDate={(date) => date.toLocaleDateString()}
-          parseDate={(str) => new Date(str)}
+          {...dateInputFormatter}
           popoverProps={{ position: Position.BOTTOM, minimal: true }}
           inputProps={{
             leftIcon: <Icon icon={'date-range'} />,

--- a/packages/webapp/src/containers/Dialogs/InventoryAdjustmentFormDialog/InventoryAdjustmentFormDialogFields.tsx
+++ b/packages/webapp/src/containers/Dialogs/InventoryAdjustmentFormDialog/InventoryAdjustmentFormDialogFields.tsx
@@ -29,9 +29,9 @@ import {
   FAccountsSuggestField,
 } from '@/components';
 import { Features } from '@/constants';
-import { useAutofocus } from '@/hooks';
+import { useAutofocus, useDateInputFormatter } from '@/hooks';
 import { useFeatureCan } from '@/hooks/state';
-import { momentFormatter, toSafeNumber } from '@/utils';
+import { toSafeNumber } from '@/utils';
 
 export function InventoryAdjustmentFormDialogFields(): React.ReactElement {
   const { featureCan } = useFeatureCan();
@@ -39,6 +39,7 @@ export function InventoryAdjustmentFormDialogFields(): React.ReactElement {
   const adjustmentTypes = useGetAdjustmentTypeOptions();
 
   const dateFieldRef = useAutofocus<HTMLInputElement>();
+  const dateInputFormatter = useDateInputFormatter();
 
   const { accounts, branches, warehouses } = useInventoryAdjContext();
   const { values, setFieldValue } =
@@ -100,7 +101,7 @@ export function InventoryAdjustmentFormDialogFields(): React.ReactElement {
           >
             <FDateInput
               name={'date'}
-              {...momentFormatter('YYYY/MM/DD')}
+              {...dateInputFormatter}
               popoverProps={{
                 position: Position.BOTTOM,
                 minimal: true,

--- a/packages/webapp/src/containers/Dialogs/LockingTransactionsDialog/LockingTransactionsFormFields.tsx
+++ b/packages/webapp/src/containers/Dialogs/LockingTransactionsDialog/LockingTransactionsFormFields.tsx
@@ -9,14 +9,14 @@ import {
   FFormGroup,
 } from '@/components';
 import { CLASSES } from '@/constants/classes';
-import { useAutofocus } from '@/hooks';
-import { momentFormatter } from '@/utils';
+import { useAutofocus, useDateInputFormatter } from '@/hooks';
 
 /**
  * Locking transactions form fields.
  */
 export function LockingTransactionsFormFields(): React.ReactElement {
   const reasonFieldRef = useAutofocus<HTMLTextAreaElement>();
+  const dateInputFormatter = useDateInputFormatter();
 
   return (
     <div className={Classes.DIALOG_BODY}>
@@ -30,7 +30,7 @@ export function LockingTransactionsFormFields(): React.ReactElement {
       >
         <FDateInput
           name={'lock_to_date'}
-          {...momentFormatter('YYYY/MM/DD')}
+          {...dateInputFormatter}
           popoverProps={{
             position: Position.BOTTOM,
             minimal: true,

--- a/packages/webapp/src/containers/Dialogs/QuickPaymentMadeFormDialog/QuickPaymentMadeFormFields.tsx
+++ b/packages/webapp/src/containers/Dialogs/QuickPaymentMadeFormDialog/QuickPaymentMadeFormFields.tsx
@@ -26,9 +26,8 @@ import {
   FMoneyInputGroup,
 } from '@/components';
 import { CLASSES, ACCOUNT_TYPE, Features } from '@/constants';
-import { useAutofocus } from '@/hooks';
+import { useAutofocus, useDateInputFormatter } from '@/hooks';
 import { useCurrentOrganizationBaseCurrency } from '@/hooks/query';
-import { momentFormatter } from '@/utils';
 
 /**
  * Quick payment made form fields.
@@ -44,6 +43,7 @@ function QuickPaymentMadeFormFieldsInner(): React.ReactElement {
 
   // Sets the primary branch to form.
   useSetPrimaryBranchToForm();
+  const dateInputFormatter = useDateInputFormatter();
 
   return (
     <div className={Classes.DIALOG_BODY}>
@@ -115,7 +115,7 @@ function QuickPaymentMadeFormFieldsInner(): React.ReactElement {
           >
             <FDateInput
               name={'paymentDate'}
-              {...momentFormatter('YYYY/MM/DD')}
+              {...dateInputFormatter}
               popoverProps={{ position: Position.BOTTOM, minimal: true }}
               inputProps={{
                 leftIcon: <Icon icon={'date-range'} />,

--- a/packages/webapp/src/containers/Dialogs/QuickPaymentReceiveFormDialog/QuickPaymentReceiveFormFields.tsx
+++ b/packages/webapp/src/containers/Dialogs/QuickPaymentReceiveFormDialog/QuickPaymentReceiveFormFields.tsx
@@ -25,9 +25,8 @@ import {
   FMoneyInputGroup,
 } from '@/components';
 import { Features, ACCOUNT_TYPE } from '@/constants';
-import { useAutofocus } from '@/hooks';
+import { useAutofocus, useDateInputFormatter } from '@/hooks';
 import { useCurrentOrganizationBaseCurrency } from '@/hooks/query';
-import { momentFormatter } from '@/utils';
 
 /**
  * Quick payment receive form fields.
@@ -45,6 +44,7 @@ function QuickPaymentReceiveFormFieldsInner(): React.ReactElement {
 
   // Sets the primary branch to form.
   useSetPrimaryBranchToForm();
+  const dateInputFormatter = useDateInputFormatter();
 
   return (
     <div className={Classes.DIALOG_BODY}>
@@ -117,7 +117,7 @@ function QuickPaymentReceiveFormFieldsInner(): React.ReactElement {
           {/* ------------- Payment date ------------- */}
           <FFormGroup name={'paymentDate'} label={intl.get('payment_date')}>
             <FDateInput
-              {...momentFormatter('YYYY/MM/DD')}
+              {...dateInputFormatter}
               name={'paymentDate'}
               popoverProps={{ position: Position.BOTTOM, minimal: true }}
               inputProps={{

--- a/packages/webapp/src/containers/Dialogs/RefundCreditNoteDialog/RefundCreditNoteFormFields.tsx
+++ b/packages/webapp/src/containers/Dialogs/RefundCreditNoteDialog/RefundCreditNoteFormFields.tsx
@@ -26,9 +26,8 @@ import {
 } from '@/components';
 import { Features } from '@/constants';
 import { ACCOUNT_TYPE } from '@/constants/accountTypes';
-import { useAutofocus } from '@/hooks';
+import { useAutofocus, useDateInputFormatter } from '@/hooks';
 import { useCurrentOrganizationBaseCurrency } from '@/hooks/query';
-import { momentFormatter } from '@/utils';
 
 // FFormGroup / FMoneyInputGroup / FInputGroup (blueprintjs-formik) wrappers
 // don't expose all underlying props (`fill`, `minimal`) in their public type.
@@ -68,6 +67,7 @@ function RefundCreditNoteFormFieldsInner(): React.ReactElement {
 
   // Sets the primary branch to form.
   useSetPrimaryBranchToForm();
+  const dateInputFormatter = useDateInputFormatter();
 
   return (
     <div className={Classes.DIALOG_BODY}>
@@ -97,7 +97,7 @@ function RefundCreditNoteFormFieldsInner(): React.ReactElement {
           >
             <FDateInput
               name={'date'}
-              {...momentFormatter('YYYY/MM/DD')}
+              {...dateInputFormatter}
               popoverProps={{ position: Position.BOTTOM, minimal: true }}
               inputProps={{
                 leftIcon: <Icon icon={'date-range'} />,

--- a/packages/webapp/src/containers/Dialogs/RefundVendorCreditDialog/RefundVendorCreditFormFields.tsx
+++ b/packages/webapp/src/containers/Dialogs/RefundVendorCreditDialog/RefundVendorCreditFormFields.tsx
@@ -25,9 +25,8 @@ import {
   FFormGroup,
 } from '@/components';
 import { Features, ACCOUNT_TYPE } from '@/constants';
-import { useAutofocus } from '@/hooks';
+import { useAutofocus, useDateInputFormatter } from '@/hooks';
 import { useCurrentOrganizationBaseCurrency } from '@/hooks/query';
-import { momentFormatter } from '@/utils';
 
 /**
  * Refund Vendor credit form fields.
@@ -42,6 +41,7 @@ function RefundVendorCreditFormFieldsInner(): React.ReactElement {
 
   // Sets the primary branch to form.
   useSetPrimaryBranchToForm();
+  const dateInputFormatter = useDateInputFormatter();
 
   return (
     <div className={Classes.DIALOG_BODY}>
@@ -71,7 +71,7 @@ function RefundVendorCreditFormFieldsInner(): React.ReactElement {
           >
             <FDateInput
               name={'refundDate'}
-              {...momentFormatter('YYYY/MM/DD')}
+              {...dateInputFormatter}
               popoverProps={{ position: Position.BOTTOM, minimal: true }}
               inputProps={{
                 leftIcon: <Icon icon={'date-range'} />,

--- a/packages/webapp/src/containers/Dialogs/UnlockingPartialTransactionsDialog/UnlockingPartialTransactionsFormFields.tsx
+++ b/packages/webapp/src/containers/Dialogs/UnlockingPartialTransactionsDialog/UnlockingPartialTransactionsFormFields.tsx
@@ -9,14 +9,14 @@ import {
   FTextArea,
   FFormGroup,
 } from '@/components';
-import { useAutofocus } from '@/hooks';
-import { momentFormatter } from '@/utils';
+import { useAutofocus, useDateInputFormatter } from '@/hooks';
 
 /**
  * Parial Unlocking transactions form fields.
  */
 export function UnlockingPartialTransactionsFormFields(): React.ReactElement {
   const reasonFieldRef = useAutofocus<HTMLTextAreaElement>();
+  const dateInputFormatter = useDateInputFormatter();
 
   return (
     <div className={Classes.DIALOG_BODY}>
@@ -31,7 +31,7 @@ export function UnlockingPartialTransactionsFormFields(): React.ReactElement {
           >
             <FDateInput
               name={'unlockFromDate'}
-              {...momentFormatter('YYYY/MM/DD')}
+              {...dateInputFormatter}
               popoverProps={{
                 position: Position.BOTTOM,
                 minimal: true,
@@ -51,7 +51,7 @@ export function UnlockingPartialTransactionsFormFields(): React.ReactElement {
           >
             <FDateInput
               name={'unlockToDate'}
-              {...momentFormatter('YYYY/MM/DD')}
+              {...dateInputFormatter}
               popoverProps={{
                 position: Position.BOTTOM,
                 minimal: true,

--- a/packages/webapp/src/containers/Dialogs/VendorOpeningBalanceDialog/VendorOpeningBalanceFormFields.tsx
+++ b/packages/webapp/src/containers/Dialogs/VendorOpeningBalanceDialog/VendorOpeningBalanceFormFields.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/components';
 import { FMoneyInputGroup, FFormGroup, FDateInput } from '@/components/Forms';
 import { Features } from '@/constants';
+import { useDateInputFormatter } from '@/hooks';
 import { useCurrentOrganizationBaseCurrency } from '@/hooks/query';
 
 /**
@@ -30,6 +31,7 @@ function VendorOpeningBalanceFormFieldsInner() {
 
   // Sets the primary branch to form.
   useSetPrimaryBranchToForm();
+  const dateInputFormatter = useDateInputFormatter();
 
   return (
     <div className={Classes.DIALOG_BODY}>
@@ -56,8 +58,7 @@ function VendorOpeningBalanceFormFieldsInner() {
       >
         <FDateInput
           name={'openingBalanceAt'}
-          formatDate={(date) => date.toLocaleDateString()}
-          parseDate={(str) => new Date(str)}
+          {...dateInputFormatter}
           popoverProps={{ position: Position.BOTTOM, minimal: true }}
           inputProps={{
             leftIcon: <Icon icon={'date-range'} />,

--- a/packages/webapp/src/containers/Expenses/ExpenseForm/ExpenseFormHeaderFields.tsx
+++ b/packages/webapp/src/containers/Expenses/ExpenseForm/ExpenseFormHeaderFields.tsx
@@ -25,12 +25,8 @@ import {
   Hint,
 } from '@/components';
 import { CLASSES } from '@/constants/classes';
-import {
-  momentFormatter,
-  tansformDateValue,
-  inputIntent,
-  handleDateChange,
-} from '@/utils';
+import { useDateInputFormatter } from '@/hooks';
+import { tansformDateValue, inputIntent, handleDateChange } from '@/utils';
 
 const getFieldsStyle = (theme: Theme) => css`
   .${theme.bpPrefix}-form-group {
@@ -56,6 +52,7 @@ export function ExpenseFormHeader() {
   const { currencies, accounts, customers } = useExpenseFormContext();
   const theme = useTheme() as unknown as Theme;
   const fieldsClassName = getFieldsStyle(theme);
+  const dateInputFormatter = useDateInputFormatter();
 
   return (
     <Stack spacing={18} flex={1} className={fieldsClassName}>
@@ -70,7 +67,7 @@ export function ExpenseFormHeader() {
             inline={true}
           >
             <DateInput
-              {...momentFormatter('YYYY/MM/DD')}
+              {...dateInputFormatter}
               value={tansformDateValue(value)}
               onChange={handleDateChange((formattedDate: string) => {
                 form.setFieldValue('paymentDate', formattedDate);

--- a/packages/webapp/src/containers/FinancialStatements/APAgingSummary/APAgingSummaryHeaderGeneralContent.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/APAgingSummary/APAgingSummaryHeaderGeneralContent.tsx
@@ -13,10 +13,11 @@ import {
   FDateInput,
   FInputGroup,
 } from '@/components';
-import { momentFormatter } from '@/utils';
+import { useDateInputFormatter } from '@/hooks';
 
 export function APAgingSummaryHeaderGeneralContent() {
   const { vendors } = useAPAgingSummaryGeneralContext();
+  const dateInputFormatter = useDateInputFormatter();
 
   return (
     <div>
@@ -30,7 +31,7 @@ export function APAgingSummaryHeaderGeneralContent() {
           >
             <FDateInput
               name={'asDate'}
-              {...momentFormatter('YYYY/MM/DD')}
+              {...dateInputFormatter}
               popoverProps={{ position: Position.BOTTOM_LEFT, minimal: true }}
               fill
               fastField

--- a/packages/webapp/src/containers/FinancialStatements/ARAgingSummary/ARAgingSummaryHeaderGeneralContent.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/ARAgingSummary/ARAgingSummaryHeaderGeneralContent.tsx
@@ -12,10 +12,11 @@ import {
   CustomersMultiSelect,
   FDateInput,
 } from '@/components';
-import { momentFormatter } from '@/utils';
+import { useDateInputFormatter } from '@/hooks';
 
 export function ARAgingSummaryHeaderGeneralContent() {
   const { customers } = useARAgingSummaryGeneralContext();
+  const dateInputFormatter = useDateInputFormatter();
 
   return (
     <div>
@@ -29,7 +30,7 @@ export function ARAgingSummaryHeaderGeneralContent() {
           >
             <FDateInput
               name={'asDate'}
-              {...momentFormatter('YYYY/MM/DD')}
+              {...dateInputFormatter}
               popoverProps={{ position: Position.BOTTOM_LEFT, minimal: true }}
               fill
               fastField

--- a/packages/webapp/src/containers/FinancialStatements/AuditLog/AuditLogHeader.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/AuditLog/AuditLogHeader.tsx
@@ -8,6 +8,7 @@ import { FinancialStatementHeader } from '../FinancialStatementHeader';
 import { getDefaultAuditLogQuery, getAuditLogQuerySchema } from './common';
 import { FormattedMessage as T, FFormGroup, FDateInput } from '@/components';
 import { FMultiSelect } from '@/components/Forms';
+import { useDateInputFormatter } from '@/hooks';
 import { useAuditLogFilterOptionsQuery } from '@/hooks/query';
 import { saveInvoke, transformToForm } from '@/utils';
 
@@ -56,6 +57,8 @@ export function AuditLogHeader({
   isFilterDrawerOpen,
   toggleFilterDrawer,
 }: AuditLogHeaderProps) {
+  const dateInputFormatter = useDateInputFormatter();
+
   const { data: filterOptions, isLoading: isFilterOptionsLoading } =
     useAuditLogFilterOptionsQuery({
       enabled: isFilterDrawerOpen,
@@ -205,8 +208,7 @@ export function AuditLogHeader({
                         position: Position.BOTTOM,
                         minimal: true,
                       }}
-                      formatDate={(date: Date) => date.toLocaleDateString()}
-                      parseDate={(str: string) => new Date(str)}
+                      {...dateInputFormatter}
                       inputProps={{ fill: true }}
                       fastField
                     />
@@ -220,8 +222,7 @@ export function AuditLogHeader({
                         position: Position.BOTTOM,
                         minimal: true,
                       }}
-                      formatDate={(date: Date) => date.toLocaleDateString()}
-                      parseDate={(str: string) => new Date(str)}
+                      {...dateInputFormatter}
                       inputProps={{ fill: true }}
                       fastField
                     />

--- a/packages/webapp/src/containers/FinancialStatements/CustomersBalanceSummary/CustomersBalanceSummaryGeneralPanelContent.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/CustomersBalanceSummary/CustomersBalanceSummaryGeneralPanelContent.tsx
@@ -12,13 +12,14 @@ import {
   FDateInput,
   FCheckbox,
 } from '@/components';
-import { momentFormatter } from '@/utils';
+import { useDateInputFormatter } from '@/hooks';
 
 /**
  * Customers balance header - General panel - Content
  */
 export function CustomersBalanceSummaryGeneralPanelContent() {
   const { customers } = useCustomersBalanceSummaryGeneralContext();
+  const dateInputFormatter = useDateInputFormatter();
 
   return (
     <div>
@@ -32,7 +33,7 @@ export function CustomersBalanceSummaryGeneralPanelContent() {
           >
             <FDateInput
               name={'asDate'}
-              {...momentFormatter('YYYY/MM/DD')}
+              {...dateInputFormatter}
               popoverProps={{ position: Position.BOTTOM, minimal: true }}
               fill={true}
               fastField

--- a/packages/webapp/src/containers/FinancialStatements/FinancialStatementDateRange.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/FinancialStatementDateRange.tsx
@@ -5,11 +5,14 @@ import React from 'react';
 import intl from 'react-intl-universal';
 import { dateRangeOptions } from './constants';
 import { Row, Col, Hint, FDateInput, FFormGroup } from '@/components';
-import { momentFormatter, parseDateRangeQuery } from '@/utils';
+import { useDateInputFormatter } from '@/hooks';
+import { parseDateRangeQuery } from '@/utils';
 
 const FINANCIAL_REPORT_MAX_DATE = moment().add(5, 'years').toDate();
 
 export function FinancialStatementDateRange() {
+  const dateInputFormatter = useDateInputFormatter();
+
   return (
     <>
       <Row>
@@ -60,7 +63,7 @@ export function FinancialStatementDateRange() {
           >
             <FDateInput
               name={'fromDate'}
-              {...momentFormatter('YYYY-MM-DD')}
+              {...dateInputFormatter}
               popoverProps={{ minimal: true, position: Position.BOTTOM_LEFT }}
               maxDate={FINANCIAL_REPORT_MAX_DATE}
               canClearSelection={false}
@@ -78,7 +81,7 @@ export function FinancialStatementDateRange() {
           >
             <FDateInput
               name={'toDate'}
-              {...momentFormatter('YYYY-MM-DD')}
+              {...dateInputFormatter}
               popoverProps={{ minimal: true, position: Position.BOTTOM }}
               canClearSelection={false}
               fill

--- a/packages/webapp/src/containers/FinancialStatements/InventoryValuation/InventoryValuationHeaderGeneralPanel.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/InventoryValuation/InventoryValuationHeaderGeneralPanel.tsx
@@ -14,7 +14,7 @@ import {
   FFormGroup,
   FDateInput,
 } from '@/components';
-import { momentFormatter } from '@/utils';
+import { useDateInputFormatter } from '@/hooks';
 
 /**
  * Inventory valuation - Drawer Header - General panel.
@@ -32,6 +32,7 @@ export function InventoryValuationHeaderGeneralPanel() {
  */
 function InventoryValuationHeaderGeneralPanelContent() {
   const { items } = useInventoryValuationGeneralPanelContext();
+  const dateInputFormatter = useDateInputFormatter();
 
   return (
     <div>
@@ -45,7 +46,7 @@ function InventoryValuationHeaderGeneralPanelContent() {
           >
             <FDateInput
               name={'asDate'}
-              {...momentFormatter('YYYY/MM/DD')}
+              {...dateInputFormatter}
               popoverProps={{ position: Position.BOTTOM_LEFT, minimal: true }}
               fill
               fastField

--- a/packages/webapp/src/containers/FinancialStatements/VendorsBalanceSummary/VendorsBalanceSummaryHeaderGeneralContent.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/VendorsBalanceSummary/VendorsBalanceSummaryHeaderGeneralContent.tsx
@@ -13,18 +13,15 @@ import {
   FFormGroup,
   VendorsMultiSelect,
 } from '@/components';
-import {
-  momentFormatter,
-  tansformDateValue,
-  inputIntent,
-  handleDateChange,
-} from '@/utils';
+import { useDateInputFormatter } from '@/hooks';
+import { tansformDateValue, inputIntent, handleDateChange } from '@/utils';
 
 /**
  * Vendors balance header - General panel - Content.
  */
 export function VendorsBalanceSummaryHeaderGeneralContent() {
   const { vendors } = useVendorsBalanceSummaryGeneralPanelContext();
+  const dateInputFormatter = useDateInputFormatter();
 
   return (
     <div>
@@ -42,7 +39,7 @@ export function VendorsBalanceSummaryHeaderGeneralContent() {
             }) => (
               <FormGroup label={intl.get('as_date')} labelInfo={<FieldHint />}>
                 <DateInput
-                  {...momentFormatter('YYYY/MM/DD')}
+                  {...dateInputFormatter}
                   value={tansformDateValue(value)}
                   onChange={handleDateChange((selectedDate: Date) => {
                     form.setFieldValue('asDate', selectedDate);

--- a/packages/webapp/src/containers/PaymentLink/dialogs/SharePaymentLinkDialog/SharePaymentLinkFormContent.tsx
+++ b/packages/webapp/src/containers/PaymentLink/dialogs/SharePaymentLinkDialog/SharePaymentLinkFormContent.tsx
@@ -21,6 +21,7 @@ import {
   Stack,
 } from '@/components';
 import { useDialogContext } from '@/components/Dialog/DialogProvider';
+import { useDateInputFormatter } from '@/hooks';
 import { useDialogActions } from '@/hooks/state';
 import { useClipboard } from '@/hooks/utils/useClipboard';
 
@@ -31,6 +32,7 @@ export function SharePaymentLinkFormContent() {
   const { isSubmitting } = useFormikContext();
 
   const clipboard = useClipboard();
+  const dateInputFormatter = useDateInputFormatter();
 
   const handleCopyBtnClick = () => {
     clipboard.copy(url);
@@ -84,8 +86,7 @@ export function SharePaymentLinkFormContent() {
             <FDateInput
               name={'expiryDate'}
               popoverProps={{ position: Position.BOTTOM, minimal: true }}
-              formatDate={(date) => date.toLocaleDateString()}
-              parseDate={(str) => new Date(str)}
+              {...dateInputFormatter}
               inputProps={{
                 fill: true,
                 style: { minWidth: 260 },

--- a/packages/webapp/src/containers/Projects/containers/ProjectBillableEntriesFormDialog/ProjectBillableEntriesFormFields.tsx
+++ b/packages/webapp/src/containers/Projects/containers/ProjectBillableEntriesFormDialog/ProjectBillableEntriesFormFields.tsx
@@ -16,12 +16,8 @@ import {
   FieldRequiredHint,
 } from '@/components';
 import { CLASSES } from '@/constants/classes';
-import {
-  inputIntent,
-  momentFormatter,
-  tansformDateValue,
-  handleDateChange,
-} from '@/utils';
+import { useDateInputFormatter } from '@/hooks';
+import { inputIntent, tansformDateValue, handleDateChange } from '@/utils';
 
 /**
  * Project billable entries form fields.
@@ -32,6 +28,7 @@ export function ProjectBillableEntriesFormFields() {
   const { values } = useFormikContext();
 
   const { billableEntries } = useProjectBillableEntriesFormContext();
+  const dateInputFormatter = useDateInputFormatter();
 
   return (
     <div className={Classes.DIALOG_BODY}>
@@ -43,9 +40,8 @@ export function ProjectBillableEntriesFormFields() {
         className={classNames(CLASSES.FILL, 'form-group--date')}
       >
         <FDateInput
-          {...momentFormatter('YYYY/MM/DD')}
+          {...dateInputFormatter}
           name="date"
-          formatDate={(date) => date.toLocaleString()}
           popoverProps={{
             position: Position.BOTTOM,
             minimal: true,

--- a/packages/webapp/src/containers/Projects/containers/ProjectExpenseForm/ProjectExpenseFormFields.tsx
+++ b/packages/webapp/src/containers/Projects/containers/ProjectExpenseForm/ProjectExpenseFormFields.tsx
@@ -19,13 +19,15 @@ import {
   FormattedMessage as T,
 } from '@/components';
 import { CLASSES } from '@/constants/classes';
-import { momentFormatter } from '@/utils';
+import { useDateInputFormatter } from '@/hooks';
 
 /**
  * Project expense form fields.
  * @returns
  */
 export function ProjectExpenseFormFields() {
+  const dateInputFormatter = useDateInputFormatter();
+
   return (
     <div className={Classes.DIALOG_BODY}>
       {/*------------ Expense Name -----------*/}
@@ -55,9 +57,8 @@ export function ProjectExpenseFormFields() {
         className={classNames(CLASSES.FILL, 'form-group--date')}
       >
         <FDateInput
-          {...momentFormatter('YYYY/MM/DD')}
+          {...dateInputFormatter}
           name="expemseDate"
-          formatDate={(date) => date.toLocaleString()}
           popoverProps={{
             position: Position.BOTTOM,
             minimal: true,

--- a/packages/webapp/src/containers/Projects/containers/ProjectFormDialog/ProjectFormFields.tsx
+++ b/packages/webapp/src/containers/Projects/containers/ProjectFormDialog/ProjectFormFields.tsx
@@ -17,7 +17,7 @@ import {
   CustomersSelect,
 } from '@/components';
 import { CLASSES } from '@/constants/classes';
-import { momentFormatter } from '@/utils';
+import { useDateInputFormatter } from '@/hooks';
 
 /**
  * Project form fields.
@@ -26,6 +26,7 @@ import { momentFormatter } from '@/utils';
 export function ProjectFormFields() {
   // Formik context.
   const { values } = useFormikContext();
+  const dateInputFormatter = useDateInputFormatter();
 
   return (
     <div className={Classes.DIALOG_BODY}>
@@ -49,9 +50,8 @@ export function ProjectFormFields() {
             className={classNames(CLASSES.FILL, 'form-group--date')}
           >
             <FDateInput
-              {...momentFormatter('YYYY/MM/DD')}
+              {...dateInputFormatter}
               name="deadline"
-              formatDate={(date) => date.toLocaleString()}
               popoverProps={{
                 position: Position.BOTTOM,
                 minimal: true,

--- a/packages/webapp/src/containers/Projects/containers/ProjectInvoicingFormDialog/ProjectInvoicingFormFields.tsx
+++ b/packages/webapp/src/containers/Projects/containers/ProjectInvoicingFormDialog/ProjectInvoicingFormFields.tsx
@@ -10,13 +10,15 @@ import {
   FieldRequiredHint,
 } from '@/components';
 import { CLASSES } from '@/constants/classes';
-import { momentFormatter } from '@/utils';
+import { useDateInputFormatter } from '@/hooks';
 
 /**
  * Project invoicing form fields.
  * @returns
  */
 export function ProjectInvoicingFormFields() {
+  const dateInputFormatter = useDateInputFormatter();
+
   return (
     <div className={Classes.DIALOG_BODY}>
       {/*------------ Date -----------*/}
@@ -26,9 +28,8 @@ export function ProjectInvoicingFormFields() {
         className={classNames(CLASSES.FILL, 'form-group--date')}
       >
         <FDateInput
-          {...momentFormatter('YYYY/MM/DD')}
+          {...dateInputFormatter}
           name="date"
-          formatDate={(date) => date.toLocaleString()}
           popoverProps={{
             position: Position.BOTTOM,
             minimal: true,

--- a/packages/webapp/src/containers/Projects/containers/ProjectTimeEntryFormDialog/ProjectTimeEntryFormFields.tsx
+++ b/packages/webapp/src/containers/Projects/containers/ProjectTimeEntryFormDialog/ProjectTimeEntryFormFields.tsx
@@ -21,7 +21,7 @@ import {
   Stack,
 } from '@/components';
 import { CLASSES } from '@/constants/classes';
-import { momentFormatter } from '@/utils';
+import { useDateInputFormatter } from '@/hooks';
 
 /**
  * Project time entry form fields.
@@ -34,6 +34,7 @@ export function ProjectTimeEntryFormFields() {
 
   // Sets the project id.
   useSetProjectToForm();
+  const dateInputFormatter = useDateInputFormatter();
 
   return (
     <div className={Classes.DIALOG_BODY}>
@@ -45,9 +46,8 @@ export function ProjectTimeEntryFormFields() {
           className={classNames(CLASSES.FILL, 'form-group--date')}
         >
           <FDateInput
-            {...momentFormatter('YYYY/MM/DD')}
+            {...dateInputFormatter}
             name="date"
-            formatDate={(date) => date.toLocaleString()}
             popoverProps={{
               position: Position.BOTTOM,
               minimal: true,

--- a/packages/webapp/src/containers/Purchases/Bills/BillForm/BillFormHeaderFields.tsx
+++ b/packages/webapp/src/containers/Purchases/Bills/BillForm/BillFormHeaderFields.tsx
@@ -27,7 +27,8 @@ import { Features } from '@/constants';
 import { CLASSES } from '@/constants/classes';
 import { withDialogActions } from '@/containers/Dialog/withDialogActions';
 import { ProjectsSelect } from '@/containers/Projects/components';
-import { momentFormatter, compose } from '@/utils';
+import { useDateInputFormatter } from '@/hooks';
+import { compose } from '@/utils';
 
 const getBillFieldsStyle = (theme: Theme) => css`
   .${theme.bpPrefix}-form-group {
@@ -55,6 +56,7 @@ function BillFormHeader() {
 
   const theme = useTheme();
   const billFieldsClassName = getBillFieldsStyle(theme);
+  const dateInputFormatter = useDateInputFormatter();
 
   return (
     <Stack spacing={18} flex={1} className={billFieldsClassName}>
@@ -77,7 +79,7 @@ function BillFormHeader() {
       >
         <FDateInput
           name={'billDate'}
-          {...momentFormatter('YYYY/MM/DD')}
+          {...dateInputFormatter}
           popoverProps={{ position: Position.BOTTOM, minimal: true }}
           inputProps={{ leftIcon: <Icon icon={'date-range'} /> }}
           fill
@@ -94,7 +96,7 @@ function BillFormHeader() {
       >
         <FDateInput
           name={'dueDate'}
-          {...momentFormatter('YYYY/MM/DD')}
+          {...dateInputFormatter}
           popoverProps={{ position: Position.BOTTOM, minimal: true }}
           inputProps={{
             leftIcon: <Icon icon={'date-range'} />,

--- a/packages/webapp/src/containers/Purchases/CreditNotes/CreditNoteForm/VendorCreditNoteFormHeaderFields.tsx
+++ b/packages/webapp/src/containers/Purchases/CreditNotes/CreditNoteForm/VendorCreditNoteFormHeaderFields.tsx
@@ -26,7 +26,8 @@ import {
   FInputGroup,
 } from '@/components';
 import { withDialogActions } from '@/containers/Dialog/withDialogActions';
-import { momentFormatter, compose } from '@/utils';
+import { useDateInputFormatter } from '@/hooks';
+import { compose } from '@/utils';
 
 const getFieldsStyle = (theme: Theme & { bpPrefix?: string }) => css`
   .${theme.bpPrefix}-form-group {
@@ -56,6 +57,7 @@ function VendorCreditNoteFormHeaderFieldsInner({
 }: VendorCreditNoteFormHeaderFieldsInnerProps) {
   const theme = useTheme();
   const fieldsClassName = getFieldsStyle(theme);
+  const dateInputFormatter = useDateInputFormatter();
   const { values } = useFormikContext<VendorCreditFormValues>();
   const { vendorCreditSettings } = useVendorCreditNoteFormContext();
   const vendorcreditAutoIncrement = vendorCreditSettings?.autoIncrement as
@@ -115,7 +117,7 @@ function VendorCreditNoteFormHeaderFieldsInner({
       >
         <FDateInput
           name={'vendorCreditDate'}
-          {...momentFormatter('YYYY/MM/DD')}
+          {...dateInputFormatter}
           popoverProps={{ position: Position.BOTTOM_LEFT, minimal: true }}
           inputProps={{ leftIcon: <Icon icon={'date-range'} />, fill: true }}
           fill

--- a/packages/webapp/src/containers/Purchases/PaymentsMade/PaymentForm/PaymentMadeFormHeaderFields.tsx
+++ b/packages/webapp/src/containers/Purchases/PaymentsMade/PaymentForm/PaymentMadeFormHeaderFields.tsx
@@ -35,8 +35,9 @@ import {
   VendorsSelect,
 } from '@/components';
 import { ACCOUNT_TYPE } from '@/constants/accountTypes';
+import { useDateInputFormatter } from '@/hooks';
 import { useCurrentOrganizationBaseCurrency } from '@/hooks/query';
-import { momentFormatter, safeSumBy } from '@/utils';
+import { safeSumBy } from '@/utils';
 
 type VendorContact = {
   id: string | number;
@@ -72,6 +73,7 @@ function PaymentMadeFormHeaderFieldsInner() {
   } = useFormikContext<PaymentMadeFormValues>();
 
   const theme = useTheme() as Theme;
+  const dateInputFormatter = useDateInputFormatter();
   const fieldsClassName = getFieldsStyle(theme);
 
   const { accounts } = usePaymentMadeFormContext();
@@ -115,7 +117,7 @@ function PaymentMadeFormHeaderFieldsInner() {
       >
         <FDateInput
           name={'paymentDate'}
-          {...momentFormatter('YYYY/MM/DD')}
+          {...dateInputFormatter}
           popoverProps={{ position: Position.BOTTOM, minimal: true }}
           inputProps={{ leftIcon: <Icon icon={'date-range'} /> }}
           fill

--- a/packages/webapp/src/containers/Sales/CreditNotes/CreditNoteForm/CreditNoteFormHeaderFields.tsx
+++ b/packages/webapp/src/containers/Sales/CreditNotes/CreditNoteForm/CreditNoteFormHeaderFields.tsx
@@ -24,6 +24,7 @@ import {
 } from '@/components';
 import { CLASSES } from '@/constants/classes';
 import { useCustomerUpdateExRate } from '@/containers/Entries/withExRateItemEntriesPriceRecalc';
+import { useDateInputFormatter } from '@/hooks';
 
 const getCreditNoteFieldsStyle = (theme: Theme & { bpPrefix?: string }) => css`
   .${theme.bpPrefix}-form-group {
@@ -47,6 +48,7 @@ const getCreditNoteFieldsStyle = (theme: Theme & { bpPrefix?: string }) => css`
 export function CreditNoteFormHeaderFields() {
   const theme = useTheme();
   const styleClassName = getCreditNoteFieldsStyle(theme);
+  const dateInputFormatter = useDateInputFormatter();
 
   return (
     <Stack spacing={18} flex={1} className={styleClassName}>
@@ -66,8 +68,7 @@ export function CreditNoteFormHeaderFields() {
       >
         <FDateInput
           name={'creditNoteDate'}
-          formatDate={(date) => date.toLocaleDateString()}
-          parseDate={(str) => new Date(str)}
+          {...dateInputFormatter}
           popoverProps={{ position: Position.BOTTOM_LEFT, minimal: true }}
           inputProps={{
             leftIcon: <Icon icon={'date-range'} />,

--- a/packages/webapp/src/containers/Sales/Estimates/EstimateForm/EstimateFormHeaderFields.tsx
+++ b/packages/webapp/src/containers/Sales/Estimates/EstimateForm/EstimateFormHeaderFields.tsx
@@ -29,6 +29,7 @@ import {
 import { Features } from '@/constants';
 import { useCustomerUpdateExRate } from '@/containers/Entries/withExRateItemEntriesPriceRecalc';
 import { ProjectsSelect } from '@/containers/Projects/components';
+import { useDateInputFormatter } from '@/hooks';
 
 const getEstimateFieldsStyle = (theme: Theme) => css`
   .${theme.bpPrefix}-form-group {
@@ -56,6 +57,7 @@ export function EstimateFormHeader() {
   const theme = useTheme();
   const { projects } = useEstimateFormContext();
   const styleClassName = getEstimateFieldsStyle(theme);
+  const dateInputFormatter = useDateInputFormatter();
 
   return (
     <Stack spacing={18} flex={1} className={styleClassName}>
@@ -75,8 +77,7 @@ export function EstimateFormHeader() {
       >
         <FDateInput
           name={'estimateDate'}
-          formatDate={(date: Date) => date.toLocaleDateString()}
-          parseDate={(str: string) => new Date(str)}
+          {...dateInputFormatter}
           popoverProps={{ position: Position.BOTTOM_LEFT, minimal: true }}
           inputProps={{
             leftIcon: <Icon icon={'date-range'} />,
@@ -96,8 +97,7 @@ export function EstimateFormHeader() {
       >
         <FDateInput
           name={'expirationDate'}
-          formatDate={(date: Date) => date.toLocaleDateString()}
-          parseDate={(str: string) => new Date(str)}
+          {...dateInputFormatter}
           popoverProps={{ position: Position.BOTTOM_LEFT, minimal: true }}
           inputProps={{
             leftIcon: <Icon icon={'date-range'} />,

--- a/packages/webapp/src/containers/Sales/Invoices/InvoiceForm/InvoiceFormHeaderFields.tsx
+++ b/packages/webapp/src/containers/Sales/Invoices/InvoiceForm/InvoiceFormHeaderFields.tsx
@@ -32,6 +32,7 @@ import {
   ProjectsSelect,
   ProjectBillableEntriesLink,
 } from '@/containers/Projects/components';
+import { useDateInputFormatter } from '@/hooks';
 
 const getInvoiceFieldsStyle = (theme: Theme & { bpPrefix?: string }) => css`
   .${theme.bpPrefix}-form-group {
@@ -58,6 +59,7 @@ export function InvoiceFormHeaderFields() {
   const { projects } = useInvoiceFormContext();
   const { values } = useFormikContext<InvoiceFormValues>();
   const invoiceFieldsClassName = getInvoiceFieldsStyle(theme);
+  const dateInputFormatter = useDateInputFormatter();
 
   return (
     <Stack spacing={18} flex={1} className={invoiceFieldsClassName}>
@@ -77,8 +79,7 @@ export function InvoiceFormHeaderFields() {
       >
         <FDateInput
           name={'invoiceDate'}
-          formatDate={(date) => date.toLocaleDateString()}
-          parseDate={(str) => new Date(str)}
+          {...dateInputFormatter}
           popoverProps={{
             position: Position.BOTTOM_LEFT,
             minimal: true,
@@ -102,8 +103,7 @@ export function InvoiceFormHeaderFields() {
       >
         <FDateInput
           name={'dueDate'}
-          formatDate={(date) => date.toLocaleDateString()}
-          parseDate={(str) => new Date(str)}
+          {...dateInputFormatter}
           popoverProps={{
             position: Position.BOTTOM_LEFT,
             minimal: true,

--- a/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentReceiveForm/PaymentReceiveHeaderFields.tsx
+++ b/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentReceiveForm/PaymentReceiveHeaderFields.tsx
@@ -43,6 +43,7 @@ import {
 import { Features } from '@/constants';
 import { ACCOUNT_TYPE } from '@/constants/accountTypes';
 import { ProjectsSelect } from '@/containers/Projects/components';
+import { useDateInputFormatter } from '@/hooks';
 import { safeSumBy } from '@/utils';
 
 const getHeaderFieldsStyle = (theme: Theme) => css`
@@ -67,6 +68,7 @@ const getHeaderFieldsStyle = (theme: Theme) => css`
 export function PaymentReceiveHeaderFields() {
   const theme = useTheme() as Theme;
   const styleClassName = getHeaderFieldsStyle(theme);
+  const dateInputFormatter = useDateInputFormatter();
 
   const { accounts, projects } = usePaymentReceiveFormContext();
 
@@ -112,8 +114,7 @@ export function PaymentReceiveHeaderFields() {
       >
         <FDateInput
           name={'paymentDate'}
-          formatDate={(date: Date) => date.toLocaleDateString()}
-          parseDate={(str: string) => new Date(str)}
+          {...dateInputFormatter}
           popoverProps={{ position: Position.BOTTOM_LEFT, minimal: true }}
           inputProps={{
             leftIcon: <Icon icon={'date-range'} />,

--- a/packages/webapp/src/containers/Sales/Receipts/ReceiptForm/ReceiptFormHeaderFields.tsx
+++ b/packages/webapp/src/containers/Sales/Receipts/ReceiptForm/ReceiptFormHeaderFields.tsx
@@ -31,6 +31,7 @@ import { Features } from '@/constants';
 import { ACCOUNT_TYPE } from '@/constants/accountTypes';
 import { useCustomerUpdateExRate } from '@/containers/Entries/withExRateItemEntriesPriceRecalc';
 import { ProjectsSelect } from '@/containers/Projects/components';
+import { useDateInputFormatter } from '@/hooks';
 
 const getEstimateFieldsStyle = (theme: Theme & { bpPrefix?: string }) => css`
   .${theme.bpPrefix}-form-group {
@@ -56,6 +57,7 @@ export function ReceiptFormHeader() {
   const theme = useTheme();
   const receiptFieldsClassName = getEstimateFieldsStyle(theme);
   const { accounts, projects } = useReceiptFormContext();
+  const dateInputFormatter = useDateInputFormatter();
 
   return (
     <Stack spacing={18} flex={1} className={receiptFieldsClassName}>
@@ -97,8 +99,7 @@ export function ReceiptFormHeader() {
       >
         <FDateInput
           name={'receiptDate'}
-          formatDate={(date) => date.toLocaleDateString()}
-          parseDate={(str) => new Date(str)}
+          {...dateInputFormatter}
           popoverProps={{ position: Position.BOTTOM_LEFT, minimal: true }}
           inputProps={{
             leftIcon: <Icon icon={'date-range'} />,

--- a/packages/webapp/src/containers/Vendors/VendorForm/VendorFinanicalPanelTab.tsx
+++ b/packages/webapp/src/containers/Vendors/VendorForm/VendorFinanicalPanelTab.tsx
@@ -21,6 +21,7 @@ import {
   FDateInput,
 } from '@/components';
 import { Features } from '@/constants';
+import { useDateInputFormatter } from '@/hooks';
 import { useCurrentOrganizationBaseCurrency } from '@/hooks/query';
 
 /**
@@ -114,6 +115,7 @@ function VendorOpeningBalanceField() {
  */
 function VendorOpeningBalanceAtField() {
   const { vendorId } = useVendorFormContext();
+  const dateInputFormatter = useDateInputFormatter();
 
   // Cannot continue if the vendor id is defined.
   if (vendorId) return null;
@@ -130,8 +132,7 @@ function VendorOpeningBalanceAtField() {
         name={'openingBalanceAt'}
         popoverProps={{ position: Position.BOTTOM, minimal: true }}
         disabled={Boolean(vendorId)}
-        formatDate={(date: Date) => date.toLocaleDateString()}
-        parseDate={(str: string) => new Date(str)}
+        {...dateInputFormatter}
         fill
         fastField
       />

--- a/packages/webapp/src/containers/Vendors/VendorForm/VendorFormFinancialSection.tsx
+++ b/packages/webapp/src/containers/Vendors/VendorForm/VendorFormFinancialSection.tsx
@@ -23,6 +23,7 @@ import {
   Box,
 } from '@/components';
 import { Features } from '@/constants';
+import { useDateInputFormatter } from '@/hooks';
 import { useCurrentOrganizationBaseCurrency } from '@/hooks/query';
 
 export function VendorFormFinancialSection() {
@@ -77,6 +78,7 @@ export function VendorFormFinancialSection() {
  */
 function VendorOpeningBalanceAtField() {
   const { vendorId } = useVendorFormContext();
+  const dateInputFormatter = useDateInputFormatter();
 
   // Cannot continue if the vendor id is defined.
   if (vendorId) return null;
@@ -92,8 +94,7 @@ function VendorOpeningBalanceAtField() {
         name={'openingBalanceAt'}
         popoverProps={{ position: Position.BOTTOM, minimal: true }}
         disabled={Boolean(vendorId)}
-        formatDate={(date: Date) => date.toLocaleDateString()}
-        parseDate={(str: string) => new Date(str)}
+        {...dateInputFormatter}
         inputProps={{
           leftIcon: <Icon icon={'date-range'} />,
         }}

--- a/packages/webapp/src/containers/WarehouseTransfers/WarehouseTransferForm/WarehouseTransferFormHeaderFields.tsx
+++ b/packages/webapp/src/containers/WarehouseTransfers/WarehouseTransferForm/WarehouseTransferFormHeaderFields.tsx
@@ -17,7 +17,8 @@ import { FieldRequiredHint, Icon, InputPrependButton } from '@/components';
 import { CLASSES } from '@/constants/classes';
 import { withDialogActions } from '@/containers/Dialog/withDialogActions';
 import type { WithDialogActionsProps } from '@/containers/Dialog/withDialogActions';
-import { momentFormatter, compose } from '@/utils';
+import { useDateInputFormatter } from '@/hooks';
+import { compose } from '@/utils';
 
 /** Blueprint FormGroup/InputGroup support `fastField`/`asyncControl`; package typings omit them. */
 interface FFormGroupFieldProps {
@@ -93,6 +94,8 @@ function WarehouseTransferFormHeaderFieldsInner({
     Number(warehouseTransferNextNumber ?? 0),
   );
 
+  const dateInputFormatter = useDateInputFormatter();
+
   return (
     <div className={classNames(CLASSES.PAGE_FORM_HEADER_FIELDS)}>
       {/* ----------- Date ----------- */}
@@ -106,7 +109,7 @@ function WarehouseTransferFormHeaderFieldsInner({
       >
         <FDateInput
           name={'date'}
-          {...momentFormatter('YYYY/MM/DD')}
+          {...dateInputFormatter}
           popoverProps={{ position: Position.BOTTOM_LEFT, minimal: true }}
           inputProps={{
             leftIcon: <Icon icon={'date-range'} />,

--- a/packages/webapp/src/hooks/index.tsx
+++ b/packages/webapp/src/hooks/index.tsx
@@ -5,6 +5,7 @@ import type { RefObject } from 'react';
 
 export * from './utils';
 export * from './useQueryString';
+export * from './useDateInputFormatter';
 
 export function useIsValuePassed<T>(value: T, compatatorValue: T) {
   const cache = useRef<T[]>([value]);

--- a/packages/webapp/src/hooks/useDateInputFormatter.ts
+++ b/packages/webapp/src/hooks/useDateInputFormatter.ts
@@ -1,0 +1,16 @@
+import { useMemo } from 'react';
+import { useCurrentOrganizationMetadata } from '@/hooks/query';
+import { momentFormatter } from '@/utils';
+
+const DEFAULT_DATE_FORMAT = 'DD MMM YYYY';
+
+/**
+ * Returns the formatter props (`formatDate`, `parseDate`, `placeholder`) for
+ * date inputs based on the current organization's configured date format.
+ */
+export function useDateInputFormatter() {
+  const metadata = useCurrentOrganizationMetadata();
+  const dateFormat = metadata?.dateFormat ?? DEFAULT_DATE_FORMAT;
+
+  return useMemo(() => momentFormatter(dateFormat), [dateFormat]);
+}


### PR DESCRIPTION
## Description

Date inputs across the web app ignore the organization's configured date format (Preferences > General > Date Format), hard-coding formats via `momentFormatter('YYYY/MM/DD')` spreads or inline `toLocaleDateString()`/`new Date(str)` pairs.

This PR introduces a new `useDateInputFormatter` hook that derives the `formatDate`/`parseDate`/`placeholder` props from the current organization's `dateFormat` (falls back to the server default `DD MMM YYYY` while metadata loads) and applies it to every `<DateInput>`/`<FDateInput>` in the app (~58 usages across 52 files).

The onboarding/setup pages are intentionally left untouched since the organization's date format is not defined yet at that point.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Ran `yarn typecheck` (`tsc --noEmit`) on `packages/webapp` — no new type errors introduced (53 errors before and after, all pre-existing).
- Ran ESLint on all changed files — no new errors or warnings introduced; one pre-existing unused-`momentFormatter` warning was removed.
- Diffed lint/typecheck output against the pristine baseline to confirm the change set is clean.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>