### PR TITLE
feat(webapp): add duplicate action for invoices

### DIFF
--- a/packages/webapp/src/containers/Sales/Invoices/InvoiceForm/InvoiceFormProvider.tsx
+++ b/packages/webapp/src/containers/Sales/Invoices/InvoiceForm/InvoiceFormProvider.tsx
@@ -1,7 +1,11 @@
 import { isEmpty, pick } from 'lodash';
 import React, { createContext, useState } from 'react';
 import { useLocation } from 'react-router-dom';
-import { transformToEditForm, ITEMS_FILTER_ROLES_QUERY } from './utils';
+import {
+  transformToEditForm,
+  transformToDuplicateForm,
+  ITEMS_FILTER_ROLES_QUERY,
+} from './utils';
 import type {
   SaleInvoice,
   CreateSaleInvoiceBody,
@@ -101,7 +105,13 @@ function InvoiceFormProvider({
   ...props
 }: InvoiceFormProviderProps) {
   const { state } = useLocation();
-  const estimateId = (state as { action?: string })?.action;
+  const locationState = state as
+    | { action?: string; duplicateInvoiceId?: string | number }
+    | undefined;
+  const duplicateInvoiceId = locationState?.duplicateInvoiceId
+    ? Number(locationState.duplicateInvoiceId)
+    : undefined;
+  const estimateId = locationState?.action;
   const estimateIdNum = estimateId ? Number(estimateId) : undefined;
 
   // Features guard.
@@ -125,8 +135,12 @@ function InvoiceFormProvider({
   // Fetches the estimate by the given id.
   const { data: estimate, isLoading: isEstimateLoading } = useEstimate(
     estimateIdNum,
-    { enabled: !!estimateIdNum },
+    { enabled: !!estimateIdNum && !duplicateInvoiceId },
   );
+
+  // Fetches the duplicate invoice.
+  const { data: duplicateInvoice, isLoading: isDuplicateInvoiceLoading } =
+    useInvoice(duplicateInvoiceId, { enabled: !!duplicateInvoiceId });
 
   // Fetches branding templates of invoice.
   const { data: brandingTemplates, isLoading: isBrandingTemplatesLoading } =
@@ -136,11 +150,17 @@ function InvoiceFormProvider({
   const { data: paymentServices, isLoading: isPaymentServicesLoading } =
     useGetPaymentServices();
 
-  const newInvoice = !isEmpty(estimate)
-    ? transformToEditForm({
-        ...pick(estimate, ['customerId', 'currencyCode', 'entries']),
-      })
-    : ([] as []);
+  const newInvoice = !isEmpty(duplicateInvoice)
+    ? transformToDuplicateForm(
+        duplicateInvoice as Partial<SaleInvoice> & {
+          entries: SaleInvoice['entries'];
+        },
+      )
+    : !isEmpty(estimate)
+      ? transformToEditForm({
+          ...pick(estimate, ['customerId', 'currencyCode', 'entries']),
+        })
+      : ([] as []);
 
   // Handle fetching the items table based on the given query.
   const { data: itemsData, isLoading: isItemsLoading } = useItems({
@@ -184,7 +204,7 @@ function InvoiceFormProvider({
   >();
 
   // Detarmines whether the form in new mode.
-  const isNewMode = !invoiceId;
+  const isNewMode = Boolean(duplicateInvoiceId) || !invoiceId;
 
   // Determines whether the warehouse and branches are loading.
   const isFeatureLoading =
@@ -198,6 +218,7 @@ function InvoiceFormProvider({
     isItemsLoading ||
     isCustomersLoading ||
     isEstimateLoading ||
+    isDuplicateInvoiceLoading ||
     isSettingsLoading ||
     isInvoiceStateLoading;
 

--- a/packages/webapp/src/containers/Sales/Invoices/InvoiceForm/utils.tsx
+++ b/packages/webapp/src/containers/Sales/Invoices/InvoiceForm/utils.tsx
@@ -384,7 +384,13 @@ export const useSetPrimaryWarehouseToForm = () => {
         setFieldValue('warehouseId', primaryWarehouse.id);
       }
     }
-  }, [isWarehousesSuccess, setFieldValue, warehouses, isNewMode, values.warehouseId]);
+  }, [
+    isWarehousesSuccess,
+    setFieldValue,
+    warehouses,
+    isNewMode,
+    values.warehouseId,
+  ]);
 };
 
 export const useSetPrimaryBranchToForm = () => {

--- a/packages/webapp/src/containers/Sales/Invoices/InvoiceForm/utils.tsx
+++ b/packages/webapp/src/containers/Sales/Invoices/InvoiceForm/utils.tsx
@@ -138,6 +138,29 @@ export const defaultReqInvoiceEntry = {
 };
 
 /**
+ * Transform a duplicated invoice to form values.
+ * Copies customer, items, notes, etc. but resets invoice-specific fields:
+ * invoice number, dates (to today), delivered status.
+ */
+export function transformToDuplicateForm(
+  invoice: Partial<SaleInvoice> & { entries: SaleInvoice['entries'] },
+): InvoiceFormValues {
+  const base = transformToEditForm(invoice);
+  const today = moment(new Date()).format('YYYY-MM-DD');
+  // Omit invoice-specific fields so auto-increment can generate a fresh number.
+  // The form's initialValues merger applies the auto next-number before spreading
+  // duplicate data, so omitting invoiceNo preserves that generated number.
+  const withoutNumber = omit(base, ['invoiceNo', 'invoiceNoManually']);
+  return {
+    ...withoutNumber,
+    invoiceDate: today,
+    dueDate: today,
+    delivered: '',
+    referenceNo: '',
+  } as unknown as InvoiceFormValues;
+}
+
+/**
  * Transform invoice to initial values in edit mode.
  *
  * Accepts a partial invoice shape: the provider seeds a new invoice from a
@@ -348,12 +371,12 @@ const transformPaymentMethodsToForm = (
 };
 
 export const useSetPrimaryWarehouseToForm = () => {
-  const { setFieldValue } = useFormikContext<InvoiceFormValues>();
+  const { values, setFieldValue } = useFormikContext<InvoiceFormValues>();
   const { warehouses, isWarehousesSuccess, isNewMode } =
     useInvoiceFormContext();
 
   React.useEffect(() => {
-    if (isWarehousesSuccess && isNewMode) {
+    if (isWarehousesSuccess && isNewMode && !values.warehouseId) {
       const primaryWarehouse =
         warehouses.find((b) => b.primary) || first(warehouses);
 
@@ -361,22 +384,22 @@ export const useSetPrimaryWarehouseToForm = () => {
         setFieldValue('warehouseId', primaryWarehouse.id);
       }
     }
-  }, [isWarehousesSuccess, setFieldValue, warehouses, isNewMode]);
+  }, [isWarehousesSuccess, setFieldValue, warehouses, isNewMode, values.warehouseId]);
 };
 
 export const useSetPrimaryBranchToForm = () => {
-  const { setFieldValue } = useFormikContext<InvoiceFormValues>();
+  const { values, setFieldValue } = useFormikContext<InvoiceFormValues>();
   const { branches, isBranchesSuccess, isNewMode } = useInvoiceFormContext();
 
   React.useEffect(() => {
-    if (isBranchesSuccess && isNewMode) {
+    if (isBranchesSuccess && isNewMode && !values.branchId) {
       const primaryBranch = branches.find((b) => b.primary) || first(branches);
 
       if (primaryBranch) {
         setFieldValue('branchId', primaryBranch.id);
       }
     }
-  }, [isBranchesSuccess, setFieldValue, branches, isNewMode]);
+  }, [isBranchesSuccess, setFieldValue, branches, isNewMode, values.branchId]);
 };
 
 /**

--- a/packages/webapp/src/containers/Sales/Invoices/InvoicesLanding/InvoicesDataTable.tsx
+++ b/packages/webapp/src/containers/Sales/Invoices/InvoicesLanding/InvoicesDataTable.tsx
@@ -95,6 +95,10 @@ function InvoicesDataTableInner({
     openDrawer(DRAWERS.INVOICE_SEND_MAIL, { invoiceId: id });
   };
 
+  const handleDuplicateInvoice = ({ id }: InvoiceTableRow) => {
+    history.push('/invoices/new', { duplicateInvoiceId: id });
+  };
+
   const handleCellClick = (cell: any, _event: React.MouseEvent) => {
     openDrawer(DRAWERS.INVOICE_DETAILS, { invoiceId: cell.row.original.id });
   };
@@ -172,6 +176,7 @@ function InvoicesDataTableInner({
           onPrint: handlePrintInvoice,
           onConvert: handleConvertToCreitNote,
           onSendMail: handleSendMailInvoice,
+          onDuplicate: handleDuplicateInvoice,
         }}
       />
     </DashboardContentTable>

--- a/packages/webapp/src/containers/Sales/Invoices/InvoicesLanding/components.tsx
+++ b/packages/webapp/src/containers/Sales/Invoices/InvoicesLanding/components.tsx
@@ -34,6 +34,7 @@ interface InvoiceActionsPayload {
   onViewDetails: (invoice: InvoiceTableRow) => void;
   onPrint: (invoice: InvoiceTableRow) => void;
   onSendMail: (invoice: InvoiceTableRow) => void;
+  onDuplicate: (invoice: InvoiceTableRow) => void;
 }
 
 interface ActionsMenuProps {
@@ -142,6 +143,7 @@ export function ActionsMenu({
     onViewDetails,
     onPrint,
     onSendMail,
+    onDuplicate,
   },
   row: { original },
 }: ActionsMenuProps) {
@@ -158,6 +160,11 @@ export function ActionsMenu({
           icon={<Icon icon="pen-18" />}
           text={intl.get('edit_invoice')}
           onClick={safeCallback(onEdit, original)}
+        />
+        <MenuItem
+          icon={<Icon icon="duplicate" />}
+          text={intl.get('duplicate')}
+          onClick={safeCallback(onDuplicate, original)}
         />
         <MenuItem
           icon={<Icon icon="convert_to" />}


### PR DESCRIPTION
## Description

Fixes #1309

Invoices had no duplicate/clone action unlike customers and items. This adds a Duplicate entry to the invoices list that reuses the existing fetch-and-create flow to open a new invoice pre-filled from the original with a fresh auto-increment number, today's dates and draft status.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Manually verified duplicate opens the new invoice form pre-filled and saves as a new invoice; existing create, edit and estimate-to-invoice flows remain unchanged.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Reviewers: @abouolia @naoswilbrink