### PR TITLE
feat(server): auto-update webapp and server containers via watchtower

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -123,6 +123,6 @@ STRIPE_PAYMENT_WEBHOOKS_SECRET=
 # Replace example.com with the correct domain
 STRIPE_PAYMENT_REDIRECT_URL=https://example.com/preferences/payment-methods/stripe/callback
 
-# Auto-update (watchtower) poll interval in seconds.
+# Auto-update (watchtower) poll interval; must be a positive number of seconds.
 # To disable auto-update, comment out the auto-update service in docker-compose.prod.yml.
 AUTO_UPDATE_INTERVAL=3600

--- a/.env.example
+++ b/.env.example
@@ -122,3 +122,6 @@ STRIPE_PAYMENT_CLIENT_ID=
 STRIPE_PAYMENT_WEBHOOKS_SECRET=
 # Replace example.com with the correct domain
 STRIPE_PAYMENT_REDIRECT_URL=https://example.com/preferences/payment-methods/stripe/callback
+
+# Auto-update (watchtower) poll interval in seconds. 0 disables auto-update.
+AUTO_UPDATE_INTERVAL=3600

--- a/.env.example
+++ b/.env.example
@@ -123,5 +123,6 @@ STRIPE_PAYMENT_WEBHOOKS_SECRET=
 # Replace example.com with the correct domain
 STRIPE_PAYMENT_REDIRECT_URL=https://example.com/preferences/payment-methods/stripe/callback
 
-# Auto-update (watchtower) poll interval in seconds. 0 disables auto-update.
+# Auto-update (watchtower) poll interval in seconds.
+# To disable auto-update, comment out the auto-update service in docker-compose.prod.yml.
 AUTO_UPDATE_INTERVAL=3600

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -23,7 +23,7 @@ services:
     image: bigcapitalhq/webapp:latest
     restart: on-failure
     labels:
-      - "bigcapital.auto-update=true"
+      - "com.centurylinklabs.watchtower.enable=true"
     networks:
       - bigcapital_network
 
@@ -41,7 +41,7 @@ services:
       - garage
     restart: on-failure
     labels:
-      - "bigcapital.auto-update=true"
+      - "com.centurylinklabs.watchtower.enable=true"
     networks:
       - bigcapital_network
     environment:
@@ -206,15 +206,15 @@ services:
     networks:
       - bigcapital_network
 
-  # Auto-updates the containers labelled "bigcapital.auto-update=true"
+  # Auto-updates the containers labelled "com.centurylinklabs.watchtower.enable=true"
   # (webapp and server) by polling the registry for newer :latest images.
   # Everything else (mysql, redis, gotenberg, proxy) is untouched.
   auto-update:
     container_name: bigcapital-auto-update
-    image: containrrr/watchtower
+    image: containrrr/watchtower:1.7.1
     restart: on-failure
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+      - /var/run/docker.sock:/var/run/docker.sock:ro
     command: --label-enable --cleanup --interval ${AUTO_UPDATE_INTERVAL:-3600}
     networks:
       - bigcapital_network

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -22,6 +22,8 @@ services:
     container_name: bigcapital-webapp
     image: bigcapitalhq/webapp:latest
     restart: on-failure
+    labels:
+      - "bigcapital.auto-update=true"
     networks:
       - bigcapital_network
 
@@ -38,6 +40,8 @@ services:
       - redis
       - garage
     restart: on-failure
+    labels:
+      - "bigcapital.auto-update=true"
     networks:
       - bigcapital_network
     environment:
@@ -199,6 +203,19 @@ services:
     expose:
       - '3900'
       - '3903'
+    networks:
+      - bigcapital_network
+
+  # Auto-updates the containers labelled "bigcapital.auto-update=true"
+  # (webapp and server) by polling the registry for newer :latest images.
+  # Everything else (mysql, redis, gotenberg, proxy) is untouched.
+  auto-update:
+    container_name: bigcapital-auto-update
+    image: containrrr/watchtower
+    restart: on-failure
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: --label-enable --cleanup --interval ${AUTO_UPDATE_INTERVAL:-3600}
     networks:
       - bigcapital_network
 


### PR DESCRIPTION
Closes #495.

## What

Adds a [watchtower](https://github.com/containrrr/watchtower) sidecar to `docker-compose.prod.yml` that auto-updates the `webapp` and `server` containers from their `:latest` images.

## How it stays safe

- **Label-enable scoping**: Watchtower runs with `--label-enable`, and only `webapp` and `server` carry `com.centurylinklabs.watchtower.enable=true`. All other services are unlabelled and therefore excluded.
- **Configurable cadence**: `--interval ${AUTO_UPDATE_INTERVAL:-3600}` uses an hourly default. `AUTO_UPDATE_INTERVAL` must be a positive number of seconds; to disable auto-update, comment out the `auto-update` service as documented in `.env.example`.
- **Pinned sidecar**: `containrrr/watchtower:1.7.1` is used explicitly, the Docker socket is mounted read-only, and `--cleanup` removes dangling old images after an update.

## Verification note

Docker is not available in the environment this was prepared in, so the compose file could not be run end-to-end here. What was verified: YAML parses cleanly; the label-enabled set is exactly {webapp, server}; the watchtower service carries image/volumes/command/restart; watchtower's flag set (`--label-enable`, `--cleanup`, `--interval <seconds>`) matches its documented CLI. The pre-commit format hook fails in this environment for unrelated reasons (corepack pnpm version drift tries to purge node_modules without a TTY); no formatted file types (only .yml and .env.example) are touched.
