### PR TITLE
fix(webapp): report date range select always displayed "Today"

### DIFF
--- a/packages/webapp/src/containers/FinancialStatements/FinancialStatementDateRange.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/FinancialStatementDateRange.tsx
@@ -1,9 +1,10 @@
 import { HTMLSelect, FormGroup, Position } from '@blueprintjs/core';
-import { FastField } from 'formik';
+import { useFormikContext } from 'formik';
 import moment from 'moment';
-import React from 'react';
+import React, { useMemo } from 'react';
 import intl from 'react-intl-universal';
 import { dateRangeOptions } from './constants';
+import { resolveDateRange } from './dateRange';
 import { Row, Col, Hint, FDateInput, FFormGroup } from '@/components';
 import { useDateInputFormatter } from '@/hooks';
 import { parseDateRangeQuery } from '@/utils';
@@ -12,44 +13,40 @@ const FINANCIAL_REPORT_MAX_DATE = moment().add(5, 'years').toDate();
 
 export function FinancialStatementDateRange() {
   const dateInputFormatter = useDateInputFormatter();
+  const { values, setFieldValue } = useFormikContext<any>();
+
+  const selectedDateRange = useMemo(
+    () => resolveDateRange(values.dateRange, values.fromDate, values.toDate),
+    [values.dateRange, values.fromDate, values.toDate],
+  );
 
   return (
     <>
       <Row>
         <Col xs={4}>
-          <FastField name={'date_range'}>
-            {({ form: { setFieldValue }, field: { value } }: any) => (
-              <FormGroup
-                label={intl.get('report_date_range')}
-                labelInfo={<Hint />}
-              >
-                <HTMLSelect
-                  fill={true}
-                  options={dateRangeOptions}
-                  value={value}
-                  onChange={(e) => {
-                    const newValue = e.target.value;
+          <FormGroup label={intl.get('report_date_range')} labelInfo={<Hint />}>
+            <HTMLSelect
+              fill={true}
+              options={dateRangeOptions}
+              value={selectedDateRange}
+              onChange={(e) => {
+                const newValue = e.target.value;
 
-                    if (newValue !== 'custom') {
-                      const dateRange = parseDateRangeQuery(newValue);
+                if (newValue !== 'custom') {
+                  const dateRange = parseDateRangeQuery(newValue);
 
-                      if (dateRange) {
-                        setFieldValue(
-                          'fromDate',
-                          moment(dateRange.fromDate).toDate(),
-                        );
-                        setFieldValue(
-                          'toDate',
-                          moment(dateRange.toDate).toDate(),
-                        );
-                      }
-                    }
-                    setFieldValue('dateRange', newValue);
-                  }}
-                />
-              </FormGroup>
-            )}
-          </FastField>
+                  if (dateRange) {
+                    setFieldValue(
+                      'fromDate',
+                      moment(dateRange.fromDate).toDate(),
+                    );
+                    setFieldValue('toDate', moment(dateRange.toDate).toDate());
+                  }
+                }
+                setFieldValue('dateRange', newValue);
+              }}
+            />
+          </FormGroup>
         </Col>
       </Row>
 

--- a/packages/webapp/src/containers/FinancialStatements/__tests__/dateRange.spec.ts
+++ b/packages/webapp/src/containers/FinancialStatements/__tests__/dateRange.spec.ts
@@ -1,0 +1,81 @@
+// @ts-nocheck
+import moment from 'moment';
+import { inferDateRange, resolveDateRange } from '../dateRange';
+
+const asDay = (date) => moment(date).format('YYYY-MM-DD');
+const day = (value) => moment(value, 'YYYY-MM-DD').toDate();
+
+const startOf = (range) => moment().startOf(range).toDate();
+const endOf = (range) => moment().endOf(range).toDate();
+
+describe('inferDateRange', () => {
+  it('should infer today', () => {
+    expect(inferDateRange(startOf('day'), endOf('day'))).toBe('today');
+  });
+
+  it('should infer this_week', () => {
+    expect(inferDateRange(startOf('week'), endOf('week'))).toBe('this_week');
+  });
+
+  it('should infer this_month', () => {
+    expect(inferDateRange(startOf('month'), endOf('month'))).toBe('this_month');
+  });
+
+  it('should infer this_quarter', () => {
+    expect(inferDateRange(startOf('quarter'), endOf('quarter'))).toBe(
+      'this_quarter',
+    );
+  });
+
+  it('should infer this_year', () => {
+    expect(inferDateRange(startOf('year'), endOf('year'))).toBe('this_year');
+  });
+
+  it('should still infer a preset after a YYYY-MM-DD round-trip', () => {
+    // The query string flattens `endOf()`'s 23:59:59.999 to midnight.
+    expect(
+      inferDateRange(day(asDay(startOf('year'))), day(asDay(endOf('year')))),
+    ).toBe('this_year');
+  });
+
+  it('should return custom for a range matching no preset', () => {
+    expect(inferDateRange(day('2025-01-01'), day('2025-12-31'))).toBe('custom');
+  });
+
+  it('should return custom when either date is missing', () => {
+    expect(inferDateRange(null, day('2025-12-31'))).toBe('custom');
+    expect(inferDateRange(day('2025-01-01'), null)).toBe('custom');
+    expect(inferDateRange(undefined, undefined)).toBe('custom');
+  });
+});
+
+describe('resolveDateRange', () => {
+  it('should honour an explicit custom choice even when the dates match a preset', () => {
+    // Regression: deriving alone snapped the select back to the matching
+    // preset, which made `custom` impossible to select.
+    expect(resolveDateRange('custom', startOf('year'), endOf('year'))).toBe(
+      'custom',
+    );
+  });
+
+  it('should prefer the dates over a stale stored preset', () => {
+    expect(
+      resolveDateRange('this_year', day('2025-01-01'), day('2025-12-31')),
+    ).toBe('custom');
+  });
+
+  it('should derive when nothing is stored, as after a URL round-trip', () => {
+    expect(resolveDateRange(undefined, startOf('year'), endOf('year'))).toBe(
+      'this_year',
+    );
+    expect(
+      resolveDateRange(undefined, day('2025-01-01'), day('2025-12-31')),
+    ).toBe('custom');
+  });
+
+  it('should follow a newly picked preset', () => {
+    expect(resolveDateRange('today', startOf('day'), endOf('day'))).toBe(
+      'today',
+    );
+  });
+});

--- a/packages/webapp/src/containers/FinancialStatements/dateRange.ts
+++ b/packages/webapp/src/containers/FinancialStatements/dateRange.ts
@@ -1,0 +1,69 @@
+import moment from 'moment';
+import { dateRangeOptions } from './constants';
+import { parseDateRangeQuery } from '@/utils';
+
+/**
+ * The date range options `parseDateRangeQuery` can actually resolve.
+ *
+ * It throws for any keyword missing from its own lookup, so the options are
+ * filtered once here at module load. Otherwise adding an option to
+ * `dateRangeOptions` without adding it there would throw during render and
+ * blank out every financial report.
+ */
+const DATE_RANGE_PRESETS = dateRangeOptions
+  .map((option) => option.value)
+  .filter((value) => value !== 'custom')
+  .filter((value) => {
+    try {
+      parseDateRangeQuery(value);
+      return true;
+    } catch {
+      return false;
+    }
+  });
+
+const formatDay = (date: Date | string | null | undefined): string | null =>
+  date ? moment(date).format('YYYY-MM-DD') : null;
+
+/**
+ * Derives the preset whose range matches the given dates, otherwise `custom`.
+ *
+ * Compared at day granularity so it matches `parseDateRangeQuery`'s `endOf()`
+ * timestamps both as generated (23:59:59.999) and after a `YYYY-MM-DD`
+ * round-trip through the query string.
+ */
+export const inferDateRange = (
+  fromDate: Date | string | null | undefined,
+  toDate: Date | string | null | undefined,
+): string => {
+  const from = formatDay(fromDate);
+  const to = formatDay(toDate);
+
+  if (!from || !to) {
+    return 'custom';
+  }
+  const matched = DATE_RANGE_PRESETS.find((preset) => {
+    const range = parseDateRangeQuery(preset);
+
+    return formatDay(range.fromDate) === from && formatDay(range.toDate) === to;
+  });
+  return matched || 'custom';
+};
+
+/**
+ * Resolves the option the date range select should display.
+ *
+ * `custom` is a mode rather than a range, so an explicit `custom` choice is
+ * honoured: deriving alone would snap the select back to whichever preset the
+ * dates still match, leaving `custom` impossible to select. Any other stored
+ * value defers to the dates, because `dateRange` does not survive the round-trip
+ * back into the form - `transformToForm()` whitelists form keys against each
+ * report's default query and none of them declare it - and because the dates can
+ * be edited directly, which leaves a stored preset stale.
+ */
+export const resolveDateRange = (
+  dateRange: string | null | undefined,
+  fromDate: Date | string | null | undefined,
+  toDate: Date | string | null | undefined,
+): string =>
+  dateRange === 'custom' ? 'custom' : inferDateRange(fromDate, toDate);


### PR DESCRIPTION
## The bug

On every financial report, opening **Customize Report** shows "Today" in the **Report date range** select, regardless of the range actually in force — including immediately after choosing "Custom Range" and calculating.

Reproduce on any report (Balance Sheet, P&L, …):

1. Customize Report → Report date range → **Custom Range**, set e.g. 2025-01-01 → 2025-12-31 → Calculate report.
2. The report renders correctly for that range, and the URL keeps `dateRange=custom`.
3. Reopen Customize Report → the select reads **Today**, while From/To still show the custom dates.

## Cause

Two independent defects:

1. `FinancialStatementDateRange` reads `<FastField name={'date_range'}>` (snake_case) but its `onChange` writes `setFieldValue('dateRange', ...)` (camelCase). `date_range` is never written anywhere in the codebase — it appears only on that one line — so `HTMLSelect` gets `value={undefined}`, becomes uncontrolled, and falls back to its first option, `today`.

2. Simply renaming the field is not sufficient. `dateRange` is persisted to the query string, but stripped on the way back into the form: `transformToForm()` is a `_.pickBy` whitelist keyed on each report's `getDefault*Query()`, and none of them declare `dateRange` — even though every report's Yup schema does.

## Impact beyond the wrong label

Because the select's DOM value genuinely *is* `today`, re-selecting "Today" fires no `change` event — so `fromDate`/`toDate` are never updated and the previous range silently persists. "Today" is the one preset a user cannot switch to.

## Fix

The displayed option is derived from `fromDate`/`toDate` — the values that actually drive the report — instead of from a stored key that cannot survive the round-trip. This fixes every report screen through the shared component, with no per-report changes, and keeps the label honest when dates are edited by hand.

An explicit `custom` choice is still honoured, because `custom` is a mode rather than a range: deriving alone would snap the select back to whichever preset the dates still matched, which would make `custom` unselectable — the same class of bug, mirrored.

`FastField` is replaced by `useFormikContext`, matching the sibling comparison panels, since the select needs to re-render when a date input changes.

The derivation lives in `dateRange.ts` so it can be unit tested. It filters `dateRangeOptions` through `parseDateRangeQuery` once at module load, because that function `throw`s on an unknown keyword — without the filter, adding an option to `constants.tsx` without adding it to the `queries` map would throw inside render and blank out every financial report.

## Tests

`src/containers/FinancialStatements/__tests__/dateRange.spec.ts` covers all five presets, the `YYYY-MM-DD` round-trip (which flattens `endOf()`'s `23:59:59.999` to midnight), missing dates, the explicit-`custom` case, and a stale stored preset.

Note these did not run via `pnpm --filter @bigcapital/webapp test`: that script points at `scripts/test.js`, which is not in the repo, so the existing `MoneyInputGroup` specs appear to be orphaned too. I ran them with a standalone vitest against the real module — 12 passed, and I confirmed the `custom` case fails without the fix. Happy to wire up a runner in a separate PR if that would help.

## Verification

Built and deployed on a v0.25.20 instance. The select reports the range in force on Balance Sheet and Profit & Loss, for a custom range, a preset range, and a URL carrying no `dateRange` param at all; "Today" is selectable from a custom range, and "Custom Range" is selectable from a preset range.