### PR TITLE
fix(server): compute item quantity on hand from inventory transactions

### DIFF
--- a/packages/server/src/modules/Items/GetItem.service.ts
+++ b/packages/server/src/modules/Items/GetItem.service.ts
@@ -24,11 +24,15 @@ export class GetItemService {
   ) {}
 
   private async getQuantityOnHand(itemId: number): Promise<number> {
-    const result = await this.inventoryTransactionModel()
+    const result = (await this.inventoryTransactionModel()
       .query()
       .where('itemId', itemId)
-      .select(raw("COALESCE(SUM(CASE WHEN direction = 'IN' THEN quantity WHEN direction = 'OUT' THEN -quantity ELSE 0 END), 0) as quantityOnHand"))
-      .first() as any;
+      .select(
+        raw(
+          "COALESCE(SUM(CASE WHEN direction = 'IN' THEN quantity WHEN direction = 'OUT' THEN -quantity ELSE 0 END), 0) as quantityOnHand",
+        ),
+      )
+      .first()) as any;
 
     return Number(result?.quantityOnHand ?? 0);
   }

--- a/packages/server/src/modules/Items/GetItem.service.ts
+++ b/packages/server/src/modules/Items/GetItem.service.ts
@@ -1,21 +1,37 @@
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { Inject, Injectable } from '@nestjs/common';
 import { Item } from './models/Item';
+import { InventoryTransaction } from '@/modules/InventoryCost/models/InventoryTransaction';
 import { events } from '@/common/events/events';
 import { TransformerInjectable } from '../Transformer/TransformerInjectable.service';
 import { ItemTransformer } from './Item.transformer';
 import { TenantModelProxy } from '../System/models/TenantBaseModel';
 import { ClsService } from 'nestjs-cls';
+import { raw } from 'objection';
 
 @Injectable()
 export class GetItemService {
   constructor(
     @Inject(Item.name)
     private readonly itemModel: TenantModelProxy<typeof Item>,
+    @Inject(InventoryTransaction.name)
+    private readonly inventoryTransactionModel: TenantModelProxy<
+      typeof InventoryTransaction
+    >,
     private readonly eventEmitter2: EventEmitter2,
     private readonly transformerInjectable: TransformerInjectable,
     private readonly clsService: ClsService,
   ) {}
+
+  private async getQuantityOnHand(itemId: number): Promise<number> {
+    const result = await this.inventoryTransactionModel()
+      .query()
+      .where('itemId', itemId)
+      .select(raw("COALESCE(SUM(CASE WHEN direction = 'IN' THEN quantity WHEN direction = 'OUT' THEN -quantity ELSE 0 END), 0) as quantityOnHand"))
+      .first() as any;
+
+    return Number(result?.quantityOnHand ?? 0);
+  }
 
   /**
    * Retrieve the item details of the given id with associated details.
@@ -34,6 +50,10 @@ export class GetItemService {
       .withGraphFetched('sellTaxRate')
       .withGraphFetched('purchaseTaxRate')
       .throwIfNotFound();
+
+    if (item.type === 'inventory') {
+      (item as any).quantityOnHand = await this.getQuantityOnHand(itemId);
+    }
 
     const transformed = await this.transformerInjectable.transform(
       item,

--- a/packages/server/src/modules/Items/GetItems.service.ts
+++ b/packages/server/src/modules/Items/GetItems.service.ts
@@ -36,7 +36,9 @@ export class GetItemsService {
       .whereIn('itemId', ids)
       .select('itemId')
       .select(
-        raw("COALESCE(SUM(CASE WHEN direction = 'IN' THEN quantity WHEN direction = 'OUT' THEN -quantity ELSE 0 END), 0) as quantityOnHand"),
+        raw(
+          "COALESCE(SUM(CASE WHEN direction = 'IN' THEN quantity WHEN direction = 'OUT' THEN -quantity ELSE 0 END), 0) as quantityOnHand",
+        ),
       )
       .groupBy('itemId');
 

--- a/packages/server/src/modules/Items/GetItems.service.ts
+++ b/packages/server/src/modules/Items/GetItems.service.ts
@@ -3,11 +3,13 @@ import { Inject, Injectable } from '@nestjs/common';
 import { TransformerInjectable } from '../Transformer/TransformerInjectable.service';
 import { DynamicListService } from '../DynamicListing/DynamicList.service';
 import { Item } from './models/Item';
+import { InventoryTransaction } from '@/modules/InventoryCost/models/InventoryTransaction';
 import { IItemsFilter } from './types/Items.types';
 import { ItemTransformer } from './Item.transformer';
 import { TenantModelProxy } from '../System/models/TenantBaseModel';
 import { ISortOrder } from '../DynamicListing/DynamicFilter/DynamicFilter.types';
 import { GetItemsQueryDto } from './dtos/GetItemsQuery.dto';
+import { raw } from 'objection';
 
 @Injectable()
 export class GetItemsService {
@@ -17,7 +19,34 @@ export class GetItemsService {
 
     @Inject(Item.name)
     private readonly itemModel: TenantModelProxy<typeof Item>,
+
+    @Inject(InventoryTransaction.name)
+    private readonly inventoryTransactionModel: TenantModelProxy<
+      typeof InventoryTransaction
+    >,
   ) {}
+
+  private async attachQuantityOnHand(items: Item[]): Promise<void> {
+    const inventoryItems = items.filter((i) => i.type === 'inventory');
+    if (inventoryItems.length === 0) return;
+
+    const ids = inventoryItems.map((i) => i.id);
+    const rows: any[] = await this.inventoryTransactionModel()
+      .query()
+      .whereIn('itemId', ids)
+      .select('itemId')
+      .select(
+        raw("COALESCE(SUM(CASE WHEN direction = 'IN' THEN quantity WHEN direction = 'OUT' THEN -quantity ELSE 0 END), 0) as quantityOnHand"),
+      )
+      .groupBy('itemId');
+
+    const map = new Map<number, number>();
+    rows.forEach((r) => map.set(Number(r.itemId), Number(r.quantityOnHand)));
+
+    inventoryItems.forEach((item) => {
+      (item as any).quantityOnHand = map.get(item.id) ?? 0;
+    });
+  }
 
   /**
    * Parses items list filter DTO.
@@ -63,6 +92,8 @@ export class GetItemsService {
         dynamicFilter.buildQuery()(builder);
       })
       .pagination(filter.page - 1, filter.pageSize);
+
+    await this.attachQuantityOnHand(items as any);
 
     // Retrieves the transformed items.
     const data = await this.transformer.transform(items, new ItemTransformer());


### PR DESCRIPTION
## Description

Item page showed a different quantity on hand than the inventory details report. The page read the cached `items.quantity_on_hand` while the report aggregates `inventory_transactions`; this change computes quantity on hand from `inventory_transactions` at read time so both views share the same source. Non-inventory items are unaffected.

Fixes #1268

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Verified the ledger-vs-cache divergence by code inspection and the fix by local code review; existing server tests and type checks will run in CI.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Reviewers: @abouolia @naoswilbrink @jtbuffmire