### PR TITLE
fix: organization branding/settings save silently persists nothing (snake_case body)

### DIFF
--- a/packages/server/src/common/decorators/SnakeCaseBody.spec.ts
+++ b/packages/server/src/common/decorators/SnakeCaseBody.spec.ts
@@ -1,0 +1,54 @@
+import { addCamelCaseAliases } from './SnakeCaseBody';
+
+describe('addCamelCaseAliases', () => {
+  it('adds a camelCase alias next to every snake_case key, keeping the original', () => {
+    expect(
+      addCamelCaseAliases({ primary_color: '#c2b942', logo_key: '' }),
+    ).toEqual({
+      primary_color: '#c2b942',
+      primaryColor: '#c2b942',
+      logo_key: '',
+      logoKey: '',
+    });
+  });
+
+  it('recurses into nested objects and arrays', () => {
+    expect(
+      addCamelCaseAliases({
+        address: { state_province: 'AK', postal_code: '99603' },
+        tags: [{ tag_name: 'a' }],
+      }),
+    ).toEqual({
+      address: {
+        state_province: 'AK',
+        stateProvince: 'AK',
+        postal_code: '99603',
+        postalCode: '99603',
+      },
+      tags: [{ tag_name: 'a', tagName: 'a' }],
+    });
+  });
+
+  it('leaves already-camelCase and single-word keys untouched', () => {
+    expect(addCamelCaseAliases({ primaryColor: '#fff', name: 'Acme' })).toEqual(
+      {
+        primaryColor: '#fff',
+        name: 'Acme',
+      },
+    );
+  });
+
+  it('does not overwrite an explicit camelCase sibling', () => {
+    expect(
+      addCamelCaseAliases({ logo_key: 'snake', logoKey: 'camel' }),
+    ).toEqual({ logo_key: 'snake', logoKey: 'camel' });
+  });
+
+  it('ignores leading-underscore keys and passes through primitives / null', () => {
+    expect(addCamelCaseAliases({ _internal_flag: 1 })).toEqual({
+      _internal_flag: 1,
+    });
+    expect(addCamelCaseAliases(null)).toBeNull();
+    expect(addCamelCaseAliases('x')).toBe('x');
+  });
+});

--- a/packages/server/src/common/decorators/SnakeCaseBody.ts
+++ b/packages/server/src/common/decorators/SnakeCaseBody.ts
@@ -1,0 +1,54 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+/**
+ * Recursively adds a camelCase alias next to every snake_case key, keeping the
+ * original key in place. Additive only — nothing is removed.
+ */
+export function addCamelCaseAliases<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map((item) => addCamelCaseAliases(item)) as unknown as T;
+  }
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+  const source = value as Record<string, unknown>;
+  const result: Record<string, unknown> = {};
+
+  for (const key of Object.keys(source)) {
+    const aliased = addCamelCaseAliases(source[key]);
+    result[key] = aliased;
+
+    if (key.includes('_') && !key.startsWith('_')) {
+      const camelKey = key.replace(/_+([a-z0-9])/g, (_m, char: string) =>
+        char.toUpperCase(),
+      );
+      if (camelKey !== key && !(camelKey in source)) {
+        result[camelKey] = aliased;
+      }
+    }
+  }
+  return result as T;
+}
+
+/**
+ * Drop-in replacement for `@Body()` for routes whose DTO declares camelCase
+ * properties but whose real callers send snake_case.
+ *
+ * The webapp and `@bigcapital/sdk-ts` serialise request bodies to snake_case
+ * (the SDK's snake-case request middleware; the API responds in snake_case
+ * too). `class-transformer` maps by exact key name, so camelCase DTO
+ * properties stay `undefined` and are then dropped by the global
+ * `ValidationPipe`'s `whitelist: true` — e.g. `PUT /api/organization` used to
+ * answer `200` while persisting nothing.
+ *
+ * This decorator runs before the pipes, so it hands the pipeline a body that
+ * carries both the original snake_case keys and their camelCase aliases;
+ * callers that already send camelCase are unaffected, and the surplus keys are
+ * stripped by the whitelist.
+ */
+export const SnakeCaseBody = createParamDecorator(
+  (_data: unknown, ctx: ExecutionContext) => {
+    const request = ctx.switchToHttp().getRequest();
+    return addCamelCaseAliases(request.body);
+  },
+);

