### PR TITLE
fix(server): delete Plaid item by plaidItemId on bank account disconnect

### DIFF
--- a/packages/server/src/modules/BankingAccounts/commands/DisconnectBankAccount.service.ts
+++ b/packages/server/src/modules/BankingAccounts/commands/DisconnectBankAccount.service.ts
@@ -58,7 +58,7 @@ export class DisconnectBankAccountService {
       // Remove the Plaid item from the system.
       await this.plaidItemModel()
         .query(trx)
-        .findById(account.plaidItemId)
+        .findOne('plaidItemId', account.plaidItemId)
         .delete();
 
       // Remove the plaid item association to the bank account.


### PR DESCRIPTION
## Description

When disconnecting a bank account, `DisconnectBankAccountService.disconnectBankAccount` deleted the Plaid item using `findById(account.plaidItemId)`. `account.plaidItemId` holds the Plaid string item id (e.g. `plaid-item-123`), while `findById` matches the integer primary key of the `plaid_items` table. As a result the `WHERE id = 'plaid-item-123'` clause matched nothing, leaving the tenant's Plaid item (and its access token) orphaned. The system item was never removed and future Plaid webhooks still resolved the item, allowing the accounts to be re-created.

This changes the deletion to look up the item by the `plaidItemId` string column, matching the correct pattern already used in `DisconnectPlaidItemOnAccountDeleted` (`findOne('plaidItemId', ...)`).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Ran `pnpm typecheck` and eslint on the changed file; both pass.
- No automated test exists for `DisconnectBankAccountService`. The change mirrors the query pattern already used by the sibling handler `DisconnectPlaidItemOnAccountDeleted` and by other Plaid lookups (`findOne({ plaidItemId })`), so behavior is verified by consistency with existing code paths.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>