### PR TITLE
fix: auto-fetch exchange rate when selecting a foreign customer

### DIFF
--- a/packages/server/src/modules/ExchangeRates/ExchangeRates.application.ts
+++ b/packages/server/src/modules/ExchangeRates/ExchangeRates.application.ts
@@ -11,14 +11,12 @@ export class ExchangeRateApplication {
 
   /**
    * Gets the latest exchange rate.
-   * @param {number} tenantId
    * @param {ExchangeRateLatestDTO} exchangeRateLatestDTO
    * @returns {Promise<EchangeRateLatestPOJO>}
    */
   public latest(
-    tenantId: number,
     exchangeRateLatestDTO: ExchangeRateLatestDTO,
   ): Promise<EchangeRateLatestPOJO> {
-    return this.exchangeRateService.latest(tenantId, exchangeRateLatestDTO);
+    return this.exchangeRateService.latest(exchangeRateLatestDTO);
   }
 }

--- a/packages/server/src/modules/ExchangeRates/ExchangeRates.controller.ts
+++ b/packages/server/src/modules/ExchangeRates/ExchangeRates.controller.ts
@@ -2,19 +2,13 @@ import {
   Controller,
   Get,
   Query,
-  Req,
   UsePipes,
   ValidationPipe,
 } from '@nestjs/common';
-import { Request } from 'express';
 import { ApiOperation, ApiTags, ApiResponse, ApiQuery } from '@nestjs/swagger';
 import { ExchangeRateApplication } from './ExchangeRates.application';
 import { ExchangeRateLatestQueryDto } from './dtos/ExchangeRateLatestQuery.dto';
 import { ExchangeRateLatestResponseDto } from './dtos/ExchangeRateLatestResponse.dto';
-
-interface RequestWithTenantId extends Request {
-  tenantId: number;
-}
 
 @Controller('exchange-rates')
 @ApiTags('Exchange Rates')
