### PR TITLE
fix(webapp): add ISO 4217 currencies missing from js-money

### DIFF
--- a/packages/webapp/src/constants/__tests__/currencies.spec.ts
+++ b/packages/webapp/src/constants/__tests__/currencies.spec.ts
@@ -1,0 +1,48 @@
+// @ts-nocheck
+import jsMoneyCurrencies from 'js-money/lib/currency';
+import { additionalCurrencies } from '../additionalCurrencies';
+import { allCurrencies, getAllCurrenciesOptions } from '../currencies';
+
+describe('allCurrencies', () => {
+  it('includes every js-money currency', () => {
+    for (const code of Object.keys(jsMoneyCurrencies)) {
+      expect(allCurrencies[code]).toBeDefined();
+    }
+  });
+
+  it('includes the ISO 4217 currencies missing from js-money', () => {
+    // Regression guard for #1182 (LRD, SLE/SLL) and #909 (GYD).
+    for (const code of ['LRD', 'SLL', 'SLE', 'GYD', 'XCD']) {
+      expect(jsMoneyCurrencies[code]).toBeUndefined();
+      expect(allCurrencies[code]).toBeDefined();
+      expect(allCurrencies[code].name).toBeTruthy();
+    }
+  });
+
+  it('lets js-money win on key clashes', () => {
+    expect(allCurrencies.USD).toBe(jsMoneyCurrencies.USD);
+  });
+
+  it('does not lose any additional currency to a clash', () => {
+    for (const code of Object.keys(additionalCurrencies)) {
+      expect(allCurrencies[code]).toBeDefined();
+    }
+  });
+});
+
+describe('getAllCurrenciesOptions', () => {
+  const options = getAllCurrenciesOptions();
+
+  it('returns one { key, name } entry per known currency', () => {
+    expect(options).toHaveLength(Object.keys(allCurrencies).length);
+    expect(options.find((o) => o.key === 'LRD')).toEqual({
+      key: 'LRD',
+      name: 'LRD - Liberian Dollar',
+    });
+  });
+
+  it('is sorted by currency code', () => {
+    const codes = options.map((o) => o.key);
+    expect(codes).toEqual([...codes].sort());
+  });
+});

