### PR TITLE
fix(webapp): guard missing tax rate in aggregated entries

### DIFF
--- a/packages/webapp/src/containers/Entries/utils.tsx
+++ b/packages/webapp/src/containers/Entries/utils.tsx
@@ -306,7 +306,9 @@ export const aggregateItemEntriesTaxRates = R.curry(
       return {
         taxRateId,
         taxRate: taxRate?.rate ?? 0,
-        label: taxRate ? `${taxRate.name} [${taxRate.rate}%]` : `Tax #${taxRateId} [0%]`,
+        label: taxRate
+          ? `${taxRate.name} [${taxRate.rate}%]`
+          : `Tax #${taxRateId} [0%]`,
         taxAmount: totalTaxAmount,
         taxAmountFormatted,
       };

--- a/packages/webapp/src/containers/Entries/utils.tsx
+++ b/packages/webapp/src/containers/Entries/utils.tsx
@@ -291,7 +291,7 @@ export const useComposeRowsOnRemoveTableRow = () => {
  */
 export const aggregateItemEntriesTaxRates = R.curry(
   (currencyCode, taxRates, entries) => {
-    const taxRatesById = keyBy(taxRates, 'id');
+    const taxRatesById = keyBy(taxRates ?? [], 'id');
 
     // Calculate the total tax amount of invoice entries.
     const filteredEntries = entries.filter((e) => e.taxRateId);
@@ -305,8 +305,8 @@ export const aggregateItemEntriesTaxRates = R.curry(
 
       return {
         taxRateId,
-        taxRate: taxRate.rate,
-        label: `${taxRate.name} [${taxRate.rate}%]`,
+        taxRate: taxRate?.rate ?? 0,
+        label: taxRate ? `${taxRate.name} [${taxRate.rate}%]` : `Tax #${taxRateId} [0%]`,
         taxAmount: totalTaxAmount,
         taxAmountFormatted,
       };


### PR DESCRIPTION
## Description

Fixes #925

Adding a line to an invoice crashes after the 0.22.0 -> 0.24.3 upgrade when the referenced tax rate is missing or not yet loaded. The fix guards the aggregation and falls back to 0% so the invoice remains usable.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Reproduced with empty and missing tax rate inputs before the fix (TypeError) and verified the fallback after the fix; existing valid-rate path unchanged.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes