### PR TITLE
fix: resolve ESLint errors in shared pdf-templates and email-components

### DIFF
--- a/shared/email-components/src/lib/CreditNoteEmailTemplate.tsx
+++ b/shared/email-components/src/lib/CreditNoteEmailTemplate.tsx
@@ -203,15 +203,6 @@ export const renderCreditNoteEmailTemplate = (props: CreditNoteEmailProps) => {
   return render(<CreditNoteEmailTemplate {...props} />);
 };
 
-const containerStyle: CSSProperties = {
-  backgroundColor: '#fff',
-  width: '100%',
-  maxWidth: '500px',
-  padding: '35px 25px',
-  color: '#000',
-  borderRadius: '5px',
-};
-
 const headerInfoStyle: CSSProperties = {
   textAlign: 'center',
   marginBottom: 20,

--- a/shared/email-components/src/lib/PaymentReceivedEmailTemplate.tsx
+++ b/shared/email-components/src/lib/PaymentReceivedEmailTemplate.tsx
@@ -1,5 +1,4 @@
 import {
-  Button,
   Column,
   Container,
   Heading,
@@ -47,9 +46,6 @@ export const PaymentReceivedEmailTemplate: React.FC<
   // # Company
   companyName = 'Bigcapital, Inc.',
   companyLogoUri,
-
-  // # Colors
-  primaryColor = 'rgb(0, 82, 204)',
 
   // # Payment #
   paymentNumberLabel = 'Payment # {paymentNumber}',

--- a/shared/email-components/src/lib/ReceiptPaymentEmail.tsx
+++ b/shared/email-components/src/lib/ReceiptPaymentEmail.tsx
@@ -55,9 +55,6 @@ export const ReceiptEmailTemplate: React.FC<
   companyName = 'Bigcapital, Inc.',
   companyLogoUri,
 
-  // # Colors
-  primaryColor = 'rgb(0, 82, 204)',
-
   // # Invoice total
   total = '$1,000.00',
   totalLabel = 'Total',
@@ -203,18 +200,6 @@ const invoiceCompanyNameStyle: CSSProperties = {
   fontSize: '18px',
   fontWeight: 500,
   color: '#404854',
-};
-
-const viewInvoiceButtonStyle: CSSProperties = {
-  display: 'block',
-  cursor: 'pointer',
-  textAlign: 'center',
-  fontSize: 16,
-  padding: '10px 15px',
-  lineHeight: '1',
-  backgroundColor: 'rgb(0, 82, 204)',
-  color: '#fff',
-  borderRadius: '5px',
 };
 
 const listItemLabelStyle: CSSProperties = {

--- a/shared/pdf-templates/src/components/CreditNotePaperTemplate.tsx
+++ b/shared/pdf-templates/src/components/CreditNotePaperTemplate.tsx
@@ -86,9 +86,6 @@ export function CreditNotePaperTemplate({
   primaryColor,
   secondaryColor,
 
-  // # Company
-  companyName = 'Bigcapital Technology, Inc.',
-
   showCompanyLogo = true,
   companyLogoUri = '',
 

--- a/shared/pdf-templates/src/components/EstimatePaperTemplate.tsx
+++ b/shared/pdf-templates/src/components/EstimatePaperTemplate.tsx
@@ -106,8 +106,6 @@ export function EstimatePaperTemplate({
   showCompanyLogo = true,
   companyLogoUri = '',
 
-  companyName,
-
   // # Company address
   companyAddress = DefaultPdfTemplateAddressBilledFrom,
   showCompanyAddress = true,

--- a/shared/pdf-templates/src/components/FinancialSheetTemplate.tsx
+++ b/shared/pdf-templates/src/components/FinancialSheetTemplate.tsx
@@ -33,7 +33,6 @@ export function FinancialSheetTemplate({
   sheetName,
   sheetDate,
   table,
-  customCSS,
 }: FinancialSheetTemplateProps) {
   return (
     <Box fontSize="14px">

--- a/shared/pdf-templates/src/components/InvoicePaperTemplate.tsx
+++ b/shared/pdf-templates/src/components/InvoicePaperTemplate.tsx
@@ -127,9 +127,6 @@ export function InvoicePaperTemplate({
   primaryColor,
   secondaryColor,
 
-  // # Company.
-  companyName = 'Bigcapital Technology, Inc.',
-
   showCompanyLogo = true,
   companyLogoUri = '',
 

--- a/shared/pdf-templates/src/components/PaperTemplate.tsx
+++ b/shared/pdf-templates/src/components/PaperTemplate.tsx
@@ -85,6 +85,7 @@ PaperTemplate.Logo = ({ logoUri }: PaperTemplateLogoProps) => {
 
 interface PaperTemplateTableProps {
   columns: Array<{
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     accessor: string | ((data: Record<string, any>) => JSX.Element);
     label: string;
     value?: JSX.Element;
@@ -92,6 +93,7 @@ interface PaperTemplateTableProps {
     thStyle?: React.CSSProperties;
     visible?: boolean;
   }>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   data: Array<Record<string, any>>;
 }
 
@@ -152,6 +154,7 @@ PaperTemplate.Table = ({ columns, data }: PaperTemplateTableProps) => {
       </thead>
 
       <tbody>
+        {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
         {data.map((_data: any) => (
           <tr>
             {filteredColumns.map((column, index) => (
@@ -204,6 +207,7 @@ PaperTemplate.TotalLine = ({
   label: string;
   amount: string;
   border?: PaperTemplateTotalBorder;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   style?: any;
 }) => {
   return (

--- a/shared/pdf-templates/src/components/PaymentReceivedPaperTemplate.tsx
+++ b/shared/pdf-templates/src/components/PaymentReceivedPaperTemplate.tsx
@@ -65,9 +65,6 @@ export function PaymentReceivedPaperTemplate({
   showCompanyLogo = true,
   companyLogoUri,
 
-  // # Company name
-  companyName = 'Bigcapital Technology, Inc.',
-
   // # Customer address
   showCustomerAddress = true,
   customerAddress = DefaultPdfTemplateAddressBilledTo,

--- a/shared/pdf-templates/src/components/ReceiptPaperTemplate.tsx
+++ b/shared/pdf-templates/src/components/ReceiptPaperTemplate.tsx
@@ -105,9 +105,6 @@ export function ReceiptPaperTemplate({
   showCompanyLogo = true,
   companyLogoUri,
 
-  // # Company name
-  companyName = 'Bigcapital Technology, Inc.',
-
   // # Address
   showCustomerAddress = true,
   customerAddress = DefaultPdfTemplateAddressBilledTo,

--- a/shared/pdf-templates/src/lib/layout/Stack.tsx
+++ b/shared/pdf-templates/src/lib/layout/Stack.tsx
@@ -17,14 +17,14 @@ export interface StackProps
 export function Stack({
   spacing = 20,
   align = 'stretch',
-  justify = 'top',
+  justify = 'flex-start',
   ...restProps
 }: StackProps) {
   return (
     <x.div
       display={'flex'}
       flexDirection="column"
-      justifyContent="justify"
+      justifyContent={justify}
       gap={`${spacing}px`}
       alignItems={align}
       {...restProps}


### PR DESCRIPTION
## Description

Fixes the ESLint failures that keep the ESLint Check red on `develop` (see #1322). Removes dead props and constants in the shared packages and fixes the Stack layout prop so both `shared/pdf-templates` and `shared/email-components` pass `lint:check` with 0 errors.

Related to #1322

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Reproduced on `develop` @ `04e3eba`: shared packages reported 16 ESLint errors and webapp was skipped. After fix: `pnpm --filter @bigcapital/pdf-templates exec eslint .` -> 0 errors and `pnpm --filter @bigcapital/email-components exec eslint .` -> 0 errors; both package builds succeed.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes