### PR TITLE
fix(server): apply item filters and date range in inventory valuation sheet

### DIFF
--- a/packages/server/src/modules/FinancialStatements/modules/InventoryValuationSheet/InventoryValuationSheet.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/InventoryValuationSheet/InventoryValuationSheet.ts
@@ -224,7 +224,12 @@ export class InventoryValuationSheet extends FinancialSheet {
    * Detarmines whether the items post filter is active.
    */
   private isItemsPostFilter = (): boolean => {
-    return !isEmpty(this.query.itemsIds);
+    return (
+      !isEmpty(this.query.itemsIds) ||
+      this.query.noneZero ||
+      this.query.noneTransactions ||
+      this.query.onlyActive
+    );
   };
 
   /**

--- a/packages/server/src/modules/FinancialStatements/modules/InventoryValuationSheet/InventoryValuationSheetRepository.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/InventoryValuationSheet/InventoryValuationSheetRepository.ts
@@ -118,6 +118,9 @@ export class InventoryValuationSheetRepository {
       builder.select('itemId');
       builder.groupBy('itemId');
 
+      if (this.filter.asDate) {
+        builder.modify('filterDateRange', null, this.filter.asDate);
+      }
       if (!isEmpty(this.filter.branchesIds)) {
         builder.modify('filterByBranches', this.filter.branchesIds);
       }


### PR DESCRIPTION
## Description

This pull request fixes filtering behavior in the Inventory Valuation Sheet financial statement.

Two issues are addressed:

1. **Post-filter activation**: The items post-filtering logic was only triggered when specific `itemsIds` were provided. The `noneZero`, `noneTransactions`, and `onlyActive` query flags were not taken into account, so the sheet did not respect these filters. The check now also activates the post-filter when any of these flags is set.

2. **Date range filtering**: When an `asDate` filter was provided, the item-id selection query did not apply the date range scope, so items could be included or excluded incorrectly. The date range filter modifier is now applied when an `asDate` is present.

These changes ensure the Inventory Valuation Sheet correctly applies active item, non-zero, and non-transaction filters along with the as-of date when determining which items are included.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Manually verified the Inventory Valuation Sheet report with combinations of the item filters (`noneZero`, `noneTransactions`, `onlyActive`) and the as-of date to confirm the item list is filtered as expected. No automated tests were added for these server changes.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>
