### PR TITLE
fix(webapp): render the Generate API Key dialog

### DIFF
--- a/e2e/api-keys.spec.ts
+++ b/e2e/api-keys.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect, type Page } from '@playwright/test';
+import { faker } from '@faker-js/faker';
+
+/**
+ * Waits until the API keys preferences page is loaded.
+ */
+async function waitForApiKeysPage(page: Page) {
+  await expect(
+    page.getByRole('button', { name: 'Generate API Key' }),
+  ).toBeVisible({ timeout: 30_000 });
+}
+
+test.describe('api keys', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/preferences/api-keys');
+  });
+
+  test('should show the api keys preferences page.', async ({ page }) => {
+    await waitForApiKeysPage(page);
+  });
+
+  test('should open the generate dialog and generate a key.', async ({
+    page,
+  }) => {
+    await waitForApiKeysPage(page);
+
+    await page.getByRole('button', { name: 'Generate API Key' }).click();
+
+    // Regression: the dialog previously never rendered because the redux
+    // `<Dialog>` wrapper around the form content was missing.
+    const dialog = page.getByRole('dialog', { name: 'Generate API Key' });
+    await expect(dialog).toBeVisible({ timeout: 15_000 });
+
+    await dialog
+      .getByPlaceholder('Enter API key name')
+      .fill(`e2e ${faker.string.alphanumeric(6)}`);
+    await dialog.getByRole('button', { name: 'Generate', exact: true }).click();
+
+    // The generated key is returned by the SDK and shown once in a
+    // read-only field.
+    await expect(
+      dialog.getByText('This API key will only be shown once.', {
+        exact: false,
+      }),
+    ).toBeVisible({ timeout: 15_000 });
+    await expect(dialog.locator('input[readonly]')).toHaveValue(
+      /^bc_[0-9a-f]+$/,
+      { timeout: 15_000 },
+    );
+
+    await dialog.getByRole('button', { name: 'Done' }).click();
+    await expect(dialog).toBeHidden({ timeout: 15_000 });
+  });
+
+  test('should validate the required name field.', async ({ page }) => {
+    await waitForApiKeysPage(page);
+
+    await page.getByRole('button', { name: 'Generate API Key' }).click();
+
+    const dialog = page.getByRole('dialog', { name: 'Generate API Key' });
+    await expect(dialog).toBeVisible({ timeout: 15_000 });
+
+    await dialog.getByRole('button', { name: 'Generate', exact: true }).click();
+    await expect(dialog).toContainText('Name is required');
+  });
+});

--- a/packages/webapp/src/containers/Dialogs/ApiKeysGenerateDialog/ApiKeysGenerateDialog.tsx
+++ b/packages/webapp/src/containers/Dialogs/ApiKeysGenerateDialog/ApiKeysGenerateDialog.tsx
@@ -1,111 +1,43 @@
-import { Formik, type FormikHelpers } from 'formik';
-import React, { useState } from 'react';
-import { ApiKeyDisplayView } from './ApiKeyDisplayView';
-import { CreateApiKeyFormSchema as ApiKeysGenerateFormSchema } from './ApiKeysGenerateForm.schema';
-import { ApiKeysGenerateFormContent } from './ApiKeysGenerateFormContent';
-import type { WithDialogActionsProps } from '@/containers/Dialog/withDialogActions';
-import { withDialogActions } from '@/containers/Dialog/withDialogActions';
-import { useGenerateApiKey } from '@/hooks/query';
+import React, { lazy } from 'react';
+import type { DialogBaseProps } from '@/components/DialogReduxConnect';
+import { Dialog, DialogSuspense, FormattedMessage as T } from '@/components';
+import withDialogRedux from '@/components/DialogReduxConnect';
 import { compose } from '@/utils';
 
-interface ApiKeyFormValues {
-  name: string;
-}
+const ApiKeysGenerateDialogContent = lazy(() =>
+  import('./ApiKeysGenerateDialogContent').then((m) => ({
+    default: m.ApiKeysGenerateDialogContent,
+  })),
+);
 
