### PR TITLE
fix(webapp): enable camelCase transform for bill landed cost transactions

### DIFF
--- a/packages/webapp/src/hooks/query/landed-cost/queries.ts
+++ b/packages/webapp/src/hooks/query/landed-cost/queries.ts
@@ -88,7 +88,7 @@ export function useBillLocatedLandedCost(
     'queryKey' | 'queryFn'
   >,
 ) {
-  const fetcher = useApiFetcher();
+  const fetcher = useApiFetcher({ enableCamelCaseTransform: true });
 
   return useQuery({
     ...props,


### PR DESCRIPTION
Fixes empty columns in the Bill Drawer landed cost transactions table.\n\nThe backend serializes outgoing JSON as snake_case, but the table columns expect camelCase fields (formattedAmount, allocationMethodFormatted, fromTransactionType, fromTransactionId). Enabling the camelCase transform in useBillLocatedLandedCost aligns the response keys with the accessors and SDK types.