### PR TITLE
fix: add missing currencies LRD and SLE

### DIFF
--- a/packages/server/src/modules/Currencies/commands/InitialCurrenciesSeed.service.ts
+++ b/packages/server/src/modules/Currencies/commands/InitialCurrenciesSeed.service.ts
@@ -5,6 +5,34 @@ import { InitialCurrencies } from '../Currencies.constants';
 import { TenantModelProxy } from '../../System/models/TenantBaseModel';
 import { Currency } from '../models/Currency.model';
 
+// ISO 4217 currencies missing from js-money@0.6.3 – supplement at runtime.
+const EXTRA_CURRENCIES: Record<string, any> = {
+  LRD: {
+    symbol: 'L$',
+    name: 'Liberian Dollar',
+    symbol_native: 'L$',
+    decimal_digits: 2,
+    rounding: 0,
+    code: 'LRD',
+    name_plural: 'Liberian dollars',
+  },
+  SLE: {
+    symbol: 'Le',
+    name: 'Sierra Leonean Leone',
+    symbol_native: 'Le',
+    decimal_digits: 2,
+    rounding: 0,
+    code: 'SLE',
+    name_plural: 'Sierra Leonean leones',
+  },
+};
+
+Object.entries(EXTRA_CURRENCIES).forEach(([code, meta]) => {
+  if (!(Currencies as Record<string, any>)[code]) {
+    (Currencies as Record<string, any>)[code] = meta;
+  }
+});
+
 @Injectable()
 export class InitialCurrenciesSeedService {
   constructor(

--- a/packages/server/src/utils/format-number.ts
+++ b/packages/server/src/utils/format-number.ts
@@ -2,6 +2,34 @@ import { get } from 'lodash';
 import * as accounting from 'accounting';
 import * as Currencies from 'js-money/lib/currency';
 
+// Supplement missing ISO 4217 currencies (js-money@0.6.3 lacks LRD/SLE).
+const EXTRA_CURRENCY_SYMBOLS: Record<string, any> = {
+  LRD: {
+    symbol: 'L$',
+    name: 'Liberian Dollar',
+    symbol_native: 'L$',
+    decimal_digits: 2,
+    rounding: 0,
+    code: 'LRD',
+    name_plural: 'Liberian dollars',
+  },
+  SLE: {
+    symbol: 'Le',
+    name: 'Sierra Leonean Leone',
+    symbol_native: 'Le',
+    decimal_digits: 2,
+    rounding: 0,
+    code: 'SLE',
+    name_plural: 'Sierra Leonean leones',
+  },
+};
+
+Object.entries(EXTRA_CURRENCY_SYMBOLS).forEach(([code, meta]) => {
+  if (!(Currencies as Record<string, any>)[code]) {
+    (Currencies as Record<string, any>)[code] = meta;
+  }
+});
+
 const getNegativeFormat = (formatName) => {
   switch (formatName) {
     case 'parentheses':

--- a/packages/webapp/src/constants/currencies.tsx
+++ b/packages/webapp/src/constants/currencies.tsx
@@ -2,6 +2,34 @@ import currencies from 'js-money/lib/currency';
 import { sortBy } from 'lodash';
 import intl from 'react-intl-universal';
 
+// Supplement missing currencies absent in js-money@0.6.3.
+const EXTRA_CURRENCIES: Record<string, any> = {
+  LRD: {
+    symbol: 'L$',
+    name: 'Liberian Dollar',
+    symbol_native: 'L$',
+    decimal_digits: 2,
+    rounding: 0,
+    code: 'LRD',
+    name_plural: 'Liberian dollars',
+  },
+  SLE: {
+    symbol: 'Le',
+    name: 'Sierra Leonean Leone',
+    symbol_native: 'Le',
+    decimal_digits: 2,
+    rounding: 0,
+    code: 'SLE',
+    name_plural: 'Sierra Leonean leones',
+  },
+};
+
+Object.entries(EXTRA_CURRENCIES).forEach(([code, meta]) => {
+  if (!(currencies as Record<string, any>)[code]) {
+    (currencies as Record<string, any>)[code] = meta;
+  }
+});
+
 export interface CurrencyOption {
   name: string;
   code: string;

--- a/packages/webapp/src/utils/index.tsx
+++ b/packages/webapp/src/utils/index.tsx
@@ -5,6 +5,37 @@ import clsx from 'classnames';
 import jsCookie from 'js-cookie';
 import Currencies from 'js-money/lib/currency';
 import Currency from 'js-money/lib/currency';
+
+// Supplement missing ISO 4217 currencies not present in js-money@0.6.3.
+const EXTRA_CURRENCIES: Record<string, any> = {
+  LRD: {
+    symbol: 'L$',
+    name: 'Liberian Dollar',
+    symbol_native: 'L$',
+    decimal_digits: 2,
+    rounding: 0,
+    code: 'LRD',
+    name_plural: 'Liberian dollars',
+  },
+  SLE: {
+    symbol: 'Le',
+    name: 'Sierra Leonean Leone',
+    symbol_native: 'Le',
+    decimal_digits: 2,
+    rounding: 0,
+    code: 'SLE',
+    name_plural: 'Sierra Leonean leones',
+  },
+};
+
+Object.entries(EXTRA_CURRENCIES).forEach(([code, meta]) => {
+  if (!(Currencies as Record<string, any>)[code]) {
+    (Currencies as Record<string, any>)[code] = meta;
+  }
+  if (!(Currency as Record<string, any>)[code]) {
+    (Currency as Record<string, any>)[code] = meta;
+  }
+});
 import _ from 'lodash';
 import { isEqual, castArray, isEmpty, includes, pickBy } from 'lodash';
 import moment from 'moment';


### PR DESCRIPTION
## Description

Fixes #1182. js-money@0.6.3 omits LRD and SLE so they cannot be selected as base currency; this supplements the registry at runtime so both currencies are selectable and seed correctly.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Verified the currencies were missing on base and that LRD/SLE now appear in the selector and seed with the expected symbols.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes