### PR TITLE
refactor(webapp): typescript conversion of sales modules

### DIFF
--- a/packages/webapp/src/components/Forms/ColorInput.tsx
+++ b/packages/webapp/src/components/Forms/ColorInput.tsx
@@ -1,4 +1,5 @@
 import {
+  HTMLInputProps,
   IInputGroupProps,
   InputGroup,
   IPopoverProps,
@@ -19,7 +20,7 @@ export interface ColorInputProps {
   initialValue?: string;
   onChange?: (value: string) => void;
   popoverProps?: Partial<IPopoverProps>;
-  inputProps?: Partial<IInputGroupProps>;
+  inputProps?: Partial<IInputGroupProps & HTMLInputProps>;
   pickerProps?: Partial<BoxProps>;
   pickerWrapProps?: Partial<BoxProps>;
 }

--- a/packages/webapp/src/components/Forms/FColorInput.tsx
+++ b/packages/webapp/src/components/Forms/FColorInput.tsx
@@ -1,12 +1,14 @@
 import { Intent } from '@blueprintjs/core';
 import { Field } from '@blueprintjs-formik/core';
-import { getIn, FieldConfig, FieldProps } from 'formik';
+import { getIn, FieldConfig, FieldProps, FastField } from 'formik';
 import React from 'react';
 import { ColorInput, ColorInputProps } from './ColorInput';
 
 interface ColorInputInputGroupProps
   extends Omit<FieldConfig, 'children' | 'component' | 'as' | 'value'>,
-    ColorInputProps {}
+    ColorInputProps {
+  fastField?: boolean;
+}
 
 export interface ColorInputToInputProps
   extends Omit<FieldProps, 'onChange'>,
@@ -58,7 +60,9 @@ function ColorInputToInputGroup({
  * @returns {JSX.Element}
  */
 export function FColorInput({
+  fastField,
   ...props
 }: ColorInputInputGroupProps): JSX.Element {
-  return <Field {...props} component={ColorInputToInputGroup} />;
+  const FieldComponent = fastField ? FastField : Field;
+  return <FieldComponent {...props} component={ColorInputToInputGroup} />;
 }

--- a/packages/webapp/src/containers/ElementCustomize/ElementCustomizeFieldsGroup.tsx
+++ b/packages/webapp/src/containers/ElementCustomize/ElementCustomizeFieldsGroup.tsx
@@ -1,15 +1,22 @@
 // @ts-nocheck
-import { SwitchProps } from '@blueprintjs/core';
+import { InputGroupProps, SwitchProps } from '@blueprintjs/core';
 import { FInputGroup, FSwitch, Group, Stack } from '@/components';
 import { CLASSES } from '@/constants';
+
+interface ElementCustomizeFieldsGroupProps {
+  label: string;
+  children: React.ReactNode;
+}
+
+interface ElementCustomizeContentItemFieldGroupProps {
+  inputGroupProps: InputGroupProps & { name?: string; label?: string };
+  switchProps?: SwitchProps;
+}
 
 export function ElementCustomizeFieldsGroup({
   label,
   children,
-}: {
-  label: string;
-  children: React.ReactNode;
-}) {
+}: ElementCustomizeFieldsGroupProps) {
   return (
     <Stack spacing={20}>
       <h4 className={CLASSES.TEXT_MUTED} style={{ fontWeight: 600 }}>
@@ -24,10 +31,7 @@ export function ElementCustomizeFieldsGroup({
 export function ElementCustomizeContentItemFieldGroup({
   inputGroupProps,
   switchProps,
-}: {
-  inputGroupProps: InputGroupProps & { label?: string };
-  switchProps?: SwitchProps;
-}) {
+}: ElementCustomizeContentItemFieldGroupProps) {
   return (
     <Group spacing={14} position={'apart'}>
       <FSwitch {...inputGroupProps} fastField />

--- a/packages/webapp/src/containers/ElementCustomize/ElementCustomizeFieldsGroup.tsx
+++ b/packages/webapp/src/containers/ElementCustomize/ElementCustomizeFieldsGroup.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { InputGroupProps, SwitchProps } from '@blueprintjs/core';
+import { SwitchProps } from '@blueprintjs/core';
 import { FInputGroup, FSwitch, Group, Stack } from '@/components';
 import { CLASSES } from '@/constants';
 
@@ -25,7 +25,7 @@ export function ElementCustomizeContentItemFieldGroup({
   inputGroupProps,
   switchProps,
 }: {
-  inputGroupProps: InputGroupProps;
+  inputGroupProps: InputGroupProps & { label?: string };
   switchProps?: SwitchProps;
 }) {
   return (

--- a/packages/webapp/src/containers/Sales/CreditNotes/CreditNoteCustomize/CreditNoteCustomizeDrawer.tsx
+++ b/packages/webapp/src/containers/Sales/CreditNotes/CreditNoteCustomize/CreditNoteCustomizeDrawer.tsx
@@ -1,6 +1,6 @@
-// @ts-nocheck
 import * as R from 'ramda';
 import React from 'react';
+import type { WithDrawersProps } from '@/containers/Drawer/withDrawers';
 import { Drawer, DrawerSuspense } from '@/components';
 import { withDrawers } from '@/containers/Drawer/withDrawers';
 
@@ -9,6 +9,13 @@ const CreditNoteCustomizeDrawerBody = React.lazy(() =>
     default: m.CreditNoteCustomizeDrawerBody,
   })),
 );
+
+interface CreditNoteCustomizeDrawerRootProps {
+  name: string;
+}
+
+type CreditNoteCustomizeDrawerRootConnectedProps =
+  CreditNoteCustomizeDrawerRootProps & WithDrawersProps;
 
 /**
  * Invoice customize drawer.
@@ -19,7 +26,7 @@ function CreditNoteCustomizeDrawerRoot({
   // #withDrawer
   isOpen,
   payload,
-}) {
+}: CreditNoteCustomizeDrawerRootConnectedProps) {
   return (
     <Drawer
       isOpen={isOpen}

--- a/packages/webapp/src/containers/Sales/CreditNotes/CreditNoteCustomize/CreditNoteCustomizeGeneralFields.tsx
+++ b/packages/webapp/src/containers/Sales/CreditNotes/CreditNoteCustomize/CreditNoteCustomizeGeneralFields.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Classes } from '@blueprintjs/core';
 import { Overlay } from '../../Invoices/InvoiceCustomize/Overlay';
 import {

--- a/packages/webapp/src/containers/Sales/CreditNotes/CreditNoteCustomize/CreditNoteCutomizeContentFields.tsx
+++ b/packages/webapp/src/containers/Sales/CreditNotes/CreditNoteCustomize/CreditNoteCutomizeContentFields.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Classes } from '@blueprintjs/core';
 import { fieldsGroups } from './constants';
 import { Stack } from '@/components';

--- a/packages/webapp/src/containers/Sales/CreditNotes/CreditNoteUniversalSearch.tsx
+++ b/packages/webapp/src/containers/Sales/CreditNotes/CreditNoteUniversalSearch.tsx
@@ -1,12 +1,21 @@
-// @ts-nocheck
 import { MenuItem, Intent } from '@blueprintjs/core';
 import React from 'react';
 import intl from 'react-intl-universal';
+import type { WithDrawerActionsProps } from '@/containers/Drawer/withDrawerActions';
+import type { CreditNote } from '@bigcapital/sdk-ts';
+import type { ItemRendererProps } from '@blueprintjs/select';
 import { Icon, Choose, T, TextStatus } from '@/components';
 import { AbilitySubject, CreditNoteAction } from '@/constants/abilityOption';
 import { DRAWERS } from '@/constants/drawers';
 import { RESOURCES_TYPES } from '@/constants/resourcesTypes';
 import { withDrawerActions } from '@/containers/Drawer/withDrawerActions';
+
+interface CreditNoteUniversalSearchSelectComponentProps
+  extends WithDrawerActionsProps {
+  resourceType: string;
+  resourceId: number;
+  onAction?: () => void;
+}
 
 /**
  * Credit note universal search item select action.
@@ -19,7 +28,7 @@ function CreditNoteUniversalSearchSelectComponent({
 
   // #withDrawerActions
   openDrawer,
-}) {
+}: CreditNoteUniversalSearchSelectComponentProps) {
   if (resourceType === RESOURCES_TYPES.CREDIT_NOTE) {
     openDrawer(DRAWERS.CREDIT_NOTE_DETAILS, { creditNoteId: resourceId });
     onAction && onAction();
@@ -34,7 +43,7 @@ export const CreditNoteUniversalSearchSelect = withDrawerActions(
 /**
  * Status accessor.
  */
-function CreditNoteUniversalSearchStatus({ receipt }) {
+function CreditNoteUniversalSearchStatus({ receipt }: { receipt: CreditNote }) {
   return (
     <Choose>
       <Choose.When condition={receipt.isClosed}>
@@ -61,9 +70,16 @@ function CreditNoteUniversalSearchStatus({ receipt }) {
 /**
  * Credit note universal search item.
  */
+interface CreditNoteUniversalSearchItemType {
+  id: number;
+  text: string;
+  label: string;
+  reference: CreditNote;
+}
+
 export function CreditNoteUniversalSearchItem(
-  item,
-  { handleClick, modifiers, query },
+  item: CreditNoteUniversalSearchItemType,
+  { handleClick, modifiers }: ItemRendererProps,
 ) {
   return (
     <MenuItem
@@ -71,16 +87,16 @@ export function CreditNoteUniversalSearchItem(
       text={
         <div>
           <div>{item.text}</div>
-          <span class="bp4-text-muted">
+          <span className="bp4-text-muted">
             {item.reference.creditNoteNumber}{' '}
             <Icon icon={'caret-right-16'} iconSize={16} />
             {item.reference.formattedCreditNoteDate}
           </span>
         </div>
       }
-      label={
+      labelElement={
         <>
-          <div class="amount">{item.reference.formattedAmount}</div>
+          <div className="amount">{item.reference.formattedAmount}</div>
           <CreditNoteUniversalSearchStatus receipt={item.reference} />
         </>
       }
@@ -93,7 +109,9 @@ export function CreditNoteUniversalSearchItem(
 /**
  * Transformes receipt resource item to search item.
  */
-const transformReceiptsToSearch = (creditNote) => ({
+const transformReceiptsToSearch = (
+  creditNote: CreditNote,
+): CreditNoteUniversalSearchItemType => ({
   id: creditNote.id,
   text: creditNote.customer?.displayName ?? '',
   label: creditNote.formattedAmount ?? '',

--- a/packages/webapp/src/containers/Sales/CreditNotes/CreditNoteUniversalSearch.tsx
+++ b/packages/webapp/src/containers/Sales/CreditNotes/CreditNoteUniversalSearch.tsx
@@ -43,7 +43,13 @@ export const CreditNoteUniversalSearchSelect = withDrawerActions(
 /**
  * Status accessor.
  */
-function CreditNoteUniversalSearchStatus({ receipt }: { receipt: CreditNote }) {
+interface CreditNoteUniversalSearchStatusProps {
+  receipt: CreditNote;
+}
+
+function CreditNoteUniversalSearchStatus({
+  receipt,
+}: CreditNoteUniversalSearchStatusProps) {
   return (
     <Choose>
       <Choose.When condition={receipt.isClosed}>

--- a/packages/webapp/src/containers/Sales/CreditNotes/CreditNotesAlerts.tsx
+++ b/packages/webapp/src/containers/Sales/CreditNotes/CreditNotesAlerts.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import React from 'react';
 
 const CreditNoteDeleteAlert = React.lazy(() =>

--- a/packages/webapp/src/containers/Sales/CreditNotes/CreditNotesImport.tsx
+++ b/packages/webapp/src/containers/Sales/CreditNotes/CreditNotesImport.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { useHistory } from 'react-router-dom';
 import { DashboardInsider } from '@/components';
 import { ImportView } from '@/containers/Import';

--- a/packages/webapp/src/containers/Sales/CreditNotes/CreditNotesLanding/CreditNotesActionsBar.tsx
+++ b/packages/webapp/src/containers/Sales/CreditNotes/CreditNotesLanding/CreditNotesActionsBar.tsx
@@ -18,6 +18,7 @@ import { useBulkDeleteCreditNotesDialog } from './hooks/use-bulk-delete-credit-n
 import { withCreditNotes } from './withCreditNotes';
 import { withCreditNotesActions } from './withCreditNotesActions';
 import type { WithCreditNotesProps } from './withCreditNotes';
+import type { WithCreditNotesActionsProps } from './withCreditNotesActions';
 import type { WithDialogActionsProps } from '@/containers/Dialog/withDialogActions';
 import type { WithDrawerActionsProps } from '@/containers/Drawer/withDrawerActions';
 import {
@@ -38,10 +39,6 @@ import { withDrawerActions } from '@/containers/Drawer/withDrawerActions';
 import { useSaveSettings } from '@/hooks/query';
 import { useDownloadExportPdf } from '@/hooks/query/FinancialReports/use-export-pdf';
 import { compose } from '@/utils';
-
-interface WithCreditNotesActionsProps {
-  setCreditNotesTableState: (state: Record<string, any>) => void;
-}
 
 interface CreditNotesActionsBarProps
   extends Pick<WithCreditNotesProps, 'creditNotesSelectedRows'>,

--- a/packages/webapp/src/containers/Sales/CreditNotes/CreditNotesLanding/CreditNotesDataTable.tsx
+++ b/packages/webapp/src/containers/Sales/CreditNotes/CreditNotesLanding/CreditNotesDataTable.tsx
@@ -7,6 +7,7 @@ import { withCreditNotes } from './withCreditNotes';
 import { withCreditNotesActions } from './withCreditNotesActions';
 import type { CreditNoteTableRow } from './components';
 import type { WithCreditNotesProps } from './withCreditNotes';
+import type { WithCreditNotesActionsProps } from './withCreditNotesActions';
 import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import type { WithDialogActionsProps } from '@/containers/Dialog/withDialogActions';
 import type { WithDrawerActionsProps } from '@/containers/Drawer/withDrawerActions';
@@ -24,11 +25,6 @@ import { withDialogActions } from '@/containers/Dialog/withDialogActions';
 import { withDrawerActions } from '@/containers/Drawer/withDrawerActions';
 import { useMemorizedColumnsWidths } from '@/hooks';
 import { compose } from '@/utils';
-
-interface WithCreditNotesActionsProps {
-  setCreditNotesTableState: (state: Record<string, any>) => void;
-  setCreditNotesSelectedRows: (ids: number[]) => void;
-}
 
 interface CreditNotesDataTableProps
   extends Pick<

--- a/packages/webapp/src/containers/Sales/CreditNotes/CreditNotesLanding/CreditNotesList.tsx
+++ b/packages/webapp/src/containers/Sales/CreditNotes/CreditNotesLanding/CreditNotesList.tsx
@@ -8,13 +8,9 @@ import { CreditNotesListProvider } from './CreditNotesListProvider';
 import { withCreditNotes } from './withCreditNotes';
 import { withCreditNotesActions } from './withCreditNotesActions';
 import type { WithCreditNotesProps } from './withCreditNotes';
+import type { WithCreditNotesActionsProps } from './withCreditNotesActions';
 import { DashboardPageContent } from '@/components';
 import { transformTableStateToQuery, compose } from '@/utils';
-
-interface WithCreditNotesActionsProps {
-  resetCreditNotesTableState: () => void;
-  resetCreditNotesSelectedRows: () => void;
-}
 
 interface CreditNotesListProps
   extends Pick<

--- a/packages/webapp/src/containers/Sales/CreditNotes/CreditNotesLanding/CreditNotesViewTabs.tsx
+++ b/packages/webapp/src/containers/Sales/CreditNotes/CreditNotesLanding/CreditNotesViewTabs.tsx
@@ -4,16 +4,12 @@ import { useCreditNoteListContext } from './CreditNotesListProvider';
 import { withCreditNotes } from './withCreditNotes';
 import { withCreditNotesActions } from './withCreditNotesActions';
 import type { WithCreditNotesProps } from './withCreditNotes';
+import type { WithCreditNotesActionsProps } from './withCreditNotesActions';
 import { DashboardViewsTabs } from '@/components';
 import { compose, transfromViewsToTabs } from '@/utils';
 
-interface WithCreditNotesActionsProps {
-  setCreditNotesTableState: (state: Record<string, any>) => void;
-}
-
-interface CreditNotesViewTabsProps {
+interface CreditNotesViewTabsProps extends WithCreditNotesActionsProps {
   creditNoteCurrentView: string;
-  setCreditNotesTableState: WithCreditNotesActionsProps['setCreditNotesTableState'];
 }
 
 function CreditNotesViewTabsInner({

--- a/packages/webapp/src/containers/Sales/Estimates/EstimateCustomize/EstimateCustomizeDrawer.tsx
+++ b/packages/webapp/src/containers/Sales/Estimates/EstimateCustomize/EstimateCustomizeDrawer.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import * as R from 'ramda';
 import React from 'react';
 import { Drawer, DrawerSuspense } from '@/components';
@@ -10,6 +9,12 @@ const EstimateCustomizeDrawerBody = React.lazy(() =>
   })),
 );
 
+interface EstimateCustomizeDrawerProps {
+  name: string;
+  isOpen?: boolean;
+  payload?: Record<string, any>;
+}
+
 /**
  * Estimate customize drawer.
  * @returns {React.ReactNode}
@@ -20,7 +25,7 @@ function EstimateCustomizeDrawerRoot({
   // #withDrawer
   isOpen,
   payload,
-}) {
+}: EstimateCustomizeDrawerProps) {
   return (
     <Drawer
       isOpen={isOpen}

--- a/packages/webapp/src/containers/Sales/Estimates/EstimateCustomize/EstimateCustomizeFieldsContent.tsx
+++ b/packages/webapp/src/containers/Sales/Estimates/EstimateCustomize/EstimateCustomizeFieldsContent.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Classes } from '@blueprintjs/core';
 import { fieldsGroups } from './constants';
 import { FInputGroup, FSwitch, Group, Stack } from '@/components';

--- a/packages/webapp/src/containers/Sales/Estimates/EstimateCustomize/EstimateCustomizeFieldsGeneral.tsx
+++ b/packages/webapp/src/containers/Sales/Estimates/EstimateCustomize/EstimateCustomizeFieldsGeneral.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Classes } from '@blueprintjs/core';
 import { Overlay } from '../../Invoices/InvoiceCustomize/Overlay';
 import {

--- a/packages/webapp/src/containers/Sales/Estimates/EstimateForm/EstimateFormCurrencyTag.tsx
+++ b/packages/webapp/src/containers/Sales/Estimates/EstimateForm/EstimateFormCurrencyTag.tsx
@@ -1,6 +1,6 @@
-// @ts-nocheck
-import React from 'react';
-import { useEstimateFormContext } from './EstimateFormProvider';
+import { useFormikContext } from 'formik';
+import { useEstimateIsForeignCustomer } from './utils';
+import type { EstimateFormValues } from './utils';
 import { BaseCurrency, BaseCurrencyRoot } from '@/components';
 
 /**
@@ -8,14 +8,17 @@ import { BaseCurrency, BaseCurrencyRoot } from '@/components';
  * @returns
  */
 export function EstimateFromCurrencyTag() {
-  const { isForeignCustomer, selectCustomer } = useEstimateFormContext();
+  const isForeignCustomer = useEstimateIsForeignCustomer();
+  const {
+    values: { currencyCode },
+  } = useFormikContext<EstimateFormValues>();
 
   if (!isForeignCustomer) {
     return null;
   }
   return (
     <BaseCurrencyRoot>
-      <BaseCurrency currency={selectCustomer?.currency_code} />
+      <BaseCurrency currency={currencyCode} />
     </BaseCurrencyRoot>
   );
 }

--- a/packages/webapp/src/containers/Sales/Estimates/EstimateSendMailDrawer/EstimateSendMailDrawer.tsx
+++ b/packages/webapp/src/containers/Sales/Estimates/EstimateSendMailDrawer/EstimateSendMailDrawer.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import * as R from 'ramda';
 import React from 'react';
 import { Drawer, DrawerSuspense } from '@/components';

--- a/packages/webapp/src/containers/Sales/Estimates/EstimateSendMailDrawer/EstimateSendMailForm.tsx
+++ b/packages/webapp/src/containers/Sales/Estimates/EstimateSendMailDrawer/EstimateSendMailForm.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Intent } from '@blueprintjs/core';
 import { css } from '@emotion/css';
 import { Form, Formik, FormikHelpers } from 'formik';
@@ -14,6 +13,7 @@ import { transformToForm } from '@/utils';
 const initialValues: EstimateSendMailFormValues = {
   subject: '',
   message: '',
+  from: [],
   to: [],
   cc: [],
   bcc: [],

--- a/packages/webapp/src/containers/Sales/Estimates/EstimateSendMailDrawer/_interfaces.ts
+++ b/packages/webapp/src/containers/Sales/Estimates/EstimateSendMailDrawer/_interfaces.ts
@@ -1,5 +1,5 @@
 import { SendMailViewFormValues } from '../SendMailViewDrawer/_types';
 
-export interface EstimateSendMailFormValues extends SendMailViewFormValues {
+export type EstimateSendMailFormValues = SendMailViewFormValues & {
   attachPdf?: boolean;
-}
+};

--- a/packages/webapp/src/containers/Sales/Estimates/EstimatesAlerts.tsx
+++ b/packages/webapp/src/containers/Sales/Estimates/EstimatesAlerts.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import React from 'react';
 
 const EstimateDeleteAlert = React.lazy(() =>

--- a/packages/webapp/src/containers/Sales/Estimates/EstimatesImport.tsx
+++ b/packages/webapp/src/containers/Sales/Estimates/EstimatesImport.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { useHistory } from 'react-router-dom';
 import { DashboardInsider } from '@/components';
 import { ImportView } from '@/containers/Import';

--- a/packages/webapp/src/containers/Sales/Estimates/EstimatesLanding/EstimateUniversalSearch.tsx
+++ b/packages/webapp/src/containers/Sales/Estimates/EstimatesLanding/EstimateUniversalSearch.tsx
@@ -1,12 +1,19 @@
-// @ts-nocheck
 import { MenuItem, Intent } from '@blueprintjs/core';
 import React from 'react';
 import intl from 'react-intl-universal';
+import type { WithDrawerActionsProps } from '@/containers/Drawer/withDrawerActions';
+import type { ItemRenderer } from '@blueprintjs/select';
 import { Choose, T, Icon, TextStatus } from '@/components';
 import { AbilitySubject, SaleEstimateAction } from '@/constants/abilityOption';
 import { DRAWERS } from '@/constants/drawers';
 import { RESOURCES_TYPES } from '@/constants/resourcesTypes';
 import { withDrawerActions } from '@/containers/Drawer/withDrawerActions';
+
+interface EstimateUniversalSearchItemSelectProps
+  extends WithDrawerActionsProps {
+  resourceType: string;
+  resourceId: number;
+}
 
 /**
  * Estimate universal search item select action.
@@ -18,7 +25,7 @@ function EstimateUniversalSearchSelectComponent({
 
   // #withDrawerActions
   openDrawer,
-}) {
+}: EstimateUniversalSearchItemSelectProps) {
   if (resourceType === RESOURCES_TYPES.ESTIMATE) {
     openDrawer(DRAWERS.ESTIMATE_DETAILS, { estimateId: resourceId });
   }
@@ -29,10 +36,32 @@ export const EstimateUniversalSearchSelect = withDrawerActions(
   EstimateUniversalSearchSelectComponent,
 );
 
+interface EstimateUniversalSearchReference {
+  id: number;
+  estimateNumber: string;
+  formattedEstimateDate: string;
+  formattedAmount: string;
+  isDelivered: boolean;
+  isApproved: boolean;
+  isRejected: boolean;
+  customer?: { displayName?: string };
+}
+
+interface EstimateUniversalSearchItem {
+  id: number;
+  text: string;
+  label?: string;
+  reference: EstimateUniversalSearchReference;
+}
+
 /**
  * Status accessor.
  */
-export const EstimateStatus = ({ estimate }) => (
+export const EstimateStatus = ({
+  estimate,
+}: {
+  estimate: EstimateUniversalSearchReference;
+}) => (
   <Choose>
     <Choose.When condition={estimate.isDelivered && estimate.isApproved}>
       <TextStatus intent={Intent.SUCCESS}>
@@ -64,39 +93,36 @@ export const EstimateStatus = ({ estimate }) => (
 /**
  * Estimate universal search item.
  */
-export function EstimateUniversalSearchItem(
-  item,
-  { handleClick, modifiers, query },
-) {
+export const EstimateUniversalSearchItem: ItemRenderer<
+  EstimateUniversalSearchItem
+> = (item, { handleClick, modifiers }) => {
   return (
     <MenuItem
       active={modifiers.active}
       text={
         <div>
           <div>{item.text}</div>
-          <span class="bp4-text-muted">
+          <span className="bp4-text-muted">
             {item.reference.estimateNumber}{' '}
             <Icon icon={'caret-right-16'} iconSize={16} />
             {item.reference.formattedEstimateDate}
           </span>
-        </div>
-      }
-      label={
-        <>
-          <div class="amount">{item.reference.formattedAmount}</div>
+          <div className="amount">{item.reference.formattedAmount}</div>
           <EstimateStatus estimate={item.reference} />
-        </>
+        </div>
       }
       onClick={handleClick}
       className={'universal-search__item--estimate'}
     />
   );
-}
+};
 
 /**
  * Transformes the estimates to search items.
  */
-const transformEstimatesToSearch = (estimate) => ({
+const transformEstimatesToSearch = (
+  estimate: EstimateUniversalSearchReference,
+): EstimateUniversalSearchItem => ({
   id: estimate.id,
   text: estimate.customer?.displayName ?? '',
   label: estimate.formattedAmount ?? '',

--- a/packages/webapp/src/containers/Sales/Estimates/EstimatesLanding/EstimateUniversalSearch.tsx
+++ b/packages/webapp/src/containers/Sales/Estimates/EstimatesLanding/EstimateUniversalSearch.tsx
@@ -57,11 +57,11 @@ interface EstimateUniversalSearchItem {
 /**
  * Status accessor.
  */
-export const EstimateStatus = ({
-  estimate,
-}: {
+interface EstimateStatusProps {
   estimate: EstimateUniversalSearchReference;
-}) => (
+}
+
+export const EstimateStatus = ({ estimate }: EstimateStatusProps) => (
   <Choose>
     <Choose.When condition={estimate.isDelivered && estimate.isApproved}>
       <TextStatus intent={Intent.SUCCESS}>

--- a/packages/webapp/src/containers/Sales/Estimates/EstimatesLanding/EstimatesActionsBar.tsx
+++ b/packages/webapp/src/containers/Sales/Estimates/EstimatesLanding/EstimatesActionsBar.tsx
@@ -19,6 +19,7 @@ import { useBulkDeleteEstimatesDialog } from './hooks/use-bulk-delete-estimates-
 import { withEstimates } from './withEstimates';
 import { withEstimatesActions } from './withEstimatesActions';
 import type { WithEstimatesProps } from './withEstimates';
+import type { WithEstimatesActionsProps } from './withEstimatesActions';
 import type { WithDialogActionsProps } from '@/containers/Dialog/withDialogActions';
 import type { WithDrawerActionsProps } from '@/containers/Drawer/withDrawerActions';
 import {
@@ -40,10 +41,6 @@ import { useSaveSettings } from '@/hooks/query';
 import { useRefreshEstimates } from '@/hooks/query/estimates';
 import { useDownloadExportPdf } from '@/hooks/query/FinancialReports/use-export-pdf';
 import { compose } from '@/utils';
-
-interface WithEstimatesActionsProps {
-  setEstimatesTableState: (state: Record<string, any>) => void;
-}
 
 interface EstimateActionsBarProps
   extends Pick<WithEstimatesProps, 'estimatesSelectedRows'>,

--- a/packages/webapp/src/containers/Sales/Estimates/EstimatesLanding/EstimatesDataTable.tsx
+++ b/packages/webapp/src/containers/Sales/Estimates/EstimatesLanding/EstimatesDataTable.tsx
@@ -7,6 +7,7 @@ import { withEstimates } from './withEstimates';
 import { withEstimatesActions } from './withEstimatesActions';
 import type { EstimateTableRow } from './components';
 import type { WithEstimatesProps } from './withEstimates';
+import type { WithEstimatesActionsProps } from './withEstimatesActions';
 import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import type { WithDialogActionsProps } from '@/containers/Dialog/withDialogActions';
 import type { WithDrawerActionsProps } from '@/containers/Drawer/withDrawerActions';
@@ -23,11 +24,6 @@ import { withDialogActions } from '@/containers/Dialog/withDialogActions';
 import { withDrawerActions } from '@/containers/Drawer/withDrawerActions';
 import { useMemorizedColumnsWidths } from '@/hooks';
 import { compose } from '@/utils';
-
-interface WithEstimatesActionsProps {
-  setEstimatesTableState: (state: Record<string, any>) => void;
-  setEstimatesSelectedRows: (ids: number[]) => void;
-}
 
 interface EstimatesDataTableProps
   extends Pick<

--- a/packages/webapp/src/containers/Sales/Estimates/EstimatesLanding/EstimatesList.tsx
+++ b/packages/webapp/src/containers/Sales/Estimates/EstimatesLanding/EstimatesList.tsx
@@ -7,14 +7,10 @@ import { EstimatesListProvider } from './EstimatesListProvider';
 import { withEstimates } from './withEstimates';
 import { withEstimatesActions } from './withEstimatesActions';
 import type { WithEstimatesProps } from './withEstimates';
+import type { WithEstimatesActionsProps } from './withEstimatesActions';
 import { DashboardPageContent } from '@/components';
 import '@/style/pages/SaleEstimate/List.scss';
 import { compose, transformTableStateToQuery } from '@/utils';
-
-interface WithEstimatesActionsProps {
-  resetEstimatesTableState: () => void;
-  resetEstimatesSelectedRows: () => void;
-}
 
 interface EstimatesListProps
   extends Pick<

--- a/packages/webapp/src/containers/Sales/Estimates/EstimatesLanding/EstimatesViewTabs.tsx
+++ b/packages/webapp/src/containers/Sales/Estimates/EstimatesLanding/EstimatesViewTabs.tsx
@@ -4,15 +4,11 @@ import { useEstimatesListContext } from './EstimatesListProvider';
 import { withEstimates } from './withEstimates';
 import { withEstimatesActions } from './withEstimatesActions';
 import type { WithEstimatesProps } from './withEstimates';
+import type { WithEstimatesActionsProps } from './withEstimatesActions';
 import { DashboardViewsTabs } from '@/components';
 import { compose, transfromViewsToTabs } from '@/utils';
 
-interface WithEstimatesActionsProps {
-  setEstimatesTableState: (state: Record<string, any>) => void;
-}
-
-interface EstimateViewTabsProps {
-  setEstimatesTableState: WithEstimatesActionsProps['setEstimatesTableState'];
+interface EstimateViewTabsProps extends WithEstimatesActionsProps {
   estimatesCurrentView: string;
 }
 

--- a/packages/webapp/src/containers/Sales/Estimates/SendMailViewDrawer/SendMailViewMessageField.tsx
+++ b/packages/webapp/src/containers/Sales/Estimates/SendMailViewDrawer/SendMailViewMessageField.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Button, Icon, Position } from '@blueprintjs/core';
 import { FormGroupProps, TextAreaProps } from '@blueprintjs-formik/core';
 import { SelectOptionProps } from '@blueprintjs-formik/select';
@@ -80,7 +79,7 @@ export function SendMailViewMessageField({
             input={() => (
               <Button
                 minimal
-                rightIcon={<Icon icon={'caret-down-16'} color={'#8F99A8'} />}
+                rightIcon={<Icon icon={'caret-down'} color={'#8F99A8'} />}
               >
                 Insert Variable
               </Button>

--- a/packages/webapp/src/containers/Sales/Estimates/SendMailViewDrawer/SendMailViewToAddressField.tsx
+++ b/packages/webapp/src/containers/Sales/Estimates/SendMailViewDrawer/SendMailViewToAddressField.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Button, MenuItem } from '@blueprintjs/core';
 import { FormGroupProps } from '@blueprintjs-formik/core';
 import { SelectOptionProps } from '@blueprintjs-formik/select';

--- a/packages/webapp/src/containers/Sales/Estimates/SendMailViewDrawer/_types.ts
+++ b/packages/webapp/src/containers/Sales/Estimates/SendMailViewDrawer/_types.ts
@@ -1,8 +1,8 @@
-export interface SendMailViewFormValues {
+export type SendMailViewFormValues = {
   from: Array<string>;
   to: Array<string>;
   cc: Array<string>;
   bcc: Array<string>;
   subject: string;
   message: string;
-}
+};

--- a/packages/webapp/src/containers/Sales/Invoices/InvoiceCustomize/InvoiceCustomize.tsx
+++ b/packages/webapp/src/containers/Sales/Invoices/InvoiceCustomize/InvoiceCustomize.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Classes } from '@blueprintjs/core';
 import { InvoiceCustomizeContent } from './InvoiceCustomizeContent';
 import { Box } from '@/components';

--- a/packages/webapp/src/containers/Sales/Invoices/InvoiceCustomize/InvoiceCustomizeDrawer.tsx
+++ b/packages/webapp/src/containers/Sales/Invoices/InvoiceCustomize/InvoiceCustomizeDrawer.tsx
@@ -1,12 +1,18 @@
-// @ts-nocheck
 import * as R from 'ramda';
 import React from 'react';
 import { Drawer, DrawerSuspense } from '@/components';
-import { withDrawers } from '@/containers/Drawer/withDrawers';
+import { withDrawers, WithDrawersProps } from '@/containers/Drawer/withDrawers';
 
 const InvoiceCustomize = React.lazy(() =>
   import('./InvoiceCustomize').then((m) => ({ default: m.InvoiceCustomize })),
 );
+
+interface InvoiceCustomizeDrawerRootProps {
+  name: string;
+}
+
+type InvoiceCustomizeDrawerRootConnectedProps =
+  InvoiceCustomizeDrawerRootProps & WithDrawersProps;
 
 /**
  * Invoice customize drawer.
@@ -17,7 +23,7 @@ function InvoiceCustomizeDrawerRoot({
   // #withDrawer
   isOpen,
   payload,
-}) {
+}: InvoiceCustomizeDrawerRootConnectedProps) {
   return (
     <Drawer
       isOpen={isOpen}

--- a/packages/webapp/src/containers/Sales/Invoices/InvoiceCustomize/InvoiceCustomizeGeneralFields.tsx
+++ b/packages/webapp/src/containers/Sales/Invoices/InvoiceCustomize/InvoiceCustomizeGeneralFields.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Classes, Text } from '@blueprintjs/core';
 import { Link } from 'react-router-dom';
 import { MANAGE_LINK_URL } from './constants';

--- a/packages/webapp/src/containers/Sales/Invoices/InvoiceCustomize/InvoiceCutomizeContentFields.tsx
+++ b/packages/webapp/src/containers/Sales/Invoices/InvoiceCustomize/InvoiceCutomizeContentFields.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Classes } from '@blueprintjs/core';
 import { fieldsGroups } from './constants';
 import { Stack } from '@/components';

--- a/packages/webapp/src/containers/Sales/Invoices/InvoiceSendMailDrawer/InvoiceSendMailDrawer.tsx
+++ b/packages/webapp/src/containers/Sales/Invoices/InvoiceSendMailDrawer/InvoiceSendMailDrawer.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import * as R from 'ramda';
 import React from 'react';
 import { Drawer, DrawerSuspense } from '@/components';

--- a/packages/webapp/src/containers/Sales/Invoices/InvoiceUniversalSearch.tsx
+++ b/packages/webapp/src/containers/Sales/Invoices/InvoiceUniversalSearch.tsx
@@ -1,13 +1,21 @@
-// @ts-nocheck
 import { MenuItem, Intent } from '@blueprintjs/core';
 import React from 'react';
 import intl from 'react-intl-universal';
+import type { SaleInvoice } from '@bigcapital/sdk-ts';
 import { T, Choose, Icon, TextStatus } from '@/components';
 import { AbilitySubject, SaleInvoiceAction } from '@/constants/abilityOption';
 import { DRAWERS } from '@/constants/drawers';
 import { RESOURCES_TYPES } from '@/constants/resourcesTypes';
-import { withDrawerActions } from '@/containers/Drawer/withDrawerActions';
+import {
+  withDrawerActions,
+  WithDrawerActionsProps,
+} from '@/containers/Drawer/withDrawerActions';
 import { highlightText } from '@/utils';
+
+interface InvoiceUniversalSearchSelectProps extends WithDrawerActionsProps {
+  resourceType: string;
+  resourceId: number;
+}
 
 /**
  * Universal search invoice item select action.
@@ -19,7 +27,7 @@ function InvoiceUniversalSearchSelectComponent({
 
   // #withDrawerActions
   openDrawer,
-}) {
+}: InvoiceUniversalSearchSelectProps) {
   if (resourceType === RESOURCES_TYPES.INVOICE) {
     openDrawer(DRAWERS.INVOICE_DETAILS, { invoiceId: resourceId });
   }
@@ -33,7 +41,7 @@ export const InvoiceUniversalSearchSelect = withDrawerActions(
 /**
  * Invoice status.
  */
-function InvoiceStatus({ customer }) {
+function InvoiceStatus({ customer }: { customer: SaleInvoice }) {
   return (
     <Choose>
       <Choose.When condition={customer.isFullyPaid && customer.isDelivered}>
@@ -68,9 +76,22 @@ function InvoiceStatus({ customer }) {
 /**
  * Universal search invoice item.
  */
+interface InvoiceUniversalSearchItemData {
+  id: number;
+  text: string;
+  label: string;
+  reference: SaleInvoice;
+}
+
+interface InvoiceUniversalSearchItemActions {
+  handleClick: () => void;
+  modifiers: { active: boolean };
+  query: string;
+}
+
 export function InvoiceUniversalSearchItem(
-  item,
-  { handleClick, modifiers, query },
+  item: InvoiceUniversalSearchItemData,
+  { handleClick, modifiers, query }: InvoiceUniversalSearchItemActions,
 ) {
   return (
     <MenuItem
@@ -78,16 +99,16 @@ export function InvoiceUniversalSearchItem(
       text={
         <div>
           <div>{highlightText(item.text, query)}</div>
-          <span class="bp4-text-muted">
+          <span className="bp4-text-muted">
             {highlightText(item.reference.invoiceNo, query)}{' '}
             <Icon icon={'caret-right-16'} iconSize={16} />
             {item.reference.invoiceDateFormatted}
           </span>
         </div>
       }
-      label={
+      labelElement={
         <>
-          <div class="amount">{item.reference.totalFormatted}</div>
+          <div className="amount">{item.reference.totalFormatted}</div>
           <InvoiceStatus customer={item.reference} />
         </>
       }
@@ -101,7 +122,7 @@ export function InvoiceUniversalSearchItem(
  * @param {*} invoice
  * @returns
  */
-const transformInvoicesToSearch = (invoice) => ({
+const transformInvoicesToSearch = (invoice: SaleInvoice) => ({
   id: invoice.id,
   text: invoice.customer?.displayName ?? '',
   label: invoice.totalFormatted ?? '',

--- a/packages/webapp/src/containers/Sales/Invoices/InvoiceUniversalSearch.tsx
+++ b/packages/webapp/src/containers/Sales/Invoices/InvoiceUniversalSearch.tsx
@@ -41,7 +41,11 @@ export const InvoiceUniversalSearchSelect = withDrawerActions(
 /**
  * Invoice status.
  */
-function InvoiceStatus({ customer }: { customer: SaleInvoice }) {
+interface InvoiceStatusProps {
+  customer: SaleInvoice;
+}
+
+function InvoiceStatus({ customer }: InvoiceStatusProps) {
   return (
     <Choose>
       <Choose.When condition={customer.isFullyPaid && customer.isDelivered}>

--- a/packages/webapp/src/containers/Sales/Invoices/InvoicesAlerts.tsx
+++ b/packages/webapp/src/containers/Sales/Invoices/InvoicesAlerts.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import React from 'react';
 
 const InvoiceDeleteAlert = React.lazy(() =>

--- a/packages/webapp/src/containers/Sales/Invoices/InvoicesImport.tsx
+++ b/packages/webapp/src/containers/Sales/Invoices/InvoicesImport.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { useHistory } from 'react-router-dom';
 import { DashboardInsider } from '@/components';
 import { ImportView } from '@/containers/Import';

--- a/packages/webapp/src/containers/Sales/Invoices/InvoicesLanding/InvoiceViewTabs.tsx
+++ b/packages/webapp/src/containers/Sales/Invoices/InvoicesLanding/InvoiceViewTabs.tsx
@@ -4,16 +4,12 @@ import { useHistory } from 'react-router-dom';
 import { useInvoicesListContext } from './InvoicesListProvider';
 import { withInvoiceActions } from './withInvoiceActions';
 import { withInvoices } from './withInvoices';
+import type { WithInvoiceActionsProps } from './withInvoiceActions';
 import type { WithInvoicesProps } from './withInvoices';
 import { DashboardViewsTabs } from '@/components';
 import { compose, transfromViewsToTabs } from '@/utils';
 
-interface WithInvoiceActionsProps {
-  setInvoicesTableState: (state: Record<string, any>) => void;
-}
-
-interface InvoiceViewTabsProps {
-  setInvoicesTableState: WithInvoiceActionsProps['setInvoicesTableState'];
+interface InvoiceViewTabsProps extends WithInvoiceActionsProps {
   invoicesCurrentView: string;
 }
 

--- a/packages/webapp/src/containers/Sales/Invoices/InvoicesLanding/InvoicesActionsBar.tsx
+++ b/packages/webapp/src/containers/Sales/Invoices/InvoicesLanding/InvoicesActionsBar.tsx
@@ -18,6 +18,7 @@ import { useBulkDeleteInvoicesDialog } from '../hooks/use-bulk-delete-accounts-d
 import { useInvoicesListContext } from './InvoicesListProvider';
 import { withInvoiceActions } from './withInvoiceActions';
 import { withInvoices } from './withInvoices';
+import type { WithInvoiceActionsProps } from './withInvoiceActions';
 import type { WithInvoicesProps } from './withInvoices';
 import type { WithDialogActionsProps } from '@/containers/Dialog/withDialogActions';
 import type { WithDrawerActionsProps } from '@/containers/Drawer/withDrawerActions';
@@ -39,10 +40,6 @@ import { useSaveSettings } from '@/hooks/query';
 import { useDownloadExportPdf } from '@/hooks/query/FinancialReports/use-export-pdf';
 import { useRefreshInvoices } from '@/hooks/query/invoices';
 import { compose } from '@/utils';
-
-interface WithInvoiceActionsProps {
-  setInvoicesTableState: (state: Record<string, any>) => void;
-}
 
 interface InvoiceActionsBarProps
   extends Pick<WithInvoicesProps, 'invoicesSelectedRows'>,

--- a/packages/webapp/src/containers/Sales/Invoices/InvoicesLanding/InvoicesDataTable.tsx
+++ b/packages/webapp/src/containers/Sales/Invoices/InvoicesLanding/InvoicesDataTable.tsx
@@ -6,6 +6,7 @@ import { useInvoicesListContext } from './InvoicesListProvider';
 import { withInvoiceActions } from './withInvoiceActions';
 import { withInvoices } from './withInvoices';
 import type { InvoiceTableRow } from './components';
+import type { WithInvoiceActionsProps } from './withInvoiceActions';
 import type { WithInvoicesProps } from './withInvoices';
 import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import type { WithDialogActionsProps } from '@/containers/Dialog/withDialogActions';
@@ -24,11 +25,6 @@ import { withDialogActions } from '@/containers/Dialog/withDialogActions';
 import { withDrawerActions } from '@/containers/Drawer/withDrawerActions';
 import { useMemorizedColumnsWidths } from '@/hooks';
 import { compose } from '@/utils';
-
-interface WithInvoiceActionsProps {
-  setInvoicesTableState: (state: Record<string, any>) => void;
-  setInvoicesSelectedRows: (ids: number[]) => void;
-}
 
 interface InvoicesDataTableProps
   extends Pick<

--- a/packages/webapp/src/containers/Sales/Invoices/InvoicesLanding/InvoicesList.tsx
+++ b/packages/webapp/src/containers/Sales/Invoices/InvoicesLanding/InvoicesList.tsx
@@ -7,15 +7,11 @@ import { InvoicesListDrawers } from './InvoicesListDrawers';
 import { InvoicesListProvider } from './InvoicesListProvider';
 import { withInvoiceActions } from './withInvoiceActions';
 import { withInvoices } from './withInvoices';
+import type { WithInvoiceActionsProps } from './withInvoiceActions';
 import type { WithInvoicesProps } from './withInvoices';
 import { DashboardPageContent } from '@/components';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
 import { transformTableStateToQuery, compose } from '@/utils';
-
-interface WithInvoiceActionsProps {
-  resetInvoicesTableState: () => void;
-  resetInvoicesSelectedRows: () => void;
-}
 
 interface InvoicesListProps
   extends Pick<

--- a/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentReceiveUniversalSearch.tsx
+++ b/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentReceiveUniversalSearch.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { MenuItem } from '@blueprintjs/core';
 import React from 'react';
 import intl from 'react-intl-universal';
@@ -9,8 +8,17 @@ import {
 } from '@/constants/abilityOption';
 import { DRAWERS } from '@/constants/drawers';
 import { RESOURCES_TYPES } from '@/constants/resourcesTypes';
-import { withDrawerActions } from '@/containers/Drawer/withDrawerActions';
+import {
+  withDrawerActions,
+  WithDrawerActionsProps,
+} from '@/containers/Drawer/withDrawerActions';
 import { highlightText } from '@/utils';
+
+interface PaymentReceiveUniversalSearchSelectProps
+  extends WithDrawerActionsProps {
+  resourceType: string;
+  resourceId: number;
+}
 
 /**
  * Payment receive universal search item select action.
@@ -22,7 +30,7 @@ function PaymentReceiveUniversalSearchSelectComponent({
 
   // #withDrawerActions
   openDrawer,
-}) {
+}: PaymentReceiveUniversalSearchSelectProps) {
   if (resourceType === RESOURCES_TYPES.PAYMENT_RECEIVE) {
     openDrawer(DRAWERS.PAYMENT_RECEIVED_DETAILS, {
       paymentReceiveId: resourceId,
@@ -35,12 +43,29 @@ export const PaymentReceiveUniversalSearchSelect = withDrawerActions(
   PaymentReceiveUniversalSearchSelectComponent,
 );
 
+interface PaymentReceiveUniversalSearchItemData {
+  id: number;
+  text: string;
+  label: string;
+  reference: {
+    paymentReceiveNo: string;
+    formattedPaymentDate: string;
+    formattedAmount: string;
+  };
+}
+
+interface PaymentReceiveUniversalSearchItemActions {
+  handleClick: () => void;
+  modifiers: { active: boolean };
+  query: string;
+}
+
 /**
  * Payment receive universal search item.
  */
 export function PaymentReceiveUniversalSearchItem(
-  item,
-  { handleClick, modifiers, query },
+  item: PaymentReceiveUniversalSearchItemData,
+  { handleClick, modifiers, query }: PaymentReceiveUniversalSearchItemActions,
 ) {
   return (
     <MenuItem
@@ -49,14 +74,16 @@ export function PaymentReceiveUniversalSearchItem(
         <div>
           <div>{highlightText(item.text, query)}</div>
 
-          <span class="bp4-text-muted">
+          <span className="bp4-text-muted">
             {highlightText(item.reference.paymentReceiveNo, query)}{' '}
             <Icon icon={'caret-right-16'} iconSize={16} />
             {highlightText(item.reference.formattedPaymentDate, query)}
           </span>
         </div>
       }
-      label={<div class="amount">{item.reference.formattedAmount}</div>}
+      labelElement={
+        <div className="amount">{item.reference.formattedAmount}</div>
+      }
       onClick={handleClick}
       className={'universal-search__item--invoice'}
     />
@@ -66,7 +93,12 @@ export function PaymentReceiveUniversalSearchItem(
 /**
  * Transformes payment receives to search.
  */
-const paymentReceivesToSearch = (payment) => ({
+const paymentReceivesToSearch = (payment: {
+  id: number;
+  customer?: { displayName?: string };
+  formattedPaymentDate?: string;
+  formattedAmount?: string;
+}) => ({
   id: payment.id,
   text: payment.customer?.displayName ?? '',
   subText: payment.formattedPaymentDate ?? '',

--- a/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentReceivedCustomize/PaymentReceivedCustomizeDrawer.tsx
+++ b/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentReceivedCustomize/PaymentReceivedCustomizeDrawer.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import * as R from 'ramda';
 import React from 'react';
 import { Drawer, DrawerSuspense } from '@/components';
@@ -10,6 +9,12 @@ const PaymentReceivedCustomize = React.lazy(() =>
   })),
 );
 
+interface PaymentReceivedCustomizeDrawerProps {
+  name: string;
+  isOpen?: boolean;
+  payload?: Record<string, any>;
+}
+
 /**
  * PaymentReceived customize drawer.
  * @returns {React.ReactNode}
@@ -19,7 +24,7 @@ function PaymentReceivedCustomizeDrawerRoot({
   // #withDrawer
   isOpen,
   payload,
-}) {
+}: PaymentReceivedCustomizeDrawerProps) {
   return (
     <Drawer isOpen={isOpen} name={name} size={'100%'} payload={payload}>
       <DrawerSuspense>

--- a/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentReceivedCustomize/PaymentReceivedCustomizeFieldsContent.tsx
+++ b/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentReceivedCustomize/PaymentReceivedCustomizeFieldsContent.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Classes } from '@blueprintjs/core';
 import { fieldsGroups } from './constants';
 import { Stack } from '@/components';

--- a/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentReceivedCustomize/PaymentReceivedCustomizeFieldsGeneral.tsx
+++ b/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentReceivedCustomize/PaymentReceivedCustomizeFieldsGeneral.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Classes } from '@blueprintjs/core';
 import { Overlay } from '../../Invoices/InvoiceCustomize/Overlay';
 import {

--- a/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentReceivedMailDrawer/PaymentReceivedMailDrawer.tsx
+++ b/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentReceivedMailDrawer/PaymentReceivedMailDrawer.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import * as R from 'ramda';
 import React from 'react';
 import { Drawer, DrawerSuspense } from '@/components';

--- a/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentReceivedMailDrawer/PaymentReceivedMailFields.tsx
+++ b/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentReceivedMailDrawer/PaymentReceivedMailFields.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Button, Intent } from '@blueprintjs/core';
 import { useFormikContext } from 'formik';
 import { useSendMailItems } from '../../Estimates/SendMailViewDrawer/hooks';

--- a/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentsLanding/PaymentsReceivedActionsBar.tsx
+++ b/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentsLanding/PaymentsReceivedActionsBar.tsx
@@ -19,6 +19,7 @@ import { usePaymentsReceivedListContext } from './PaymentsReceivedListProvider';
 import { withPaymentsReceived } from './withPaymentsReceived';
 import { withPaymentsReceivedActions } from './withPaymentsReceivedActions';
 import type { WithPaymentsReceivedProps } from './withPaymentsReceived';
+import type { WithPaymentsReceivedActionsProps } from './withPaymentsReceivedActions';
 import type { WithDialogActionsProps } from '@/containers/Dialog/withDialogActions';
 import type { WithDrawerActionsProps } from '@/containers/Drawer/withDrawerActions';
 import {
@@ -43,10 +44,6 @@ import { useSaveSettings } from '@/hooks/query';
 import { useDownloadExportPdf } from '@/hooks/query/FinancialReports/use-export-pdf';
 import { useRefreshPaymentReceive } from '@/hooks/query/payment-receives';
 import { compose } from '@/utils';
-
-interface WithPaymentsReceivedActionsProps {
-  setPaymentReceivesTableState: (state: Record<string, any>) => void;
-}
 
 interface PaymentsReceivedActionsBarProps
   extends Pick<WithPaymentsReceivedProps, 'paymentReceivesSelectedRows'>,

--- a/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentsLanding/PaymentsReceivedList.tsx
+++ b/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentsLanding/PaymentsReceivedList.tsx
@@ -8,13 +8,9 @@ import { PaymentsReceivedTable as PaymentReceivesTable } from './PaymentsReceive
 import { withPaymentsReceived } from './withPaymentsReceived';
 import { withPaymentsReceivedActions } from './withPaymentsReceivedActions';
 import type { WithPaymentsReceivedProps } from './withPaymentsReceived';
+import type { WithPaymentsReceivedActionsProps } from './withPaymentsReceivedActions';
 import { DashboardPageContent } from '@/components';
 import { compose, transformTableStateToQuery } from '@/utils';
-
-interface WithPaymentsReceivedActionsProps {
-  resetPaymentReceivesTableState: () => void;
-  resetPaymentReceivesSelectedRows: () => void;
-}
 
 interface PaymentsReceivedListProps
   extends Pick<

--- a/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentsLanding/PaymentsReceivedTable.tsx
+++ b/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentsLanding/PaymentsReceivedTable.tsx
@@ -7,6 +7,7 @@ import { withPaymentsReceived } from './withPaymentsReceived';
 import { withPaymentsReceivedActions } from './withPaymentsReceivedActions';
 import type { PaymentReceiveTableRow } from './components';
 import type { WithPaymentsReceivedProps } from './withPaymentsReceived';
+import type { WithPaymentsReceivedActionsProps } from './withPaymentsReceivedActions';
 import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import type { WithDialogActionsProps } from '@/containers/Dialog/withDialogActions';
 import type { WithDrawerActionsProps } from '@/containers/Drawer/withDrawerActions';
@@ -23,11 +24,6 @@ import { withDialogActions } from '@/containers/Dialog/withDialogActions';
 import { withDrawerActions } from '@/containers/Drawer/withDrawerActions';
 import { useMemorizedColumnsWidths } from '@/hooks';
 import { compose } from '@/utils';
-
-interface WithPaymentsReceivedActionsProps {
-  setPaymentReceivesTableState: (state: Record<string, any>) => void;
-  setPaymentReceivesSelectedRows: (ids: number[]) => void;
-}
 
 interface PaymentsReceivedDataTableProps
   extends Pick<

--- a/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentsLanding/PaymentsReceivedViewTabs.tsx
+++ b/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentsLanding/PaymentsReceivedViewTabs.tsx
@@ -4,13 +4,14 @@ import { useHistory } from 'react-router-dom';
 import { usePaymentsReceivedListContext } from './PaymentsReceivedListProvider';
 import { withPaymentsReceived } from './withPaymentsReceived';
 import { withPaymentsReceivedActions } from './withPaymentsReceivedActions';
+import type { WithPaymentsReceivedProps } from './withPaymentsReceived';
+import type { WithPaymentsReceivedActionsProps } from './withPaymentsReceivedActions';
 import { FormattedMessage as T, DashboardViewsTabs } from '@/components';
 import { compose, transfromViewsToTabs } from '@/utils';
 
-interface PaymentsReceivedViewTabsProps {
-  setPaymentReceivesTableState: (state: Record<string, any>) => void;
-  paymentReceivesTableState: { customViewId?: number | null };
-}
+interface PaymentsReceivedViewTabsProps
+  extends WithPaymentsReceivedActionsProps,
+    Pick<WithPaymentsReceivedProps, 'paymentReceivesTableState'> {}
 
 /**
  * Payment receive view tabs.

--- a/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentsLanding/PaymentsReceivedViewTabs.tsx
+++ b/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentsLanding/PaymentsReceivedViewTabs.tsx
@@ -1,30 +1,31 @@
-// @ts-nocheck
 import { Alignment, Navbar, NavbarGroup } from '@blueprintjs/core';
-import { pick } from 'lodash';
 import React from 'react';
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import { usePaymentsReceivedListContext } from './PaymentsReceivedListProvider';
 import { withPaymentsReceived } from './withPaymentsReceived';
 import { withPaymentsReceivedActions } from './withPaymentsReceivedActions';
 import { FormattedMessage as T, DashboardViewsTabs } from '@/components';
-import { compose } from '@/utils';
+import { compose, transfromViewsToTabs } from '@/utils';
+
+interface PaymentsReceivedViewTabsProps {
+  setPaymentReceivesTableState: (state: Record<string, any>) => void;
+  paymentReceivesTableState: { customViewId?: number | null };
+}
 
 /**
  * Payment receive view tabs.
  */
 function PaymentsReceivedViewTabsInner({
   // #withPaymentsReceivedActions
-  addPaymentReceivesTableQueries,
+  setPaymentReceivesTableState,
 
   // #withPaymentsReceived
   paymentReceivesTableState,
-}) {
+}: PaymentsReceivedViewTabsProps) {
   const history = useHistory();
-  const { paymentReceivesViews, ...res } = usePaymentsReceivedListContext();
+  const { paymentReceivesViews } = usePaymentsReceivedListContext();
 
-  const tabs = paymentReceivesViews.map((view) => ({
-    ...pick(view, ['name', 'id']),
-  }));
+  const tabs = transfromViewsToTabs(paymentReceivesViews);
 
   // Handles click a new view tab.
   const handleClickNewView = () => {
@@ -32,8 +33,8 @@ function PaymentsReceivedViewTabsInner({
   };
 
   // Handles the active tab chaing.
-  const handleTabsChange = (customView) => {
-    addPaymentReceivesTableQueries({
+  const handleTabsChange = (customView: number | null) => {
+    setPaymentReceivesTableState({
       customViewId: customView || null,
     });
   };
@@ -42,7 +43,8 @@ function PaymentsReceivedViewTabsInner({
     <Navbar className={'navbar--dashboard-views'}>
       <NavbarGroup align={Alignment.LEFT}>
         <DashboardViewsTabs
-          customViewId={paymentReceivesTableState.customViewId}
+          currentViewSlug={paymentReceivesTableState.customViewId}
+          resourceName={'payment-received'}
           tabs={tabs}
           defaultTabText={<T id={'all_payments'} />}
           onNewViewTabClick={handleClickNewView}

--- a/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentsReceivedAlerts.tsx
+++ b/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentsReceivedAlerts.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import React from 'react';
 
 const PaymentReceivedDeleteAlert = React.lazy(() =>

--- a/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentsReceivedImport.tsx
+++ b/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentsReceivedImport.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { useHistory } from 'react-router-dom';
 import { DashboardInsider } from '@/components';
 import { ImportView } from '@/containers/Import';

--- a/packages/webapp/src/containers/Sales/Receipts/ReceiptCustomize/ReceiptCustomizeDrawer.tsx
+++ b/packages/webapp/src/containers/Sales/Receipts/ReceiptCustomize/ReceiptCustomizeDrawer.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import * as R from 'ramda';
 import React from 'react';
 import { Drawer, DrawerSuspense } from '@/components';
@@ -10,6 +9,12 @@ const ReceiptCustomizeDrawerBody = React.lazy(() =>
   })),
 );
 
+interface ReceiptCustomizeDrawerProps {
+  name: string;
+  isOpen?: boolean;
+  payload?: Record<string, any>;
+}
+
 /**
  * Receipt customize drawer.
  * @returns {React.ReactNode}
@@ -19,7 +24,7 @@ function ReceiptCustomizeDrawerRoot({
   // #withDrawer
   isOpen,
   payload,
-}) {
+}: ReceiptCustomizeDrawerProps) {
   return (
     <Drawer
       isOpen={isOpen}

--- a/packages/webapp/src/containers/Sales/Receipts/ReceiptCustomize/ReceiptCustomizeFieldsContent.tsx
+++ b/packages/webapp/src/containers/Sales/Receipts/ReceiptCustomize/ReceiptCustomizeFieldsContent.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Classes } from '@blueprintjs/core';
 import { fieldsGroups } from './constants';
 import { Stack } from '@/components';

--- a/packages/webapp/src/containers/Sales/Receipts/ReceiptCustomize/ReceiptCustomizeFieldsGeneral.tsx
+++ b/packages/webapp/src/containers/Sales/Receipts/ReceiptCustomize/ReceiptCustomizeFieldsGeneral.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Classes } from '@blueprintjs/core';
 import { Overlay } from '../../Invoices/InvoiceCustomize/Overlay';
 import {

--- a/packages/webapp/src/containers/Sales/Receipts/ReceiptSendMailDrawer/ReceiptSendMailBoot.tsx
+++ b/packages/webapp/src/containers/Sales/Receipts/ReceiptSendMailDrawer/ReceiptSendMailBoot.tsx
@@ -1,16 +1,39 @@
-// @ts-nocheck
 import { Spinner } from '@blueprintjs/core';
 import React, { createContext, useContext } from 'react';
 import { useDrawerContext } from '@/components/Drawer/DrawerProvider';
-import {
-  GetSaleReceiptMailStateResponse,
-  useSaleReceiptMailState,
-} from '@/hooks/query';
+import { useSaleReceiptMailState } from '@/hooks/query';
+
+interface ReceiptSendMailState {
+  from: string[];
+  to: string[];
+  cc?: string[];
+  bcc?: string[];
+  subject: string;
+  message: string;
+  formatArgs?: Record<string, string>;
+  toOptions: Array<{ label: string; mail: string; primary?: boolean }>;
+  fromOptions: Array<{ label: string; mail: string; primary?: boolean }>;
+  attachPdf?: boolean;
+  receiptNumber: string;
+  total: number;
+  totalFormatted: string;
+  subtotal: number;
+  subtotalFormatted: string;
+  discount: number;
+  discountAmountFormatted: string;
+  adjustment: number;
+  adjustmentFormatted: string;
+  companyName: string;
+  companyLogoUri: string | null;
+  primaryColor: string | null;
+  customerName: string;
+  entries: Array<{ name: string; quantity: number; totalFormatted: string }>;
+}
 
 interface ReceiptSendMailBootValues {
   receiptId: number;
 
-  receiptMailState: GetSaleReceiptMailStateResponse | null;
+  receiptMailState: ReceiptSendMailState | undefined;
   isReceiptMailState: boolean;
 }
 interface ReceiptSendMailBootProps {
@@ -26,8 +49,9 @@ export const ReceiptSendMailBoot = ({ children }: ReceiptSendMailBootProps) => {
   } = useDrawerContext();
 
   // Receipt mail options.
-  const { data: receiptMailState, isLoading: isReceiptMailState } =
+  const { data, isLoading: isReceiptMailState } =
     useSaleReceiptMailState(receiptId);
+  const receiptMailState = data as ReceiptSendMailState | undefined;
 
   const isLoading = isReceiptMailState;
 

--- a/packages/webapp/src/containers/Sales/Receipts/ReceiptSendMailDrawer/ReceiptSendMailDrawer.tsx
+++ b/packages/webapp/src/containers/Sales/Receipts/ReceiptSendMailDrawer/ReceiptSendMailDrawer.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import * as R from 'ramda';
 import React from 'react';
 import { Drawer, DrawerSuspense } from '@/components';

--- a/packages/webapp/src/containers/Sales/Receipts/ReceiptSendMailDrawer/ReceiptSendMailForm.tsx
+++ b/packages/webapp/src/containers/Sales/Receipts/ReceiptSendMailDrawer/ReceiptSendMailForm.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Intent } from '@blueprintjs/core';
 import { css } from '@emotion/css';
 import { Form, Formik, FormikHelpers } from 'formik';
@@ -14,6 +13,7 @@ import { transformToForm } from '@/utils';
 const initialValues: ReceiptSendMailFormValues = {
   subject: '',
   message: '',
+  from: [],
   to: [],
   cc: [],
   bcc: [],

--- a/packages/webapp/src/containers/Sales/Receipts/ReceiptSendMailDrawer/_types.ts
+++ b/packages/webapp/src/containers/Sales/Receipts/ReceiptSendMailDrawer/_types.ts
@@ -1,3 +1,5 @@
 import { SendMailViewFormValues } from '../../Estimates/SendMailViewDrawer/_types';
 
-export interface ReceiptSendMailFormValues extends SendMailViewFormValues {}
+export type ReceiptSendMailFormValues = SendMailViewFormValues & {
+  attachPdf?: boolean;
+};

--- a/packages/webapp/src/containers/Sales/Receipts/ReceiptUniversalSearch.tsx
+++ b/packages/webapp/src/containers/Sales/Receipts/ReceiptUniversalSearch.tsx
@@ -1,12 +1,19 @@
-// @ts-nocheck
 import { MenuItem, Intent } from '@blueprintjs/core';
 import React from 'react';
 import intl from 'react-intl-universal';
+import type { WithDrawerActionsProps } from '@/containers/Drawer/withDrawerActions';
 import { Icon, Choose, T, TextStatus } from '@/components';
 import { AbilitySubject, SaleReceiptAction } from '@/constants/abilityOption';
 import { DRAWERS } from '@/constants/drawers';
 import { RESOURCES_TYPES } from '@/constants/resourcesTypes';
 import { withDrawerActions } from '@/containers/Drawer/withDrawerActions';
+
+interface ReceiptUniversalSearchSelectComponentProps
+  extends WithDrawerActionsProps {
+  resourceType: string;
+  resourceId: number;
+  onAction?: () => void;
+}
 
 /**
  * Receipt universal search item select action.
@@ -19,7 +26,7 @@ function ReceiptUniversalSearchSelectComponent({
 
   // #withDrawerActions
   openDrawer,
-}) {
+}: ReceiptUniversalSearchSelectComponentProps) {
   if (resourceType === RESOURCES_TYPES.RECEIPT) {
     openDrawer(DRAWERS.RECEIPT_DETAILS, { receiptId: resourceId });
     onAction && onAction();
@@ -34,7 +41,7 @@ export const ReceiptUniversalSearchSelect = withDrawerActions(
 /**
  * Status accessor.
  */
-function ReceiptStatus({ receipt }) {
+function ReceiptStatus({ receipt }: { receipt: any }) {
   return (
     <Choose>
       <Choose.When condition={receipt.isClosed}>
@@ -52,12 +59,18 @@ function ReceiptStatus({ receipt }) {
   );
 }
 
+interface ReceiptUniversalSearchItemProps {
+  handleClick: () => void;
+  modifiers: any;
+  query: string;
+}
+
 /**
  * Receipt universal search item.
  */
 export function ReceiptUniversalSearchItem(
-  item,
-  { handleClick, modifiers, query },
+  item: any,
+  { handleClick, modifiers }: ReceiptUniversalSearchItemProps,
 ) {
   return (
     <MenuItem
@@ -65,16 +78,16 @@ export function ReceiptUniversalSearchItem(
       text={
         <div>
           <div>{item.text}</div>
-          <span class="bp4-text-muted">
+          <span className="bp4-text-muted">
             {item.reference.receiptNumber}{' '}
             <Icon icon={'caret-right-16'} iconSize={16} />
             {item.reference.formattedReceiptDate}
           </span>
         </div>
       }
-      label={
+      labelElement={
         <>
-          <div class="amount">{item.reference.formattedAmount}</div>
+          <div className="amount">{item.reference.formattedAmount}</div>
           <ReceiptStatus receipt={item.reference} />
         </>
       }
@@ -87,7 +100,7 @@ export function ReceiptUniversalSearchItem(
 /**
  * Transformes receipt resource item to search item.
  */
-const transformReceiptsToSearch = (receipt) => ({
+const transformReceiptsToSearch = (receipt: any) => ({
   id: receipt.id,
   text: receipt.customer?.displayName ?? '',
   label: receipt.formattedAmount ?? '',

--- a/packages/webapp/src/containers/Sales/Receipts/ReceiptUniversalSearch.tsx
+++ b/packages/webapp/src/containers/Sales/Receipts/ReceiptUniversalSearch.tsx
@@ -2,6 +2,7 @@ import { MenuItem, Intent } from '@blueprintjs/core';
 import React from 'react';
 import intl from 'react-intl-universal';
 import type { WithDrawerActionsProps } from '@/containers/Drawer/withDrawerActions';
+import type { SaleReceipt } from '@bigcapital/sdk-ts';
 import { Icon, Choose, T, TextStatus } from '@/components';
 import { AbilitySubject, SaleReceiptAction } from '@/constants/abilityOption';
 import { DRAWERS } from '@/constants/drawers';
@@ -41,7 +42,11 @@ export const ReceiptUniversalSearchSelect = withDrawerActions(
 /**
  * Status accessor.
  */
-function ReceiptStatus({ receipt }: { receipt: any }) {
+interface ReceiptStatusProps {
+  receipt: SaleReceipt;
+}
+
+function ReceiptStatus({ receipt }: ReceiptStatusProps) {
   return (
     <Choose>
       <Choose.When condition={receipt.isClosed}>

--- a/packages/webapp/src/containers/Sales/Receipts/ReceiptsAlerts.tsx
+++ b/packages/webapp/src/containers/Sales/Receipts/ReceiptsAlerts.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import React from 'react';
 
 const ReceiptDeleteAlert = React.lazy(() =>

--- a/packages/webapp/src/containers/Sales/Receipts/ReceiptsLanding/ReceiptActionsBar.tsx
+++ b/packages/webapp/src/containers/Sales/Receipts/ReceiptsLanding/ReceiptActionsBar.tsx
@@ -19,6 +19,7 @@ import { useReceiptsListContext } from './ReceiptsListProvider';
 import { withReceipts } from './withReceipts';
 import { withReceiptsActions } from './withReceiptsActions';
 import type { WithReceiptsProps } from './withReceipts';
+import type { WithReceiptsActionsProps } from './withReceiptsActions';
 import type { WithDialogActionsProps } from '@/containers/Dialog/withDialogActions';
 import type { WithDrawerActionsProps } from '@/containers/Drawer/withDrawerActions';
 import {
@@ -43,10 +44,6 @@ import { useSaveSettings } from '@/hooks/query';
 import { useDownloadExportPdf } from '@/hooks/query/FinancialReports/use-export-pdf';
 import { useRefreshReceipts } from '@/hooks/query/receipts';
 import { compose } from '@/utils';
-
-interface WithReceiptsActionsProps {
-  setReceiptsTableState: (state: Record<string, any>) => void;
-}
 
 interface ReceiptActionsBarProps
   extends Pick<WithReceiptsProps, 'receiptSelectedRows'>,

--- a/packages/webapp/src/containers/Sales/Receipts/ReceiptsLanding/ReceiptActionsBar.tsx
+++ b/packages/webapp/src/containers/Sales/Receipts/ReceiptsLanding/ReceiptActionsBar.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import {
   Button,
   Classes,
@@ -13,12 +12,15 @@ import {
   MenuItem,
 } from '@blueprintjs/core';
 import { isEmpty } from 'lodash';
-import React, { useState } from 'react';
+import React from 'react';
 import { useHistory } from 'react-router-dom';
 import { useBulkDeleteReceiptsDialog } from './hooks/use-bulk-delete-receipts-dialog';
 import { useReceiptsListContext } from './ReceiptsListProvider';
 import { withReceipts } from './withReceipts';
 import { withReceiptsActions } from './withReceiptsActions';
+import type { WithReceiptsProps } from './withReceipts';
+import type { WithDialogActionsProps } from '@/containers/Dialog/withDialogActions';
+import type { WithDrawerActionsProps } from '@/containers/Drawer/withDrawerActions';
 import {
   Icon,
   AdvancedFilterPopover,
@@ -42,31 +44,42 @@ import { useDownloadExportPdf } from '@/hooks/query/FinancialReports/use-export-
 import { useRefreshReceipts } from '@/hooks/query/receipts';
 import { compose } from '@/utils';
 
+interface WithReceiptsActionsProps {
+  setReceiptsTableState: (state: Record<string, any>) => void;
+}
+
+interface ReceiptActionsBarProps
+  extends Pick<WithReceiptsProps, 'receiptSelectedRows'>,
+    WithReceiptsActionsProps,
+    WithDialogActionsProps,
+    WithDrawerActionsProps {
+  receiptsFilterConditions: any[];
+}
+
 /**
  * Receipts actions bar.
  */
 function ReceiptActionsBarInner({
   // #withReceiptsActions
   setReceiptsTableState,
-  setReceiptsSelectedRows,
 
   // #withReceipts
   receiptsFilterConditions,
-  receiptSelectedRows,
+  receiptSelectedRows = [],
 
   // #withDialogActions
   openDialog,
 
   // #withDrawerActions
   openDrawer,
-}) {
+}: ReceiptActionsBarProps) {
   const { mutateAsync: saveSettings } = useSaveSettings();
 
   const history = useHistory();
 
   // Sale receipts list context.
   const { receiptsViews, fields, receiptSettings } = useReceiptsListContext();
-  const receiptsTableSize = receiptSettings?.tableSize;
+  const receiptsTableSize = receiptSettings?.tableSize as string | undefined;
 
   // Exports pdf document.
   const { downloadAsync: downloadExportPdf } = useDownloadExportPdf();
@@ -79,7 +92,7 @@ function ReceiptActionsBarInner({
   // Sale receipt refresh action.
   const { refresh } = useRefreshReceipts();
 
-  const handleTabChange = (view) => {
+  const handleTabChange = (view: { slug?: string } | null) => {
     setReceiptsTableState({
       viewSlug: view ? view.slug : null,
     });
@@ -91,7 +104,7 @@ function ReceiptActionsBarInner({
   };
 
   // Handle table row size change.
-  const handleTableRowSizeChange = (size) => {
+  const handleTableRowSizeChange = (size: any) => {
     saveSettings({
       options: [{ group: 'salesReceipts', key: 'tableSize', value: size }],
     });
@@ -120,7 +133,7 @@ function ReceiptActionsBarInner({
 
   if (!isEmpty(receiptSelectedRows)) {
     const handleBulkDelete = () => {
-      openBulkDeleteDialog(receiptSelectedRows);
+      openBulkDeleteDialog(receiptSelectedRows as number[]);
     };
     return (
       <DashboardActionsBar>
@@ -163,7 +176,7 @@ function ReceiptActionsBarInner({
             conditions: receiptsFilterConditions,
             defaultFieldKey: 'reference_no',
             fields: fields,
-            onFilterChange: (filterConditions) => {
+            onFilterChange: (filterConditions: any) => {
               setReceiptsTableState({ filterRoles: filterConditions });
             },
           }}
@@ -183,7 +196,7 @@ function ReceiptActionsBarInner({
         </If>
         <Button
           className={Classes.MINIMAL}
-          icon={<Icon icon={'print-16'} iconSize={'16'} />}
+          icon={<Icon icon={'print-16'} iconSize={16} />}
           text={<T id={'print'} />}
           onClick={handlePrintButtonClick}
         />
@@ -195,7 +208,7 @@ function ReceiptActionsBarInner({
         />
         <Button
           className={Classes.MINIMAL}
-          icon={<Icon icon={'file-export-16'} iconSize={'16'} />}
+          icon={<Icon icon={'file-export-16'} iconSize={16} />}
           text={<T id={'export'} />}
           onClick={handleExportBtnClick}
         />

--- a/packages/webapp/src/containers/Sales/Receipts/ReceiptsLanding/ReceiptViewTabs.tsx
+++ b/packages/webapp/src/containers/Sales/Receipts/ReceiptsLanding/ReceiptViewTabs.tsx
@@ -1,11 +1,20 @@
-// @ts-nocheck
 import { Alignment, Navbar, NavbarGroup } from '@blueprintjs/core';
 import React from 'react';
 import { useReceiptsListContext } from './ReceiptsListProvider';
 import { withReceipts } from './withReceipts';
-import { withReceiptActions } from './withReceiptsActions';
+import { withReceiptsActions } from './withReceiptsActions';
+import type { WithReceiptsProps } from './withReceipts';
 import { DashboardViewsTabs } from '@/components';
 import { compose, transfromViewsToTabs } from '@/utils';
+
+interface WithReceiptsActionsProps {
+  setReceiptsTableState: (state: Record<string, any>) => void;
+}
+
+interface ReceiptViewTabsProps {
+  setReceiptsTableState: WithReceiptsActionsProps['setReceiptsTableState'];
+  receiptsCurrentView: string;
+}
 
 /**
  * Receipts views tabs.
@@ -16,14 +25,14 @@ function ReceiptViewTabsInner({
 
   // #withReceipts
   receiptsCurrentView,
-}) {
+}: ReceiptViewTabsProps) {
   // Receipts list context.
   const { receiptsViews } = useReceiptsListContext();
 
   const tabs = transfromViewsToTabs(receiptsViews);
 
   // Handles the active tab chaning.
-  const handleTabsChange = (viewSlug) => {
+  const handleTabsChange = (viewSlug: string | null) => {
     setReceiptsTableState({
       viewSlug: viewSlug || null,
     });
@@ -44,8 +53,8 @@ function ReceiptViewTabsInner({
 }
 
 export const ReceiptViewTabs = compose(
-  withReceiptActions,
-  withReceipts(({ receiptTableState }) => ({
+  withReceiptsActions,
+  withReceipts(({ receiptTableState }: WithReceiptsProps) => ({
     receiptsCurrentView: receiptTableState.viewSlug,
   })),
 )(ReceiptViewTabsInner);

--- a/packages/webapp/src/containers/Sales/Receipts/ReceiptsLanding/ReceiptViewTabs.tsx
+++ b/packages/webapp/src/containers/Sales/Receipts/ReceiptsLanding/ReceiptViewTabs.tsx
@@ -4,15 +4,11 @@ import { useReceiptsListContext } from './ReceiptsListProvider';
 import { withReceipts } from './withReceipts';
 import { withReceiptsActions } from './withReceiptsActions';
 import type { WithReceiptsProps } from './withReceipts';
+import type { WithReceiptsActionsProps } from './withReceiptsActions';
 import { DashboardViewsTabs } from '@/components';
 import { compose, transfromViewsToTabs } from '@/utils';
 
-interface WithReceiptsActionsProps {
-  setReceiptsTableState: (state: Record<string, any>) => void;
-}
-
-interface ReceiptViewTabsProps {
-  setReceiptsTableState: WithReceiptsActionsProps['setReceiptsTableState'];
+interface ReceiptViewTabsProps extends WithReceiptsActionsProps {
   receiptsCurrentView: string;
 }
 

--- a/packages/webapp/src/containers/Sales/Receipts/ReceiptsLanding/ReceiptsEmptyStatus.tsx
+++ b/packages/webapp/src/containers/Sales/Receipts/ReceiptsLanding/ReceiptsEmptyStatus.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Button, Intent } from '@blueprintjs/core';
 import React from 'react';
 import { useHistory } from 'react-router-dom';

--- a/packages/webapp/src/containers/Sales/Receipts/ReceiptsLanding/ReceiptsList.tsx
+++ b/packages/webapp/src/containers/Sales/Receipts/ReceiptsLanding/ReceiptsList.tsx
@@ -7,14 +7,10 @@ import { ReceiptsTable } from './ReceiptsTable';
 import { withReceipts } from './withReceipts';
 import { withReceiptsActions } from './withReceiptsActions';
 import type { WithReceiptsProps } from './withReceipts';
+import type { WithReceiptsActionsProps } from './withReceiptsActions';
 import { DashboardPageContent } from '@/components';
 import '@/style/pages/SaleReceipt/List.scss';
 import { transformTableStateToQuery, compose } from '@/utils';
-
-interface WithReceiptsActionsProps {
-  resetReceiptsTableState: () => void;
-  resetReceiptsSelectedRows: () => void;
-}
 
 interface ReceiptsListProps
   extends Pick<

--- a/packages/webapp/src/containers/Sales/Receipts/ReceiptsLanding/ReceiptsList.tsx
+++ b/packages/webapp/src/containers/Sales/Receipts/ReceiptsLanding/ReceiptsList.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import React from 'react';
 import { ReceiptActionsBar } from './ReceiptActionsBar';
 import { ReceiptsListDialogs } from './ReceiptsListDialogs';
@@ -7,9 +6,22 @@ import { ReceiptsListProvider } from './ReceiptsListProvider';
 import { ReceiptsTable } from './ReceiptsTable';
 import { withReceipts } from './withReceipts';
 import { withReceiptsActions } from './withReceiptsActions';
+import type { WithReceiptsProps } from './withReceipts';
 import { DashboardPageContent } from '@/components';
 import '@/style/pages/SaleReceipt/List.scss';
 import { transformTableStateToQuery, compose } from '@/utils';
+
+interface WithReceiptsActionsProps {
+  resetReceiptsTableState: () => void;
+  resetReceiptsSelectedRows: () => void;
+}
+
+interface ReceiptsListProps
+  extends Pick<
+      WithReceiptsProps,
+      'receiptTableState' | 'receiptsTableStateChanged'
+    >,
+    WithReceiptsActionsProps {}
 
 /**
  * Receipts list page.
@@ -22,7 +34,7 @@ function ReceiptsListInner({
   // #withReceiptsActions
   resetReceiptsTableState,
   resetReceiptsSelectedRows,
-}) {
+}: ReceiptsListProps) {
   // Resets the receipts table state and selected rows once the page unmount.
   React.useEffect(
     () => () => {

--- a/packages/webapp/src/containers/Sales/Receipts/ReceiptsLanding/ReceiptsListProvider.tsx
+++ b/packages/webapp/src/containers/Sales/Receipts/ReceiptsLanding/ReceiptsListProvider.tsx
@@ -1,6 +1,12 @@
-// @ts-nocheck
+import { keepPreviousData } from '@tanstack/react-query';
 import { isEmpty } from 'lodash';
 import React, { createContext } from 'react';
+import type { ReceiptTableRow } from './components';
+import type { IResourceField } from '@/components/AdvancedFilter/interfaces';
+import type {
+  SettingsGroup,
+  SaleReceiptsListResponse,
+} from '@bigcapital/sdk-ts';
 import { DashboardInsider } from '@/components/Dashboard';
 import {
   useResourceMeta,
@@ -10,10 +16,37 @@ import {
 } from '@/hooks/query';
 import { getFieldsFromResourceMeta } from '@/utils';
 
-const ReceiptsListContext = createContext();
+interface ReceiptsListProviderProps {
+  query?: any;
+  tableStateChanged?: boolean;
+  children?: React.ReactNode;
+}
+
+export interface ReceiptsListContextValue {
+  receipts: SaleReceiptsListResponse['data'] | undefined;
+  pagination: { total?: number; [key: string]: any } | undefined;
+  resourceMeta: any;
+  fields: IResourceField[];
+  receiptsViews: any;
+  isResourceLoading: boolean;
+  isResourceFetching: boolean;
+  isReceiptsLoading: boolean;
+  isReceiptsFetching: boolean;
+  isViewsLoading: boolean;
+  isEmptyStatus: boolean;
+  receiptSettings: SettingsGroup | undefined;
+}
+
+const ReceiptsListContext = createContext<ReceiptsListContextValue>(
+  {} as ReceiptsListContextValue,
+);
 
 // Receipts list provider.
-function ReceiptsListProvider({ query, tableStateChanged, ...props }) {
+function ReceiptsListProvider({
+  query,
+  tableStateChanged,
+  ...props
+}: ReceiptsListProviderProps) {
   // Fetch receipts resource views and fields.
   const { data: receiptsViews, isLoading: isViewsLoading } =
     useResourceViews('sale_receipt');
@@ -29,7 +62,7 @@ function ReceiptsListProvider({ query, tableStateChanged, ...props }) {
     data: receiptsData,
     isLoading: isReceiptsLoading,
     isFetching: isReceiptsFetching,
-  } = useReceipts(query, { keepPreviousData: true });
+  } = useReceipts(query, { placeholderData: keepPreviousData });
 
   const { data: receiptSettings } = useSettingsReceipts();
 
@@ -37,7 +70,7 @@ function ReceiptsListProvider({ query, tableStateChanged, ...props }) {
   const isEmptyStatus =
     isEmpty(receiptsData?.data) && !tableStateChanged && !isReceiptsLoading;
 
-  const provider = {
+  const provider: ReceiptsListContextValue = {
     receipts: receiptsData?.data,
     pagination: receiptsData?.pagination,
 

--- a/packages/webapp/src/containers/Sales/Receipts/ReceiptsLanding/ReceiptsTable.tsx
+++ b/packages/webapp/src/containers/Sales/Receipts/ReceiptsLanding/ReceiptsTable.tsx
@@ -10,6 +10,7 @@ import { useReceiptsListContext } from './ReceiptsListProvider';
 import { withReceipts } from './withReceipts';
 import { withReceiptsActions } from './withReceiptsActions';
 import type { WithReceiptsProps } from './withReceipts';
+import type { WithReceiptsActionsProps } from './withReceiptsActions';
 import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
 import type { WithDialogActionsProps } from '@/containers/Dialog/withDialogActions';
 import type { WithDrawerActionsProps } from '@/containers/Drawer/withDrawerActions';
@@ -27,11 +28,6 @@ import { withDialogActions } from '@/containers/Dialog/withDialogActions';
 import { withDrawerActions } from '@/containers/Drawer/withDrawerActions';
 import { useMemorizedColumnsWidths } from '@/hooks';
 import { compose } from '@/utils';
-
-interface WithReceiptsActionsProps {
-  setReceiptsTableState: (state: Record<string, any>) => void;
-  setReceiptsSelectedRows: (ids: number[]) => void;
-}
 
 interface ReceiptsDataTableProps
   extends Pick<WithReceiptsProps, 'receiptTableState' | 'receiptSelectedRows'>,

--- a/packages/webapp/src/containers/Sales/Receipts/ReceiptsLanding/ReceiptsTable.tsx
+++ b/packages/webapp/src/containers/Sales/Receipts/ReceiptsLanding/ReceiptsTable.tsx
@@ -1,11 +1,18 @@
-// @ts-nocheck
 import React, { useCallback } from 'react';
 import { useHistory } from 'react-router-dom';
-import { useReceiptsTableColumns, ActionsMenu } from './components';
+import {
+  useReceiptsTableColumns,
+  ActionsMenu,
+  ReceiptTableRow,
+} from './components';
 import { ReceiptsEmptyStatus } from './ReceiptsEmptyStatus';
 import { useReceiptsListContext } from './ReceiptsListProvider';
 import { withReceipts } from './withReceipts';
 import { withReceiptsActions } from './withReceiptsActions';
+import type { WithReceiptsProps } from './withReceipts';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
+import type { WithDialogActionsProps } from '@/containers/Dialog/withDialogActions';
+import type { WithDrawerActionsProps } from '@/containers/Drawer/withDrawerActions';
 import {
   DataTable,
   DashboardContentTable,
@@ -20,6 +27,18 @@ import { withDialogActions } from '@/containers/Dialog/withDialogActions';
 import { withDrawerActions } from '@/containers/Drawer/withDrawerActions';
 import { useMemorizedColumnsWidths } from '@/hooks';
 import { compose } from '@/utils';
+
+interface WithReceiptsActionsProps {
+  setReceiptsTableState: (state: Record<string, any>) => void;
+  setReceiptsSelectedRows: (ids: number[]) => void;
+}
+
+interface ReceiptsDataTableProps
+  extends Pick<WithReceiptsProps, 'receiptTableState' | 'receiptSelectedRows'>,
+    WithReceiptsActionsProps,
+    WithAlertActionsProps,
+    WithDrawerActionsProps,
+    WithDialogActionsProps {}
 
 /**
  * Sale receipts datatable.
@@ -41,7 +60,7 @@ function ReceiptsDataTable({
 
   // #withDialogAction
   openDialog,
-}) {
+}: ReceiptsDataTableProps) {
   const history = useHistory();
 
   // Receipts list context.
@@ -53,38 +72,38 @@ function ReceiptsDataTable({
     isEmptyStatus,
     receiptSettings,
   } = useReceiptsListContext();
-  const receiptsTableSize = receiptSettings?.tableSize;
+  const receiptsTableSize = receiptSettings?.tableSize as string | undefined;
 
   // Receipts table columns.
   const columns = useReceiptsTableColumns();
 
   // Handle receipt edit action.
-  const handleEditReceipt = ({ id }) => {
+  const handleEditReceipt = ({ id }: ReceiptTableRow) => {
     history.push(`/receipts/${id}/edit`);
   };
 
   // Handles receipt delete action.
-  const handleDeleteReceipt = (receipt) => {
+  const handleDeleteReceipt = (receipt: ReceiptTableRow) => {
     openAlert('receipt-delete', { receiptId: receipt.id });
   };
 
   // Handles receipt close action.
-  const handleCloseReceipt = (receipt) => {
+  const handleCloseReceipt = (receipt: ReceiptTableRow) => {
     openAlert('receipt-close', { receiptId: receipt.id });
   };
 
   // Handle view detail receipt.
-  const handleViewDetailReceipt = ({ id }) => {
+  const handleViewDetailReceipt = ({ id }: ReceiptTableRow) => {
     openDrawer(DRAWERS.RECEIPT_DETAILS, { receiptId: id });
   };
 
   // Handle print receipt.
-  const handlePrintInvoice = ({ id }) => {
+  const handlePrintInvoice = ({ id }: ReceiptTableRow) => {
     openDialog('receipt-pdf-preview', { receiptId: id });
   };
 
   // Handle send mail receipt.
-  const handleSendMailReceipt = ({ id }) => {
+  const handleSendMailReceipt = ({ id }: ReceiptTableRow) => {
     openDrawer(DRAWERS.RECEIPT_SEND_MAIL, { receiptId: id });
   };
 
@@ -94,7 +113,15 @@ function ReceiptsDataTable({
 
   // Handles the datable fetch data once the state changing.
   const handleDataTableFetchData = useCallback(
-    ({ sortBy, pageIndex, pageSize }) => {
+    ({
+      sortBy,
+      pageIndex,
+      pageSize,
+    }: {
+      pageSize: number;
+      pageIndex: number;
+      sortBy: Array<{ id: string; desc: boolean }>;
+    }) => {
       setReceiptsTableState({
         pageIndex,
         pageSize,
@@ -104,12 +131,12 @@ function ReceiptsDataTable({
     [setReceiptsTableState],
   );
   // Handle cell click.
-  const handleCellClick = (cell, event) => {
+  const handleCellClick = (cell: any, _event: React.MouseEvent) => {
     openDrawer(DRAWERS.RECEIPT_DETAILS, { receiptId: cell.row.original.id });
   };
   // Handle selected rows change.
   const handleSelectedRowsChange = useCallback(
-    (selectedRows) => {
+    (selectedRows: Array<{ original: ReceiptTableRow }>) => {
       const selectedIds = selectedRows?.map((row) => row.original.id) || [];
       setReceiptsSelectedRows(selectedIds);
     },

--- a/packages/webapp/src/containers/Sales/Receipts/ReceiptsLanding/components.tsx
+++ b/packages/webapp/src/containers/Sales/Receipts/ReceiptsLanding/components.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import {
   Position,
   Menu,
@@ -12,11 +11,31 @@ import {
 import clsx from 'classnames';
 import React from 'react';
 import intl from 'react-intl-universal';
+import type { DataTableColumn } from '@/components/Datatable/types';
+import type { SaleReceiptsListResponse } from '@bigcapital/sdk-ts';
 import { FormattedMessage as T } from '@/components';
 import { FormatDateCell, Choose, Money, Icon, If, Can } from '@/components';
 import { SaleReceiptAction, AbilitySubject } from '@/constants/abilityOption';
 import { CLASSES } from '@/constants/classes';
 import { safeCallback } from '@/utils';
+
+export type ReceiptTableRow = NonNullable<
+  SaleReceiptsListResponse['data']
+>[number];
+
+interface ReceiptActionsPayload {
+  onEdit: (receipt: ReceiptTableRow) => void;
+  onDelete: (receipt: ReceiptTableRow) => void;
+  onClose: (receipt: ReceiptTableRow) => void;
+  onSendMail: (receipt: ReceiptTableRow) => void;
+  onViewDetails: (receipt: ReceiptTableRow) => void;
+  onPrint: (receipt: ReceiptTableRow) => void;
+}
+
+interface ActionsMenuProps {
+  row: { original: ReceiptTableRow };
+  payload: ReceiptActionsPayload;
+}
 
 /**
  * Receipts table row actions menu.
@@ -25,7 +44,7 @@ import { safeCallback } from '@/utils';
 export function ActionsMenu({
   payload: { onEdit, onDelete, onClose, onSendMail, onViewDetails, onPrint },
   row: { original: receipt },
-}) {
+}: ActionsMenuProps) {
   return (
     <Menu>
       <MenuItem
@@ -77,7 +96,7 @@ export function ActionsMenu({
 /**
  * Actions cell.
  */
-export function ActionsCell(props) {
+export function ActionsCell(props: ActionsMenuProps) {
   return (
     <Popover
       content={<ActionsMenu {...props} />}
@@ -91,7 +110,7 @@ export function ActionsCell(props) {
 /**
  * Status accessor.
  */
-export function StatusAccessor(receipt) {
+export function StatusAccessor(receipt: ReceiptTableRow) {
   return (
     <Choose>
       <Choose.When condition={receipt.isClosed}>
@@ -112,74 +131,77 @@ export function StatusAccessor(receipt) {
 /**
  * Retrieve receipts table columns.
  */
-export function useReceiptsTableColumns() {
+export function useReceiptsTableColumns(): DataTableColumn<ReceiptTableRow>[] {
   return React.useMemo(
-    () => [
-      {
-        id: 'receipt_date',
-        Header: intl.get('receipt_date'),
-        accessor: 'formattedReceiptDate',
-        width: 140,
-        className: 'receipt_date',
-        clickable: true,
-        textOverview: true,
-      },
-      {
-        id: 'customer',
-        Header: intl.get('customer_name'),
-        accessor: 'customer.displayName',
-        width: 140,
-        className: 'customer_id',
-        clickable: true,
-        textOverview: true,
-      },
-      {
-        id: 'receipt_number',
-        Header: intl.get('receipt_number'),
-        accessor: 'receiptNumber',
-        width: 140,
-        className: 'receipt_number',
-        clickable: true,
-        textOverview: true,
-      },
-      {
-        id: 'deposit_account',
-        Header: intl.get('deposit_account'),
-        accessor: 'depositAccount.name',
-        width: 140,
-        className: 'deposit_account',
-        clickable: true,
-        textOverview: true,
-      },
-      {
-        id: 'amount',
-        Header: intl.get('amount'),
-        accessor: (r) => <Money amount={r.amount} currency={r.currencyCode} />,
-        width: 140,
-        align: 'right',
-        clickable: true,
-        textOverview: true,
-        money: true,
-        className: clsx(CLASSES.FONT_BOLD),
-      },
-      {
-        id: 'status',
-        Header: intl.get('status'),
-        accessor: StatusAccessor,
-        width: 140,
-        className: 'status',
-        clickable: true,
-      },
-      {
-        id: 'reference_no',
-        Header: intl.get('reference_no'),
-        accessor: 'referenceNo',
-        width: 140,
-        className: 'reference_no',
-        clickable: true,
-        textOverview: true,
-      },
-    ],
+    () =>
+      [
+        {
+          id: 'receipt_date',
+          Header: intl.get('receipt_date'),
+          accessor: 'formattedReceiptDate',
+          width: 140,
+          className: 'receipt_date',
+          clickable: true,
+          textOverview: true,
+        },
+        {
+          id: 'customer',
+          Header: intl.get('customer_name'),
+          accessor: 'customer.displayName',
+          width: 140,
+          className: 'customer_id',
+          clickable: true,
+          textOverview: true,
+        },
+        {
+          id: 'receipt_number',
+          Header: intl.get('receipt_number'),
+          accessor: 'receiptNumber',
+          width: 140,
+          className: 'receipt_number',
+          clickable: true,
+          textOverview: true,
+        },
+        {
+          id: 'deposit_account',
+          Header: intl.get('deposit_account'),
+          accessor: 'depositAccount.name',
+          width: 140,
+          className: 'deposit_account',
+          clickable: true,
+          textOverview: true,
+        },
+        {
+          id: 'amount',
+          Header: intl.get('amount'),
+          accessor: (r: ReceiptTableRow) => (
+            <Money amount={r.total} currency={r.currencyCode} />
+          ),
+          width: 140,
+          align: 'right',
+          clickable: true,
+          textOverview: true,
+          money: true,
+          className: clsx(CLASSES.FONT_BOLD),
+        },
+        {
+          id: 'status',
+          Header: intl.get('status'),
+          accessor: StatusAccessor,
+          width: 140,
+          className: 'status',
+          clickable: true,
+        },
+        {
+          id: 'reference_no',
+          Header: intl.get('reference_no'),
+          accessor: 'referenceNo',
+          width: 140,
+          className: 'reference_no',
+          clickable: true,
+          textOverview: true,
+        },
+      ] as DataTableColumn<ReceiptTableRow>[],
     [],
   );
 }

--- a/packages/webapp/src/containers/Sales/Receipts/ReceiptsLanding/hooks/use-bulk-delete-receipts-dialog.ts
+++ b/packages/webapp/src/containers/Sales/Receipts/ReceiptsLanding/hooks/use-bulk-delete-receipts-dialog.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { DialogsName } from '@/constants/dialogs';
 import { useBulkDeleteDialog } from '@/hooks/dialogs/useBulkDeleteDialog';
 import { useValidateBulkDeleteReceipts } from '@/hooks/query/receipts';

--- a/packages/webapp/src/containers/Sales/Receipts/SaleReceiptsImport.tsx
+++ b/packages/webapp/src/containers/Sales/Receipts/SaleReceiptsImport.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { useHistory } from 'react-router-dom';
 import { DashboardInsider } from '@/components';
 import { ImportView } from '@/containers/Import';

--- a/packages/webapp/src/hooks/query/receipts/queries.ts
+++ b/packages/webapp/src/hooks/query/receipts/queries.ts
@@ -168,7 +168,10 @@ export function useCloseReceipt(
 
 export function useReceipts(
   query?: GetSaleReceiptsQuery,
-  props?: UseQueryOptions<SaleReceiptsListResponse, Error>,
+  props?: Omit<
+    UseQueryOptions<SaleReceiptsListResponse, Error, SaleReceiptsListResponse>,
+    'queryKey' | 'queryFn'
+  >,
 ) {
   const fetcher = useApiFetcher({ enableCamelCaseTransform: true });
   return useQuery({

--- a/packages/webapp/src/store/store.types.ts
+++ b/packages/webapp/src/store/store.types.ts
@@ -5,6 +5,7 @@ export interface TableQuery {
   pageIndex: number;
   filterRoles: IFilterRole[];
   viewSlug?: string | null;
+  customViewId?: number | null;
   inactiveMode?: boolean;
   sortBy?: Array<{ id: string; desc: boolean }>;
 }


### PR DESCRIPTION
## Description

Converts the webapp sales modules (Invoices, Estimates, Credit Notes, Payments Received, and Receipts) to fully typed TypeScript. Removes `@ts-nocheck` directives across the sales containers, types components and hooks (form contexts, universal search, receipts landing components/table/provider), and fixes related type issues in the shared `ColorInput`/`FColorInput` components and the receipts query hooks.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Run the webapp typecheck (`pnpm --filter @bigcapital/webapp run typecheck`) and lint (`pnpm --filter @bigcapital/webapp run lint:check`) on the branch to verify no TypeScript errors are introduced.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>