-const defaultInitialValues: ApiKeyFormValues = {
-  name: '',
-};
-
-interface ApiKeysGenerateDialogContentProps extends WithDialogActionsProps {
+interface ApiKeysGenerateDialogProps extends DialogBaseProps {
   dialogName: string;
 }
 
 /**
- * API Keys Generate form dialog content.
+ * API keys generate dialog.
  */
-function ApiKeysGenerateDialogContentInner({
-  closeDialog,
+function ApiKeysGenerateDialogRoot({
   dialogName,
-}: ApiKeysGenerateDialogContentProps): React.ReactElement {
-  const [generatedApiKey, setGeneratedApiKey] = useState<string | null>(null);
-  const generateApiKeyMutate = useGenerateApiKey();
-
-  // Handles the form submit.
-  const handleFormSubmit = (
-    values: ApiKeyFormValues,
-    { setSubmitting, setErrors }: FormikHelpers<ApiKeyFormValues>,
-  ) => {
-    const form = { name: values.name || undefined };
-
-    // Handle request response errors.
-    const handleError = (error: unknown) => {
-      const err = error as {
-        response?: { data?: { errors?: Record<string, string[]> } };
-      };
-      const errors = err?.response?.data?.errors;
-      if (errors) {
-        const errorsTransformed = Object.keys(errors).reduce(
-          (acc: Record<string, string>, key) => {
-            acc[key] = errors[key][0];
-            return acc;
-          },
-          {},
-        );
-        setErrors(errorsTransformed);
-      }
-      setSubmitting(false);
-    };
-
-    generateApiKeyMutate.mutate(form, {
-      onSuccess: (response: unknown) => {
-        // The API returns { key, id }, which might be wrapped in response.data.
-        const apiKey =
-          // FIXME: response shape not typed by SDK; original runtime probing preserved.
-          ((response as { data?: { key?: string } })?.data?.key as string) ||
-          ((response as { key?: string })?.key as string);
-        if (apiKey) {
-          setGeneratedApiKey(apiKey);
-        } else {
-          setSubmitting(false);
-        }
-      },
-      onError: handleError,
-    });
-  };
-
-  // If API key has been generated, show the display view
-  if (generatedApiKey) {
-    return (
-      <ApiKeyDisplayView
-        dialogName={dialogName}
-        apiKey={generatedApiKey}
-        onClose={() => {
-          setGeneratedApiKey(null);
-          closeDialog(dialogName);
-        }}
-      />
-    );
-  }
-
-  // Otherwise, show the generate form
+  isOpen,
+}: ApiKeysGenerateDialogProps): React.ReactElement {
   return (
-    <Formik
-      validationSchema={ApiKeysGenerateFormSchema}
-      initialValues={defaultInitialValues}
-      onSubmit={handleFormSubmit}
+    <Dialog
+      name={dialogName}
+      title={<T id={'api_key.dialog.generate_title'} />}
+      isOpen={isOpen}
+      autoFocus={true}
+      canEscapeKeyClose={true}
+      canOutsideClickClose={true}
+      style={{ width: '400px' }}
     >
-      <ApiKeysGenerateFormContent dialogName={dialogName} />
-    </Formik>
+      <DialogSuspense>
+        <ApiKeysGenerateDialogContent dialogName={dialogName} />
+      </DialogSuspense>
+    </Dialog>
   );
 }
 
-export const ApiKeysGenerateDialogContent = compose(withDialogActions)(
-  ApiKeysGenerateDialogContentInner,
+export const ApiKeysGenerateDialog = compose(withDialogRedux())(
+  ApiKeysGenerateDialogRoot,
 );
-
-// FIXME: latent bug preserved — `index.tsx` re-exports `ApiKeysGenerateDialog`
-// but this module historically only exported `ApiKeysGenerateDialogContent`.
-// The Dialog wrapper (`<Dialog>...`) was never created in the original code;
-// instead the dialog content is used directly. Re-export under the dialog
-// name to keep external consumers (DialogsContainer.tsx) working.
-export { ApiKeysGenerateDialogContent as ApiKeysGenerateDialog };

--- a/packages/webapp/src/containers/Dialogs/ApiKeysGenerateDialog/ApiKeysGenerateDialogContent.tsx
+++ b/packages/webapp/src/containers/Dialogs/ApiKeysGenerateDialog/ApiKeysGenerateDialogContent.tsx
@@ -30,14 +30,18 @@ function ApiKeysGenerateDialogContentInner({
   const generateApiKeyMutate = useGenerateApiKey();
 
   // Handles the form submit.
-  const handleFormSubmit = (
+  const handleFormSubmit = async (
     values: ApiKeyFormValues,
     { setSubmitting, setErrors }: FormikHelpers<ApiKeyFormValues>,
   ) => {
     const form = { name: values.name || undefined };
 
-    // Handle request response errors.
-    const handleError = (error: unknown) => {
+    try {
+      const response = await generateApiKeyMutate.mutateAsync(form);
+      if (response?.key) {
+        setGeneratedApiKey(response.key);
+      }
+    } catch (error: unknown) {
       const err = error as {
         response?: { data?: { errors?: Record<string, string[]> } };
       };
@@ -52,19 +56,9 @@ function ApiKeysGenerateDialogContentInner({
         );
         setErrors(errorsTransformed);
       }
+    } finally {
       setSubmitting(false);
-    };
-
-    generateApiKeyMutate.mutate(form, {
-      onSuccess: (response) => {
-        if (response?.key) {
-          setGeneratedApiKey(response.key);
-        } else {
-          setSubmitting(false);
-        }
-      },
-      onError: handleError,
-    });
+    }
   };
 
   // If API key has been generated, show the display view

--- a/packages/webapp/src/containers/Dialogs/ApiKeysGenerateDialog/ApiKeysGenerateDialogContent.tsx
+++ b/packages/webapp/src/containers/Dialogs/ApiKeysGenerateDialog/ApiKeysGenerateDialogContent.tsx
@@ -1,1 +1,98 @@
-export { ApiKeysGenerateDialogContent } from './ApiKeysGenerateDialog';
+import { Formik, type FormikHelpers } from 'formik';
+import React, { useState } from 'react';
+import { ApiKeyDisplayView } from './ApiKeyDisplayView';
+import { CreateApiKeyFormSchema as ApiKeysGenerateFormSchema } from './ApiKeysGenerateForm.schema';
+import { ApiKeysGenerateFormContent } from './ApiKeysGenerateFormContent';
+import type { WithDialogActionsProps } from '@/containers/Dialog/withDialogActions';
+import { withDialogActions } from '@/containers/Dialog/withDialogActions';
+import { useGenerateApiKey } from '@/hooks/query';
+
+interface ApiKeyFormValues {
+  name: string;
+}
+
+const defaultInitialValues: ApiKeyFormValues = {
+  name: '',
+};
+
+interface ApiKeysGenerateDialogContentProps extends WithDialogActionsProps {
+  dialogName: string;
+}
+
+/**
+ * API Keys Generate form dialog content.
+ */
+function ApiKeysGenerateDialogContentInner({
+  closeDialog,
+  dialogName,
+}: ApiKeysGenerateDialogContentProps): React.ReactElement {
+  const [generatedApiKey, setGeneratedApiKey] = useState<string | null>(null);
+  const generateApiKeyMutate = useGenerateApiKey();
+
+  // Handles the form submit.
+  const handleFormSubmit = (
+    values: ApiKeyFormValues,
+    { setSubmitting, setErrors }: FormikHelpers<ApiKeyFormValues>,
+  ) => {
+    const form = { name: values.name || undefined };
+
+    // Handle request response errors.
+    const handleError = (error: unknown) => {
+      const err = error as {
+        response?: { data?: { errors?: Record<string, string[]> } };
+      };
+      const errors = err?.response?.data?.errors;
+      if (errors) {
+        const errorsTransformed = Object.keys(errors).reduce(
+          (acc: Record<string, string>, key) => {
+            acc[key] = errors[key][0];
+            return acc;
+          },
+          {},
+        );
+        setErrors(errorsTransformed);
+      }
+      setSubmitting(false);
+    };
+
+    generateApiKeyMutate.mutate(form, {
+      onSuccess: (response) => {
+        if (response?.key) {
+          setGeneratedApiKey(response.key);
+        } else {
+          setSubmitting(false);
+        }
+      },
+      onError: handleError,
+    });
+  };
+
+  // If API key has been generated, show the display view
+  if (generatedApiKey) {
+    return (
+      <ApiKeyDisplayView
+        dialogName={dialogName}
+        apiKey={generatedApiKey}
+        onClose={() => {
+          setGeneratedApiKey(null);
+          closeDialog(dialogName);
+        }}
+      />
+    );
+  }
+
+  // Otherwise, show the generate form
+  return (
+    <Formik
+      validationSchema={ApiKeysGenerateFormSchema}
+      initialValues={defaultInitialValues}
+      onSubmit={handleFormSubmit}
+    >
+      <ApiKeysGenerateFormContent dialogName={dialogName} />
+    </Formik>
+  );
+}
+
+export const ApiKeysGenerateDialogContent = withDialogActions(
+  ApiKeysGenerateDialogContentInner,
+);

--- a/packages/webapp/src/containers/Dialogs/ApiKeysGenerateDialog/index.tsx
+++ b/packages/webapp/src/containers/Dialogs/ApiKeysGenerateDialog/index.tsx
@@ -1,4 +1,2 @@
-export {
-  ApiKeysGenerateDialog,
-  ApiKeysGenerateDialogContent,
-} from './ApiKeysGenerateDialog';
+export { ApiKeysGenerateDialog } from './ApiKeysGenerateDialog';
+export { ApiKeysGenerateDialogContent } from './ApiKeysGenerateDialogContent';

--- a/packages/webapp/src/hooks/query/api-keys/queries.ts
+++ b/packages/webapp/src/hooks/query/api-keys/queries.ts
@@ -8,7 +8,11 @@ import {
 } from '@tanstack/react-query';
 import { useApiFetcher } from '../../useRequest';
 import { apiKeysKeys } from './query-keys';
-import type { ApiKeysList, GenerateApiKeyBody } from '@bigcapital/sdk-ts';
+import type {
+  ApiKeysList,
+  GenerateApiKeyBody,
+  GenerateApiKeyResponse,
+} from '@bigcapital/sdk-ts';
 
 const commonInvalidateQueries = (
   queryClient: ReturnType<typeof useQueryClient>,
@@ -28,7 +32,7 @@ export function useApiKeys(
 }
 
 export function useGenerateApiKey(
-  props?: UseMutationOptions<void, Error, GenerateApiKeyBody>,
+  props?: UseMutationOptions<GenerateApiKeyResponse, Error, GenerateApiKeyBody>,
 ) {
   const client = useQueryClient();
   const fetcher = useApiFetcher();

--- a/shared/sdk-ts/src/api-keys.ts
+++ b/shared/sdk-ts/src/api-keys.ts
@@ -10,6 +10,7 @@ export const API_KEYS_ROUTES = {
 
 export type ApiKeysList = OpResponseBody<OpForPath<typeof API_KEYS_ROUTES.LIST, 'get'>>;
 export type GenerateApiKeyBody = OpRequestBody<OpForPath<typeof API_KEYS_ROUTES.GENERATE, 'post'>>;
+export type GenerateApiKeyResponse = OpResponseBody<OpForPath<typeof API_KEYS_ROUTES.GENERATE, 'post'>>;
 
 export async function fetchApiKeys(fetcher: ApiFetcher): Promise<ApiKeysList> {
   const get = fetcher.path(API_KEYS_ROUTES.LIST).method('get').create();
@@ -20,9 +21,10 @@ export async function fetchApiKeys(fetcher: ApiFetcher): Promise<ApiKeysList> {
 export async function generateApiKey(
   fetcher: ApiFetcher,
   body: GenerateApiKeyBody
-): Promise<void> {
+): Promise<GenerateApiKeyResponse> {
   const post = fetcher.path(API_KEYS_ROUTES.GENERATE).method('post').create();
-  await post(body);
+  const { data } = await post(body);
+  return data;
 }
 
 export async function revokeApiKey(fetcher: ApiFetcher, id: number): Promise<void> {


### PR DESCRIPTION
Closes #1311

## Problem

On **Preferences → API Keys**, clicking **Generate API Key** does nothing — no dialog appears.

`ApiKeysActions` calls `openDialog('api-keys-generate')`, which updates the dialog redux state, but nothing ever mounts a Blueprint `<Dialog>` for that name. `DialogsContainer` renders `<ApiKeysGenerateDialog dialogName={DialogsName.ApiKeysGenerate} />`, but `ApiKeysGenerateDialog` was only an **alias for the Formik form content** — there was no `withDialogRedux()` + `<Dialog isOpen>` wrapper like every other dialog in the app (`CurrencyFormDialog`, etc.). A source comment in the file even acknowledged the wrapper "was never created in the original code".

Result: the API Keys feature is unusable from the UI — a key can only be inserted directly into the database.

## Fix

- **`ApiKeysGenerateDialog.tsx`** — now a real redux-connected `<Dialog>` wrapper (mirrors `CurrencyFormDialog`), lazy-loading the form content and using the already-defined `api_key.dialog.generate_title` i18n key as the title.
- **`ApiKeysGenerateDialogContent.tsx`** — holds the Formik form / generated-key display view (moved out of the dialog file).
- **`shared/sdk-ts` `generateApiKey()`** — returned `Promise<void>` and discarded the response, so even with the dialog rendering, the "copy your key" view never had a key to show (`ApiKeysGenerateDialogContent` was reading `response.data.key` off `undefined`). It now returns the `ApiKeyResponseDto` (`{ id, key }`) body from the 201 response; `useGenerateApiKey` is typed with the new `GenerateApiKeyResponse`.

## Tests

- New `e2e/api-keys.spec.ts`: page loads → open dialog (regression guard) → fill name → generate → `bc_…` key shown in the read-only field → **Done** closes it; plus required-name validation.

## Verification

- `shared/sdk-ts` `tsc --noEmit`: clean.
- `packages/webapp` `tsc --noEmit`: 55 errors, all pre-existing on `develop` (56 before this branch — net −1); none in the touched files.
- Prettier (`packages/webapp/.prettierrc`) and ESLint: clean on all changed files.
- Playwright e2e not run locally (needs the full stack) — relying on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
