### PR TITLE
fix: company logo / attachment upload logs the user out

### DIFF
--- a/packages/server/src/modules/Attachments/Attachments.controller.ts
+++ b/packages/server/src/modules/Attachments/Attachments.controller.ts
@@ -9,6 +9,7 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import {
+  BadRequestException,
   Body,
   Controller,
   Delete,
@@ -17,7 +18,6 @@ import {
   Param,
   Post,
   Res,
-  UnauthorizedException,
   UploadedFile,
   UseGuards,
   UseInterceptors,
@@ -68,14 +68,14 @@ export class AttachmentsController {
     description: 'The document has been uploaded successfully',
   })
   @ApiResponse({
-    status: 401,
-    description: 'Unauthorized - File upload failed',
+    status: 400,
+    description: 'Bad request - no file was provided in the upload',
   })
   async uploadAttachment(@UploadedFile() file: Express.Multer.File) {
     if (!file) {
-      throw new UnauthorizedException({
+      throw new BadRequestException({
         errorType: 'FILE_UPLOAD_FAILED',
-        message: 'Now file uploaded.',
+        message: 'No file uploaded.',
       });
     }
     const data = await this.attachmentsApplication.upload(file);

--- a/shared/sdk-ts/src/attachments.ts
+++ b/shared/sdk-ts/src/attachments.ts
@@ -1,4 +1,4 @@
-import type { ApiFetcher } from './fetch-utils';
+import { withFormData, type ApiFetcher } from './fetch-utils';
 import { paths } from './schema';
 
 export const ATTACHMENTS_ROUTES = {
@@ -18,19 +18,22 @@ export interface UploadAttachmentResponse {
 }
 
 /**
- * Upload an attachment via multipart/form-data. Uses the fetcher's baseUrl and init (headers).
- * The OpenAPI client may not support FormData, so we use fetch with the same config.
+ * Upload an attachment via multipart/form-data. The generated typed fetcher's
+ * JSON body serializer would turn a `FormData` instance into `"{}"` (dropping
+ * the file entirely), so the body is smuggled through the `withFormData` init
+ * property that the form-data middleware swaps back in before `fetch` runs.
+ * Same pattern as `uploadImportFile`; keeps the call on the full middleware
+ * pipeline (camelCase response transform, `ApiError` on failure).
  */
 export async function uploadAttachment(
   fetcher: ApiFetcher,
   formData: FormData
 ): Promise<UploadAttachmentResponse> {
   const post = fetcher.path(ATTACHMENTS_ROUTES.LIST).method('post').create();
-  // Generated client expects typed body; FormData is valid for multipart/form-data at runtime
-  const res = await (
-    post as unknown as (body: FormData) => Promise<{ data?: { data?: UploadAttachmentResponse } }>
-  )(formData);
-  const data = (res as { data?: { data?: UploadAttachmentResponse } })?.data?.data;
+  const res = (await post({} as never, withFormData(formData))) as {
+    data?: { data?: UploadAttachmentResponse };
+  };
+  const data = res?.data?.data;
   if (!data) {
     throw new Error('Upload attachment: no data in response');
   }


### PR DESCRIPTION
## Description

Fixes #1305 — uploading a company logo (Preferences → Branding), or any attachment, **logs the user out** and redirects to `/auth/login`.

Two stacked bugs, one commit each:

### 1. `fix(sdk-ts): send attachment uploads as multipart, not JSON`

`shared/sdk-ts/src/attachments.ts` → `uploadAttachment()` passed the `FormData` straight into the generated `openapi-typescript-fetch` client. That client's `getBody()` calls `JSON.stringify()` on every payload, and `JSON.stringify(formData) === "{}"`, so the file was silently dropped and the server got a 2-byte `application/json` body.

Now routed through `withFormData()` / `createFormDataMiddleware()` — the exact helper `uploadImportFile()` in `shared/sdk-ts/src/import.ts` already uses for the same reason. The browser now sends a real `multipart/form-data` body (with boundary), and the call still flows through the middleware pipeline (camelCase response transform, `ApiError` on failure).

### 2. `fix(server): return 400 not 401 when attachment upload has no file`

`packages/server/src/modules/Attachments/Attachments.controller.ts` threw `UnauthorizedException` (HTTP 401) when `@UploadedFile()` was empty. A missing file is a client error, not an auth failure.

The webapp treats **every** 401 as an expired session — `useApiFetcherOnError` / `useRequest` call `setLogout()` on `status === 401`, which clears the auth cookies and reloads to `/auth/login`. So any empty `POST /api/attachments` (bug 1, or a future client bug, or a malformed request) force-logs-out the user. `BadRequestException` keeps the session intact and lets the caller surface the real error. Also fixes the response message typo (`"Now file uploaded."` → `"No file uploaded."`).

Either fix alone is insufficient: #1 makes the upload actually work; #2 stops the logout when an upload reaches the endpoint without a file for any reason.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Self-hosted instance, S3 storage configured and confirmed working.

- **Before:** `POST /api/attachments` from the Branding page → `401`, request body ~2 bytes, browser redirected to `/auth/login`. `curl -X POST /api/attachments -H 'Authorization: Bearer <valid>' -H 'Content-Type: application/json' -d '{}'` → `401 {"errorType":"FILE_UPLOAD_FAILED","message":"Now file uploaded."}`.
- **After the server change** (verified on the running instance): the same empty request → `400` with the same body shape; session preserved, no logout. A real `multipart/form-data` upload with a `file` part still returns `200` and the object lands in S3.
- **sdk-ts change:** `pnpm --filter @bigcapital/sdk-ts build` succeeds; `tsc --noEmit` on `shared/sdk-ts` is clean. The change mirrors the already-tested `uploadImportFile()` path 1:1.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<sub>Notes: no docs change needed. Happy to add tests / split this into two PRs if you'd prefer — flagged in #1305 first per CONTRIBUTING.md.</sub>
