### PR TITLE
fix(webapp): sort Chart of Accounts by Code asc/desc

### DIFF
--- a/packages/webapp/src/containers/Accounts/utils.tsx
+++ b/packages/webapp/src/containers/Accounts/utils.tsx
@@ -54,12 +54,17 @@ export const handleDeleteErrors = (errors: DeleteError[]) => {
   }
 };
 
-export const AccountCodeAccessor = (row: AccountTableRow) =>
-  !isBlank(row.code) ? (
+export function AccountCodeCell({
+  cell: { value },
+}: {
+  cell: { value?: string };
+}) {
+  return !isBlank(value) ? (
     <Tag minimal round intent={Intent.NONE}>
-      {row.code}
+      {value}
     </Tag>
   ) : null;
+}
 
 /**
  * Accounts table columns.
@@ -81,7 +86,8 @@ export const useAccountsTableColumns =
           {
             id: 'code',
             Header: intl.get('code'),
-            accessor: AccountCodeAccessor,
+            accessor: 'code',
+            Cell: AccountCodeCell,
             className: 'code',
             width: 80,
             clickable: true,


### PR DESCRIPTION
## Description

Sorting the Code column in Chart of Accounts did not work for ASC/DESC. The column sorted rendered `<Tag>` elements (`"[object Object]"`) instead of raw code strings. Changed the column to `accessor: 'code'` with `Cell: AccountCodeCell` to restore correct sorting while preserving the Tag presentation.

Fixes #788

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Verified the column definition and simulated ASC/DESC sorting before and after the change; `git diff --check` clean, Prettier clean, single-file change.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes