### PR TITLE
fix(docker): make the database migration job run reliably and only once

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -135,6 +135,10 @@ services:
 
   database_migration:
     container_name: bigcapital-database-migration
+    # One-shot job: runs the migrations once and exits. Declared explicitly so
+    # orchestrators that default to "always"/"unless-stopped" don't restart it
+    # in a loop. This matches Docker Compose's own default.
+    restart: "no"
     build:
       context: ./
       dockerfile: docker/migration/Dockerfile

--- a/docker/migration/Dockerfile
+++ b/docker/migration/Dockerfile
@@ -35,4 +35,4 @@ WORKDIR /app/packages/server
 RUN git clone https://github.com/vishnubob/wait-for-it.git
 
 # Once we listen the mysql port run the migration task.
-CMD ./wait-for-it/wait-for-it.sh mysql:3306 -- sh -c "node dist/cli.js system:migrate:latest && node dist/cli.js tenants:migrate:latest"
+CMD ./wait-for-it/wait-for-it.sh mysql:3306 --timeout=0 -- sh -c "node dist/cli.js system:migrate:latest && node dist/cli.js tenants:migrate:latest"


### PR DESCRIPTION
Two issues with the `database_migration` one-shot job in `docker-compose.prod.yml`.

## 1. The migration races the database

`docker/migration/Dockerfile`:

```
CMD ./wait-for-it/wait-for-it.sh mysql:3306 -- sh -c "node dist/cli.js system:migrate:latest && ..."
```

`wait-for-it.sh` defaults to a **15 second** timeout, and `depends_on: mysql` carries no `condition: service_healthy`, so nothing guarantees MariaDB is accepting connections when the migration starts. A first boot that initialises the data directory regularly takes longer than 15s.

Because `--strict` is not passed, wait-for-it **executes the command anyway** once the timeout expires. The migration then runs against a database that is not listening yet and exits non-zero.

Since the service declares no restart policy, Docker leaves it exited — so the stack comes up looking healthy while the migrations were never applied. The failure is silent unless you happen to inspect that specific container.

`--timeout=0` waits for the database instead of racing it.

## 2. The one-shot intent is implicit

The service relies on Docker Compose's default `restart: no`. That is correct for `docker compose` users and this change is a no-op for them.

It matters for PaaS layers that deploy this compose file directly and apply their own default restart policy of `always` or `unless-stopped` — Coolify, Dokploy and similar. There the container exits cleanly after migrating and is restarted every couple of minutes indefinitely, which can trip restart-limit protections and stop the entire stack.

Declaring `restart: "no"` makes the intent explicit without changing behaviour for anyone using Compose directly.

## Verified

On a self-hosted deployment, before and after:

```
# before
database_migration ...  restarting, 101 restarts, whole stack taken down

# after
database_migration ...  Exited (0)
proxy / server / webapp / mysql / redis / garage / gotenberg ...  Up
```

Migration container log after the change:

```
wait-for-it.sh: waiting for mysql:3306 without a timeout
wait-for-it.sh: mysql:3306 is available after 2 seconds
Already up to date
Already up to date
Tenant bigcapital_tenant_xxxxxxxx > Batch 2 run: 0 migrations
-------------------
All tenants are migrated.
```

## Alternative worth considering

The cleaner long-term fix for issue 1 is a healthcheck on the `mysql` service plus `depends_on: { mysql: { condition: service_healthy } }`, which would remove the need for `wait-for-it` in this image entirely. That is a larger change touching `docker/mariadb` and the legacy `version: '3.3'` header, so I kept this PR minimal — happy to take that approach instead if you would prefer it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)