### PR TITLE
fix(webapp): persist preferences tabs in URL query param

### DIFF
--- a/packages/webapp/src/containers/Preferences/SMSIntegration/SMSIntegrationTabs.tsx
+++ b/packages/webapp/src/containers/Preferences/SMSIntegration/SMSIntegrationTabs.tsx
@@ -5,10 +5,11 @@ import intl from 'react-intl-universal';
 import styled from 'styled-components';
 import { SMSIntegrationForm } from './SMSIntegrationForm';
 import { SMSMessagesDataTable } from './SMSMessagesDataTable';
+import type { WithDashboardActionsProps } from '@/containers/Dashboard/withDashboardActions';
 import { Card } from '@/components';
 import { CLASSES } from '@/constants/classes';
 import { withDashboardActions } from '@/containers/Dashboard/withDashboardActions';
-import type { WithDashboardActionsProps } from '@/containers/Dashboard/withDashboardActions';
+import { useAppQueryString } from '@/hooks';
 import { compose } from '@/utils';
 
 import '@/style/pages/Preferences/SMSIntegration.scss';
@@ -25,6 +26,15 @@ function SMSIntegrationTabsInner({
   // #withDashboardActions
   changePreferencesPageTitle,
 }: SMSIntegrationTabsInnerProps) {
+  const [locationQuery, setLocationQuery] = useAppQueryString();
+
+  const activeTab =
+    locationQuery?.tab === 'overview' ? 'overview' : 'sms_messages';
+
+  const handleTabChange = (tabId: string | number) => {
+    setLocationQuery({ tab: String(tabId) });
+  };
+
   React.useEffect(() => {
     changePreferencesPageTitle(intl.get('sms_integration.label'));
   }, [changePreferencesPageTitle]);
@@ -32,7 +42,13 @@ function SMSIntegrationTabsInner({
   return (
     <SMSIntegrationCard>
       <div className={classNames(CLASSES.PREFERENCES_PAGE_TABS)}>
-        <Tabs animate={true} defaultSelectedTabId={'sms_messages'}>
+        <Tabs
+          id="sms-integration-tabs"
+          animate={true}
+          selectedTabId={activeTab}
+          onChange={handleTabChange}
+          renderActiveTabPanelOnly={true}
+        >
           <Tab
             id="overview"
             title={intl.get('sms_integration.label.overview')}

--- a/packages/webapp/src/containers/Preferences/Users/Users.tsx
+++ b/packages/webapp/src/containers/Preferences/Users/Users.tsx
@@ -12,9 +12,16 @@ import {
   withDialogActions,
   type WithDialogActionsProps,
 } from '@/containers/Dialog/withDialogActions';
+import { useAppQueryString } from '@/hooks';
 
 function UsersPreferences({ openDialog }: WithDialogActionsProps) {
-  const onChangeTabs = (currentTabId: string) => {};
+  const [locationQuery, setLocationQuery] = useAppQueryString();
+
+  const activeTab = locationQuery?.tab === 'roles' ? 'roles' : 'users';
+
+  const onChangeTabs = (tabId: string | number) => {
+    setLocationQuery({ tab: String(tabId) });
+  };
 
   return (
     <div
@@ -25,7 +32,13 @@ function UsersPreferences({ openDialog }: WithDialogActionsProps) {
     >
       <UsersPereferencesCard>
         <div className={classNames(CLASSES.PREFERENCES_PAGE_TABS)}>
-          <Tabs animate={true} onChange={onChangeTabs}>
+          <Tabs
+            id="users-preferences-tabs"
+            animate={true}
+            selectedTabId={activeTab}
+            onChange={onChangeTabs}
+            renderActiveTabPanelOnly={true}
+          >
             <Tab
               id="users"
               title={intl.get('users')}


### PR DESCRIPTION
## Description

Persists the active tab of the tabbed Preferences pages in the URL via the `?tab=` query param, using the existing `useAppQueryString` hook (`@/hooks`).

Previously, switching tabs on `/preferences/users` (Users/Roles) and `/preferences/sms-message` (Overview/Messages) kept the state only in memory (uncontrolled Blueprint `<Tabs>`, including an empty `onChangeTabs` stub in `Users.tsx`), so the URL never changed and a page refresh always reset to the default tab. Both `<Tabs>` are now controlled (`selectedTabId` derived from `?tab=`, `onChange` writing via `setLocationQuery`), so refresh, bookmarks, and shared links restore the active tab. Missing/invalid values fall back to the previous defaults (`users`, `sms_messages`). Only the query string changes, so the preferences sidebar highlight and topbar exact-route matching keep working with no route changes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- `tsc --noEmit` (webapp): no errors in the two changed files (repo has unrelated pre-existing errors elsewhere).
- `eslint` on `SMSIntegrationTabs.tsx`: clean (`Users.tsx` has one pre-existing `import/order` error also present on `develop`).
- `prettier --check` on both files: pass.
- Manual verification steps: open `/preferences/users`, switch to Roles (URL becomes `?tab=roles`), refresh stays on Roles; same for `/preferences/sms-message` Overview/Messages; direct links with `?tab=` open the correct tab.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>
