### PR TITLE
fix(webapp): fix role form save and retrieve saved values

### DIFF
--- a/packages/server/src/modules/Roles/dtos/RoleResponse.dto.ts
+++ b/packages/server/src/modules/Roles/dtos/RoleResponse.dto.ts
@@ -4,6 +4,12 @@ import { Type } from 'class-transformer';
 // RolePermissionResponseDto
 export class RolePermissionResponseDto {
   @ApiProperty({
+    example: 1,
+    description: 'The permission ID',
+  })
+  id: number;
+
+  @ApiProperty({
     example: 'read',
     description: 'The action/ability of the permission',
   })

--- a/packages/webapp/src/containers/Preferences/Users/Roles/RolesForm/RolesForm.tsx
+++ b/packages/webapp/src/containers/Preferences/Users/Roles/RolesForm/RolesForm.tsx
@@ -79,9 +79,10 @@ function RolesFormInner({
     values: RolesFormValues,
     { setSubmitting }: FormikHelpers<RolesFormValues>,
   ) => {
-    const permission = transformToArray(values);
+    const permission = transformToArray(values, role);
     const form = {
-      ...values,
+      roleName: values.role_name,
+      roleDescription: values.role_description,
       permissions: permission,
     };
     setSubmitting(true);

--- a/packages/webapp/src/containers/Preferences/Users/Roles/RolesForm/types.ts
+++ b/packages/webapp/src/containers/Preferences/Users/Roles/RolesForm/types.ts
@@ -2,6 +2,7 @@ export interface RolesFormPermission {
   subject: string;
   ability: string;
   value: boolean;
+  permissionId?: number;
 }
 
 export interface RolesFormValues {

--- a/packages/webapp/src/containers/Preferences/Users/Roles/RolesForm/utils.tsx
+++ b/packages/webapp/src/containers/Preferences/Users/Roles/RolesForm/utils.tsx
@@ -56,18 +56,28 @@ export const FULL_ACCESS_CHECKBOX_STATE = {
 /**
  * Transformes the permissions object to array.
  */
-export const transformToArray = ({
-  permissions,
-}: {
-  permissions: Record<string, boolean>;
-}): RolesFormPermission[] => {
+export const transformToArray = (
+  { permissions }: { permissions: Record<string, boolean> },
+  role?: {
+    permissions: Array<{
+      id: number;
+      subject: string;
+      ability: string;
+      value: boolean;
+    }>;
+  },
+): RolesFormPermission[] => {
   return Object.keys(permissions).map((index) => {
-    const [value, key] = index.split('/');
+    const [subject, ability] = index.split('/');
+    const existingPerm = role?.permissions.find(
+      (p) => p.subject === subject && p.ability === ability,
+    );
 
     return {
-      subject: value,
-      ability: key,
+      subject,
+      ability,
       value: permissions[index],
+      ...(existingPerm ? { permissionId: existingPerm.id } : {}),
     };
   });
 };

--- a/packages/webapp/src/hooks/query/roles/queries.ts
+++ b/packages/webapp/src/hooks/query/roles/queries.ts
@@ -39,7 +39,10 @@ export function useEditRolePermissionSchema(
     ...props,
     mutationFn: ([id, values]: [number, EditRoleBody]) =>
       editRole(fetcher, id, values),
-    onSuccess: () => commonInvalidateQueries(queryClient),
+    onSuccess: (_data, [id]) => {
+      queryClient.invalidateQueries({ queryKey: rolesKeys.detail(id) });
+      commonInvalidateQueries(queryClient);
+    },
   });
 }
 


### PR DESCRIPTION
## Description

Fixes the user role form where saving appears successful but saved values are not present when navigating back to the form.

Two root causes were identified:

1. **Field name mismatch**: The form sent `role_name`/`role_description` (snake_case) but the server DTO expected `roleName`/`roleDescription` (camelCase). The global `ValidationPipe` rejected the request with a 400, but the error handler destructured the wrong error shape, silently swallowing the error.

2. **Missing permissionId on edit**: `transformToArray` created permission objects without `permissionId`, so `EditRoleService` mapped `undefined` → `id` for `upsertGraph`, creating duplicate permission records instead of updating existing ones.

Additionally, the `useEditRolePermissionSchema` mutation did not invalidate the specific role detail query, causing stale cache on re-fetch.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

1. Create a new role with a name, description, and custom permissions
2. Save the role — verify success toast appears
3. Navigate back to edit the same role — verify name, description, and permissions are all present
4. Edit permissions and save again — verify changes persist on re-fetch
5. Verify no duplicate permission records are created on repeated edits

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
Fixed role form save/retrieve by correcting field name casing (role_name→roleName), including permissionId in edit payloads, and invalidating the role detail query after mutation.
</pr_agent:summary>

<pr_agent:walkthrough>
1. **RoleResponse.dto.ts**: Added `id` field to `RolePermissionResponseDto` so the API exposes permission IDs.
2. **RolesForm.tsx**: Changed submit handler to send `roleName`/`roleDescription` (camelCase) instead of `role_name`/`role_description`, and passes the existing `role` to `transformToArray`.
3. **utils.tsx**: Updated `transformToArray` to accept an optional `role` parameter and include `permissionId` from existing permissions when editing.
4. **types.ts**: Added optional `permissionId` to `RolesFormPermission`.
5. **queries.ts**: `useEditRolePermissionSchema` now explicitly invalidates `rolesKeys.detail(id)` after mutation.
</pr_agent:walkthrough>
