### PR TITLE
fix(server): correct CreditNote ability subject typo blocking role saves

### DIFF
--- a/packages/server/src/modules/Roles/Roles.types.ts
+++ b/packages/server/src/modules/Roles/Roles.types.ts
@@ -63,7 +63,7 @@ export enum AbilitySubject {
   Cashflow = 'Cashflow',
   ManualJournal = 'ManualJournal',
   Preferences = 'Preferences',
-  CreditNote = 'CreditNode',
+  CreditNote = 'CreditNote',
   VendorCredit = 'VendorCredit',
   Project = 'Project',
   TaxRate = 'TaxRate',


### PR DESCRIPTION
## Problem

`AbilitySubject.CreditNote` is defined as `'CreditNode'`:

https://github.com/bigcapitalhq/bigcapital/blob/develop/packages/server/src/modules/Roles/Roles.types.ts#L66

```ts
CreditNote = 'CreditNode',
```

The webapp sends `CreditNote` (`packages/webapp/src/constants/abilityOption.tsx`), but `AbilitySchema` registers the subject under `CreditNode`. `getInvalidPermissions()` in `packages/server/src/modules/Roles/utils.ts` looks up `schemaMap['CreditNote']`, finds nothing, and flags every credit note permission as invalid.

**Result: no role can be granted any Credit Note permission.**

## Reproduction

1. Go to Preferences → Roles → New Role.
2. Tick any Credit note permission (View / Create / Edit / Delete / Refund).
3. Save.

```json
{
  "errors": [{
    "statusCode": 400,
    "type": "INVALIDATE_PERMISSIONS",
    "payload": { "invalidPermissions": [
      { "subject": "CreditNote", "ability": "View",   "value": true },
      { "subject": "CreditNote", "ability": "Create", "value": true },
      { "subject": "CreditNote", "ability": "Edit",   "value": true }
    ]}
  }]
}
```

The role cannot be saved at all until every Credit note box is unticked.

## Fix

One character — `'CreditNode'` → `'CreditNote'`.

## Data safety

`'CreditNode'` appears exactly once in the repository, and no seed or migration writes it (`20210812121909_seed_roles_permissions.ts` seeds no credit note rows). Since the value could never be persisted through the API in the first place, no existing `role_permissions` rows reference it, so this needs no data migration.

Found while setting up an Accountant role on a self-hosted instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)