### PR TITLE
fix(server): include formattedQuantity in item transactions transformers

### DIFF
--- a/packages/server/src/modules/Items/ItemBillsTransactions.transformer.ts
+++ b/packages/server/src/modules/Items/ItemBillsTransactions.transformer.ts
@@ -10,7 +10,7 @@ export class ItemBillTransactionTransformer extends Transformer {
       'formattedAmount',
       'formattedBillDate',
       'formattedRate',
-      'formattedCost',
+      'formattedQuantity',
     ];
   };
 

--- a/packages/server/src/modules/Items/ItemEstimatesTransaction.transformer.ts
+++ b/packages/server/src/modules/Items/ItemEstimatesTransaction.transformer.ts
@@ -10,7 +10,7 @@ export class ItemEstimateTransactionTransformer extends Transformer {
       'formattedAmount',
       'formattedEstimateDate',
       'formattedRate',
-      'formattedCost',
+      'formattedQuantity',
     ];
   };
 

--- a/packages/server/src/modules/Items/ItemInvoicesTransactions.transformer.ts
+++ b/packages/server/src/modules/Items/ItemInvoicesTransactions.transformer.ts
@@ -10,7 +10,7 @@ export class ItemInvoicesTransactionsTransformer extends Transformer {
       'formattedAmount',
       'formattedInvoiceDate',
       'formattedRate',
-      'formattedCost',
+      'formattedQuantity',
     ];
   };
 

--- a/packages/server/src/modules/Items/ItemReceiptsTransactions.transformer.ts
+++ b/packages/server/src/modules/Items/ItemReceiptsTransactions.transformer.ts
@@ -10,7 +10,7 @@ export class ItemReceiptTransactionTransformer extends Transformer {
       'formattedAmount',
       'formattedReceiptDate',
       'formattedRate',
-      'formattedCost',
+      'formattedQuantity',
     ];
   };
 


### PR DESCRIPTION
## Description

The "Quantity Sold" column for receipt transactions in the item drawer rendered blank. The item transaction transformers listed `formattedCost` (a no-op) in their `includeAttributes` instead of `formattedQuantity`, so the `formattedQuantity` virtual attribute was never computed by the Transformer and the API returned `formattedQuantity` as `undefined`. Since the receipt (and estimate) columns read `formattedQuantity`, the column appeared empty.

This change replaces `formattedCost` with `formattedQuantity` in the `includeAttributes` list of the receipt, estimate, invoice, and bill item transaction transformers, aligning the runtime response with the declared DTO/OpenAPI contract.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Ran `tsc --noEmit` (typecheck) on `packages/server` — passes with no errors.
- Verified the transformer output now includes a populated `formattedQuantity` for each entry.
- Manually confirmed the receipt transformer's `formattedQuantity` method is now invoked via `includeAttributes`.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>