### PR TITLE
refactor(webapp): migrate legacy useApiRequest hooks to useApiFetcher SDK

### DIFF
--- a/packages/webapp/src/containers/Dialogs/NotifyInvoiceViaSMSDialog/NotifyInvoiceViaSMSForm.tsx
+++ b/packages/webapp/src/containers/Dialogs/NotifyInvoiceViaSMSDialog/NotifyInvoiceViaSMSForm.tsx
@@ -1,5 +1,4 @@
 import { Intent } from '@blueprintjs/core';
-import { pick } from 'lodash';
 import React from 'react';
 import intl from 'react-intl-universal';
 import { useNotifyInvoiceViaSMSContext } from './NotifyInvoiceViaSMSFormProvider';
@@ -29,12 +28,6 @@ interface NotifyViaSMSFormValues {
   notification_key: string;
   [key: string]: unknown;
 }
-
-const transformFormValuesToRequest = (
-  values: NotifyViaSMSFormValues,
-): Record<string, unknown> => {
-  return pick(values, ['notification_key']);
-};
 
 // Momerize the notification types.
 const notificationTypes = [
@@ -69,7 +62,7 @@ function NotifyInvoiceViaSMSFormInner({
 
   // Handles the form submit.
   const handleFormSubmit = (
-    values: NotifyViaSMSFormValues,
+    _values: NotifyViaSMSFormValues,
     {
       setSubmitting,
       setErrors,
@@ -100,12 +93,11 @@ function NotifyInvoiceViaSMSFormInner({
       }
       setSubmitting(false);
     };
-    // Transformes the form values to request.
-    const requestValues = transformFormValuesToRequest(values);
-
     // Submits invoice SMS notification.
-    // @ts-expect-error — invoiceId may be null in theory; dialog is only opened with a real id.
-    createNotifyInvoiceBySMSMutate([invoiceId, requestValues])
+    createNotifyInvoiceBySMSMutate([
+      invoiceId as number,
+      notificationType as 'details' | 'reminder',
+    ])
       .then(onSuccess)
       .catch(onError);
   };
@@ -114,9 +106,12 @@ function NotifyInvoiceViaSMSFormInner({
     closeDialog(dialogName);
   }, [closeDialog, dialogName]);
 
+  // `NotifyViaSMSForm` expects snake_case field keys.
   const initialValues = {
+    customer_name: invoiceSMSDetail.customerName ?? '',
+    customer_phone_number: invoiceSMSDetail.customerPhoneNumber ?? '',
+    sms_message: invoiceSMSDetail.smsMessage ?? '',
     notification_key: notificationType,
-    ...invoiceSMSDetail,
   };
   // Handle form values change.
   const handleValuesChange = (values: NotifyViaSMSFormValues) => {

--- a/packages/webapp/src/containers/Dialogs/NotifyInvoiceViaSMSDialog/NotifyInvoiceViaSMSFormProvider.tsx
+++ b/packages/webapp/src/containers/Dialogs/NotifyInvoiceViaSMSDialog/NotifyInvoiceViaSMSFormProvider.tsx
@@ -1,4 +1,6 @@
+import { keepPreviousData } from '@tanstack/react-query';
 import React, { createContext } from 'react';
+import type { SaleInvoiceSmsDetailsResponse } from '@bigcapital/sdk-ts';
 import { DialogContent } from '@/components';
 import {
   useCreateNotifyInvoiceBySMS,
@@ -7,7 +9,7 @@ import {
 
 interface NotifyInvoiceViaSMSContextValue {
   invoiceId: number | null;
-  invoiceSMSDetail: Record<string, unknown>;
+  invoiceSMSDetail: Partial<SaleInvoiceSmsDetailsResponse>;
   dialogName: string;
   createNotifyInvoiceBySMSMutate: ReturnType<
     typeof useCreateNotifyInvoiceBySMS
@@ -37,23 +39,19 @@ function NotifyInvoiceViaSMSFormProvider({
 }: NotifyInvoiceViaSMSFormProviderProps) {
   const [notificationType, setNotificationType] = React.useState('details');
 
-  // Retrieve the invoice sms notification message details. The hook returns
-  // `unknown` from the SDK; cast narrow.
+  // Retrieve the invoice sms notification message details.
   const { data: invoiceSMSDetailRaw, isLoading: isInvoiceSMSDetailLoading } =
     useInvoiceSMSDetail(
       // Hook signature requires `number`; provider may receive null when
       // dialog is closed. Cast to satisfy TS — runtime guards via `enabled`.
       invoiceId as number,
-      {
-        notification_key: notificationType,
-      },
+      notificationType as 'details' | 'reminder',
       {
         enabled: !!invoiceId,
-        keepPreviousData: true,
+        placeholderData: keepPreviousData,
       },
     );
-  const invoiceSMSDetail =
-    (invoiceSMSDetailRaw as Record<string, unknown> | undefined) ?? {};
+  const invoiceSMSDetail = invoiceSMSDetailRaw ?? {};
 
   // Create notfiy invoice by sms mutations.
   const { mutateAsync: createNotifyInvoiceBySMSMutate } =

--- a/packages/webapp/src/containers/Dialogs/NotifyPaymentReceiveViaSMSDialog/NotifyPaymentReceiveViaFormProvider.tsx
+++ b/packages/webapp/src/containers/Dialogs/NotifyPaymentReceiveViaSMSDialog/NotifyPaymentReceiveViaFormProvider.tsx
@@ -1,4 +1,5 @@
 import React, { createContext } from 'react';
+import type { PaymentReceiveSmsDetailsResponse } from '@bigcapital/sdk-ts';
 import { DialogContent } from '@/components';
 import {
   useCreateNotifyPaymentReceiveBySMS,
@@ -8,7 +9,7 @@ import {
 interface NotifyPaymentReceiveViaSMSContextValue {
   paymentReceiveId: number | null;
   dialogName: string;
-  paymentReceiveMSDetail: Record<string, unknown>;
+  paymentReceiveMSDetail: Partial<PaymentReceiveSmsDetailsResponse>;
   createNotifyPaymentReceivetBySMSMutate: ReturnType<
     typeof useCreateNotifyPaymentReceiveBySMS
   >['mutateAsync'];
@@ -40,8 +41,7 @@ function NotifyPaymentReceiveViaFormProvider({
   } = usePaymentReceiveSMSDetail(paymentReceiveId as number, {
     enabled: !!paymentReceiveId,
   });
-  const paymentReceiveMSDetail =
-    (paymentReceiveMSDetailRaw as Record<string, unknown> | undefined) ?? {};
+  const paymentReceiveMSDetail = paymentReceiveMSDetailRaw ?? {};
 
   // State provider.
   const provider: NotifyPaymentReceiveViaSMSContextValue = {

--- a/packages/webapp/src/containers/Dialogs/NotifyPaymentReceiveViaSMSDialog/NotifyPaymentReceiveViaSMSForm.tsx
+++ b/packages/webapp/src/containers/Dialogs/NotifyPaymentReceiveViaSMSDialog/NotifyPaymentReceiveViaSMSForm.tsx
@@ -53,7 +53,7 @@ function NotifyPaymentReceiveViaSMSFormInner({
 
   // Handles the form submit.
   const handleFormSubmit = (
-    values: NotifyViaSMSFormValues,
+    _values: NotifyViaSMSFormValues,
     {
       setErrors,
     }: {
@@ -82,7 +82,7 @@ function NotifyPaymentReceiveViaSMSFormInner({
       }
     };
     // @ts-expect-error — paymentReceiveId may be null in theory; dialog only opens with real id.
-    createNotifyPaymentReceivetBySMSMutate([paymentReceiveId, values])
+    createNotifyPaymentReceivetBySMSMutate(paymentReceiveId)
       .then(onSuccess)
       .catch(onError);
   };
@@ -91,10 +91,12 @@ function NotifyPaymentReceiveViaSMSFormInner({
     closeDialog(dialogName);
   };
 
-  // Form initial values.
+  // Form initial values. `NotifyViaSMSForm` expects snake_case field keys.
   const initialValues = React.useMemo(
     () => ({
-      ...paymentReceiveMSDetail,
+      customer_name: paymentReceiveMSDetail.customerName ?? '',
+      customer_phone_number: paymentReceiveMSDetail.customerPhoneNumber ?? '',
+      sms_message: paymentReceiveMSDetail.smsMessage ?? '',
       notification_key: notificationType.key,
     }),
     [paymentReceiveMSDetail],

--- a/packages/webapp/src/containers/Dialogs/NotifyReceiptViaSMSDialog/NotifyReceiptViaSMSForm.tsx
+++ b/packages/webapp/src/containers/Dialogs/NotifyReceiptViaSMSDialog/NotifyReceiptViaSMSForm.tsx
@@ -53,7 +53,7 @@ function NotifyReceiptViaSMSFormInner({
 
   // Handles the form submit.
   const handleFormSubmit = (
-    values: NotifyViaSMSFormValues,
+    _values: NotifyViaSMSFormValues,
     {
       setErrors,
     }: {
@@ -80,18 +80,18 @@ function NotifyReceiptViaSMSFormInner({
       }
     };
     // @ts-expect-error — receiptId may be null in theory; dialog only opens with real id.
-    createNotifyReceiptBySMSMutate([receiptId, values])
-      .then(onSuccess)
-      .catch(onError);
+    createNotifyReceiptBySMSMutate(receiptId).then(onSuccess).catch(onError);
   };
   // Handle the form cancel.
   const handleFormCancel = () => {
     closeDialog(dialogName);
   };
-  // Initial values.
+  // Initial values. `NotifyViaSMSForm` expects snake_case field keys.
   const initialValues = React.useMemo(
     () => ({
-      ...receiptSMSDetail,
+      customer_name: receiptSMSDetail.customerName ?? '',
+      customer_phone_number: receiptSMSDetail.customerPhoneNumber ?? '',
+      sms_message: receiptSMSDetail.smsMessage ?? '',
       notification_key: notificationType.key,
     }),
     [receiptSMSDetail],

--- a/packages/webapp/src/containers/Dialogs/NotifyReceiptViaSMSDialog/NotifyReceiptViaSMSFormProvider.tsx
+++ b/packages/webapp/src/containers/Dialogs/NotifyReceiptViaSMSDialog/NotifyReceiptViaSMSFormProvider.tsx
@@ -1,4 +1,5 @@
 import React, { createContext } from 'react';
+import type { SaleReceiptSmsDetailsResponse } from '@bigcapital/sdk-ts';
 import { DialogContent } from '@/components';
 import {
   useCreateNotifyReceiptBySMS,
@@ -8,7 +9,7 @@ import {
 interface NotifyReceiptViaSMSContextValue {
   receiptId: number | null;
   dialogName: string;
-  receiptSMSDetail: Record<string, unknown>;
+  receiptSMSDetail: Partial<SaleReceiptSmsDetailsResponse>;
   createNotifyReceiptBySMSMutate: ReturnType<
     typeof useCreateNotifyReceiptBySMS
   >['mutateAsync'];
@@ -39,8 +40,7 @@ function NotifyReceiptViaSMSFormProvider({
     useReceiptSMSDetail(receiptId as number, {
       enabled: !!receiptId,
     });
-  const receiptSMSDetail =
-    (receiptSMSDetailRaw as Record<string, unknown> | undefined) ?? {};
+  const receiptSMSDetail = receiptSMSDetailRaw ?? {};
 
   // State provider.
   const provider: NotifyReceiptViaSMSContextValue = {

--- a/packages/webapp/src/hooks/query/invoices/queries.ts
+++ b/packages/webapp/src/hooks/query/invoices/queries.ts
@@ -15,6 +15,8 @@ import {
   fetchSaleInvoiceState,
   fetchInvoicePayments,
   fetchSaleInvoiceHtml,
+  notifySaleInvoiceBySms,
+  fetchSaleInvoiceSmsDetails,
 } from '@bigcapital/sdk-ts';
 import {
   useQueryClient,
@@ -25,7 +27,6 @@ import {
   UseQueryOptions,
   UseQueryResult,
 } from '@tanstack/react-query';
-import { useRequestQuery } from '../../useQueryRequest';
 import { useApiFetcher } from '../../useRequest';
 import useApiRequest from '../../useRequest';
 import { useRequestPdf } from '../../useRequestPdf';
@@ -48,6 +49,7 @@ import type {
   SaleInvoiceStateResponse,
   InvoicePaymentTransactionsResponse,
   SaleInvoiceHtmlContentResponse,
+  SaleInvoiceSmsDetailsResponse,
 } from '@bigcapital/sdk-ts';
 import { transformToCamelCase } from '@/utils';
 
@@ -294,17 +296,18 @@ export function useCancelBadDebt(
   });
 }
 
-// Not in OpenAPI schema for sale-invoices; keep using apiRequest.
+export type InvoiceSmsNotificationKey = 'details' | 'reminder';
+
 export function useCreateNotifyInvoiceBySMS(
-  props?: UseMutationOptions<unknown, Error, [number, Record<string, unknown>]>,
+  props?: UseMutationOptions<void, Error, [number, InvoiceSmsNotificationKey]>,
 ) {
   const queryClient = useQueryClient();
-  const apiRequest = useApiRequest();
+  const fetcher = useApiFetcher();
 
   return useMutation({
     ...props,
-    mutationFn: ([id, values]: [number, Record<string, unknown>]) =>
-      apiRequest.post(`sale-invoices/${id}/notify-by-sms`, values, {}),
+    mutationFn: ([id, notificationKey]: [number, InvoiceSmsNotificationKey]) =>
+      notifySaleInvoiceBySms(fetcher, id, notificationKey),
     onSuccess: (_data, [id]) => {
       queryClient.invalidateQueries({ queryKey: invoicesKeys.notifyBySms(id) });
       commonInvalidateQueries(queryClient);
@@ -312,25 +315,23 @@ export function useCreateNotifyInvoiceBySMS(
   });
 }
 
-// Not in OpenAPI schema for sale-invoices; keep using useRequestQuery.
 export function useInvoiceSMSDetail(
-  invoiceId: number,
-  query?: Record<string, unknown>,
-  props?: Record<string, unknown>,
+  invoiceId: number | null | undefined,
+  notificationKey: InvoiceSmsNotificationKey = 'details',
+  props?: Omit<
+    UseQueryOptions<SaleInvoiceSmsDetailsResponse, Error>,
+    'queryKey' | 'queryFn'
+  >,
 ) {
-  return useRequestQuery(
-    [...invoicesKeys.smsDetail(invoiceId), query],
-    {
-      method: 'get',
-      url: `sale-invoices/${invoiceId}/sms-details`,
-      params: query,
-    } as { method: string; url: string; params?: Record<string, unknown> },
-    {
-      select: (res: { data: unknown }) => res.data,
-      defaultData: {},
-      ...props,
-    },
-  );
+  const fetcher = useApiFetcher({ enableCamelCaseTransform: true });
+
+  return useQuery({
+    ...props,
+    queryKey: [...invoicesKeys.smsDetail(invoiceId), notificationKey],
+    queryFn: () =>
+      fetchSaleInvoiceSmsDetails(fetcher, invoiceId!, notificationKey),
+    enabled: invoiceId != null,
+  });
 }
 
 export function useInvoicePaymentTransactions(

--- a/packages/webapp/src/hooks/query/organization/queries.ts
+++ b/packages/webapp/src/hooks/query/organization/queries.ts
@@ -11,7 +11,6 @@ import {
   UseMutationOptions,
   UseQueryOptions,
 } from '@tanstack/react-query';
-import { useRequestQuery } from '../../useQueryRequest';
 import { useApiFetcher } from '../../useRequest';
 import { organizationKeys } from './query-keys';
 import type {
@@ -20,28 +19,6 @@ import type {
   BuildOrganizationBody,
   OrgBaseCurrencyMutateAbilitiesResponse,
 } from '@bigcapital/sdk-ts';
-
-/**
- * Retrieve organizations of the authenticated user.
- * Uses useRequestQuery because organization/all is not in OpenAPI schema.
- */
-export function useOrganizations(props?: Record<string, unknown>) {
-  return useRequestQuery(
-    organizationKeys.all(),
-    { method: 'get', url: `organization/all` },
-    {
-      select: (res: { data: { organizations: unknown[] } }) =>
-        res.data.organizations,
-      initialDataUpdatedAt: 0,
-      initialData: {
-        data: {
-          organizations: [],
-        },
-      },
-      ...props,
-    },
-  );
-}
 
 /**
  * Retrieve the current organization. Response keys are transformed to camelCase

--- a/packages/webapp/src/hooks/query/payment-receives/queries.ts
+++ b/packages/webapp/src/hooks/query/payment-receives/queries.ts
@@ -11,6 +11,8 @@ import {
   sendPaymentReceiveMail,
   fetchPaymentReceivedState,
   fetchPaymentReceiveHtmlContent,
+  notifyPaymentReceiveBySms,
+  fetchPaymentReceiveSmsDetails,
 } from '@bigcapital/sdk-ts';
 import {
   useMutation,
@@ -21,8 +23,7 @@ import {
   UseMutationOptions,
   UseMutationResult,
 } from '@tanstack/react-query';
-import { useRequestQuery } from '../../useQueryRequest';
-import useApiRequest, { useApiFetcher } from '../../useRequest';
+import { useApiFetcher } from '../../useRequest';
 import { useRequestPdf } from '../../useRequestPdf';
 import { accountsKeys } from '../accounts/query-keys';
 import { cashflowAccountsKeys } from '../cashflow-accounts/query-keys';
@@ -45,6 +46,7 @@ import type {
   PaymentReceiveMailStateResponse,
   SendPaymentReceiveMailBody,
   SendPaymentReceiveMailResponse,
+  PaymentReceiveSmsDetailsResponse,
 } from '@bigcapital/sdk-ts';
 import { saveInvoke } from '@/utils';
 
@@ -210,18 +212,15 @@ export function useRefreshPaymentReceive() {
   };
 }
 
-/** Notify by SMS – no SDK route in schema; kept on apiRequest. */
 export function useCreateNotifyPaymentReceiveBySMS(
-  props?: UseMutationOptions<unknown, Error, [number, Record<string, unknown>]>,
+  props?: UseMutationOptions<void, Error, number>,
 ) {
   const queryClient = useQueryClient();
-  const apiRequest = useApiRequest();
-
+  const fetcher = useApiFetcher();
   return useMutation({
     ...props,
-    mutationFn: ([id, values]: [number, Record<string, unknown>]) =>
-      apiRequest.post(`payments-received/${id}/notify-by-sms`, values, {}),
-    onSuccess: (_res, [id]) => {
+    mutationFn: (id: number) => notifyPaymentReceiveBySms(fetcher, id),
+    onSuccess: (_data, id) => {
       queryClient.invalidateQueries({
         queryKey: paymentReceivesKeys.notifyBySms(id),
       });
@@ -230,25 +229,20 @@ export function useCreateNotifyPaymentReceiveBySMS(
   });
 }
 
-/** SMS detail – no SDK route in schema; kept on useRequestQuery. */
 export function usePaymentReceiveSMSDetail(
   paymentReceiveId: number | null | undefined,
-  props?: Record<string, unknown>,
-  requestProps?: Record<string, unknown>,
+  props?: Omit<
+    UseQueryOptions<PaymentReceiveSmsDetailsResponse, Error>,
+    'queryKey' | 'queryFn'
+  >,
 ) {
-  return useRequestQuery(
-    paymentReceivesKeys.smsDetail(paymentReceiveId),
-    {
-      method: 'get',
-      url: `payments-received/${paymentReceiveId}/sms-details`,
-      ...requestProps,
-    },
-    {
-      select: (res: { data: unknown }) => res.data,
-      defaultData: {},
-      ...props,
-    },
-  );
+  const fetcher = useApiFetcher({ enableCamelCaseTransform: true });
+  return useQuery({
+    ...props,
+    queryKey: paymentReceivesKeys.smsDetail(paymentReceiveId),
+    queryFn: () => fetchPaymentReceiveSmsDetails(fetcher, paymentReceiveId!),
+    enabled: paymentReceiveId != null,
+  });
 }
 
 export function usePdfPaymentReceive(paymentReceiveId: number) {

--- a/packages/webapp/src/hooks/query/receipts/queries.ts
+++ b/packages/webapp/src/hooks/query/receipts/queries.ts
@@ -11,6 +11,8 @@ import {
   sendSaleReceiptMail,
   fetchSaleReceiptState,
   fetchSaleReceiptHtmlContent,
+  notifySaleReceiptBySms,
+  fetchSaleReceiptSmsDetails,
 } from '@bigcapital/sdk-ts';
 import {
   useQueryClient,
@@ -20,8 +22,7 @@ import {
   UseQueryOptions,
   UseMutationOptions,
 } from '@tanstack/react-query';
-import { useRequestQuery } from '../../useQueryRequest';
-import useApiRequest, { useApiFetcher } from '../../useRequest';
+import { useApiFetcher } from '../../useRequest';
 import { useRequestPdf } from '../../useRequestPdf';
 import { accountsKeys } from '../accounts/query-keys';
 import { cashflowAccountsKeys } from '../cashflow-accounts/query-keys';
@@ -42,6 +43,7 @@ import type {
   SaleReceiptHtmlContentResponse,
   GetSaleReceiptsQuery,
   BulkDeleteReceiptsBody,
+  SaleReceiptSmsDetailsResponse,
 } from '@bigcapital/sdk-ts';
 
 function commonInvalidateQueries(
@@ -202,41 +204,37 @@ export function useRefreshReceipts() {
   };
 }
 
-// Not in OpenAPI schema for sale-receipts; keep using apiRequest until server exposes.
 export function useCreateNotifyReceiptBySMS(
-  props?: UseMutationOptions<unknown, Error, [number, Record<string, unknown>]>,
+  props?: UseMutationOptions<void, Error, number>,
 ) {
   const queryClient = useQueryClient();
-  const apiRequest = useApiRequest();
+  const fetcher = useApiFetcher();
+
   return useMutation({
     ...props,
-    mutationFn: ([id, values]: [number, Record<string, unknown>]) =>
-      apiRequest.post(`sale-receipts/${id}/notify-by-sms`, values),
-    onSuccess: (_data, [id]) => {
+    mutationFn: (id: number) => notifySaleReceiptBySms(fetcher, id),
+    onSuccess: (_data, id) => {
       queryClient.invalidateQueries({ queryKey: receiptsKeys.notifyBySms(id) });
       commonInvalidateQueries(queryClient);
     },
   });
 }
 
-// Not in OpenAPI schema for sale-receipts; keep using useRequestQuery.
 export function useReceiptSMSDetail(
-  receiptId: number,
-  props?: Record<string, unknown>,
-  requestProps?: Record<string, unknown>,
+  receiptId: number | null | undefined,
+  props?: Omit<
+    UseQueryOptions<SaleReceiptSmsDetailsResponse, Error>,
+    'queryKey' | 'queryFn'
+  >,
 ) {
-  return useRequestQuery(
-    receiptsKeys.smsDetail(receiptId),
-    {
-      method: 'get',
-      url: `sale-receipts/${receiptId}/sms-details`,
-      ...requestProps,
-    },
-    {
-      defaultData: {},
-      ...props,
-    },
-  );
+  const fetcher = useApiFetcher({ enableCamelCaseTransform: true });
+
+  return useQuery({
+    ...props,
+    queryKey: receiptsKeys.smsDetail(receiptId),
+    queryFn: () => fetchSaleReceiptSmsDetails(fetcher, receiptId!),
+    enabled: receiptId != null,
+  });
 }
 
 export function useSendSaleReceiptMail(

--- a/packages/webapp/src/hooks/useDownloadFile.ts
+++ b/packages/webapp/src/hooks/useDownloadFile.ts
@@ -1,39 +1,3 @@
-import { useMutation } from '@tanstack/react-query';
-import useApiRequest from './useRequest';
-import type { AxiosRequestConfig } from 'axios';
-
-interface IArgs {
-  url: string;
-  filename: string;
-  mime?: string;
-  config?: AxiosRequestConfig;
-  onDownloadProgress?: (progress: number) => void;
-}
-
-export const useDownloadFile = (args: IArgs) => {
-  const apiRequest = useApiRequest();
-
-  const mutation = useMutation({
-    mutationFn: () =>
-      apiRequest
-        .get(args.url, {
-          responseType: 'blob',
-          onDownloadProgress: (ev) => {
-            args.onDownloadProgress &&
-              args.onDownloadProgress(
-                Math.round((ev.loaded * 100) / (ev.total ?? 0)),
-              );
-          },
-          ...args.config,
-        })
-        .then((res) => {
-          downloadFile(res.data, args.filename, args.mime);
-          return res;
-        }),
-  });
-  return { ...mutation };
-};
-
 export function downloadFile(
   data: BlobPart,
   filename: string,


### PR DESCRIPTION
## Description

Migrates the remaining webapp query/mutation hooks off the legacy axios-based `useApiRequest` / `useRequestQuery` onto the typed SDK fetcher (`useApiFetcher` + `@bigcapital/sdk-ts` functions), per the data-flow convention documented in AGENTS.md.

Summary of changes:

- **Payment receives**: `useCreateNotifyPaymentReceiveBySMS` now calls SDK `notifyPaymentReceiveBySms` (id-only; the request body was never read server-side). `usePaymentReceiveSMSDetail` is a typed `useQuery` returning camelCase via SDK `fetchPaymentReceiveSmsDetails`.
- **Sale invoices**: `useCreateNotifyInvoiceBySMS` takes `[id, notificationKey]` via SDK `notifySaleInvoiceBySms`; `useInvoiceSMSDetail` is keyed by notification type (`details`/`reminder`) via SDK `fetchSaleInvoiceSmsDetails`, with v5 `placeholderData: keepPreviousData`.
- **Sale receipts**: `useCreateNotifyReceiptBySMS` simplified to id-only via SDK `notifySaleReceiptBySms`; `useReceiptSMSDetail` returns camelCase via SDK `fetchSaleReceiptSmsDetails`.
- **Organization**: removed dead `useOrganizations` hook (zero callers; `organization/all` is not in the OpenAPI schema).
- **useDownloadFile**: removed the dead `useDownloadFile` hook (zero callers; axios-only `onDownloadProgress`/`responseType: blob` features have no fetcher equivalent). The widely used `downloadFile` utility is unchanged.
- SMS dialog providers/forms: typed contexts (`Partial<...SmsDetailsResponse>`), explicit camelCase → snake_case initial-value mapping for the shared `NotifyViaSMSForm`, and id-only / `[id, key]` mutate calls.
- Removed several stale "not in OpenAPI schema" comments — the routes were already in the schema and SDK.

Remaining legacy usage is intentionally isolated: `useRequestQuery` keeps its single caller (`useResourceData` universal search, blocked on `search_keyword` not being in the OpenAPI schema) and `useApiRequest` remains for `useRequestPdf`, `use-export-pdf`, and `useGetSaleInvoiceBrandingTemplate`.

No dependencies required.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- `npx tsc --noEmit -p packages/webapp/tsconfig.json` — no errors in any touched file (repo has unrelated pre-existing errors).
- `npx eslint` on all modified files — clean (one auto-fixed import order).
- Verified via `rg` that remaining `useRequestQuery` references are only `useResourceData` and remaining `useApiRequest` references are only the intentionally kept call sites.
- Manual check recommended: open each "Notify via SMS" dialog (payment receive, invoice with details/reminder toggle, receipt) and confirm message prefill, submit success toast, and query invalidation.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>
