### PR TITLE
fix(server): create user_tenants membership on invite accept

### DIFF
--- a/packages/server/src/database/system/migrations/20260905000001_backfill_user_tenants_for_invited_users.js
+++ b/packages/server/src/database/system/migrations/20260905000001_backfill_user_tenants_for_invited_users.js
@@ -1,0 +1,20 @@
+/**
+ * Backfills `user_tenants` membership for users who joined via an invite
+ * and accepted before the invite flow started creating the membership row.
+ * Such users have `invite_accepted_at` set but no `user_tenants` entry,
+ * which prevents them from signing in.
+ */
+exports.up = function (knex) {
+  return knex.raw(`
+    INSERT IGNORE INTO USER_TENANTS (USER_ID, TENANT_ID, ROLE, CREATED_AT, UPDATED_AT)
+    SELECT ID, TENANT_ID, 'member', CREATED_AT, UPDATED_AT
+    FROM   USERS
+    WHERE  INVITE_ACCEPTED_AT IS NOT NULL
+      AND  TENANT_ID IS NOT NULL
+  `);
+};
+
+exports.down = function () {
+  // Cannot safely reverse a backfill.
+  return Promise.resolve();
+};

--- a/packages/server/src/modules/UsersModule/Users.module.ts
+++ b/packages/server/src/modules/UsersModule/Users.module.ts
@@ -19,6 +19,7 @@ import { UsersApplication } from './Users.application';
 import { GetUsersService } from './queries/GetUsers.service';
 import { AcceptInviteUserService } from './commands/AcceptInviteUser.service';
 import { InviteTenantUserService } from './commands/InviteUser.service';
+import { UserTenant } from '../System/models/UserTenant.model';
 import { UsersInviteController } from './UsersInvite.controller';
 import { UsersInvitePublicController } from './UsersInvitePublic.controller';
 import { InjectSystemModel } from '../System/SystemModels/SystemModels.module';
@@ -29,7 +30,7 @@ import { SendInviteUsersMailMessage } from './commands/SendInviteUsersMailMessag
 import { SendBulkInvitesService } from './commands/SendBulkInvites.service';
 import { MailModule } from '../Mail/Mail.module';
 