@@ -55,11 +49,8 @@ export class ExchangeRatesController {
   })
   async getLatestExchangeRate(
     @Query() query: ExchangeRateLatestQueryDto,
-    @Req() req: RequestWithTenantId,
   ): Promise<ExchangeRateLatestResponseDto> {
-    const tenantId = req.tenantId;
-
-    const exchangeRate = await this.exchangeRateApp.latest(tenantId, {
+    const exchangeRate = await this.exchangeRateApp.latest({
       fromCurrency: query.from_currency,
       toCurrency: query.to_currency,
     });

--- a/packages/server/src/modules/ExchangeRates/ExchangeRates.module.ts
+++ b/packages/server/src/modules/ExchangeRates/ExchangeRates.module.ts
@@ -2,8 +2,10 @@ import { Module } from '@nestjs/common';
 import { ExchangeRatesController } from './ExchangeRates.controller';
 import { ExchangeRatesService } from './ExchangeRates.service';
 import { ExchangeRateApplication } from './ExchangeRates.application';
+import { TenancyModule } from '@/modules/Tenancy/Tenancy.module';
 
 @Module({
+  imports: [TenancyModule],
   providers: [ExchangeRatesService, ExchangeRateApplication],
   controllers: [ExchangeRatesController],
   exports: [ExchangeRatesService, ExchangeRateApplication],

--- a/packages/server/src/modules/ExchangeRates/ExchangeRates.service.ts
+++ b/packages/server/src/modules/ExchangeRates/ExchangeRates.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { ExchangeRate } from './lib/ExchangeRate';
 import { ExchangeRateServiceType } from './lib/types';
-import { TenantMetadata } from '@/modules/System/models/TenantMetadataModel';
+import { TenancyContext } from '@/modules/Tenancy/TenancyContext.service';
 import {
   ExchangeRateLatestDTO,
   EchangeRateLatestPOJO,
@@ -9,24 +9,23 @@ import {
 
 @Injectable()
 export class ExchangeRatesService {
+  constructor(private readonly tenancyContext: TenancyContext) {}
+
   /**
    * Gets the latest exchange rate.
-   * @param {number} tenantId
    * @param {ExchangeRateLatestDTO} exchangeRateLatestDTO
    * @returns {EchangeRateLatestPOJO}
    */
   public async latest(
-    tenantId: number,
     exchangeRateLatestDTO: ExchangeRateLatestDTO,
   ): Promise<EchangeRateLatestPOJO> {
-    const organization = await TenantMetadata.query().findOne({ tenantId });
+    const tenantMetadata = await this.tenancyContext.getTenantMetadata();
 
     // Assign the organization base currency as a default currency
     // if no currency is provided
-    const fromCurrency =
-      exchangeRateLatestDTO.fromCurrency || organization.baseCurrency;
-    const toCurrency =
-      exchangeRateLatestDTO.toCurrency || organization.baseCurrency;
+    const baseCurrency = tenantMetadata?.baseCurrency;
+    const fromCurrency = exchangeRateLatestDTO.fromCurrency || baseCurrency;
+    const toCurrency = exchangeRateLatestDTO.toCurrency || baseCurrency;
 
     const exchange = new ExchangeRate(ExchangeRateServiceType.OpenExchangeRate);
     const exchangeRate = await exchange.latest(fromCurrency, toCurrency);

--- a/packages/webapp/src/containers/Entries/AutoExchangeProvider.tsx
+++ b/packages/webapp/src/containers/Entries/AutoExchangeProvider.tsx
@@ -9,7 +9,7 @@ interface AutoExchangeRateProviderValue {
   autoExRateCurrency: string | null;
   setAutoExRateCurrency: (currency: string | null) => void;
   isAutoExchangeRateLoading: boolean;
-  autoExchangeRate?: { exchange_rate?: number } | null;
+  autoExchangeRate?: { exchangeRate?: number } | null;
 }
 
 const AutoExchangeRateContext =

--- a/packages/webapp/src/containers/Entries/withExRateItemEntriesPriceRecalc.tsx
+++ b/packages/webapp/src/containers/Entries/withExRateItemEntriesPriceRecalc.tsx
@@ -62,7 +62,7 @@ export function withExchangeRateFetchingLoading<P>(
 }
 
 interface CustomerWithCurrency {
-  currency_code: string;
+  currencyCode: string;
 }
 
 /**
@@ -71,7 +71,7 @@ interface CustomerWithCurrency {
  */
 export const useCustomerUpdateExRate = () => {
   const { setFieldValue, values } = useFormikContext<{
-    exchange_rate: number | string;
+    exchangeRate: number | string;
   }>();
   const { setAutoExRateCurrency } = useAutoExRateContext();
 
@@ -86,18 +86,18 @@ export const useCustomerUpdateExRate = () => {
       setAutoExRateCurrency(null);
 
       // If the customer's currency code equals the same base currency.
-      if (customer.currency_code === baseCurrency) {
-        setFieldValue('exchange_rate', DEFAULT_EX_RATE + '');
+      if (customer.currencyCode === baseCurrency) {
+        setFieldValue('exchangeRate', DEFAULT_EX_RATE + '');
         setFieldValue(
           'entries',
           updateEntriesOnExChange(
-            Number(values.exchange_rate),
+            Number(values.exchangeRate),
             DEFAULT_EX_RATE,
           ),
         );
       } else {
         // Sets the currency code to fetch exchange rate of the given currency code.
-        setAutoExRateCurrency(customer?.currency_code);
+        setAutoExRateCurrency(customer?.currencyCode);
       }
     },
     [
@@ -105,7 +105,7 @@ export const useCustomerUpdateExRate = () => {
       setAutoExRateCurrency,
       setFieldValue,
       updateEntriesOnExChange,
-      values.exchange_rate,
+      values.exchangeRate,
     ],
   );
 };
@@ -120,7 +120,7 @@ interface UseSyncExRateToFormProps {
  */
 export const useSyncExRateToForm = ({ onSynced }: UseSyncExRateToFormProps) => {
   const { setFieldValue, values } = useFormikContext<{
-    exchange_rate: number | string;
+    exchangeRate: number | string;
   }>();
   const { autoExRateCurrency, autoExchangeRate, isAutoExchangeRateLoading } =
     useAutoExRateContext();
@@ -131,18 +131,18 @@ export const useSyncExRateToForm = ({ onSynced }: UseSyncExRateToFormProps) => {
     if (!isAutoExchangeRateLoading && autoExRateCurrency) {
       // Sets a default ex. rate to 1 in case the exchange rate service wasn't configured.
       // or returned an error from the server-side.
-      const exchangeRate = autoExchangeRate?.exchange_rate || 1;
+      const exchangeRate = autoExchangeRate?.exchangeRate || 1;
 
-      setFieldValue('exchange_rate', exchangeRate + '');
+      setFieldValue('exchangeRate', exchangeRate + '');
       setFieldValue(
         'entries',
-        updateEntriesOnExChange(Number(values.exchange_rate), exchangeRate),
+        updateEntriesOnExChange(Number(values.exchangeRate), exchangeRate),
       );
       onSynced?.();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
-    autoExchangeRate?.exchange_rate,
+    autoExchangeRate?.exchangeRate,
     autoExRateCurrency,
     isAutoExchangeRateLoading,
   ]);

--- a/packages/webapp/src/containers/Sales/CreditNotes/CreditNoteForm/CreditNoteFormHeaderFields.tsx
+++ b/packages/webapp/src/containers/Sales/CreditNotes/CreditNoteForm/CreditNoteFormHeaderFields.tsx
@@ -103,10 +103,10 @@ function CreditNoteCustomersSelect() {
   // Handles item change.
   const handleItemChange = (customer: {
     id: number;
-    currency_code: string;
+    currencyCode: string;
   }) => {
     setFieldValue('customerId', customer.id);
-    setFieldValue('currencyCode', customer?.currency_code);
+    setFieldValue('currencyCode', customer?.currencyCode);
 
     updateEntries(customer);
   };

--- a/packages/webapp/src/containers/Sales/Estimates/EstimateForm/EstimateFormHeaderFields.tsx
+++ b/packages/webapp/src/containers/Sales/Estimates/EstimateForm/EstimateFormHeaderFields.tsx
@@ -48,7 +48,7 @@ const getEstimateFieldsStyle = (theme: Theme) => css`
   }
 `;
 
-type Customer = { id: number; currency_code: string };
+type Customer = { id: number; currencyCode: string };
 
 /**
  * Estimate form header.
@@ -152,7 +152,7 @@ function EstimateFormCustomerSelect() {
   // Handles the customer item change.
   const handleItemChange = (customer: Customer) => {
     setFieldValue('customerId', customer.id);
-    setFieldValue('currencyCode', customer?.currency_code);
+    setFieldValue('currencyCode', customer?.currencyCode);
 
     updateEntries(customer);
   };

--- a/packages/webapp/src/containers/Sales/Invoices/InvoiceForm/InvoiceFormHeaderFields.tsx
+++ b/packages/webapp/src/containers/Sales/Invoices/InvoiceForm/InvoiceFormHeaderFields.tsx
@@ -169,12 +169,12 @@ function InvoiceFormCustomerSelect() {
   // Handles the customer item change.
   const handleItemChange = (customer: {
     id: number;
-    currency_code: string;
+    currencyCode: string;
   }) => {
     // If the customer id has changed change the customer id and currency code.
     if (values.customerId !== customer.id) {
       setFieldValue('customerId', customer.id);
-      setFieldValue('currencyCode', customer.currency_code);
+      setFieldValue('currencyCode', customer.currencyCode);
     }
     updateEntries(customer);
   };

--- a/packages/webapp/src/containers/Sales/Receipts/ReceiptForm/ReceiptFormHeaderFields.tsx
+++ b/packages/webapp/src/containers/Sales/Receipts/ReceiptForm/ReceiptFormHeaderFields.tsx
@@ -155,10 +155,10 @@ function ReceiptFormCustomerSelect() {
   // Handles the customer item change.
   const handleItemChange = (customer: {
     id: number;
-    currency_code: string;
+    currencyCode: string;
   }) => {
     setFieldValue('customerId', customer.id);
-    setFieldValue('currencyCode', customer?.currency_code);
+    setFieldValue('currencyCode', customer?.currencyCode);
 
     updateEntries(customer);
   };


### PR DESCRIPTION
## Description

Fix the auto exchange-rate feature that failed to populate when a foreign customer is selected on the Sales forms (Invoice, Estimate, Receipt, Credit Note).

Three issues prevented it from working end-to-end:

1. **Webapp — customer currency field mismatch:** customer objects were migrated to camelCase (`currencyCode`), but the selection handlers and `useCustomerUpdateExRate` still read the removed `currency_code`. This passed `undefined` to `setAutoExRateCurrency`, so the exchange-rate request was never triggered.
2. **Webapp — exchange rate field mismatch:** the auto-fetch read the server response as `exchange_rate` and wrote to a form field `exchange_rate`, but both are `exchangeRate` in camelCase, so the fetched value was never applied (always defaulted to 1).
3. **Server — tenant resolution:** `ExchangeRatesController` read `req.tenantId`, which is never set anywhere (tenancy is resolved via `nestjs-cls`/`TenancyContext` from the `organization-id` header). The `exchange-rates/latest` endpoint therefore threw an objection error for an undefined `tenantId`. It now resolves the tenant metadata through `TenancyContext`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Verified `tsc --noEmit` passes for both `packages/server` and `packages/webapp` with no errors in the changed files.
- Manually confirmed the fix path: selecting a foreign customer now triggers `GET /api/exchange-rates/latest?from_currency=XXX`, and the rate populates the form field (or defaults to 1 when the rate service is unavailable).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>
