### PR TITLE
fix(banking): show per-account uncategorized count in account switch dropdown

### DIFF
--- a/packages/server/src/modules/BankingAccounts/dtos/BankAccountResponse.dto.ts
+++ b/packages/server/src/modules/BankingAccounts/dtos/BankAccountResponse.dto.ts
@@ -99,6 +99,12 @@ export class BankAccountResponseDto {
   formattedAmount: string;
 
   @ApiProperty({
+    description: 'The uncategorized transactions count of the account',
+    example: 0,
+  })
+  uncategorizedTransactionsCount: number;
+
+  @ApiProperty({
     description: 'The Plaid item ID',
     example: 'plaid-item-123',
   })

--- a/packages/server/src/modules/BankingTransactions/queries/BankAccountTransformer.ts
+++ b/packages/server/src/modules/BankingTransactions/queries/BankAccountTransformer.ts
@@ -12,6 +12,7 @@ export class CashflowAccountTransformer extends Transformer {
       'lastFeedsUpdatedAt',
       'lastFeedsUpdatedAtFormatted',
       'lastFeedsUpdatedFromNow',
+      'uncategorizedTransactionsCount',
     ];
   };
 
@@ -62,5 +63,14 @@ export class CashflowAccountTransformer extends Transformer {
     return account.lastFeedsUpdatedAt
       ? this.formatDateFromNow(account.lastFeedsUpdatedAt)
       : '';
+  }
+
+  /**
+   * Retrieves the uncategorized transactions count of the account.
+   * @param {IAccount} account
+   * @returns {number}
+   */
+  protected uncategorizedTransactionsCount(account: Account): number {
+    return account['uncategorizedTransactions'] || 0;
   }
 }

--- a/packages/webapp/src/containers/CashFlow/AccountTransactions/AccountTransactionsDetailsBar.tsx
+++ b/packages/webapp/src/containers/CashFlow/AccountTransactions/AccountTransactionsDetailsBar.tsx
@@ -11,8 +11,18 @@ import intl from 'react-intl-universal';
 import { useHistory } from 'react-router-dom';
 import styled from 'styled-components';
 import { useAccountTransactionsContext } from './AccountTransactionsProvider';
+import type { BankingAccountsListResponse } from '@bigcapital/sdk-ts';
 import { Icon } from '@/components';
 import { useAppShellContext } from '@/components/AppShell/AppContentShell/AppContentShellProvider';
+
+/**
+ * Bank account row surfaced with the per-account uncategorized transactions
+ * count, which the SDK type does not declare yet.
+ */
+export type CashflowAccountRowWithCount =
+  BankingAccountsListResponse[number] & {
+    uncategorizedTransactionsCount?: number;
+  };
 
 function AccountSwitchButton() {
   const { currentAccount } = useAccountTransactionsContext();
@@ -35,11 +45,12 @@ function AccountSwitchItem() {
   const handleItemClick = (account: { id: number }) =>
     push(`/cashflow-accounts/${account.id}/transactions`);
 
-  const items = cashflowAccounts.map((account) => (
+  const items = cashflowAccounts.map((account: CashflowAccountRowWithCount) => (
     <AccountSwitchMenuItem
       key={account.id}
       name={account.name}
       balance={account.formattedAmount}
+      uncategorizedTransactionsCount={account.uncategorizedTransactionsCount}
       onClick={() => handleItemClick(account)}
       active={account.id === accountId}
     />
@@ -47,7 +58,7 @@ function AccountSwitchItem() {
 
   return (
     <Popover
-      content={<Menu>{items}</Menu>}
+      content={<AccountSwitchMenu>{items}</AccountSwitchMenu>}
       position={Position.BOTTOM_LEFT}
       minimal={true}
     >
@@ -126,6 +137,7 @@ export function AccountTransactionsDetailsBar() {
 interface AccountSwitchMenuItemProps {
   name: string;
   balance?: string;
+  uncategorizedTransactionsCount?: number;
   active?: boolean;
   onClick?: () => void;
 }
@@ -133,6 +145,7 @@ interface AccountSwitchMenuItemProps {
 function AccountSwitchMenuItem({
   name,
   balance,
+  uncategorizedTransactionsCount,
   active,
   onClick,
 }: AccountSwitchMenuItemProps) {
@@ -145,7 +158,9 @@ function AccountSwitchMenuItem({
         <React.Fragment>
           <AccountSwitchItemName>{name}</AccountSwitchItemName>
           <AccountSwitchItemTranscations>
-            {intl.get('cash_flow_transaction.switch_item', { value: '25' })}
+            {intl.get('cash_flow_transaction.switch_item', {
+              value: uncategorizedTransactionsCount ?? 0,
+            })}
           </AccountSwitchItemTranscations>
 
           <AccountSwitchItemUpdatedAt></AccountSwitchItemUpdatedAt>
@@ -198,6 +213,11 @@ const AccountSwitchItemTranscations = styled.div`
 const AccountSwitchItemUpdatedAt = styled.div`
   font-size: 12px;
   opacity: 0.5;
+`;
+
+const AccountSwitchMenu = styled(Menu)`
+  max-height: 320px;
+  overflow-y: auto;
 `;
 
 const AccountSwitchButtonBase = styled(Button)`


### PR DESCRIPTION
## Description

On the bank account transactions page (`/cashflow-accounts/:id/transactions?filter=uncategorized`), the account-switch dropdown previously rendered a hardcoded "Transactions 25" count for every account and could grow beyond the viewport without scrolling.

This PR:

- Makes the account-switch dropdown scrollable by applying a max-height with vertical overflow.
- Replaces the hardcoded count with each account's real uncategorized transactions count, sourced from the `uncategorized_transactions` column on the accounts table (no extra query). The count is exposed through `CashflowAccountTransformer` as `uncategorizedTransactionsCount` (`uncategorized_transactions_count` on the wire) and documented in the Swagger `BankAccountResponseDto`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Verified the account-switch dropdown renders a scrollable menu when many accounts are present.
- Verified each dropdown item shows the account's uncategorized transactions count.
- Ran `tsc --noEmit` and ESLint on the affected server and webapp files.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>