### PR TITLE
refactor(webapp): remove subscription step from onboarding wizard

### DIFF
--- a/packages/webapp/src/constants/registerWizard.tsx
+++ b/packages/webapp/src/constants/registerWizard.tsx
@@ -2,9 +2,6 @@ import intl from 'react-intl-universal';
 
 export const getSetupWizardSteps = (): Array<{ label: string }> => [
   {
-    label: intl.get('setup.plan.plans'),
-  },
-  {
     label: intl.get('setup.plan.getting_started'),
   },
   {

--- a/packages/webapp/src/containers/Setup/SetupRightSection.tsx
+++ b/packages/webapp/src/containers/Setup/SetupRightSection.tsx
@@ -1,7 +1,7 @@
 import { x } from '@xstyled/emotion';
 import React from 'react';
 import { SetupWizardContent } from './SetupWizardContent';
-import { useCurrentOrganization, useSubscription } from '@/hooks/query';
+import { useCurrentOrganization } from '@/hooks/query';
 import { useIsOrganizationSetupCompleted } from '@/hooks/state';
 
 /**
@@ -12,10 +12,8 @@ export function SetupRightSection() {
   const isOrganizationReady = !!organization?.isReady;
   const isOrganizationBuildRunning = !!organization?.isBuildRunning;
   const isOrganizationSetupCompleted = useIsOrganizationSetupCompleted();
-  const { isSubscriptionActive } = useSubscription('main');
 
   const scenarios = [
-    { condition: !isSubscriptionActive, step: 'subscription' },
     {
       condition: !isOrganizationReady && !isOrganizationBuildRunning,
       step: 'organization',

--- a/packages/webapp/src/containers/Setup/SetupWizardContent.tsx
+++ b/packages/webapp/src/containers/Setup/SetupWizardContent.tsx
@@ -3,7 +3,6 @@ import { x } from '@xstyled/emotion';
 import { SetupCongratsPage } from './SetupCongratsPage';
 import { SetupInitializingForm } from './SetupInitializingForm';
 import { SetupOrganizationPage } from './SetupOrganizationPage';
-import { SetupSubscription } from './SetupSubscription/SetupSubscription';
 import { Stepper } from '@/components/Stepper';
 
 interface SetupWizardContentProps {
@@ -30,10 +29,6 @@ export function SetupWizardContent({
           items: itemsClassName,
         }}
       >
-        <Stepper.Step label={'Subscription'}>
-          <SetupSubscription />
-        </Stepper.Step>
-
         <Stepper.Step label={'Organization'}>
           <SetupOrganizationPage />
         </Stepper.Step>


### PR DESCRIPTION
Removes the subscription step and page from the onboarding/setup wizard while keeping all subscription-related components intact for reuse elsewhere.