### PR TITLE
fix(webapp): migrate universal search to camelCase responses

### DIFF
--- a/packages/webapp/src/components/UniversalSearch/utils.tsx
+++ b/packages/webapp/src/components/UniversalSearch/utils.tsx
@@ -1,5 +1,8 @@
 // @ts-nocheck
 
 export const filterItemsByResourceType = (items, type) => {
-  return items.filter((item) => item._type === type);
+  if (!Array.isArray(items)) {
+    return [];
+  }
+  return items.filter((item) => item?._type === type);
 };

--- a/packages/webapp/src/containers/Accounting/ManualJournalUniversalSearch.tsx
+++ b/packages/webapp/src/containers/Accounting/ManualJournalUniversalSearch.tsx
@@ -33,9 +33,9 @@ export const JournalUniversalSearchSelectAction = withDrawerActions(
  */
 const manualJournalsToSearch = (manualJournal) => ({
   id: manualJournal.id,
-  text: manualJournal.journal_number,
-  subText: manualJournal.formatted_date,
-  label: manualJournal.formatted_amount,
+  text: manualJournal.journalNumber ?? '',
+  subText: manualJournal.formattedDate ?? '',
+  label: manualJournal.formattedAmount ?? '',
   reference: manualJournal,
 });
 

--- a/packages/webapp/src/containers/Customers/CustomersUniversalSearch.tsx
+++ b/packages/webapp/src/containers/Customers/CustomersUniversalSearch.tsx
@@ -37,8 +37,8 @@ const CustomerUniversalSearchSelectAction = withDrawerActions(
  */
 const customersToSearch = (contact: CustomerDetails) => ({
   id: contact.id,
-  text: contact.displayName,
-  label: contact.formattedBalance,
+  text: contact.displayName ?? '',
+  label: contact.formattedBalance ?? '',
   reference: contact,
 });
 

--- a/packages/webapp/src/containers/Purchases/Bills/BillUniversalSearch.tsx
+++ b/packages/webapp/src/containers/Purchases/Bills/BillUniversalSearch.tsx
@@ -38,28 +38,28 @@ export const BillUniversalSearchSelect = withDrawerActions(
 export function BillStatus({ bill }) {
   return (
     <Choose>
-      <Choose.When condition={bill.is_fully_paid && bill.is_open}>
+      <Choose.When condition={bill.isFullyPaid && bill.isOpen}>
         <TextStatus intent={Intent.SUCCESS}>
           <T id={'paid'} />
         </TextStatus>
       </Choose.When>
-      <Choose.When condition={bill.is_open}>
+      <Choose.When condition={bill.isOpen}>
         <Choose>
-          <Choose.When condition={bill.is_overdue}>
+          <Choose.When condition={bill.isOverdue}>
             <TextStatus intent={Intent.DANGER}>
-              {intl.get('overdue_by', { overdue: bill.overdue_days })}
+              {intl.get('overdue_by', { overdue: bill.overdueDays })}
             </TextStatus>
           </Choose.When>
           <Choose.Otherwise>
             <TextStatus intent={Intent.WARNING}>
-              {intl.get('due_in', { due: bill.remaining_days })}
+              {intl.get('due_in', { due: bill.remainingDays })}
             </TextStatus>
           </Choose.Otherwise>
         </Choose>
-        <If condition={bill.is_partially_paid}>
+        <If condition={bill.isPartiallyPaid}>
           <TextStatus intent={Intent.WARNING}>
             {intl.get('day_partially_paid', {
-              due: formattedAmount(bill.due_amount, bill.currency_code),
+              due: formattedAmount(bill.dueAmount, bill.currencyCode),
             })}
           </TextStatus>
         </If>
@@ -87,15 +87,15 @@ export function BillUniversalSearchItem(
         <div>
           <div>{item.text}</div>
           <span class="bp4-text-muted">
-            {item.reference.bill_number}{' '}
+            {item.reference.billNumber}{' '}
             <Icon icon={'caret-right-16'} iconSize={16} />
-            {item.reference.formatted_bill_date}
+            {item.reference.formattedBillDate}
           </span>
         </div>
       }
       label={
         <>
-          <div class="amount">{item.reference.formatted_amount}</div>
+          <div class="amount">{item.reference.formattedAmount}</div>
           <BillStatus bill={item.reference} />
         </>
       }
@@ -107,7 +107,7 @@ export function BillUniversalSearchItem(
 
 const billsToSearch = (bill) => ({
   id: bill.id,
-  text: bill.vendor.display_name,
+  text: bill.vendor?.displayName ?? '',
   reference: bill,
 });
 

--- a/packages/webapp/src/containers/Purchases/CreditNotes/VendorCreditIUniversalSearchBind.tsx
+++ b/packages/webapp/src/containers/Purchases/CreditNotes/VendorCreditIUniversalSearchBind.tsx
@@ -39,13 +39,13 @@ export const VendorCreditUniversalSearchSelect = withDrawerActions(
 function VendorCreditUniversalSearchStatus({ receipt }) {
   return (
     <Choose>
-      <Choose.When condition={receipt.is_closed}>
+      <Choose.When condition={receipt.isClosed}>
         <TextStatus intent={Intent.SUCCESS}>
           <T id={'closed'} />
         </TextStatus>
       </Choose.When>
 
-      <Choose.When condition={receipt.is_open}>
+      <Choose.When condition={receipt.isOpen}>
         <TextStatus intent={Intent.WARNING}>
           <T id={'closed'} />
         </TextStatus>
@@ -74,15 +74,15 @@ export function VendorCreditUniversalSearchItem(
         <div>
           <div>{item.text}</div>
           <span class="bp4-text-muted">
-            {item.reference.vendor_credit_number}{' '}
+            {item.reference.vendorCreditNumber}{' '}
             <Icon icon={'caret-right-16'} iconSize={16} />
-            {item.reference.formatted_vendor_credit_date}
+            {item.reference.formattedVendorCreditDate}
           </span>
         </div>
       }
       label={
         <>
-          <div class="amount">{item.reference.formatted_amount}</div>
+          <div class="amount">{item.reference.formattedAmount}</div>
           <VendorCreditUniversalSearchStatus receipt={item.reference} />
         </>
       }
@@ -97,8 +97,8 @@ export function VendorCreditUniversalSearchItem(
  */
 const transformVendorCreditsToSearch = (vendorCredit) => ({
   id: vendorCredit.id,
-  text: vendorCredit.vendor.display_name,
-  label: vendorCredit.formatted_amount,
+  text: vendorCredit.vendor?.displayName ?? '',
+  label: vendorCredit.formattedAmount ?? '',
   reference: vendorCredit,
 });
 

--- a/packages/webapp/src/containers/Purchases/PaymentsMade/PaymentsMadeUniversalSearch.tsx
+++ b/packages/webapp/src/containers/Purchases/PaymentsMade/PaymentsMadeUniversalSearch.tsx
@@ -45,13 +45,13 @@ export function PaymentsMadeUniversalSearchItem(
           <div>{highlightText(text, query)}</div>
 
           <span class="bp4-text-muted">
-            {reference.payment_number && (
+            {reference.paymentNumber && (
               <>
-                {highlightText(reference.payment_number, query)}
+                {highlightText(reference.paymentNumber, query)}
                 <Icon icon={'caret-right-16'} iconSize={16} />
               </>
             )}
-            {highlightText(reference.formatted_payment_date, query)}
+            {highlightText(reference.formattedPaymentDate, query)}
           </span>
         </div>
       }
@@ -67,8 +67,8 @@ export function PaymentsMadeUniversalSearchItem(
  */
 const paymentMadeToSearch = (payment) => ({
   id: payment.id,
-  text: payment.vendor.display_name,
-  label: payment.formatted_amount,
+  text: payment.vendor?.displayName ?? '',
+  label: payment.formattedAmount ?? '',
   reference: payment,
 });
 

--- a/packages/webapp/src/containers/Sales/CreditNotes/CreditNoteUniversalSearch.tsx
+++ b/packages/webapp/src/containers/Sales/CreditNotes/CreditNoteUniversalSearch.tsx
@@ -37,13 +37,13 @@ export const CreditNoteUniversalSearchSelect = withDrawerActions(
 function CreditNoteUniversalSearchStatus({ receipt }) {
   return (
     <Choose>
-      <Choose.When condition={receipt.is_closed}>
+      <Choose.When condition={receipt.isClosed}>
         <TextStatus intent={Intent.SUCCESS}>
           <T id={'closed'} />
         </TextStatus>
       </Choose.When>
 
-      <Choose.When condition={receipt.is_open}>
+      <Choose.When condition={receipt.isOpen}>
         <TextStatus intent={Intent.WARNING}>
           <T id={'open'} />
         </TextStatus>
@@ -72,15 +72,15 @@ export function CreditNoteUniversalSearchItem(
         <div>
           <div>{item.text}</div>
           <span class="bp4-text-muted">
-            {item.reference.credit_note_number}{' '}
+            {item.reference.creditNoteNumber}{' '}
             <Icon icon={'caret-right-16'} iconSize={16} />
-            {item.reference.formatted_credit_note_date}
+            {item.reference.formattedCreditNoteDate}
           </span>
         </div>
       }
       label={
         <>
-          <div class="amount">{item.reference.formatted_amount}</div>
+          <div class="amount">{item.reference.formattedAmount}</div>
           <CreditNoteUniversalSearchStatus receipt={item.reference} />
         </>
       }
@@ -95,8 +95,8 @@ export function CreditNoteUniversalSearchItem(
  */
 const transformReceiptsToSearch = (creditNote) => ({
   id: creditNote.id,
-  text: creditNote.customer.display_name,
-  label: creditNote.formatted_amount,
+  text: creditNote.customer?.displayName ?? '',
+  label: creditNote.formattedAmount ?? '',
   reference: creditNote,
 });
 

--- a/packages/webapp/src/containers/Sales/Estimates/EstimatesLanding/EstimateUniversalSearch.tsx
+++ b/packages/webapp/src/containers/Sales/Estimates/EstimatesLanding/EstimateUniversalSearch.tsx
@@ -34,19 +34,19 @@ export const EstimateUniversalSearchSelect = withDrawerActions(
  */
 export const EstimateStatus = ({ estimate }) => (
   <Choose>
-    <Choose.When condition={estimate.is_delivered && estimate.is_approved}>
+    <Choose.When condition={estimate.isDelivered && estimate.isApproved}>
       <TextStatus intent={Intent.SUCCESS}>
         <T id={'approved'} />
       </TextStatus>
     </Choose.When>
-    <Choose.When condition={estimate.is_delivered && estimate.is_rejected}>
+    <Choose.When condition={estimate.isDelivered && estimate.isRejected}>
       <TextStatus intent={Intent.DANGER}>
         <T id={'rejected'} />
       </TextStatus>
     </Choose.When>
     <Choose.When
       condition={
-        estimate.is_delivered && !estimate.is_rejected && !estimate.is_approved
+        estimate.isDelivered && !estimate.isRejected && !estimate.isApproved
       }
     >
       <TextStatus intent={Intent.SUCCESS}>
@@ -75,15 +75,15 @@ export function EstimateUniversalSearchItem(
         <div>
           <div>{item.text}</div>
           <span class="bp4-text-muted">
-            {item.reference.estimate_number}{' '}
+            {item.reference.estimateNumber}{' '}
             <Icon icon={'caret-right-16'} iconSize={16} />
-            {item.reference.formatted_estimate_date}
+            {item.reference.formattedEstimateDate}
           </span>
         </div>
       }
       label={
         <>
-          <div class="amount">{item.reference.formatted_amount}</div>
+          <div class="amount">{item.reference.formattedAmount}</div>
           <EstimateStatus estimate={item.reference} />
         </>
       }
@@ -98,8 +98,8 @@ export function EstimateUniversalSearchItem(
  */
 const transformEstimatesToSearch = (estimate) => ({
   id: estimate.id,
-  text: estimate.customer.display_name,
-  label: estimate.formatted_balance,
+  text: estimate.customer?.displayName ?? '',
+  label: estimate.formattedAmount ?? '',
   reference: estimate,
 });
 

--- a/packages/webapp/src/containers/Sales/Invoices/InvoiceUniversalSearch.tsx
+++ b/packages/webapp/src/containers/Sales/Invoices/InvoiceUniversalSearch.tsx
@@ -36,22 +36,22 @@ export const InvoiceUniversalSearchSelect = withDrawerActions(
 function InvoiceStatus({ customer }) {
   return (
     <Choose>
-      <Choose.When condition={customer.is_fully_paid && customer.is_delivered}>
+      <Choose.When condition={customer.isFullyPaid && customer.isDelivered}>
         <TextStatus intent={Intent.SUCCESS}>
           <T id={'paid'} />
         </TextStatus>
       </Choose.When>
 
-      <Choose.When condition={customer.is_delivered}>
+      <Choose.When condition={customer.isDelivered}>
         <Choose>
-          <Choose.When condition={customer.is_overdue}>
+          <Choose.When condition={customer.isOverdue}>
             <TextStatus intent={Intent.DANGER}>
-              {intl.get('overdue_by', { overdue: customer.overdue_days })}
+              {intl.get('overdue_by', { overdue: customer.overdueDays })}
             </TextStatus>
           </Choose.When>
           <Choose.Otherwise>
             <TextStatus intent={Intent.WARNING}>
-              {intl.get('due_in', { due: customer.remaining_days })}
+              {intl.get('due_in', { due: customer.remainingDays })}
             </TextStatus>
           </Choose.Otherwise>
         </Choose>
@@ -79,15 +79,15 @@ export function InvoiceUniversalSearchItem(
         <div>
           <div>{highlightText(item.text, query)}</div>
           <span class="bp4-text-muted">
-            {highlightText(item.reference.invoice_no, query)}{' '}
+            {highlightText(item.reference.invoiceNo, query)}{' '}
             <Icon icon={'caret-right-16'} iconSize={16} />
-            {item.reference.invoice_date_formatted}
+            {item.reference.invoiceDateFormatted}
           </span>
         </div>
       }
       label={
         <>
-          <div class="amount">{item.reference.total_formatted}</div>
+          <div class="amount">{item.reference.totalFormatted}</div>
           <InvoiceStatus customer={item.reference} />
         </>
       }
@@ -103,8 +103,8 @@ export function InvoiceUniversalSearchItem(
  */
 const transformInvoicesToSearch = (invoice) => ({
   id: invoice.id,
-  text: invoice.customer.display_name,
-  label: invoice.formatted_balance,
+  text: invoice.customer?.displayName ?? '',
+  label: invoice.totalFormatted ?? '',
   reference: invoice,
 });
 

--- a/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentReceiveUniversalSearch.tsx
+++ b/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentReceiveUniversalSearch.tsx
@@ -50,13 +50,13 @@ export function PaymentReceiveUniversalSearchItem(
           <div>{highlightText(item.text, query)}</div>
 
           <span class="bp4-text-muted">
-            {highlightText(item.reference.payment_receive_no, query)}{' '}
+            {highlightText(item.reference.paymentReceiveNo, query)}{' '}
             <Icon icon={'caret-right-16'} iconSize={16} />
-            {highlightText(item.reference.formatted_payment_date, query)}
+            {highlightText(item.reference.formattedPaymentDate, query)}
           </span>
         </div>
       }
-      label={<div class="amount">{item.reference.formatted_amount}</div>}
+      label={<div class="amount">{item.reference.formattedAmount}</div>}
       onClick={handleClick}
       className={'universal-search__item--invoice'}
     />
@@ -68,9 +68,9 @@ export function PaymentReceiveUniversalSearchItem(
  */
 const paymentReceivesToSearch = (payment) => ({
   id: payment.id,
-  text: payment.customer.display_name,
-  subText: payment.formatted_payment_date,
-  label: payment.formatted_amount,
+  text: payment.customer?.displayName ?? '',
+  subText: payment.formattedPaymentDate ?? '',
+  label: payment.formattedAmount ?? '',
   reference: payment,
 });
 

--- a/packages/webapp/src/containers/Sales/Receipts/ReceiptUniversalSearch.tsx
+++ b/packages/webapp/src/containers/Sales/Receipts/ReceiptUniversalSearch.tsx
@@ -37,7 +37,7 @@ export const ReceiptUniversalSearchSelect = withDrawerActions(
 function ReceiptStatus({ receipt }) {
   return (
     <Choose>
-      <Choose.When condition={receipt.is_closed}>
+      <Choose.When condition={receipt.isClosed}>
         <TextStatus intent={Intent.SUCCESS}>
           <T id={'closed'} />
         </TextStatus>
@@ -66,15 +66,15 @@ export function ReceiptUniversalSearchItem(
         <div>
           <div>{item.text}</div>
           <span class="bp4-text-muted">
-            {item.reference.receipt_number}{' '}
+            {item.reference.receiptNumber}{' '}
             <Icon icon={'caret-right-16'} iconSize={16} />
-            {item.reference.formatted_receipt_date}
+            {item.reference.formattedReceiptDate}
           </span>
         </div>
       }
       label={
         <>
-          <div class="amount">{item.reference.formatted_amount}</div>
+          <div class="amount">{item.reference.formattedAmount}</div>
           <ReceiptStatus receipt={item.reference} />
         </>
       }
@@ -89,8 +89,8 @@ export function ReceiptUniversalSearchItem(
  */
 const transformReceiptsToSearch = (receipt) => ({
   id: receipt.id,
-  text: receipt.customer.display_name,
-  label: receipt.formatted_amount,
+  text: receipt.customer?.displayName ?? '',
+  label: receipt.formattedAmount ?? '',
   reference: receipt,
 });
 

--- a/packages/webapp/src/containers/Vendors/VendorsUniversalSearch.tsx
+++ b/packages/webapp/src/containers/Vendors/VendorsUniversalSearch.tsx
@@ -40,8 +40,8 @@ const VendorUniversalSearchSelectAction = withDrawerActions(
  */
 const vendorToSearch = (contact: VendorDetails) => ({
   id: contact.id,
-  text: contact.displayName,
-  label: contact.formattedBalance,
+  text: contact.displayName ?? '',
+  label: contact.formattedBalance ?? '',
   reference: contact,
 });
 

--- a/packages/webapp/src/hooks/query/GenericResource/index.tsx
+++ b/packages/webapp/src/hooks/query/GenericResource/index.tsx
@@ -26,7 +26,7 @@ interface ResourceData {
 
 type ResourceFetcher = (
   fetcher: ApiFetcher,
-  query?: { search_keyword?: string },
+  query?: { searchKeyword?: string },
 ) => Promise<unknown>;
 
 type ResourceDataTransformer = (data: any) => ResourceData;
@@ -35,8 +35,11 @@ type ResourceDataTransformer = (data: any) => ResourceData;
  * Fetches the given resource list (for universal search) through the typed
  * SDK fetch functions, keyed by resource type.
  *
+ * Responses are transformed from snake_case to camelCase via the SDK
+ * camel-case middleware, so all universal-search binds consume camelCase.
+ *
  * @param {string} type - Resource type.
- * @param {object} query - Query params, e.g. `{ search_keyword }`.
+ * @param {object} query - Query params, e.g. `{ searchKeyword }`.
  * @param {*} props - Additional react-query options.
  * @returns
  */
@@ -45,7 +48,7 @@ export function useResourceData(
   query?: unknown,
   props?: unknown,
 ) {
-  const fetcher = useApiFetcher();
+  const fetcher = useApiFetcher({ enableCamelCaseTransform: true });
   const fetchResource = getResourceFetcherFromType(type);
   const { defaultData: defaultDataProp, ...restProps } = (props ?? {}) as {
     defaultData?: ResourceData;
@@ -57,7 +60,7 @@ export function useResourceData(
       if (!fetchResource) {
         throw new Error(`Unknown resource type: ${type}`);
       }
-      return fetchResource(fetcher, query as { search_keyword?: string });
+      return fetchResource(fetcher, query as { searchKeyword?: string });
     },
     select: transformResourceData(type),
     placeholderData: defaultDataProp ?? { items: [] },

--- a/packages/webapp/src/hooks/query/UniversalSearch/universal-search.tsx
+++ b/packages/webapp/src/hooks/query/UniversalSearch/universal-search.tsx
@@ -9,8 +9,11 @@ import { getUniversalSearchBind } from '@/containers/UniversalSearch/utils';
  * @returns
  */
 function transfromResourceDataToSearch(resource: any) {
-  const selectItem = getUniversalSearchBind(resource._type, 'itemSelect');
+  const selectItem = getUniversalSearchBind(resource?._type, 'itemSelect');
 
+  if (!resource || !Array.isArray(resource.items)) {
+    return [];
+  }
   return resource.items.map((item: unknown) => ({
     ...(selectItem ? selectItem(item) : {}),
     _type: resource._type,
@@ -31,7 +34,7 @@ export function useUniversalSearch(
   const { data, ...restProps } = useResourceData(
     type,
     {
-      search_keyword: searchKeyword,
+      searchKeyword,
     },
     props,
   );

--- a/packages/webapp/src/utils/index.tsx
+++ b/packages/webapp/src/utils/index.tsx
@@ -837,6 +837,11 @@ function escapeRegExpChars(text) {
 }
 
 export function highlightText(text, query) {
+  if (text == null) {
+    return [];
+  }
+  text = String(text);
+  query = query == null ? '' : String(query);
   let lastIndex = 0;
   const words = query
     .split(/\s+/)


### PR DESCRIPTION
## Description

Migrate universal search to camelCase SDK responses to fix fatal errors when typing with customer and vendor types selected.

`useResourceData` used `useApiFetcher()` without the camelCase transform, so it received wire `snake_case` payloads while customer/vendor/account/item binds expected `camelCase` (`displayName`). This left `item.text` undefined and `highlightText` threw on `slice`. This change enables `enableCamelCaseTransform` in the universal-search data layer and migrates all binds (invoice, estimate, receipt, bill, payment receive/made, credit note, vendor credit, manual journal) from `snake_case` to `camelCase` fields. It also hardens `highlightText` and search utils against undefined values.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Verified no remaining `snake_case` field access in `*UniversalSearch*` containers and no `search_keyword` in universal-search hooks via `rg`.
- Ran ESLint on touched webapp files: 0 errors.
- Ran `pnpm run typecheck`: no new errors in touched files (remaining failures are pre-existing).
- Manual reproduction: open global search, select customer/vendor/invoice/bill and other types, type a keyword, confirm results render without fatal errors and selection opens the correct drawer.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>