--- a/packages/webapp/src/constants/additionalCurrencies.ts
+++ b/packages/webapp/src/constants/additionalCurrencies.ts
@@ -1,0 +1,75 @@
+/**
+ * Active ISO 4217 currencies that ship with `js-money/lib/currency` are limited
+ * to ~120 entries and omit a number of circulating national currencies (e.g.
+ * LRD, GYD, SLL/SLE, XCD). This table supplements that list so every currency
+ * can be picked as a base/secondary currency and formatted with the right
+ * symbol and precision.
+ *
+ * Shape matches `js-money` currency entries so the two can be merged directly.
+ */
+export interface CurrencyEntry {
+  symbol: string;
+  name: string;
+  symbol_native: string;
+  decimal_digits: number;
+  rounding: number;
+  code: string;
+  name_plural: string;
+}
+
+const make = (
+  code: string,
+  name: string,
+  symbol: string,
+  name_plural: string,
+  decimal_digits = 2,
+): CurrencyEntry => ({
+  symbol,
+  name,
+  symbol_native: symbol,
+  decimal_digits,
+  rounding: 0,
+  code,
+  name_plural,
+});
+
+export const additionalCurrencies: Record<string, CurrencyEntry> = {
+  ANG: make('ANG', 'Netherlands Antillean Guilder', 'ƒ', 'guilders'),
+  AOA: make('AOA', 'Angolan Kwanza', 'Kz', 'kwanzas'),
+  AWG: make('AWG', 'Aruban Florin', 'ƒ', 'florin'),
+  BBD: make('BBD', 'Barbadian Dollar', '$', 'dollars'),
+  BMD: make('BMD', 'Bermudian Dollar', '$', 'dollars'),
+  BSD: make('BSD', 'Bahamian Dollar', '$', 'dollars'),
+  BTN: make('BTN', 'Bhutanese Ngultrum', 'Nu.', 'ngultrums'),
+  BYN: make('BYN', 'Belarusian Ruble', 'Br', 'rubles'),
+  CUP: make('CUP', 'Cuban Peso', '$', 'pesos'),
+  FJD: make('FJD', 'Fijian Dollar', '$', 'dollars'),
+  GMD: make('GMD', 'Gambian Dalasi', 'D', 'dalasis'),
+  GYD: make('GYD', 'Guyanese Dollar', '$', 'dollars'),
+  HTG: make('HTG', 'Haitian Gourde', 'G', 'gourdes'),
+  KGS: make('KGS', 'Kyrgyzstani Som', 'som', 'soms'),
+  KYD: make('KYD', 'Cayman Islands Dollar', '$', 'dollars'),
+  LRD: make('LRD', 'Liberian Dollar', '$', 'dollars'),
+  LSL: make('LSL', 'Lesotho Loti', 'L', 'maloti'),
+  MNT: make('MNT', 'Mongolian Tögrög', '₮', 'tögrög'),
+  MRU: make('MRU', 'Mauritanian Ouguiya', 'UM', 'ouguiyas'),
+  MVR: make('MVR', 'Maldivian Rufiyaa', 'Rf', 'rufiyaa'),
+  MWK: make('MWK', 'Malawian Kwacha', 'MK', 'kwacha'),
+  PGK: make('PGK', 'Papua New Guinean Kina', 'K', 'kina'),
+  SBD: make('SBD', 'Solomon Islands Dollar', '$', 'dollars'),
+  SCR: make('SCR', 'Seychellois Rupee', '₨', 'rupees'),
+  SLE: make('SLE', 'Sierra Leonean Leone', 'Le', 'leones'),
+  SLL: make('SLL', 'Sierra Leonean Leone (1964–2022)', 'Le', 'leones'),
+  SRD: make('SRD', 'Surinamese Dollar', '$', 'dollars'),
+  SSP: make('SSP', 'South Sudanese Pound', '£', 'pounds'),
+  STN: make('STN', 'São Tomé and Príncipe Dobra', 'Db', 'dobras'),
+  SZL: make('SZL', 'Swazi Lilangeni', 'L', 'emalangeni'),
+  TJS: make('TJS', 'Tajikistani Somoni', 'ЅМ', 'somoni'),
+  TMT: make('TMT', 'Turkmenistani Manat', 'm', 'manat'),
+  VES: make('VES', 'Venezuelan Bolívar', 'Bs.', 'bolívares'),
+  VUV: make('VUV', 'Vanuatu Vatu', 'VT', 'vatu', 0),
+  WST: make('WST', 'Samoan Tala', 'T', 'tala'),
+  XCD: make('XCD', 'East Caribbean Dollar', '$', 'dollars'),
+  XPF: make('XPF', 'CFP Franc', '₣', 'francs', 0),
+  ZWL: make('ZWL', 'Zimbabwean Dollar', '$', 'dollars'),
+};

--- a/packages/webapp/src/constants/currencies.tsx
+++ b/packages/webapp/src/constants/currencies.tsx
@@ -1,11 +1,24 @@
-import currencies from 'js-money/lib/currency';
+import jsMoneyCurrencies from 'js-money/lib/currency';
 import { sortBy } from 'lodash';
 import intl from 'react-intl-universal';
+import {
+  additionalCurrencies,
+  type CurrencyEntry,
+} from './additionalCurrencies';
 
 export interface CurrencyOption {
   name: string;
   code: string;
 }