-const models = [InjectSystemModel(UserInvite)];
+const models = [InjectSystemModel(UserInvite), InjectSystemModel(UserTenant)];
 
 @Module({
   imports: [

--- a/packages/server/src/modules/UsersModule/commands/AcceptInviteUser.service.ts
+++ b/packages/server/src/modules/UsersModule/commands/AcceptInviteUser.service.ts
@@ -2,14 +2,17 @@ import { Inject, Injectable } from '@nestjs/common';
 import * as moment from 'moment';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { ClsService } from 'nestjs-cls';
+import { Knex } from 'knex';
 import {
   IAcceptInviteEventPayload,
   ICheckInviteEventPayload,
 } from '../Users.types';
 import { SystemUser } from '@/modules/System/models/SystemUser';
+import { UserTenant } from '@/modules/System/models/UserTenant.model';
 import { events } from '@/common/events/events';
 import { hashPassword } from '@/modules/Auth/Auth.utils';
 import { TenantModel } from '@/modules/System/models/TenantModel';
+import { SystemKnexConnection } from '@/modules/System/SystemDB/SystemDB.constants';
 import { ServiceError } from '@/modules/Items/ServiceError';
 import { ERRORS } from '../Users.constants';
 import { UserInvite } from '../models/InviteUser.model';
@@ -30,10 +33,15 @@ export class AcceptInviteUserService {
     @Inject(TenantModel.name)
     private readonly tenantModel: typeof TenantModel,
 
+    @Inject(UserTenant.name)
+    private readonly userTenantModel: typeof UserTenant,
+
     @Inject(UserInvite.name)
     private readonly userInviteModel: typeof UserInvite,
     private readonly eventEmitter: EventEmitter2,
     private readonly cls: ClsService,
+    @Inject(SystemKnexConnection)
+    private readonly systemKnex: Knex,
   ) {}
 
   /**
@@ -47,33 +55,39 @@ export class AcceptInviteUserService {
     token: string,
     inviteUserDTO: InviteUserDto,
   ): Promise<void> {
-    // Retrieve the invite token or throw not found error.
-    const inviteToken = await this.getInviteTokenOrThrowError(token);
-
     // Hash the given password.
     const hashedPassword = await hashPassword(inviteUserDTO.password);
 
-    // Retrieve the system user.
-    const _user = await this.systemUserModel
-      .query()
-      .findOne('email', inviteToken.email);
+    // Accept the invite under a single system-database transaction.
+    const { systemUser, tenant, inviteToken } =
+      await this.systemKnex.transaction(async (trx) => {
+        // Retrieve the invite token or throw not found error.
+        const inviteToken = await this.getInviteTokenOrThrowError(token, trx);
 
-    // Sets the invited user details after invite accepting.
-    const systemUser = await this.systemUserModel
-      .query()
-      .updateAndFetchById(inviteToken.userId, {
-        ...inviteUserDTO,
-        inviteAcceptedAt: moment().format('YYYY-MM-DD'),
-        password: hashedPassword,
+        // Sets the invited user details after invite accepting.
+        const systemUser = await this.systemUserModel
+          .query(trx)
+          .updateAndFetchById(inviteToken.userId, {
+            ...inviteUserDTO,
+            inviteAcceptedAt: moment().format('YYYY-MM-DD'),
+            password: hashedPassword,
+          });
+        // Clear invite token by the given user id.
+        await this.clearInviteTokensByUserId(inviteToken.userId, trx);
+
+        // Retrieve the tenant to get the organizationId for CLS.
+        const tenant = await this.tenantModel
+          .query(trx)
+          .findById(inviteToken.tenantId);
+
+        // Link the invited user to the tenant as a member so they can sign in.
+        await this.userTenantModel.query(trx).insert({
+          userId: systemUser.id,
+          tenantId: inviteToken.tenantId,
+          role: 'member',
+        });
+        return { systemUser, tenant, inviteToken };
       });
-    // Clear invite token by the given user id.
-    await this.clearInviteTokensByUserId(inviteToken.userId);
-
-    // Retrieve the tenant to get the organizationId for CLS.
-    const tenant = await this.tenantModel
-      .query()
-      .findById(inviteToken.tenantId);
-
     // Set CLS values for tenant context before triggering sync events.
     this.cls.set('userId', systemUser.id);
     this.cls.set('organizationId', tenant.organizationId);
@@ -126,9 +140,10 @@ export class AcceptInviteUserService {
    */
   private getInviteTokenOrThrowError = async (
     token: string,
+    trx?: Knex.Transaction,
   ): Promise<ModelObject<UserInvite>> => {
     const inviteToken = await this.userInviteModel
-      .query()
+      .query(trx)
       .modify('notExpired')
       .findOne('token', token);
 
@@ -156,7 +171,10 @@ export class AcceptInviteUserService {
    * Clear invite tokens of the given user id.
    * @param {number} userId - User id.
    */
-  private clearInviteTokensByUserId = async (userId: number) => {
-    await this.userInviteModel.query().where('user_id', userId).delete();
+  private clearInviteTokensByUserId = async (
+    userId: number,
+    trx?: Knex.Transaction,
+  ) => {
+    await this.userInviteModel.query(trx).where('user_id', userId).delete();
   };
 }


### PR DESCRIPTION
## Description

Invited users could not sign in because the accept-invite flow never created a `user_tenants` row. The recent `user_tenants` refactor made that join table the authoritative source for org membership: both `AuthSigninService.resolveSigninTenant` and `TenancyGlobalGuard` require a membership row to authorize a user into an organization. The self-signup path creates one (via `CreateUserTenantOnSignupSubscriber`), but the invite-accept path did not, so accepted invitees had an account with no org membership and sign-in failed with "No active workspace available."

Changes:

- `AcceptInviteUserService.acceptInvite` now inserts a `user_tenants` membership (`role: 'member'`) linking the invited user to the tenant.
- All accept-invite system-database writes are wrapped in a single `systemKnex.transaction` (invite-token lookup, user update, invite-token clear, tenant read, membership insert). Removed a dead `_user` lookup.
- Registered the `UserTenant` system model in `UsersModule`.
- Added a system migration that backfills `user_tenants` for already-accepted invited users (`invite_accepted_at` set) so existing affected users can sign in too.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- `pnpm run typecheck` (server) passes.
- `eslint` on the changed server files passes.
- Backfill migration verified by inspection against the existing `20260320000002_backfill_user_tenants_from_users.js` pattern.

Reproduction to verify: create an invite for a new email, accept it, then sign in with the new credentials — sign-in should now succeed and land in the invited organization.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>