### PR TITLE
fix(server): skip account code validation for Plaid-synced accounts

### DIFF
--- a/packages/server/src/interfaces/Account.ts
+++ b/packages/server/src/interfaces/Account.ts
@@ -169,4 +169,5 @@ export enum TaxRateAction {
 
 export interface CreateAccountParams {
   ignoreUniqueName: boolean;
+  ignoreAccountCode?: boolean;
 }

--- a/packages/server/src/modules/Accounts/Accounts.types.ts
+++ b/packages/server/src/modules/Accounts/Accounts.types.ts
@@ -89,6 +89,7 @@ export enum TaxRateAction {
 
 export interface CreateAccountParams {
   ignoreUniqueName: boolean;
+  ignoreAccountCode?: boolean;
 }
 
 export interface IGetAccountTransactionPOJO {}

--- a/packages/server/src/modules/Accounts/CreateAccount.service.ts
+++ b/packages/server/src/modules/Accounts/CreateAccount.service.ts
@@ -49,7 +49,7 @@ export class CreateAccountService {
       await this.accountsSettings.getAccountsSettings();
 
     // Validate account code required when setting is enabled.
-    if (accountCodeRequired) {
+    if (accountCodeRequired && !params?.ignoreAccountCode) {
       this.validator.validateAccountCodeRequiredOrThrow(accountDTO.code);
     }
     // Validate the account code uniquiness when setting is enabled.

--- a/packages/server/src/modules/BankingPlaid/command/PlaidSyncDB.ts
+++ b/packages/server/src/modules/BankingPlaid/command/PlaidSyncDB.ts
@@ -67,6 +67,7 @@ export class PlaidSyncDb {
     }
     await this.createAccountService.createAccount(createBankAccountDTO, trx, {
       ignoreUniqueName: true,
+      ignoreAccountCode: true,
     });
   }
 

--- a/packages/webapp/src/containers/Entries/withExRateItemEntriesPriceRecalc.tsx
+++ b/packages/webapp/src/containers/Entries/withExRateItemEntriesPriceRecalc.tsx
@@ -90,10 +90,7 @@ export const useCustomerUpdateExRate = () => {
         setFieldValue('exchangeRate', DEFAULT_EX_RATE + '');
         setFieldValue(
           'entries',
-          updateEntriesOnExChange(
-            Number(values.exchangeRate),
-            DEFAULT_EX_RATE,
-          ),
+          updateEntriesOnExChange(Number(values.exchangeRate), DEFAULT_EX_RATE),
         );
       } else {
         // Sets the currency code to fetch exchange rate of the given currency code.

--- a/packages/webapp/src/containers/Sales/CreditNotes/CreditNoteForm/CreditNoteFormHeaderFields.tsx
+++ b/packages/webapp/src/containers/Sales/CreditNotes/CreditNoteForm/CreditNoteFormHeaderFields.tsx
@@ -101,10 +101,7 @@ function CreditNoteCustomersSelect() {
   const updateEntries = useCustomerUpdateExRate();
 
   // Handles item change.
-  const handleItemChange = (customer: {
-    id: number;
-    currencyCode: string;
-  }) => {
+  const handleItemChange = (customer: { id: number; currencyCode: string }) => {
     setFieldValue('customerId', customer.id);
     setFieldValue('currencyCode', customer?.currencyCode);
 

--- a/packages/webapp/src/containers/Sales/Invoices/InvoiceForm/InvoiceFormHeaderFields.tsx
+++ b/packages/webapp/src/containers/Sales/Invoices/InvoiceForm/InvoiceFormHeaderFields.tsx
@@ -167,10 +167,7 @@ function InvoiceFormCustomerSelect() {
   const updateEntries = useCustomerUpdateExRate();
 
   // Handles the customer item change.
-  const handleItemChange = (customer: {
-    id: number;
-    currencyCode: string;
-  }) => {
+  const handleItemChange = (customer: { id: number; currencyCode: string }) => {
     // If the customer id has changed change the customer id and currency code.
     if (values.customerId !== customer.id) {
       setFieldValue('customerId', customer.id);

--- a/packages/webapp/src/containers/Sales/Receipts/ReceiptForm/ReceiptFormHeaderFields.tsx
+++ b/packages/webapp/src/containers/Sales/Receipts/ReceiptForm/ReceiptFormHeaderFields.tsx
@@ -153,10 +153,7 @@ function ReceiptFormCustomerSelect() {
   const updateEntries = useCustomerUpdateExRate();
 
   // Handles the customer item change.
-  const handleItemChange = (customer: {
-    id: number;
-    currencyCode: string;
-  }) => {
+  const handleItemChange = (customer: { id: number; currencyCode: string }) => {
     setFieldValue('customerId', customer.id);
     setFieldValue('currencyCode', customer?.currencyCode);
 


### PR DESCRIPTION
## Description

Plaid-created accounts are built with an empty account code (`transformPlaidAccountToCreateAccount` sets `code: ''`). When the organization has the "Make account code required" preference enabled, Plaid connect/sync fails with `ServiceError: Account code is required.` thrown from `CommandAccountValidators.validateAccountCodeRequiredOrThrow`.

This change adds an `ignoreAccountCode` option to `CreateAccountParams` and enables it when syncing Plaid accounts, so auto-created bank accounts are exempt from the code-required validation while manual account creation still enforces the preference.

Files changed:
- `CreateAccount.service.ts`: skip the code-required check when `params.ignoreAccountCode` is set.
- `PlaidSyncDB.ts`: pass `ignoreAccountCode: true` when creating Plaid-synced accounts.
- `Accounts.types.ts` / `interfaces/Account.ts`: add `ignoreAccountCode?: boolean` to `CreateAccountParams`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- `tsc --noEmit` passes in `packages/server`.
- Reproduced the original failure with `account_code_required` enabled and verified Plaid account sync no longer throws. Manual account creation still requires an account code when the preference is on.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>