### PR TITLE
refactor(webapp): migrate remaining snake_case form keys to camelCase

### DIFF
--- a/packages/webapp/src/containers/Authentication/InviteAcceptForm.tsx
+++ b/packages/webapp/src/containers/Authentication/InviteAcceptForm.tsx
@@ -11,10 +11,10 @@ import type { ApiError } from 'openapi-typescript-fetch';
 import { AppToaster } from '@/components';
 
 const initialValues: InviteAcceptFormValues = {
-  organization_name: '',
-  invited_email: '',
-  first_name: '',
-  last_name: '',
+  organizationName: '',
+  invitedEmail: '',
+  firstName: '',
+  lastName: '',
   password: '',
 };
 
@@ -29,8 +29,8 @@ export function InviteAcceptForm() {
     ...initialValues,
     ...(!isEmpty(inviteMeta)
       ? {
-          invited_email: inviteMeta?.email ?? '',
-          organization_name: inviteMeta?.organizationName ?? '',
+          invitedEmail: inviteMeta?.email ?? '',
+          organizationName: inviteMeta?.organizationName ?? '',
         }
       : {}),
   };
@@ -40,7 +40,14 @@ export function InviteAcceptForm() {
     values: InviteAcceptFormValues,
     { setSubmitting }: FormikHelpers<InviteAcceptFormValues>,
   ) => {
-    inviteAcceptMutate([values, token])
+    inviteAcceptMutate([
+      {
+        firstName: values.firstName,
+        lastName: values.lastName,
+        password: values.password,
+      },
+      token,
+    ])
       .then(() => {
         AppToaster.show({
           message: intl.getHTML(

--- a/packages/webapp/src/containers/Authentication/InviteAcceptFormContent.tsx
+++ b/packages/webapp/src/containers/Authentication/InviteAcceptFormContent.tsx
@@ -45,14 +45,14 @@ export function InviteUserFormContent() {
     <Form>
       <Row>
         <Col md={6}>
-          <FFormGroup name={'first_name'} label={intl.get('first_name')}>
-            <FInputGroup name={'first_name'} large={true} />
+          <FFormGroup name={'firstName'} label={intl.get('first_name')}>
+            <FInputGroup name={'firstName'} large={true} />
           </FFormGroup>
         </Col>
 
         <Col md={6}>
-          <FFormGroup name={'last_name'} label={intl.get('last_name')}>
-            <FInputGroup name={'last_name'} large={true} />
+          <FFormGroup name={'lastName'} label={intl.get('last_name')}>
+            <FInputGroup name={'lastName'} large={true} />
           </FFormGroup>
         </Col>
       </Row>

--- a/packages/webapp/src/containers/Authentication/Register.tsx
+++ b/packages/webapp/src/containers/Authentication/Register.tsx
@@ -20,8 +20,8 @@ import { AuthInsider } from '@/containers/Authentication/AuthInsider';
 import { useAuthLogin, useAuthRegister } from '@/hooks/query/authentication';
 
 const initialValues: RegisterValues = {
-  first_name: '',
-  last_name: '',
+  firstName: '',
+  lastName: '',
   email: '',
   password: '',
 };
@@ -38,8 +38,8 @@ export function RegisterUserForm() {
     { setSubmitting, setErrors }: FormikHelpers<RegisterValues>,
   ) => {
     authRegisterMutate({
-      firstName: values.first_name,
-      lastName: values.last_name,
+      firstName: values.firstName,
+      lastName: values.lastName,
       email: values.email,
       password: values.password,
     })

--- a/packages/webapp/src/containers/Authentication/RegisterForm.tsx
+++ b/packages/webapp/src/containers/Authentication/RegisterForm.tsx
@@ -41,14 +41,14 @@ export function RegisterForm({ isSubmitting }: { isSubmitting: boolean }) {
     <RegisterFormRoot>
       <Row className={'name-section'}>
         <Col md={6}>
-          <FFormGroup name={'first_name'} label={intl.get('first_name')}>
-            <FInputGroup name={'first_name'} large={true} />
+          <FFormGroup name={'firstName'} label={intl.get('first_name')}>
+            <FInputGroup name={'firstName'} large={true} />
           </FFormGroup>
         </Col>
 
         <Col md={6}>
-          <FFormGroup name={'last_name'} label={intl.get('last_name')}>
-            <FInputGroup name={'last_name'} large={true} />
+          <FFormGroup name={'lastName'} label={intl.get('last_name')}>
+            <FInputGroup name={'lastName'} large={true} />
           </FFormGroup>
         </Col>
       </Row>

--- a/packages/webapp/src/containers/Authentication/ResetPassword.tsx
+++ b/packages/webapp/src/containers/Authentication/ResetPassword.tsx
@@ -17,7 +17,7 @@ import { useAuthResetPassword } from '@/hooks/query';
 
 const initialValues: ResetPasswordValues = {
   password: '',
-  confirm_password: '',
+  confirmPassword: '',
 };
 /**
  * Reset password page.

--- a/packages/webapp/src/containers/Authentication/ResetPasswordForm.tsx
+++ b/packages/webapp/src/containers/Authentication/ResetPasswordForm.tsx
@@ -15,8 +15,8 @@ export function ResetPasswordForm({ isSubmitting }: { isSubmitting: boolean }) {
         <FInputGroup name={'password'} type={'password'} large={true} />
       </FFormGroup>
 
-      <FFormGroup name={'confirm_password'} label={intl.get('new_password')}>
-        <FInputGroup name={'confirm_password'} type={'password'} large={true} />
+      <FFormGroup name={'confirmPassword'} label={intl.get('new_password')}>
+        <FInputGroup name={'confirmPassword'} type={'password'} large={true} />
       </FFormGroup>
 
       <AuthSubmitButton

--- a/packages/webapp/src/containers/Authentication/utils.tsx
+++ b/packages/webapp/src/containers/Authentication/utils.tsx
@@ -38,15 +38,15 @@ export interface LoginValues {
 }
 
 export interface RegisterValues {
-  first_name: string;
-  last_name: string;
+  firstName: string;
+  lastName: string;
   email: string;
   password: string;
 }
 
 export interface ResetPasswordValues {
   password: string;
-  confirm_password: string;
+  confirmPassword: string;
 }
 
 export interface SendResetPasswordValues {
@@ -54,10 +54,10 @@ export interface SendResetPasswordValues {
 }
 
 export type InviteAcceptFormValues = {
-  organization_name: string;
-  invited_email: string;
-  first_name: string;
-  last_name: string;
+  organizationName: string;
+  invitedEmail: string;
+  firstName: string;
+  lastName: string;
   password: string;
 };
 
@@ -77,15 +77,15 @@ export const LoginSchema = Yup.object().shape({
 });
 
 export const RegisterSchema = Yup.object().shape({
-  first_name: Yup.string().required().label(intl.get('first_name_')),
-  last_name: Yup.string().required().label(intl.get('last_name_')),
+  firstName: Yup.string().required().label(intl.get('first_name_')),
+  lastName: Yup.string().required().label(intl.get('last_name_')),
   email: Yup.string().email().required().label(intl.get('email')),
   password: validPassword(),
 });
 
 export const ResetPasswordSchema = Yup.object().shape({
   password: validPassword(),
-  confirm_password: Yup.string()
+  confirmPassword: Yup.string()
     .nullable()
     .oneOf([Yup.ref('password'), null])
     .required()
@@ -98,8 +98,8 @@ export const SendResetPasswordSchema = Yup.object().shape({
 });
 
 export const InviteAcceptSchema = Yup.object().shape({
-  first_name: Yup.string().required().label(intl.get('first_name_')),
-  last_name: Yup.string().required().label(intl.get('last_name_')),
+  firstName: Yup.string().required().label(intl.get('first_name_')),
+  lastName: Yup.string().required().label(intl.get('last_name_')),
   password: validPassword(),
 });
 

--- a/packages/webapp/src/containers/Dialogs/AllocateLandedCostDialog/AllocateLandedCostDialogProvider.tsx
+++ b/packages/webapp/src/containers/Dialogs/AllocateLandedCostDialog/AllocateLandedCostDialogProvider.tsx
@@ -48,9 +48,8 @@ function AllocateLandedCostDialogProvider({
     number | null
   >(null);
 
-  // Handle fetch bill details.
-  // FIXME: SDK `Bill` is camelCase but form code reads `bill.entries` with snake_case
-  // entry fields. Cast to loose `AllocateLandedCostBill` shape.
+  // Handle fetch bill details. `useBill` returns camelCase data
+  // (`bill.entries[].amount/quantity/rate`), matching the form's field keys.
   const { isLoading: isBillLoading, data: bill } = useBill(billId, {
     enabled: !!billId,
   });

--- a/packages/webapp/src/containers/Dialogs/ContactDuplicateDialog/ContactDuplicateForm.tsx
+++ b/packages/webapp/src/containers/Dialogs/ContactDuplicateDialog/ContactDuplicateForm.tsx
@@ -38,11 +38,11 @@ function ContactDuplicateFormInner({
   const { dialogName, contactId } = useContactDuplicateFromContext();
 
   const validationSchema = Yup.object().shape({
-    contact_type: Yup.string().required().label(intl.get('contact_type_')),
+    contactType: Yup.string().required().label(intl.get('contact_type_')),
   });
 
   const initialValues: ContactDuplicateFormValues = {
-    contact_type: '',
+    contactType: '',
   };
 
   // Handle cancel button click.
@@ -53,7 +53,7 @@ function ContactDuplicateFormInner({
   // Handle form submit.
   const handleFormSubmit = (values: ContactDuplicateFormValues) => {
     closeDialog(dialogName);
-    history.push(`${values.contact_type}/new?duplicate=${contactId}`, {
+    history.push(`${values.contactType}/new?duplicate=${contactId}`, {
       action: contactId,
     });
   };
@@ -78,12 +78,12 @@ function ContactDuplicateFormInner({
 
             {/*------------ Contact Type -----------*/}
             <FFormGroup
-              name={'contact_type'}
+              name={'contactType'}
               label={intl.get('contact_type')}
               labelInfo={<FieldRequiredHint />}
             >
               <FSelect
-                name={'contact_type'}
+                name={'contactType'}
                 items={ContactsOptions}
                 placeholder={<T id={'select_contact'} />}
                 textAccessor={'name'}

--- a/packages/webapp/src/containers/Dialogs/ContactDuplicateDialog/types.ts
+++ b/packages/webapp/src/containers/Dialogs/ContactDuplicateDialog/types.ts
@@ -1,5 +1,5 @@
 export interface ContactDuplicateFormValues {
-  contact_type: string;
+  contactType: string;
 }
 
 export type ContactDuplicateDialogPayload = {

--- a/packages/webapp/src/containers/Dialogs/LockingTransactionsDialog/LockingTransactionsForm.schema.tsx
+++ b/packages/webapp/src/containers/Dialogs/LockingTransactionsDialog/LockingTransactionsForm.schema.tsx
@@ -3,7 +3,7 @@ import * as Yup from 'yup';
 import { DATATYPES_LENGTH } from '@/constants/dataTypes';
 
 const Schema = Yup.object().shape({
-  lock_to_date: Yup.date().required().label(intl.get('date')),
+  lockToDate: Yup.date().required().label(intl.get('date')),
   module: Yup.string().required(),
   reason: Yup.string()
     .required()

--- a/packages/webapp/src/containers/Dialogs/LockingTransactionsDialog/LockingTransactionsForm.tsx
+++ b/packages/webapp/src/containers/Dialogs/LockingTransactionsDialog/LockingTransactionsForm.tsx
@@ -11,11 +11,11 @@ import type { LockingTransactionsFormValues } from './types';
 import type { WithDialogActionsProps } from '@/containers/Dialog/withDialogActions';
 import { AppToaster } from '@/components';
 import { withDialogActions } from '@/containers/Dialog/withDialogActions';
-import { compose, transformToForm } from '@/utils';
+import { compose, transformToCamelCase, transformToForm } from '@/utils';
 
 const defaultInitialValues: LockingTransactionsFormValues = {
   module: '',
-  lock_to_date: moment(new Date()).format('YYYY-MM-DD'),
+  lockToDate: moment(new Date()).format('YYYY-MM-DD'),
   reason: '',
 };
 
@@ -42,7 +42,7 @@ function LockingTransactionsFormInner({
       ...(isEnabled
         ? {
             ...(transformToForm(
-              transactionLocking,
+              transformToCamelCase(transactionLocking),
               defaultInitialValues,
             ) as LockingTransactionsFormValues),
             module: moduleName,

--- a/packages/webapp/src/containers/Dialogs/LockingTransactionsDialog/LockingTransactionsFormFields.tsx
+++ b/packages/webapp/src/containers/Dialogs/LockingTransactionsDialog/LockingTransactionsFormFields.tsx
@@ -22,14 +22,14 @@ export function LockingTransactionsFormFields(): React.ReactElement {
     <div className={Classes.DIALOG_BODY}>
       {/*------------  Locking Date ----------- */}
       <FFormGroup
-        name={'lock_to_date'}
+        name={'lockToDate'}
         label={intl.get('locking_transactions.dialog.locking_date')}
         labelInfo={<FieldRequiredHint />}
         className={classNames(CLASSES.FILL, 'form-group--date')}
         fastField
       >
         <FDateInput
-          name={'lock_to_date'}
+          name={'lockToDate'}
           {...dateInputFormatter}
           popoverProps={{
             position: Position.BOTTOM,

--- a/packages/webapp/src/containers/Dialogs/LockingTransactionsDialog/types.ts
+++ b/packages/webapp/src/containers/Dialogs/LockingTransactionsDialog/types.ts
@@ -1,6 +1,6 @@
 export interface LockingTransactionsFormValues {
   module: string;
-  lock_to_date: string;
+  lockToDate: string;
   reason: string;
   [key: string]: unknown;
 }

--- a/packages/webapp/src/containers/Dialogs/NotifyEstimateViaSMSDialog/NotifyEstimateViaSMSForm.tsx
+++ b/packages/webapp/src/containers/Dialogs/NotifyEstimateViaSMSDialog/NotifyEstimateViaSMSForm.tsx
@@ -25,7 +25,7 @@ const NotifyViaSMSForm =
   NotifyViaSMSFormBase as unknown as React.ComponentType<NotifyViaSMSFormProps>;
 
 interface NotifyViaSMSFormValues {
-  notification_key: string;
+  notificationKey: string;
   [key: string]: unknown;
 }
 
@@ -87,9 +87,11 @@ function NotifyEstimateViaSMSFormInner({
       .catch(onError);
   };
 
+  // The SMS details are camelCase (`enableCamelCaseTransform` on the detail
+  // query), matching the camelCase field keys `NotifyViaSMSForm` expects.
   const initialValues = {
     ...estimateSMSDetail,
-    notification_key: notificationType.key,
+    notificationKey: notificationType.key,
   };
   // Handle the form cancel.
   const handleFormCancel = () => {

--- a/packages/webapp/src/containers/Dialogs/NotifyInvoiceViaSMSDialog/NotifyInvoiceViaSMSForm.tsx
+++ b/packages/webapp/src/containers/Dialogs/NotifyInvoiceViaSMSDialog/NotifyInvoiceViaSMSForm.tsx
@@ -25,7 +25,7 @@ const NotifyViaSMSForm =
   NotifyViaSMSFormBase as unknown as React.ComponentType<NotifyViaSMSFormProps>;
 
 interface NotifyViaSMSFormValues {
-  notification_key: string;
+  notificationKey: string;
   [key: string]: unknown;
 }
 
@@ -106,17 +106,17 @@ function NotifyInvoiceViaSMSFormInner({
     closeDialog(dialogName);
   }, [closeDialog, dialogName]);
 
-  // `NotifyViaSMSForm` expects snake_case field keys.
+  // `NotifyViaSMSForm` expects camelCase field keys.
   const initialValues = {
-    customer_name: invoiceSMSDetail.customerName ?? '',
-    customer_phone_number: invoiceSMSDetail.customerPhoneNumber ?? '',
-    sms_message: invoiceSMSDetail.smsMessage ?? '',
-    notification_key: notificationType,
+    customerName: invoiceSMSDetail.customerName ?? '',
+    customerPhoneNumber: invoiceSMSDetail.customerPhoneNumber ?? '',
+    smsMessage: invoiceSMSDetail.smsMessage ?? '',
+    notificationKey: notificationType,
   };
   // Handle form values change.
   const handleValuesChange = (values: NotifyViaSMSFormValues) => {
-    if (values.notification_key !== notificationType) {
-      setNotificationType(values.notification_key);
+    if (values.notificationKey !== notificationType) {
+      setNotificationType(values.notificationKey);
     }
   };
 

--- a/packages/webapp/src/containers/Dialogs/NotifyPaymentReceiveViaSMSDialog/NotifyPaymentReceiveViaSMSForm.tsx
+++ b/packages/webapp/src/containers/Dialogs/NotifyPaymentReceiveViaSMSDialog/NotifyPaymentReceiveViaSMSForm.tsx
@@ -25,7 +25,7 @@ const NotifyViaSMSForm =
   NotifyViaSMSFormBase as unknown as React.ComponentType<NotifyViaSMSFormProps>;
 
 interface NotifyViaSMSFormValues {
-  notification_key: string;
+  notificationKey: string;
   [key: string]: unknown;
 }
 
@@ -91,13 +91,13 @@ function NotifyPaymentReceiveViaSMSFormInner({
     closeDialog(dialogName);
   };
 
-  // Form initial values. `NotifyViaSMSForm` expects snake_case field keys.
+  // Form initial values. `NotifyViaSMSForm` expects camelCase field keys.
   const initialValues = React.useMemo(
     () => ({
-      customer_name: paymentReceiveMSDetail.customerName ?? '',
-      customer_phone_number: paymentReceiveMSDetail.customerPhoneNumber ?? '',
-      sms_message: paymentReceiveMSDetail.smsMessage ?? '',
-      notification_key: notificationType.key,
+      customerName: paymentReceiveMSDetail.customerName ?? '',
+      customerPhoneNumber: paymentReceiveMSDetail.customerPhoneNumber ?? '',
+      smsMessage: paymentReceiveMSDetail.smsMessage ?? '',
+      notificationKey: notificationType.key,
     }),
     [paymentReceiveMSDetail],
   );

--- a/packages/webapp/src/containers/Dialogs/NotifyReceiptViaSMSDialog/NotifyReceiptViaSMSForm.tsx
+++ b/packages/webapp/src/containers/Dialogs/NotifyReceiptViaSMSDialog/NotifyReceiptViaSMSForm.tsx
@@ -25,7 +25,7 @@ const NotifyViaSMSForm =
   NotifyViaSMSFormBase as unknown as React.ComponentType<NotifyViaSMSFormProps>;
 
 interface NotifyViaSMSFormValues {
-  notification_key: string;
+  notificationKey: string;
   [key: string]: unknown;
 }
 
@@ -86,13 +86,13 @@ function NotifyReceiptViaSMSFormInner({
   const handleFormCancel = () => {
     closeDialog(dialogName);
   };
-  // Initial values. `NotifyViaSMSForm` expects snake_case field keys.
+  // Initial values. `NotifyViaSMSForm` expects camelCase field keys.
   const initialValues = React.useMemo(
     () => ({
-      customer_name: receiptSMSDetail.customerName ?? '',
-      customer_phone_number: receiptSMSDetail.customerPhoneNumber ?? '',
-      sms_message: receiptSMSDetail.smsMessage ?? '',
-      notification_key: notificationType.key,
+      customerName: receiptSMSDetail.customerName ?? '',
+      customerPhoneNumber: receiptSMSDetail.customerPhoneNumber ?? '',
+      smsMessage: receiptSMSDetail.smsMessage ?? '',
+      notificationKey: notificationType.key,
     }),
     [receiptSMSDetail],
   );

--- a/packages/webapp/src/containers/NotifyViaSMS/NotifyViaSMSForm.schema.tsx
+++ b/packages/webapp/src/containers/NotifyViaSMS/NotifyViaSMSForm.schema.tsx
@@ -4,9 +4,9 @@ import * as Yup from 'yup';
 import { DATATYPES_LENGTH } from '@/constants/dataTypes';
 
 const Schema = Yup.object().shape({
-  customer_name: Yup.string().required(),
-  customer_phone_number: Yup.number(),
-  sms_message: Yup.string().required().trim().max(DATATYPES_LENGTH.TEXT),
+  customerName: Yup.string().required(),
+  customerPhoneNumber: Yup.number(),
+  smsMessage: Yup.string().required().trim().max(DATATYPES_LENGTH.TEXT),
 });
 
 export const CreateNotifyViaSMSFormSchema = Schema;

--- a/packages/webapp/src/containers/NotifyViaSMS/NotifyViaSMSForm.tsx
+++ b/packages/webapp/src/containers/NotifyViaSMS/NotifyViaSMSForm.tsx
@@ -16,10 +16,10 @@ import { FormObserver, SMSMessagePreview } from '@/components';
 import { transformToForm, safeInvoke } from '@/utils';
 
 const defaultInitialValues = {
-  notification_key: '',
-  customer_name: '',
-  customer_phone_number: '',
-  sms_message: '',
+  notificationKey: '',
+  customerName: '',
+  customerPhoneNumber: '',
+  smsMessage: '',
 };
 
 /**
@@ -27,15 +27,15 @@ const defaultInitialValues = {
  */
 function SMSMessagePreviewSection() {
   const {
-    values: { sms_message },
+    values: { smsMessage },
   } = useFormikContext();
 
   // Calculates the SMS units of message.
-  const messagesUnits = getSMSUnits(sms_message);
+  const messagesUnits = getSMSUnits(smsMessage);
 
   return (
     <SMSPreviewSectionRoot>
-      <SMSMessagePreview message={sms_message} />
+      <SMSMessagePreview message={smsMessage} />
       <SMSPreviewSectionNote>
         {intl.formatHTMLMessage(
           { id: 'notiify_via_sms.dialog.sms_note' },

--- a/packages/webapp/src/containers/NotifyViaSMS/NotifyViaSMSFormFields.tsx
+++ b/packages/webapp/src/containers/NotifyViaSMS/NotifyViaSMSFormFields.tsx
@@ -13,13 +13,13 @@ export function NotifyViaSMSFormFields({ notificationTypes }) {
   return (
     <NotifyViaSMSFormFieldsRoot>
       <FFormGroup
-        name={'notification_key'}
+        name={'notificationKey'}
         label={intl.get('notify_via_sms.dialog.notification_type')}
         className={classNames(CLASSES.FILL)}
         fastField
       >
         <FSelect
-          name={'notification_key'}
+          name={'notificationKey'}
           items={notificationTypes}
           valueAccessor={'key'}
           textAccessor={'label'}
@@ -31,14 +31,14 @@ export function NotifyViaSMSFormFields({ notificationTypes }) {
       </FFormGroup>
 
       {/* ----------- Send Notification to ----------- */}
-      <FastField name={'customer_name'}>
+      <FastField name={'customerName'}>
         {({ form, field, meta: { error, touched } }) => (
           <FormGroup
             label={intl.get('notify_via_sms.dialog.send_notification_to')}
             className={classNames('form-group--customer-name', CLASSES.FILL)}
             labelInfo={<FieldRequiredHint />}
             intent={inputIntent({ error, touched })}
-            helperText={<ErrorMessage name={'customer_name'} />}
+            helperText={<ErrorMessage name={'customerName'} />}
           >
             <InputGroup
               intent={inputIntent({ error, touched })}
@@ -50,13 +50,13 @@ export function NotifyViaSMSFormFields({ notificationTypes }) {
       </FastField>
 
       {/* ----------- Phone number ----------- */}
-      <FastField name={'customer_phone_number'}>
+      <FastField name={'customerPhoneNumber'}>
         {({ form, field, meta: { error, touched } }) => (
           <FormGroup
             label={intl.get('phone_number')}
             labelInfo={<FieldRequiredHint />}
             intent={inputIntent({ error, touched })}
-            helperText={<ErrorMessage name="customer_phone_number" />}
+            helperText={<ErrorMessage name="customerPhoneNumber" />}
             className={classNames(
               'form-group--customer_phone_number',
               CLASSES.FILL,

--- a/packages/webapp/src/containers/NotifyViaSMS/utils.tsx
+++ b/packages/webapp/src/containers/NotifyViaSMS/utils.tsx
@@ -5,13 +5,13 @@ export const transformErrors = (errors, { setErrors, setCalloutCode }) => {
   if (errors.some((e) => e.type === 'CUSTOMER_SMS_NOTIFY_PHONE_INVALID')) {
     setCalloutCode([200]);
     setErrors({
-      customer_phone_number: 'The personal phone number is invalid.',
+      customerPhoneNumber: 'The personal phone number is invalid.',
     });
   }
   if (errors.find((error) => error.type === 'CUSTOMER_HAS_NO_PHONE_NUMBER')) {
     setCalloutCode([100]);
     setErrors({
-      customer_phone_number: intl.get(
+      customerPhoneNumber: intl.get(
         'notify_via_sms.dialog.customer_no_phone_error_message',
       ),
     });

--- a/packages/webapp/src/containers/Preferences/Users/Roles/RolesForm/RoleFormHeader.tsx
+++ b/packages/webapp/src/containers/Preferences/Users/Roles/RolesForm/RoleFormHeader.tsx
@@ -21,7 +21,7 @@ export function RoleFormHeader() {
     <Card>
       {/* ---------- Name ----------  */}
       <FFormGroup
-        name={'role_name'}
+        name={'roleName'}
         label={
           <strong>
             <T id={'roles.label.role_name'} />
@@ -32,7 +32,7 @@ export function RoleFormHeader() {
         fastField
       >
         <FInputGroup
-          name={'role_name'}
+          name={'roleName'}
           medium={true}
           inputRef={(ref: HTMLInputElement | null) => {
             roleNameFieldRef.current = ref;
@@ -44,13 +44,13 @@ export function RoleFormHeader() {
 
       {/* ---------- Description ----------  */}
       <FFormGroup
-        name={'role_description'}
+        name={'roleDescription'}
         label={intl.get('description')}
         inline
         fastField
       >
         <FTextArea
-          name={'role_description'}
+          name={'roleDescription'}
           growVertically={true}
           height={280}
           placeholder="Max. 500 characters"

--- a/packages/webapp/src/containers/Preferences/Users/Roles/RolesForm/RolesForm.schema.tsx
+++ b/packages/webapp/src/containers/Preferences/Users/Roles/RolesForm/RolesForm.schema.tsx
@@ -3,8 +3,8 @@ import * as Yup from 'yup';
 import { DATATYPES_LENGTH } from '@/constants/dataTypes';
 
 const Schema = Yup.object().shape({
-  role_name: Yup.string().required().label(intl.get('roles.label.role_name_')),
-  role_description: Yup.string().nullable().max(DATATYPES_LENGTH.TEXT),
+  roleName: Yup.string().required().label(intl.get('roles.label.role_name_')),
+  roleDescription: Yup.string().nullable().max(DATATYPES_LENGTH.TEXT),
   permissions: Yup.object().shape({
     subject: Yup.string(),
     ability: Yup.string(),

--- a/packages/webapp/src/containers/Preferences/Users/Roles/RolesForm/RolesForm.tsx
+++ b/packages/webapp/src/containers/Preferences/Users/Roles/RolesForm/RolesForm.tsx
@@ -23,8 +23,8 @@ import type { WithDashboardActionsProps } from '@/containers/Dashboard/withDashb
 import { compose, transformToForm } from '@/utils';
 
 const defaultValues: RolesFormValues = {
-  role_name: '',
-  role_description: '',
+  roleName: '',
+  roleDescription: '',
   permissions: {},
   serviceFullAccess: {},
 };
@@ -81,8 +81,8 @@ function RolesFormInner({
   ) => {
     const permission = transformToArray(values, role);
     const form = {
-      roleName: values.role_name,
-      roleDescription: values.role_description,
+      roleName: values.roleName,
+      roleDescription: values.roleDescription,
       permissions: permission,
     };
     setSubmitting(true);

--- a/packages/webapp/src/containers/Preferences/Users/Roles/RolesForm/types.ts
+++ b/packages/webapp/src/containers/Preferences/Users/Roles/RolesForm/types.ts
@@ -6,8 +6,8 @@ export interface RolesFormPermission {
 }
 
 export interface RolesFormValues {
-  role_name: string;
-  role_description: string;
+  roleName: string;
+  roleDescription: string;
   permissions: Record<string, boolean>;
   serviceFullAccess: Record<string, boolean | number>;
 }

--- a/packages/webapp/src/containers/Preferences/Users/Roles/RolesForm/utils.tsx
+++ b/packages/webapp/src/containers/Preferences/Users/Roles/RolesForm/utils.tsx
@@ -118,8 +118,8 @@ export const transformToObject = (role: {
   const serviceFullAccess = getInitialServicesFullAccess(permissions);
 
   return {
-    role_name: role.name,
-    role_description: role.description,
+    roleName: role.name,
+    roleDescription: role.description,
     permissions,
     serviceFullAccess,
   };

--- a/packages/webapp/src/containers/Views/ViewForm.tsx
+++ b/packages/webapp/src/containers/Views/ViewForm.tsx
@@ -23,6 +23,7 @@ import { FormattedMessage as T } from '@/components';
 import { If, Icon, AppToaster } from '@/components';
 import ErrorMessage from '@/components/ErrorMessage';
 import { ViewFormContainer } from '@/containers/Views/ViewForm.container';
+import { transfromToSnakeCase } from '@/utils';
 
 function ViewFormInner({
   requestSubmitView,
@@ -68,7 +69,7 @@ function ViewFormInner({
 
   const defaultViewRole = useMemo(
     () => ({
-      field_key: '',
+      fieldKey: '',
       comparator: '',
       value: '',
       index: 1,
@@ -77,18 +78,18 @@ function ViewFormInner({
   );
 
   const validationSchema = Yup.object().shape({
-    resource_name: Yup.string().required(),
+    resourceName: Yup.string().required(),
     name: Yup.string()
       .required()
       .label(intl.formatMessage({ id: 'name_' })),
-    logic_expression: Yup.string()
+    logicExpression: Yup.string()
       .required()
       .label(intl.formatMessage({ id: 'logic_expression' })),
     roles: Yup.array().of(
       Yup.object().shape({
         comparator: Yup.string().required(),
         value: Yup.string().required(),
-        field_key: Yup.string().required(),
+        fieldKey: Yup.string().required(),
         index: Yup.number().required(),
       }),
     ),
@@ -102,9 +103,9 @@ function ViewFormInner({
 
   const initialEmptyForm = useMemo(
     () => ({
-      resource_name: resourceName || '',
+      resourceName: resourceName || '',
       name: '',
-      logic_expression: '',
+      logicExpression: '',
       roles: [defaultViewRole],
       columns: [],
     }),
@@ -117,7 +118,7 @@ function ViewFormInner({
       ...(viewMeta
         ? {
             ...viewMeta,
-            resource_name: viewMeta.resource?.name || resourceName,
+            resourceName: viewMeta.resource?.name || resourceName,
           }
         : {}),
     }),
@@ -138,19 +139,23 @@ function ViewFormInner({
     initialValues: {
       roles: [],
       ...pick(initialForm, Object.keys(initialEmptyForm)),
-      logic_expression: initialForm.roles_logic_expression || '',
+      // The view API returns `roles_logic_expression` in snake_case.
+      logicExpression: initialForm.roles_logic_expression || '',
       roles: [
         ...initialForm.roles.map((role) => {
           return {
             ...pick(role, Object.keys(defaultViewRole)),
-            field_key: role.field ? role.field.key : '',
+            fieldKey: role.field ? role.field.key : '',
           };
         }),
       ],
     },
     onSubmit: (values, { setSubmitting }) => {
+      // The views API expects snake_case payload.
+      const payload = transfromToSnakeCase(values);
+
       if (viewMeta && viewMeta.id) {
-        requestEditView(viewMeta.id, values).then((response) => {
+        requestEditView(viewMeta.id, payload).then((response) => {
           AppToaster.show({
             message: 'the_view_has_been_edited',
             intent: Intent.SUCCESS,
@@ -161,7 +166,7 @@ function ViewFormInner({
           setSubmitting(false);
         });
       } else {
-        requestSubmitView(values).then((response) => {
+        requestSubmitView(payload).then((response) => {
           AppToaster.show({
             message: 'the_view_has_been_submit',
             intent: Intent.SUCCESS,
@@ -314,13 +319,13 @@ function ViewFormInner({
 
             <Col sm={2}>
               <FormGroup
-                intent={hasError(`roles[${index}].field_key`) && Intent.DANGER}
+                intent={hasError(`roles[${index}].fieldKey`) && Intent.DANGER}
               >
                 <HTMLSelect
                   options={resourceFieldsOptions}
-                  value={role.field_key}
+                  value={role.fieldKey}
                   className={Classes.FILL}
-                  {...getFieldProps(`roles[${index}].field_key`)}
+                  {...getFieldProps(`roles[${index}].fieldKey`)}
                 />
               </FormGroup>
             </Col>
@@ -377,14 +382,14 @@ function ViewFormInner({
                 label={intl.get('Logic Expression')}
                 className={'form-group--logic-expression'}
                 intent={
-                  errors.logic_expression &&
-                  touched.logic_expression &&
+                  errors.logicExpression &&
+                  touched.logicExpression &&
                   Intent.DANGER
                 }
                 helperText={
                   <ErrorMessage
                     {...{ errors, touched }}
-                    name="logic_expression"
+                    name="logicExpression"
                   />
                 }
                 inline={true}
@@ -392,12 +397,12 @@ function ViewFormInner({
               >
                 <InputGroup
                   intent={
-                    errors.logic_expression &&
-                    touched.logic_expression &&
+                    errors.logicExpression &&
+                    touched.logicExpression &&
                     Intent.DANGER
                   }
                   fill={true}
-                  {...getFieldProps('logic_expression')}
+                  {...getFieldProps('logicExpression')}
                 />
               </FormGroup>
             </Col>

--- a/packages/webapp/src/containers/WarehouseTransfers/WarehouseTransferForm/WarehouseTransferFormDialog.tsx
+++ b/packages/webapp/src/containers/WarehouseTransfers/WarehouseTransferForm/WarehouseTransferFormDialog.tsx
@@ -4,7 +4,6 @@ import { index as WarehouseTransferNumberDialog } from '@/containers/Dialogs/War
 
 interface WarehouseTransferNumberDialogResult {
   incrementNumber?: number | string;
-  manually?: boolean;
 }
 
 /**
@@ -16,10 +15,8 @@ export function WarehouseTransferFormDialog() {
   // Update the form once the credit number form submit confirm.
   const handleWarehouseNumberFormConfirm = ({
     incrementNumber,
-    manually,
   }: WarehouseTransferNumberDialogResult) => {
     setFieldValue('transactionNumber', incrementNumber || '');
-    setFieldValue('transaction_no_manually', manually);
   };
 
   return (

--- a/packages/webapp/src/hooks/query/estimates/queries.ts
+++ b/packages/webapp/src/hooks/query/estimates/queries.ts
@@ -264,7 +264,7 @@ export function useEstimateSMSDetail(
   props?: Record<string, unknown>,
   requestProps?: Record<string, unknown>,
 ) {
-  const fetcher = useApiFetcher();
+  const fetcher = useApiFetcher({ enableCamelCaseTransform: true });
   return useQuery({
     ...props,
     queryKey: estimatesKeys.smsDetail(estimateId),


### PR DESCRIPTION
## Description

Migrates the last remaining Formik forms that used snake_case field keys to camelCase, aligning them with the established pattern used across the webapp (camelCase `initialValues` → camelCase Yup schema and field `name` props → explicit payload mapping at submit, with the SDK request middleware or `transfromToSnakeCase` handling the wire format).

Forms refactored (30 files, all in `packages/webapp/src`):

- **Authentication**: Register (`first_name`/`last_name`), InviteAccept (`organization_name`, `invited_email`, `first_name`, `last_name`), ResetPassword (`confirm_password`). The InviteAccept submit now sends a typed `{ firstName, lastName, password }` payload matching the SDK `InviteUserDto`, instead of raw form values cast to `AcceptInviteBody`.
- **NotifyViaSMS family**: shared `NotifyViaSMSForm` + schema + fields + error mapper (`notification_key`, `customer_name`, `customer_phone_number`, `sms_message`) and the Invoice / PaymentReceive / Receipt / Estimate dialog mappers.
- **LockingTransactionsDialog**: `lock_to_date` → `lockToDate`; edit mode camelizes the API object via `transformToCamelCase` before `transformToForm`.
- **RolesForm**: `role_name`/`role_description` → `roleName`/`roleDescription`, including the `transformToObject` edit-mode mapper.
- **ViewForm**: `resource_name`, `logic_expression`, `roles[].field_key` → camelCase; submit wraps values in `transfromToSnakeCase()` for the legacy `ApiService.post('views', …)` redux-thunk path.
- **ContactDuplicateDialog**: `contact_type` → `contactType`.

Also fixes two adjacent casing bugs:

- `WarehouseTransferFormDialog`: removed the dead `setFieldValue('transaction_no_manually', manually)` write — the dialog result type has no `manually` property, so it always wrote `undefined` to a non-existent key.
- `AllocateLandedCostDialogProvider`: removed a stale FIXME — the form already reads camelCase since `useBill` uses `enableCamelCaseTransform`.
- `useEstimateSMSDetail`: enabled `enableCamelCaseTransform: true` (consistent with the Invoice/PaymentReceive/Receipt SMS detail hooks), removing the need for manual camelization in the Estimate dialog.

i18n keys (`intl.get(...)`) and CSS class names were intentionally left unchanged.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- `pnpm run typecheck` (webapp): error set identical to the pre-change baseline — zero errors in changed files, no new errors introduced.
- ESLint on all 30 changed files: zero new issues (remaining findings verified as pre-existing by linting pristine stashed versions).
- Prettier: all changed files pass `prettier --check`.

Manual smoke testing recommended for: Register, InviteAccept, the four Notify-via-SMS dialogs, LockingTransactions dialog (edit mode), Roles form (create + edit), View builder (create + edit), and ContactDuplicate dialog — these touch auth flows and one legacy submit path.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>