+
+/**
+ * All known currencies: the `js-money` list plus the active ISO 4217 currencies
+ * it omits (see `additionalCurrencies`). `js-money` entries win on key clashes.
+ */
+export const allCurrencies: Record<string, CurrencyEntry> = {
+  ...additionalCurrencies,
+  ...(jsMoneyCurrencies as Record<string, CurrencyEntry>),
+};
 
 export const getCurrencies = (): CurrencyOption[] => [
   { name: intl.get('us_dollar'), code: 'USD' },
@@ -17,15 +30,10 @@ export const getAllCurrenciesOptions = (): Array<{
   key: string;
   name: string;
 }> => {
-  const codes = Object.keys(currencies);
-  const sortedCodes = sortBy(codes);
+  const sortedCodes = sortBy(Object.keys(allCurrencies));
 
-  return sortedCodes.map((code) => {
-    const currency = currencies[code];
-
-    return {
-      key: code,
-      name: `${code} - ${currency.name}`,
-    };
-  });
+  return sortedCodes.map((code) => ({
+    key: code,
+    name: `${code} - ${allCurrencies[code].name}`,
+  }));
 };

--- a/packages/webapp/src/utils/index.tsx
+++ b/packages/webapp/src/utils/index.tsx
@@ -3,14 +3,13 @@ import { Intent } from '@blueprintjs/core';
 import accounting from 'accounting';
 import clsx from 'classnames';
 import jsCookie from 'js-cookie';
-import Currencies from 'js-money/lib/currency';
-import Currency from 'js-money/lib/currency';
 import _ from 'lodash';
 import { isEqual, castArray, isEmpty, includes, pickBy } from 'lodash';
 import moment from 'moment';
 import { createSelectorCreator, defaultMemoize } from 'reselect';
 import { deepMapKeys } from './map-key-deep';
 import type { IResourceField } from '@/components/AdvancedFilter/interfaces';
+import { allCurrencies } from '@/constants/currencies';
 export * from './deep';
 export * from './flatten-infinity-pages';
 
@@ -190,7 +189,7 @@ export const defaultExpanderReducer = (tableRows, level) => {
 };
 
 export function formattedAmount(cents, currencyCode = '', props = {}) {
-  const currency = Currency[currencyCode];
+  const currency = allCurrencies[currencyCode];
 
   const parsedCurrency = {
     symbol: '',
@@ -722,8 +721,8 @@ export const calculateStatus = (paymentAmount, balanceAmount) => {
 };
 
 const getCurrenciesOptions = () => {
-  return Object.keys(Currencies).map((currencyCode) => {
-    const currency = Currencies[currencyCode];
+  return Object.keys(allCurrencies).map((currencyCode) => {
+    const currency = allCurrencies[currencyCode];
 
     return {
       ...currency,


### PR DESCRIPTION
Closes #1182
Closes #909

## Problem

Currencies like **LRD** (Liberian Dollar), **GYD** (Guyanese Dollar) and **SLL/SLE** (Sierra Leonean Leone) can't be chosen as a base currency, and several others (e.g. **XCD**) are missing too.

Every currency selector in the webapp is fed from `js-money/lib/currency`:

- `getAllCurrenciesOptions()` in `packages/webapp/src/constants/currencies.tsx` → setup wizard base-currency field (`SetupOrganizationForm`), Preferences → General, workspace creation
- `getCurrenciesOptions()` in `packages/webapp/src/utils/index.tsx` → Preferences → Currencies (`CurrencyFormDialog`)
- `formattedAmount()` in the same file uses it for the symbol + decimal precision

`js-money@0.6.3` (published ~2016) ships only ~120 entries and omits a number of still-circulating ISO 4217 currencies. If a currency isn't in that list it can't be selected, and amounts in it render with no symbol and 0 decimal places (`formattedAmount` falls back to `{ symbol: '', decimal_digits: 0 }`).

## Fix

- **`packages/webapp/src/constants/additionalCurrencies.ts`** (new) — a table of active ISO 4217 currencies absent from `js-money` (LRD, GYD, SLL, SLE, XCD, and ~30 more), in the same entry shape js-money uses (`symbol`, `name`, `symbol_native`, `decimal_digits`, `rounding`, `code`, `name_plural`).
- **`constants/currencies.tsx`** — export `allCurrencies = { ...additionalCurrencies, ...jsMoneyCurrencies }` (js-money wins on any key clash) and drive `getAllCurrenciesOptions()` from it.
- **`utils/index.tsx`** — `formattedAmount()` and `getCurrenciesOptions()` now read from `allCurrencies` instead of importing `js-money/lib/currency` directly, so the extra currencies also format correctly.

## Scope

Frontend only — no server-side changes.

The server does not gate currency codes: `CreateCurrencyDto` validates `currencyCode` as `@IsString() @IsNotEmpty()` with no allowlist, and the organisation base-currency field is unvalidated, so it already accepts any of these codes. Nothing on the API side needs to change for them to work.

The `js-money` dependency is kept (it also provides `Money` elsewhere); this only supplements its currency table rather than replacing the package.

## Tests

- **`constants/__tests__/currencies.spec.ts`** (new) — asserts `allCurrencies` is a superset of the js-money list, that the reported gaps (LRD/SLL/SLE/GYD/XCD) are present, that js-money wins on clashes, and that `getAllCurrenciesOptions()` stays sorted by code.

Note: the `packages/webapp` package currently has **no wired-up unit-test runner** — the existing `src/**/__tests__/*.spec.ts` files (e.g. `FinancialStatements/__tests__/dateRange.spec.ts`) are not executed by CI and the `test` script points at a non-existent `scripts/test.js`. This spec follows that existing pattern; happy to move it into the Playwright e2e suite instead if that's preferred.

## Verification

- `packages/webapp` `tsc --noEmit`: **55 errors, all pre-existing on `develop`** (identical count with and without this branch); none in the touched files.
- ESLint (`lint:check`) and Prettier: clean on all changed files.
- Manually confirmed the missing codes now appear in the base-currency dropdown and format with their symbol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
