### PR TITLE
refactor(webapp): typescript conversion of workspace modules

### DIFF
--- a/packages/webapp/src/ee/workspaces/components/WorkspaceSwitchingOverlay.tsx
+++ b/packages/webapp/src/ee/workspaces/components/WorkspaceSwitchingOverlay.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import React from 'react';
 import { firstLettersArgs } from '@/utils';
 import '@/ee/workspaces/style/components/WorkspaceSwitchingOverlay.scss';

--- a/packages/webapp/src/ee/workspaces/containers/Alerts/WorkspacesAlerts.tsx
+++ b/packages/webapp/src/ee/workspaces/containers/Alerts/WorkspacesAlerts.tsx
@@ -1,3 +1,2 @@
-// @ts-nocheck
 // No workspace alerts - using dialogs instead
 export default [];

--- a/packages/webapp/src/ee/workspaces/containers/CreateWorkspaceDrawer/BuildingWorkspaceStep.tsx
+++ b/packages/webapp/src/ee/workspaces/containers/CreateWorkspaceDrawer/BuildingWorkspaceStep.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { ProgressBar, Intent } from '@blueprintjs/core';
 import { css } from '@emotion/css';
 import { x } from '@xstyled/emotion';
@@ -76,7 +75,7 @@ export default function BuildingWorkspaceStep({
   return (
     <x.div w="100%" maxW="700px" mx="auto" pt="80px">
       <x.div className={progressBarStyles}>
-        <ProgressBar intent={Intent.NONE} value={null} />
+        <ProgressBar intent={Intent.NONE} />
       </x.div>
 
       <x.div textAlign="center" mt={26}>

--- a/packages/webapp/src/ee/workspaces/containers/CreateWorkspaceDrawer/CreateWorkspaceDrawer.tsx
+++ b/packages/webapp/src/ee/workspaces/containers/CreateWorkspaceDrawer/CreateWorkspaceDrawer.tsx
@@ -1,11 +1,10 @@
-// @ts-nocheck
 import { Position } from '@blueprintjs/core';
 import styled from '@xstyled/emotion';
 import * as R from 'ramda';
 import React from 'react';
 import { CreateWorkspaceDrawerContent } from './CreateWorkspaceDrawerContent';
 import { Drawer, DrawerSuspense } from '@/components';
-import { withDrawers } from '@/containers/Drawer/withDrawers';
+import { withDrawers, WithDrawersProps } from '@/containers/Drawer/withDrawers';
 
 const CreateWorkspaceDrawerContainer = styled(Drawer)`
   &.bp4-drawer.bp4-dark,
@@ -22,7 +21,7 @@ function CreateWorkspaceDrawerRoot({
   // #withDrawer
   isOpen,
   payload,
-}) {
+}: WithDrawersProps & { name: string }) {
   return (
     <CreateWorkspaceDrawerContainer
       isOpen={isOpen}

--- a/packages/webapp/src/ee/workspaces/containers/CreateWorkspaceDrawer/CreateWorkspaceDrawerContent.tsx
+++ b/packages/webapp/src/ee/workspaces/containers/CreateWorkspaceDrawer/CreateWorkspaceDrawerContent.tsx
@@ -1,16 +1,20 @@
-// @ts-nocheck
 import { x } from '@xstyled/emotion';
 import * as R from 'ramda';
 import React from 'react';
 import { CreateWorkspaceStepper } from './CreateWorkspaceStepper';
 import { DrawerHeaderContent, FormattedMessage as T } from '@/components';
 import { DRAWERS } from '@/constants/drawers';
-import { withDrawerActions } from '@/containers/Drawer/withDrawerActions';
+import {
+  withDrawerActions,
+  WithDrawerActionsProps,
+} from '@/containers/Drawer/withDrawerActions';
 
 /**
  * Create workspace drawer content.
  */
-function CreateWorkspaceDrawerContentRoot({ closeDrawer }) {
+function CreateWorkspaceDrawerContentRoot({
+  closeDrawer,
+}: WithDrawerActionsProps) {
   const handleClose = () => {
     closeDrawer(DRAWERS.CREATE_WORKSPACE);
   };
@@ -20,7 +24,7 @@ function CreateWorkspaceDrawerContentRoot({ closeDrawer }) {
       display="flex"
       flex={1}
       flexDirection="column"
-      height="100%"
+      h="100%"
       minHeight={0}
     >
       <DrawerHeaderContent

--- a/packages/webapp/src/ee/workspaces/containers/CreateWorkspaceDrawer/CreateWorkspaceStepper.tsx
+++ b/packages/webapp/src/ee/workspaces/containers/CreateWorkspaceDrawer/CreateWorkspaceStepper.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { css } from '@emotion/css';
 import React, { useState } from 'react';
 import intl from 'react-intl-universal';

--- a/packages/webapp/src/ee/workspaces/containers/CreateWorkspaceDrawer/InviteUsersStep.tsx
+++ b/packages/webapp/src/ee/workspaces/containers/CreateWorkspaceDrawer/InviteUsersStep.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Button, Intent, InputGroup, MenuItem } from '@blueprintjs/core';
 import { Select } from '@blueprintjs/select';
 import { x } from '@xstyled/emotion';
@@ -34,7 +33,7 @@ export default function InviteUsersStep({
   onComplete,
 }: InviteUsersStepProps) {
   const isDarkMode = useIsDarkMode();
-  const { mutateAsync: bulkInviteMutate, isLoading: isSubmitting } =
+  const { mutateAsync: bulkInviteMutate, isPending: isSubmitting } =
     useBulkCreateInviteUsers();
   const { data: roles, isLoading: isRolesLoading } = useRoles();
 
@@ -103,7 +102,7 @@ export default function InviteUsersStep({
         try {
           emailValidationSchema.validateSync(invite.email);
         } catch (error) {
-          newErrors[invite.id] = error.message;
+          newErrors[invite.id] = (error as Error).message;
         }
 
         if (emails.includes(invite.email.toLowerCase())) {
@@ -201,7 +200,7 @@ export default function InviteUsersStep({
                   )}
                 </x.div>
 
-                <x.div width="180px">
+                <x.div w="180px">
                   <Select
                     items={roles || []}
                     itemRenderer={(role, { handleClick, modifiers }) => (

--- a/packages/webapp/src/ee/workspaces/containers/Dashboard/WorkspacesSidebar.tsx
+++ b/packages/webapp/src/ee/workspaces/containers/Dashboard/WorkspacesSidebar.tsx
@@ -1,10 +1,13 @@
-// @ts-nocheck
 import { Tooltip, Position, Spinner, Icon } from '@blueprintjs/core';
 import classNames from 'classnames';
 import * as R from 'ramda';
 import React, { useState } from 'react';
+import type { Workspace } from '@bigcapital/sdk-ts';
 import { DRAWERS } from '@/constants/drawers';
-import { withDrawerActions } from '@/containers/Drawer/withDrawerActions';
+import {
+  withDrawerActions,
+  WithDrawerActionsProps,
+} from '@/containers/Drawer/withDrawerActions';
 import { WorkspaceSwitchingOverlay } from '@/ee/workspaces/components/WorkspaceSwitchingOverlay';
 import { useWorkspaces } from '@/ee/workspaces/hooks/query';
 import { useSwitchOrganization } from '@/ee/workspaces/hooks/useSwitchOrganization';
@@ -16,7 +19,15 @@ import '@/ee/workspaces/style/containers/Dashboard/WorkspacesSidebar.scss';
 /**
  * Single workspace icon button.
  */
-function WorkspaceIcon({ workspace, isActive, onClick }) {
+function WorkspaceIcon({
+  workspace,
+  isActive,
+  onClick,
+}: {
+  workspace: Workspace;
+  isActive: boolean;
+  onClick: (organizationId: string, workspaceName: string) => void;
+}) {
   const name = workspace.metadata?.name || workspace.organizationId;
   const initials = firstLettersArgs(...(name || '').split(' '));
   const isDisabled = !workspace.isReady || workspace.isBuildRunning;
@@ -56,7 +67,11 @@ function WorkspaceIcon({ workspace, isActive, onClick }) {
 /**
  * Organizations list button.
  */
-function OrganizationsListButton({ openDrawer }) {
+function OrganizationsListButton({
+  openDrawer,
+}: {
+  openDrawer: (name: string, payload?: Record<string, unknown>) => void;
+}) {
   return (
     <Tooltip
       content="View all organizations"
@@ -80,7 +95,11 @@ function OrganizationsListButton({ openDrawer }) {
 /**
  * Add workspace button.
  */
-function AddWorkspaceButton({ openDrawer }) {
+function AddWorkspaceButton({
+  openDrawer,
+}: {
+  openDrawer: (name: string, payload?: Record<string, unknown>) => void;
+}) {
   return (
     <Tooltip
       content="Create workspace"
@@ -104,13 +123,18 @@ function AddWorkspaceButton({ openDrawer }) {
 /**
  * Workspaces sidebar container.
  */
-function WorkspacesSidebarRoot({ openDrawer }) {
+function WorkspacesSidebarRoot({ openDrawer }: WithDrawerActionsProps) {
   const { data: workspaces, isLoading } = useWorkspaces();
   const activeOrganizationId = useAuthOrganizationId();
   const switchOrganization = useSwitchOrganization();
-  const [switchingWorkspaceName, setSwitchingWorkspaceName] = useState(null);
+  const [switchingWorkspaceName, setSwitchingWorkspaceName] = useState<
+    string | null
+  >(null);
 
-  const handleSwitchWorkspace = (organizationId, workspaceName) => {
+  const handleSwitchWorkspace = (
+    organizationId: string,
+    workspaceName: string,
+  ) => {
     if (organizationId === activeOrganizationId) {
       return;
     }

--- a/packages/webapp/src/ee/workspaces/containers/Dialogs/WorkspaceDeleteDialog.tsx
+++ b/packages/webapp/src/ee/workspaces/containers/Dialogs/WorkspaceDeleteDialog.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import {
   Button,
   Classes,
@@ -13,20 +12,32 @@ import { x } from '@xstyled/emotion';
 import React, { useState } from 'react';
 import intl from 'react-intl-universal';
 import { FormattedMessage as T, AppToaster } from '@/components';
-import withDialogRedux from '@/components/DialogReduxConnect';
-import { withDialogActions } from '@/containers/Dialog/withDialogActions';
+import withDialogRedux, {
+  DialogBaseProps,
+} from '@/components/DialogReduxConnect';
+import {
+  withDialogActions,
+  WithDialogActionsProps,
+} from '@/containers/Dialog/withDialogActions';
 import { useDeleteWorkspace } from '@/ee/workspaces/hooks/query';
 import { compose } from '@/utils';
+
+type WorkspaceDeleteDialogPayload = {
+  organizationId?: string;
+  workspaceName?: string;
+};
 
 function WorkspaceDeleteDialog({
   dialogName,
   isOpen,
   payload: { organizationId, workspaceName } = {},
-
   // #withDialogActions
   closeDialog,
-}) {
-  const { mutateAsync: deleteWorkspace, isLoading } = useDeleteWorkspace();
+}: { dialogName: string } & Omit<DialogBaseProps, 'payload'> & {
+    payload?: WorkspaceDeleteDialogPayload;
+  } & WithDialogActionsProps) {
+  const { mutateAsync: deleteWorkspace, isPending: isLoading } =
+    useDeleteWorkspace();
   const [confirmText, setConfirmText] = useState('');
   const confirmationPhrase = `Delete ${workspaceName || organizationId}`;
   const canDelete = confirmText === confirmationPhrase;
@@ -37,6 +48,9 @@ function WorkspaceDeleteDialog({
   };
 
   const handleConfirmDelete = () => {
+    if (!organizationId) {
+      return;
+    }
     deleteWorkspace(organizationId)
       .then(() => {
         AppToaster.show({
@@ -117,7 +131,7 @@ function WorkspaceDeleteDialog({
             </x.li>
           </x.ul>
 
-          <Callout intent={Intent.DANGER} icon="">
+          <Callout intent={Intent.DANGER}>
             {intl.get('workspaces.delete_workspace_irreversible', {
               fallback:
                 'This action is irreversible. Please make sure you have exported any important data before proceeding.',

--- a/packages/webapp/src/ee/workspaces/containers/Dialogs/WorkspaceInactivateDialog.tsx
+++ b/packages/webapp/src/ee/workspaces/containers/Dialogs/WorkspaceInactivateDialog.tsx
@@ -1,16 +1,26 @@
-// @ts-nocheck
 import { Button, Classes, Dialog, Intent, Callout } from '@blueprintjs/core';
 import { x } from '@xstyled/emotion';
 import React from 'react';
 import intl from 'react-intl-universal';
 import { FormattedMessage as T, AppToaster } from '@/components';
-import withDialogRedux from '@/components/DialogReduxConnect';
-import { withDialogActions } from '@/containers/Dialog/withDialogActions';
+import withDialogRedux, {
+  DialogBaseProps,
+} from '@/components/DialogReduxConnect';
+import {
+  withDialogActions,
+  WithDialogActionsProps,
+} from '@/containers/Dialog/withDialogActions';
 import {
   useInactivateWorkspace,
   useActivateWorkspace,
 } from '@/ee/workspaces/hooks/query';
 import { compose } from '@/utils';
+
+type WorkspaceInactivateDialogPayload = {
+  organizationId?: string;
+  workspaceName?: string;
+  isActive?: boolean;
+};
 
 function WorkspaceInactivateDialog({
   dialogName,
@@ -19,10 +29,12 @@ function WorkspaceInactivateDialog({
 
   // #withDialogActions
   closeDialog,
-}) {
-  const { mutateAsync: inactivateWorkspace, isLoading: isInactivating } =
+}: { dialogName: string } & Omit<DialogBaseProps, 'payload'> & {
+    payload?: WorkspaceInactivateDialogPayload;
+  } & WithDialogActionsProps) {
+  const { mutateAsync: inactivateWorkspace, isPending: isInactivating } =
     useInactivateWorkspace();
-  const { mutateAsync: activateWorkspace, isLoading: isActivating } =
+  const { mutateAsync: activateWorkspace, isPending: isActivating } =
     useActivateWorkspace();
 
   const isLoading = isInactivating || isActivating;
@@ -33,6 +45,9 @@ function WorkspaceInactivateDialog({
   };
 
   const handleConfirm = () => {
+    if (!organizationId) {
+      return;
+    }
     const action = isInactivateAction ? inactivateWorkspace : activateWorkspace;
     const successMessage = isInactivateAction
       ? intl.get('workspaces.workspace_inactivated_successfully', {

--- a/packages/webapp/src/ee/workspaces/containers/OrganizationsListDrawer/OrganizationsListDrawer.tsx
+++ b/packages/webapp/src/ee/workspaces/containers/OrganizationsListDrawer/OrganizationsListDrawer.tsx
@@ -1,11 +1,10 @@
-// @ts-nocheck
 import { Position } from '@blueprintjs/core';
 import styled from '@xstyled/emotion';
 import * as R from 'ramda';
 import React from 'react';
 import { OrganizationsListDrawerContent } from './OrganizationsListDrawerContent';
 import { Drawer, DrawerSuspense } from '@/components';
-import { withDrawers } from '@/containers/Drawer/withDrawers';
+import { withDrawers, WithDrawersProps } from '@/containers/Drawer/withDrawers';
 
 const OrganizationsDrawer = styled(Drawer)`
   &.bp4-drawer.bp4-dark,
@@ -22,7 +21,7 @@ function OrganizationsListDrawerRoot({
   // #withDrawer
   isOpen,
   payload,
-}) {
+}: WithDrawersProps & { name: string }) {
   return (
     <OrganizationsDrawer
       isOpen={isOpen}

--- a/packages/webapp/src/ee/workspaces/containers/OrganizationsListDrawer/OrganizationsListDrawerContent.tsx
+++ b/packages/webapp/src/ee/workspaces/containers/OrganizationsListDrawer/OrganizationsListDrawerContent.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { FormGroup, InputGroup, Button } from '@blueprintjs/core';
 import { css } from '@emotion/css';
 import { x } from '@xstyled/emotion';
@@ -9,7 +8,10 @@ import intl from 'react-intl-universal';
 import { OrganizationsListDrawerHeader } from './OrganizationsListDrawerHeader';
 import OrganizationsListTable from './OrganizationsListTable';
 import { DRAWERS } from '@/constants/drawers';
-import { withDrawerActions } from '@/containers/Drawer/withDrawerActions';
+import {
+  withDrawerActions,
+  WithDrawerActionsProps,
+} from '@/containers/Drawer/withDrawerActions';
 import {
   useWorkspaces,
   useSetDefaultWorkspace,
@@ -62,7 +64,10 @@ const organizationsDrawerCreateBtnCss = css`
 /**
  * Organizations list drawer content.
  */
-function OrganizationsListDrawerContentRoot({ closeDrawer, openDrawer }) {
+function OrganizationsListDrawerContentRoot({
+  closeDrawer,
+  openDrawer,
+}: WithDrawerActionsProps) {
   const [searchQuery, setSearchQuery] = useState('');
   const [debouncedSearch, setDebouncedSearch] = useState('');
   const activeOrganizationId = useAuthOrganizationId();
@@ -80,13 +85,13 @@ function OrganizationsListDrawerContentRoot({ closeDrawer, openDrawer }) {
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const debouncedSetSearch = useCallback(
-    debounce((value) => {
+    debounce((value: string) => {
       setDebouncedSearch(value);
     }, 200),
     [],
   );
 
-  const handleSearchChange = (e) => {
+  const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
     setSearchQuery(value);
     debouncedSetSearch(value);
@@ -112,7 +117,7 @@ function OrganizationsListDrawerContentRoot({ closeDrawer, openDrawer }) {
   };
 
   return (
-    <x.div display="flex" flexDirection="column" height="100%" minHeight={0}>
+    <x.div display="flex" flexDirection="column" h="100%" minHeight={0}>
       <OrganizationsListDrawerHeader
         isCurrentOrgDefault={isCurrentOrgDefault}
         activeOrganizationId={activeOrganizationId}

--- a/packages/webapp/src/ee/workspaces/containers/OrganizationsListDrawer/OrganizationsListDrawerHeader.tsx
+++ b/packages/webapp/src/ee/workspaces/containers/OrganizationsListDrawer/OrganizationsListDrawerHeader.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Button, Switch } from '@blueprintjs/core';
 import { css } from '@emotion/css';
 import { x } from '@xstyled/emotion';
@@ -30,7 +29,7 @@ export function OrganizationsListDrawerHeader({
   onSetDefaultWorkspace,
   onClose,
 }: OrganizationsListDrawerHeaderProps) {
-  const handleChange = (e) => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (
       e.currentTarget.checked &&
       !isCurrentOrgDefault &&

--- a/packages/webapp/src/ee/workspaces/containers/OrganizationsListDrawer/OrganizationsListTable.tsx
+++ b/packages/webapp/src/ee/workspaces/containers/OrganizationsListDrawer/OrganizationsListTable.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import {
   Button,
   Intent,
@@ -15,6 +14,7 @@ import styled from '@xstyled/emotion';
 import React, { useState, useMemo, useCallback } from 'react';
 import intl from 'react-intl-universal';
 import { OrganizationsListWorkspaceCell } from './OrganizationsListWorkspaceCell';
+import type { Workspace } from '@bigcapital/sdk-ts';
 import { DataTable, TableSkeletonRows, AppToaster } from '@/components';
 import { DialogsName } from '@/constants/dialogs';
 import { withDialogActions } from '@/containers/Dialog/withDialogActions';
@@ -32,14 +32,21 @@ function OrganizationsListTable({
   isLoading,
   onClose,
   openDialog,
+}: {
+  workspaces: Workspace[];
+  isLoading: boolean;
+  onClose: () => void;
+  openDialog: (name: string, payload?: Record<string, unknown>) => void;
 }) {
   const activeOrganizationId = useAuthOrganizationId();
   const switchOrganization = useSwitchOrganization();
   const setDefaultWorkspace = useSetDefaultWorkspace();
-  const [switchingWorkspaceName, setSwitchingWorkspaceName] = useState(null);
+  const [switchingWorkspaceName, setSwitchingWorkspaceName] = useState<
+    string | null
+  >(null);
 
   const handleSwitchWorkspace = useCallback(
-    (organizationId, workspaceName) => {
+    (organizationId: string, workspaceName: string) => {
       if (organizationId === activeOrganizationId) {
         return;
       }
@@ -53,7 +60,7 @@ function OrganizationsListTable({
   );
 
   const handleSetDefault = useCallback(
-    (organizationId) => {
+    (organizationId: string) => {
       setDefaultWorkspace.mutateAsync({ organizationId }).then(() => {
         AppToaster.show({
           message: intl.get('workspaces.default_workspace_set_successfully', {
@@ -67,7 +74,7 @@ function OrganizationsListTable({
   );
 
   const handleDeleteWorkspace = useCallback(
-    (workspace) => {
+    (workspace: Workspace) => {
       openDialog(DialogsName.WorkspaceDelete, {
         organizationId: workspace.organizationId,
         workspaceName: workspace.metadata?.name || workspace.organizationId,
@@ -77,7 +84,7 @@ function OrganizationsListTable({
   );
 
   const handleInactivateWorkspace = useCallback(
-    (workspace) => {
+    (workspace: Workspace) => {
       openDialog(DialogsName.WorkspaceInactivate, {
         organizationId: workspace.organizationId,
         workspaceName: workspace.metadata?.name || workspace.organizationId,
@@ -95,7 +102,7 @@ function OrganizationsListTable({
         }),
         accessor: 'metadata.name',
         width: 320,
-        Cell: ({ row }) => (
+        Cell: ({ row }: { row: { original: Workspace } }) => (
           <OrganizationsListWorkspaceCell
             workspace={row.original}
             activeOrganizationId={activeOrganizationId}
@@ -106,7 +113,7 @@ function OrganizationsListTable({
         id: 'assets',
         Header: intl.get('workspaces.column_assets', { fallback: 'Assets' }),
         accessor: 'formattedTotalAssets',
-        Cell: ({ value }) => value || '-',
+        Cell: ({ value }: { value?: string }) => value || '-',
         align: 'right',
         width: 100,
       },
@@ -116,7 +123,7 @@ function OrganizationsListTable({
           fallback: 'Liabilities',
         }),
         accessor: 'formattedTotalLiabilities',
-        Cell: ({ value }) => value || '-',
+        Cell: ({ value }: { value?: string }) => value || '-',
         align: 'right',
         width: 100,
       },
@@ -125,7 +132,7 @@ function OrganizationsListTable({
         accessor: 'actions',
         width: 120,
         disableSortBy: true,
-        Cell: ({ row }) => {
+        Cell: ({ row }: { row: { original: Workspace } }) => {
           const workspace = row.original;
           const workspaceName =
             workspace.metadata?.name || workspace.organizationId;
@@ -146,7 +153,7 @@ function OrganizationsListTable({
           const canSetDefaultInMenu = !workspace.isDefault && !defaultDisabled;
 
           const menuContent = isOwner ? (
-            <Menu minimal>
+            <Menu>
               {canSetDefaultInMenu && (
                 <MenuItem
                   text={intl.get('workspaces.set_as_default', {
@@ -183,7 +190,7 @@ function OrganizationsListTable({
                 onClick={() => !isDisabled && handleDeleteWorkspace(workspace)}
               />
             </Menu>
-          ) : null;
+          ) : undefined;
 
           return (
             <x.div

--- a/packages/webapp/src/ee/workspaces/hooks/useSwitchOrganization.tsx
+++ b/packages/webapp/src/ee/workspaces/hooks/useSwitchOrganization.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';


### PR DESCRIPTION
## Description

Removes `@ts-nocheck` from all 15 files under `packages/webapp/src/ee/workspaces` and types them properly so the workspace modules type-check cleanly. The SDK types (`Workspace`, `OrganizationBuildJob`, `RoleResponseDto`) already covered the data shapes; the work was mostly wiring up HOC-injected prop types and fixing small type errors that the directive was masking.

Specific changes:
- Typed HOC-injected props using the existing typed HOCs: `WithDrawerActionsProps`, `WithDrawersProps & { name: string }`, and `DialogBaseProps` (dialogs get a local payload type for `organizationId`/`workspaceName`/`isActive`).
- Fixed react-query v5 migration: `useMutation` no longer exposes `isLoading` — switched to `isPending` in 4 spots (`InviteUsersStep`, `WorkspaceDeleteDialog`, `WorkspaceInactivateDialog`).
- Fixed Yup `catch (error)` typing — the error is `unknown` under `strict`, now cast to `Error`.
- Replaced invalid xstyled long-form props (`height="100%"` → `h="100%"`, `width="180px"` → `w="180px"`) — `@xstyled/system@3.8.1` only supports the short `w`/`h` forms.
- Removed invalid Blueprint props: `minimal` on `<Menu>` and `icon=""` on `<Callout>`; changed `menuContent` `null` → `undefined` for `Popover content`.
- Guarded mutation calls when the dialog payload `organizationId` may be `undefined`.
- Typed `OrganizationsListTable` props, callbacks, and column `Cell` renderers (DataTable has no contextual typing, so `Cell` params were previously implicit `any`).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- `npx tsc --noEmit` in `packages/webapp`: **0 errors** in `src/ee/workspaces`; no new type errors introduced elsewhere (the pre-existing errors outside `src/ee/workspaces` remain untouched).
- `npx eslint "src/ee/workspaces/**/*.{ts,tsx}"`: **0 errors** (13 pre-existing unused-variable warnings remain, none introduced by this change).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>