--- a/packages/server/src/modules/Organization/Organization.controller.ts
+++ b/packages/server/src/modules/Organization/Organization.controller.ts
@@ -7,15 +7,7 @@ import {
   getSchemaPath,
   ApiParam,
 } from '@nestjs/swagger';
-import {
-  Controller,
-  Post,
-  Put,
-  Get,
-  Body,
-  HttpCode,
-  Param,
-} from '@nestjs/common';
+import { Controller, Post, Put, Get, HttpCode, Param } from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
 import { BuildOrganizationService } from './commands/BuildOrganization.service';
 import {
@@ -37,6 +29,7 @@ import {
 import { GetCurrentOrganizationResponseDto } from './dtos/GetCurrentOrganizationResponse.dto';
 import { OrganizationBuildJobResponseDto } from './dtos/OrganizationBuildJobResponse.dto';
 import { ApiCommonHeaders } from '@/common/decorators/ApiCommonHeaders';
+import { SnakeCaseBody } from '@/common/decorators/SnakeCaseBody';
 import { OrgBaseCurrencyMutateAbilitiesResponseDto } from './dtos/OrgBaseCurrencyMutateAbilitiesResponse.dto';
 
 @ApiTags('Organization')
@@ -70,7 +63,7 @@ export class OrganizationController {
     status: 500,
     example: OrganizationBuiltResponseExample,
   })
-  async build(@Body() buildDTO: BuildOrganizationDto) {
+  async build(@SnakeCaseBody() buildDTO: BuildOrganizationDto) {
     const result = await this.buildOrganizationService.buildRunJob(buildDTO);
 
     return {
@@ -144,7 +137,7 @@ export class OrganizationController {
     status: 200,
     description: 'Organization information has been updated successfully',
   })
-  async updateOrganization(@Body() updateDTO: UpdateOrganizationDto) {
+  async updateOrganization(@SnakeCaseBody() updateDTO: UpdateOrganizationDto) {
     await this.updateOrganizationService.execute(updateDTO);
 
     return {

--- a/packages/server/test/organization.e2e-spec.ts
+++ b/packages/server/test/organization.e2e-spec.ts
@@ -25,50 +25,78 @@ describe('Organization (e2e)', () => {
       });
   });
 
-  it('/organization (POST)', async () => {
-    return request(app.getHttpServer())
+  const authHeaders = () => ({
+    Accept: 'application/json',
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${signinResponse.body.access_token}`,
+    'organization-id': signupResponse.body.organization_id,
+  });
+
+  // The webapp / `@bigcapital/sdk-ts` serialize request bodies to snake_case,
+  // so the e2e payloads below intentionally use snake_case keys.
+  it('/organization/build (POST) persists the snake_case setup payload', async () => {
+    await request(app.getHttpServer())
       .post('/organization/build')
-      .set('Accept', 'application/json')
-      .set('Content-Type', 'application/json')
-      .set('Authorization', `Bearer ${signinResponse.body.access_token}`)
-      .set('organization-id', signupResponse.body.organization_id)
+      .set(authHeaders())
       .send({
         name: 'BIGCAPITAL, INC',
-        baseCurrency: 'USD',
+        base_currency: 'USD',
         location: 'US',
         language: 'en',
-        fiscalYear: 'march',
+        fiscal_year: 'march',
         timezone: 'US/Central',
       })
       .expect(200);
+
+    const { body } = await request(app.getHttpServer())
+      .get('/organization/current')
+      .set(authHeaders())
+      .expect(200);
+
+    expect(body.metadata).toMatchObject({
+      name: 'BIGCAPITAL, INC',
+      base_currency: 'USD',
+      fiscal_year: 'march',
+      timezone: 'US/Central',
+    });
   });
 
-  it('/organization (GET)', () => {
+  it('/organization/current (GET)', () => {
     return request(app.getHttpServer())
       .get('/organization/current')
-      .set('Accept', 'application/json')
-      .set('Content-Type', 'application/json')
-      .set('Authorization', `Bearer ${signinResponse.body.access_token}`)
-      .set('organization-id', signupResponse.body.organization_id)
+      .set(authHeaders())
       .send()
       .expect(200);
   });
 
-  it('/organization (PUT)', () => {
-    return request(app.getHttpServer())
+  it('/organization (PUT) persists snake_case branding + general fields', async () => {
+    await request(app.getHttpServer())
       .put('/organization')
-      .set('Accept', 'application/json')
-      .set('Content-Type', 'application/json')
-      .set('Authorization', `Bearer ${signinResponse.body.access_token}`)
-      .set('organization-id', signupResponse.body.organization_id)
+      .set(authHeaders())
       .send({
-        name: 'BIGCAPITAL, INC',
-        baseCurrency: 'USD',
-        location: 'US',
-        language: 'en',
-        fiscalYear: 'march',
-        timezone: 'US/Central',
+        name: 'BIGCAPITAL RENAMED, INC',
+        fiscal_year: 'january',
+        primary_color: '#c2b942',
+        tax_number: '92-1234567',
+        address: { city: 'Homer', state_province: 'AK', postal_code: '99603' },
       })
       .expect(200);
+
+    const { body } = await request(app.getHttpServer())
+      .get('/organization/current')
+      .set(authHeaders())
+      .expect(200);
+
+    expect(body.metadata).toMatchObject({
+      name: 'BIGCAPITAL RENAMED, INC',
+      fiscal_year: 'january',
+      primary_color: '#c2b942',
+      tax_number: '92-1234567',
+    });
+    expect(body.metadata.address).toMatchObject({
+      city: 'Homer',
+      state_province: 'AK',
+      postal_code: '99603',
+    });
   });
 });

--- a/packages/webapp/src/components/Forms/ColorInput.tsx
+++ b/packages/webapp/src/components/Forms/ColorInput.tsx
@@ -15,6 +15,17 @@ import { Box, BoxProps } from '@/components';
 import { useUncontrolled } from '@/hooks/useUncontrolled';
 import { sanitizeToHexColor } from '@/utils/sanitize-hex-color';
 
+/** `#rgb` or `#rrggbb`. */
+const HEX_COLOR_REGEX = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i;
+
+/**
+ * Fallback fed to `<HexColorPicker>` when the field is empty or holds a
+ * partially-typed value. react-colorful runs the raw string through its
+ * hex→HSV math unconditionally; an invalid value yields `NaN` channels, and
+ * dragging the hue bar then paints the swatch as `NaN, NaN, NaN`.
+ */
+const FALLBACK_PICKER_COLOR = '#000000';
+
 export interface ColorInputProps {
   value?: string;
   initialValue?: string;
@@ -46,9 +57,13 @@ export function ColorInput({
     setIsOpen(false);
   };
 
+  const pickerColor = HEX_COLOR_REGEX.test(_value)
+    ? _value
+    : FALLBACK_PICKER_COLOR;
+
   return (
     <Popover
-      content={<HexColorPicker color={_value} onChange={handleChange} />}
+      content={<HexColorPicker color={pickerColor} onChange={handleChange} />}
       position={Position.BOTTOM}
       interactionKind={PopoverInteractionKind.CLICK}
       modifiers={{

--- a/packages/webapp/src/utils/sanitize-hex-color.ts
+++ b/packages/webapp/src/utils/sanitize-hex-color.ts
@@ -1,3 +1,18 @@
-export function sanitizeToHexColor(input: string) {
-  return input;
+/**
+ * Normalises free-text input from the colour field towards a `#rrggbb` hex
+ * string: forces a single leading `#`, drops non-hex characters and caps the
+ * length at 6 digits. Returns `''` for empty input so the field can stay
+ * blank. Downstream (`<HexColorPicker>`) still guards against partial values
+ * like `#a`.
+ */
+export function sanitizeToHexColor(input: string): string {
+  if (!input) {
+    return '';
+  }
+  const digits = input
+    .replace(/[^0-9a-fA-F]/g, '')
+    .slice(0, 6)
+    .toLowerCase();
+
+  return digits ? `#${digits}` : '#';
 }


### PR DESCRIPTION
## Problem

`PUT /api/organization` (Preferences → Branding, and the General settings form) returns `200 "Organization information has been updated successfully."` but **persists nothing**. Uploading a company logo or changing the primary brand colour has no effect.

Captured from the webapp:

```
PUT /api/organization
  request body:  {"logo_key":"","primary_color":"#c2b942"}
  response:      200  {"code":200,"message":"Organization information has been updated successfully."}

GET /api/organization/current   (immediately after)
  metadata.primary_color:  null      ← not saved
```

## Root cause

The webapp and `@bigcapital/sdk-ts` serialize every request body to **snake_case** (`createSnakeCaseRequestMiddleware`), and the API responds in snake_case (`GET /api/organization/current` → `primary_color`, `base_currency`, `state_province`, …).

`BuildOrganizationDto` / `UpdateOrganizationDto` declare only **camelCase** properties. `class-transformer` maps by exact key name, so those properties stay `undefined`, and the global `ValidationPipe`'s `validate(object, { whitelist: true })` then **deletes** the unrecognised `primary_color` / `logo_key` / `base_currency` / … keys before the service runs. `saveMetadata()` receives an (almost) empty object → silent `200` no-op.

The existing e2e test missed it by sending camelCase and only asserting `.expect(200)`, never re-reading to confirm persistence.

## Fix

- **`@SnakeCaseBody()`** (`packages/server/src/common/decorators/SnakeCaseBody.ts`) — a `createParamDecorator` that runs *before* the pipes and returns the request body with a camelCase alias added next to every snake_case key (recursively, additive — nothing removed). The global `ValidationPipe` then validates the DTO against a body that carries both spellings. Applied only to the two organization write routes (`POST /organization/build`, `PUT /organization`). Verified with a standalone NestJS 10 app that the global pipe does process a custom-decorator param and that validation/whitelist still apply (invalid hex → 400, camelCase callers unaffected). Unit tests for the alias helper included.
- **`organization.e2e-spec.ts`** — send snake_case payloads (like the real client) and assert the values are actually persisted via a follow-up `GET`.
- **`ColorInput.tsx` / `sanitize-hex-color.ts`** — when no primary colour is stored, `ColorInput` passed `''` to react-colorful's `<HexColorPicker>`, whose hex→HSV math then yields `NaN` channels and the hue bar paints the swatch `NaN, NaN, NaN`. Feed the picker a `#000000` fallback for any non-`#rgb`/`#rrggbb` value, and make `sanitizeToHexColor` actually normalise input instead of returning it unchanged.

## Notes

- The setup wizard (`POST /organization/build`) posts snake_case too and hit the same stripping for the required `base_currency` / `fiscal_year` fields → 400; this fixes that path as well. The CI seed script and old tests that send **camelCase** to `/organization/build` keep working — the decorator is additive.
- Alternative considered: `@Expose({ name: '<snake>' })` on each DTO property. Rejected because it makes the DTO snake-*only* and broke the camelCase CI seed in `server-tests.yml`.

## Verification

- Reproduced the strip and confirmed the fix (snake → persisted; camelCase → unchanged; bad hex → 400) with a standalone NestJS 10 + `class-transformer@0.5.1` + `class-validator@0.14.1` app mirroring the real pipe + `APP_PIPE` wiring.
- Prettier clean on all changed files.
- Did **not** run the full e2e/jest suites locally (need the MySQL/Redis fixture) — relying on CI.
