### PR TITLE
ci: build @bigcapital/sdk-ts before the TypeScript type check

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -56,7 +56,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build shared packages
-        run: pnpm run build --scope "@bigcapital/utils" --scope "@bigcapital/email-components" --scope "@bigcapital/pdf-templates"
+        run: pnpm run build --scope "@bigcapital/utils" --scope "@bigcapital/email-components" --scope "@bigcapital/pdf-templates" --scope "@bigcapital/sdk-ts"
 
       - name: Run TypeScript type check
         run: pnpm run typecheck


### PR DESCRIPTION
## Problem

The **TypeScript Type Check** job has failed on `develop` for a long time. Its log is ~210 copies of:

```
error TS2307: Cannot find module '@bigcapital/sdk-ts' or its corresponding type declarations.
```

plus a long tail of `Property 'x' does not exist` / `is not assignable` errors — **all of which cascade from that one unresolved module** (webapp types re-export `@bigcapital/sdk-ts`).

## Cause

`typecheck.yml` pre-builds `@bigcapital/utils`, `@bigcapital/email-components` and `@bigcapital/pdf-templates`, but **not `@bigcapital/sdk-ts`**. `shared/sdk-ts/dist/` is gitignored, and `packages/webapp` resolves `@bigcapital/sdk-ts` through its `package.json` `"types": "./dist/index.d.ts"` (no tsconfig `paths` entry pointing at source). With no `dist/`, `tsc --noEmit` in the webapp can't find the package.

`e2e.yml` / `server-tests.yml` don't hit this because they run a fuller `pnpm build` / `pnpm build:server`.

## Change

Add `--scope "@bigcapital/sdk-ts"` to the "Build shared packages" step.

## Effect — please read

This does **not** turn the check green. With `@bigcapital/sdk-ts` resolvable, the 210 phantom `TS2307`s disappear and the check surfaces **~53 genuine pre-existing type errors across ~36 webapp files** (interface-extension conflicts against the generated SDK types, `no-implicit-any` params, stale `@ts-expect-error` directives, a few overload mismatches). Those are real and out of scope here.

The value of this one-liner is that the check stops being 100% noise that everyone has learned to ignore, and starts pointing at actual type problems. Fixing the 53 is a separate effort (happy to follow up, or file an issue). If you'd rather the check stay green-by-accident, feel free to close this.

## Test plan

- [x] CI run on this PR: `Cannot find module '@bigcapital/sdk-ts'` count drops 210 → 0; remaining errors are genuine.
