### PR TITLE
test(server): add pagination e2e for manual journals

### DIFF
--- a/packages/server/test/manual-journal.e2e-spec.ts
+++ b/packages/server/test/manual-journal.e2e-spec.ts
@@ -85,6 +85,33 @@ describe('Manual Journals (e2e)', () => {
       .expect(200);
   });
 
+  it('/manual-journals (GET) honors page and pageSize query params', async () => {
+    const response = await request(app.getHttpServer())
+      .get('/manual-journals?page=2&pageSize=5')
+      .set('organization-id', orgainzationId)
+      .set('Authorization', AuthorizationHeader)
+      .expect(200);
+
+    expect(response.body.pagination).toBeDefined();
+    expect(response.body.pagination.page).toBe(2);
+    expect(response.body.pagination.page_size).toBe(5);
+    // Ensure data array present
+    expect(Array.isArray(response.body.data)).toBe(true);
+  });
+
+  it('/manual-journals (GET) defaults to page 1 pageSize 12 when params absent', async () => {
+    const response = await request(app.getHttpServer())
+      .get('/manual-journals')
+      .set('organization-id', orgainzationId)
+      .set('Authorization', AuthorizationHeader)
+      .expect(200);
+
+    expect(response.body.pagination).toBeDefined();
+    expect(response.body.pagination.page).toBe(1);
+    expect(response.body.pagination.page_size).toBe(12);
+    expect(Array.isArray(response.body.data)).toBe(true);
+  });
+
   it('/manual-journals/:id/publish (PATCH)', async () => {
     const response = await request(app.getHttpServer())
       .post('/manual-journals')


### PR DESCRIPTION
## Description

Manual Journals `GET /manual-journals` was reported in #1117 to ignore `page` and `pageSize` — every request returned page 1 with 12 items. Root cause is `DynamicFilterQueryDto` missing `page`/`pageSize` declarations, so the global `ValidationPipe` (`whitelist: true`) strips them before `GetManualJournals` sees them and the service always falls back to defaults.

The pagination fields were already hoisted to the shared `DynamicFilterQueryDto` base class in 46012a1b1 (merged via #1089, Closes #1088), which fixes all 10 collection endpoints that inherit the base DTO including `manual-journals`. `GetManualJournals` service pagination (`page: 1, pageSize: 12, ...filterDTO` + `.pagination(page-1, pageSize)`) is already correct.

This PR does not re-add the DTO fields (already present at HEAD) but adds the missing e2e coverage for the specifically reported endpoint, mirroring `expenses` pagination coverage added in the original fix.

Closes #1117

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Verified current `DynamicFilterQueryDto` declares `page`/`pageSize` with `@IsOptional @IsInt @ToNumber @ApiPropertyOptional` (HEAD c04882f).
- Compared with pre-fix revision `46012a1b1^` which lacks the fields — confirms whitelist stripping.
- Added `manual-journal.e2e-spec.ts` cases:
  - `GET /manual-journals?page=2&pageSize=5` asserts `pagination.page=2 page_size=5` and `data` array present
  - `GET /manual-journals` asserts defaults `page=1 page_size=12`
- `prettier --check` and `git diff --check` clean.
- New tests follow `expenses.e2e-spec.ts` pagination precedent and pass on the fixed base.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes