### PR TITLE
test(webapp): add manual journals e2e coverage

### DIFF
--- a/e2e/_journals.ts
+++ b/e2e/_journals.ts
@@ -1,0 +1,134 @@
+import { expect, type Page } from '@playwright/test';
+
+export const DEBIT_ACCOUNT = 'Petty Cash';
+export const CREDIT_ACCOUNT = 'Opening Balance Equity';
+
+/**
+ * Waits until the manual journals list page is loaded.
+ */
+export async function waitForJournalsPage(page: Page) {
+  await expect(page.getByTestId('dashboard-topbar').locator('h1')).toHaveText(
+    'Manual Journals',
+    { timeout: 30_000 },
+  );
+  await expect(
+    page.getByRole('button', { name: 'Journal Entry' }).first(),
+  ).toBeVisible({ timeout: 30_000 });
+}
+
+/**
+ * Waits until the journal form page is loaded for the given title
+ * (new or edit).
+ */
+export async function waitForJournalFormPage(page: Page, title: string) {
+  await expect(page.getByTestId('dashboard-topbar').locator('h1')).toHaveText(
+    title,
+    { timeout: 30_000 },
+  );
+  await expect(page.getByTestId('journal-date-input')).toBeVisible({
+    timeout: 30_000,
+  });
+}
+
+/**
+ * Selects the given account inside the journal entries table. The account cell
+ * is scoped to the journal form via `journal-account-cell`, and the given
+ * `index` targets the matching entries line.
+ */
+export async function selectEntryAccount(
+  page: Page,
+  index: number,
+  name: string,
+) {
+  const cell = page.getByTestId('journal-account-cell').nth(index);
+  const input = cell.locator('input');
+  await input.click();
+  await input.pressSequentially(name);
+
+  const item = page.getByRole('menuitem', { name: new RegExp(name) }).first();
+  await expect(item).toBeVisible({ timeout: 10_000 });
+  await item.click();
+}
+
+/**
+ * Fills the debit amount of the given entries line and commits the value by
+ * pressing Tab (which triggers the blur/commit and auto-adds the next line).
+ */
+export async function fillDebit(page: Page, index: number, amount: number) {
+  const input = page.getByTestId('journal-debit-input').nth(index);
+  await input.click();
+  await input.fill(String(amount));
+  await input.press('Tab');
+}
+
+/**
+ * Fills the credit amount of the given entries line and commits the value by
+ * pressing Tab (which triggers the blur/commit and auto-adds the next line).
+ */
+export async function fillCredit(page: Page, index: number, amount: number) {
+  const input = page.getByTestId('journal-credit-input').nth(index);
+  await input.click();
+  await input.fill(String(amount));
+  await input.press('Tab');
+}
+
+/**
+ * Creates a journal through the UI and expects the success toast alongside
+ * the redirect back to the journals list page. The journal number is
+ * auto-incremented and read from the form, and returned for later assertions.
+ */
+export async function createJournal(
+  page: Page,
+  {
+    reference,
+    description,
+    amount,
+    publish = true,
+    debitAccount = DEBIT_ACCOUNT,
+    creditAccount = CREDIT_ACCOUNT,
+  }: {
+    reference?: string;
+    description?: string;
+    amount: number;
+    publish?: boolean;
+    debitAccount?: string;
+    creditAccount?: string;
+  },
+): Promise<string> {
+  await waitForJournalsPage(page);
+
+  await page.getByRole('button', { name: 'Journal Entry' }).first().click();
+  await waitForJournalFormPage(page, 'New Journal');
+
+  const journalNumberInput = page.getByTestId('journal-number-input');
+  await expect(journalNumberInput).not.toHaveValue('', { timeout: 30_000 });
+  const journalNumber = await journalNumberInput.inputValue();
+
+  if (reference) {
+    await page.getByTestId('journal-reference-input').fill(reference);
+  }
+  if (description) {
+    const descriptionInput = page.getByTestId('journal-description-input');
+    await descriptionInput.click();
+    await descriptionInput.locator('textarea').fill(description);
+  }
+
+  await selectEntryAccount(page, 0, debitAccount);
+  await fillDebit(page, 0, amount);
+  await selectEntryAccount(page, 1, creditAccount);
+  await fillCredit(page, 1, amount);
+
+  await page
+    .getByRole('button', { name: publish ? 'Save and Publish' : 'Save as Draft' })
+    .click();
+
+  await expect(
+    page.getByText(
+      new RegExp(`The journal #${journalNumber} has been created successfully\\.`),
+    ),
+  ).toBeVisible({ timeout: 15_000 });
+
+  await waitForJournalsPage(page);
+
+  return journalNumber;
+}

--- a/e2e/manual-journals.spec.ts
+++ b/e2e/manual-journals.spec.ts
@@ -1,0 +1,257 @@
+import { test, expect, type Locator, type Page } from '@playwright/test';
+import { faker } from '@faker-js/faker';
+import {
+  createJournal,
+  selectEntryAccount,
+  waitForJournalsPage,
+  waitForJournalFormPage,
+} from './_journals';
+
+const referenceNo = () => `JR-${faker.string.alphanumeric(6).toUpperCase()}`;
+
+const journalAmount = () => faker.number.int({ min: 1000, max: 50000 });
+
+/**
+ * Filters the journals table by the given journal number and returns the
+ * matching row locator. The journal number is unique per journal, so the
+ * filtered table holds a single row.
+ */
+async function filterJournalsBy(page: Page, journalNumber: string) {
+  await page.getByRole('button', { name: /filter|filters applied/i }).click();
+  await page.getByPlaceholder('Value').first().fill(journalNumber);
+
+  const row = page.getByTestId('manual-journal-row').first();
+  await expect(row).toBeVisible({ timeout: 30_000 });
+
+  // Close the filter popover before interacting with the table.
+  await page.keyboard.press('Escape');
+
+  return row;
+}
+
+/**
+ * Deletes the given journal row through the context menu and expects the
+ * success toast.
+ */
+async function deleteJournalViaRow(page: Page, row: Locator) {
+  await row.click({ button: 'right' });
+  await page.getByRole('menuitem', { name: 'Delete Journal' }).click();
+
+  await expect(page.getByTestId('journal-delete-alert')).toBeVisible();
+  await page
+    .getByRole('dialog')
+    .filter({ has: page.getByTestId('journal-delete-alert') })
+    .getByRole('button', { name: 'Delete' })
+    .click();
+
+  await expect(
+    page.getByText('The journal has been deleted successfully'),
+  ).toBeVisible({ timeout: 15_000 });
+}
+
+/**
+ * Publishes the given draft journal row through the context menu and expects
+ * the success toast.
+ */
+async function publishJournalViaRow(page: Page, row: Locator) {
+  await row.click({ button: 'right' });
+  await page.getByRole('menuitem', { name: 'Publish Journal' }).click();
+
+  await expect(page.getByTestId('journal-publish-alert')).toBeVisible();
+  await page
+    .getByRole('dialog')
+    .filter({ has: page.getByTestId('journal-publish-alert') })
+    .getByRole('button', { name: 'Publish' })
+    .click();
+
+  await expect(
+    page.getByText('The manual journal has been published successfully.'),
+  ).toBeVisible({ timeout: 15_000 });
+}
+
+/**
+ * Opens the journal details drawer through the row context menu and returns
+ * the drawer locator.
+ */
+async function openJournalDetails(page: Page, row: Locator) {
+  await row.click({ button: 'right' });
+  await page.getByRole('menuitem', { name: 'View Details' }).click();
+
+  const drawer = page.getByTestId('journal-details-drawer');
+  await expect(drawer).toBeVisible({ timeout: 15_000 });
+
+  return drawer;
+}
+
+test.describe('manual journals', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/manual-journals');
+  });
+
+  test('should show the manual journals page.', async ({ page }) => {
+    await waitForJournalsPage(page);
+
+    await expect(
+      page.getByRole('button', { name: 'Journal Entry' }).first(),
+    ).toBeVisible();
+  });
+
+  test('should validate that credit and debit totals match.', async ({
+    page,
+  }) => {
+    await waitForJournalsPage(page);
+
+    await page.getByRole('button', { name: 'Journal Entry' }).first().click();
+    await waitForJournalFormPage(page, 'New Journal');
+
+    // Fill a single debit line without a matching credit line.
+    await selectEntryAccount(page, 0, 'Petty Cash');
+    const debitInput = page.getByTestId('journal-debit-input').first();
+    await debitInput.click();
+    await debitInput.fill(String(journalAmount()));
+    await debitInput.press('Tab');
+
+    await page.getByRole('button', { name: 'Save and Publish' }).click();
+
+    await expect(
+      page.getByText('Should total of credit and debit be equal.'),
+    ).toBeVisible({ timeout: 15_000 });
+  });
+
+  test('should create a journal (draft) successfully.', async ({ page }) => {
+    await waitForJournalsPage(page);
+
+    const reference = referenceNo();
+    const amount = journalAmount();
+
+    const journalNumber = await createJournal(page, {
+      reference,
+      description: faker.lorem.sentence(),
+      amount,
+      publish: false,
+    });
+
+    const row = await filterJournalsBy(page, journalNumber);
+    await expect(row.getByText('Draft')).toBeVisible();
+  });
+
+  test('should create and publish a journal successfully.', async ({
+    page,
+  }) => {
+    await waitForJournalsPage(page);
+
+    const reference = referenceNo();
+    const amount = journalAmount();
+
+    const journalNumber = await createJournal(page, {
+      reference,
+      description: faker.lorem.sentence(),
+      amount,
+    });
+
+    const row = await filterJournalsBy(page, journalNumber);
+    await expect(row.getByText('Published')).toBeVisible();
+  });
+
+  test('should publish a draft journal.', async ({ page }) => {
+    await waitForJournalsPage(page);
+
+    const reference = referenceNo();
+    const amount = journalAmount();
+
+    const journalNumber = await createJournal(page, {
+      reference,
+      amount,
+      publish: false,
+    });
+
+    const row = await filterJournalsBy(page, journalNumber);
+    await expect(row.getByText('Draft')).toBeVisible();
+
+    await publishJournalViaRow(page, row);
+
+    const publishedRow = await filterJournalsBy(page, journalNumber);
+    await expect(publishedRow.getByText('Published')).toBeVisible();
+  });
+
+  test('should view the journal details drawer.', async ({ page }) => {
+    await waitForJournalsPage(page);
+
+    const reference = referenceNo();
+    const amount = journalAmount();
+
+    const journalNumber = await createJournal(page, {
+      reference,
+      description: faker.lorem.sentence(),
+      amount,
+    });
+
+    const row = await filterJournalsBy(page, journalNumber);
+    const drawer = await openJournalDetails(page, row);
+
+    await expect(drawer.getByText(journalNumber)).toBeVisible();
+    await expect(drawer.getByText(reference)).toBeVisible();
+    await expect(drawer.getByText('Published')).toBeVisible();
+    await expect(drawer.getByText('Petty Cash')).toBeVisible();
+    await expect(drawer.getByText('Opening Balance Equity')).toBeVisible();
+  });
+
+  test('should edit a journal successfully.', async ({ page }) => {
+    await waitForJournalsPage(page);
+
+    const ref = referenceNo();
+    const newRef = referenceNo();
+    const amount = journalAmount();
+
+    const journalNumber = await createJournal(page, {
+      reference: ref,
+      description: faker.lorem.sentence(),
+      amount,
+    });
+
+    const row = await filterJournalsBy(page, journalNumber);
+    await row.click({ button: 'right' });
+    await page.getByRole('menuitem', { name: 'Edit Journal' }).click();
+
+    await waitForJournalFormPage(page, 'Edit Journal');
+    await expect(page.getByTestId('journal-reference-input')).toHaveValue(ref, {
+      timeout: 30_000,
+    });
+
+    await page.getByTestId('journal-reference-input').fill(newRef);
+    await page.getByRole('button', { name: 'Save', exact: true }).click();
+
+    await expect(
+      page.getByText(
+        new RegExp(`The journal #${journalNumber} has been edited successfully\\.`),
+      ),
+    ).toBeVisible({ timeout: 15_000 });
+
+    await waitForJournalsPage(page);
+
+    const editedRow = await filterJournalsBy(page, journalNumber);
+
+    // The edited reference should be reflected in the details drawer.
+    const drawer = await openJournalDetails(page, editedRow);
+    await expect(drawer.getByText(newRef)).toBeVisible();
+  });
+
+  test('should delete a journal successfully.', async ({ page }) => {
+    await waitForJournalsPage(page);
+
+    const reference = referenceNo();
+    const amount = journalAmount();
+
+    const journalNumber = await createJournal(page, {
+      reference,
+      amount,
+    });
+
+    const row = await filterJournalsBy(page, journalNumber);
+    await deleteJournalViaRow(page, row);
+
+    await expect(page.getByTestId('manual-journal-row')).toHaveCount(0, {
+      timeout: 15_000,
+    });
+  });
+});

--- a/packages/webapp/src/containers/Accounting/JournalsLanding/ManualJournalsDataTable.tsx
+++ b/packages/webapp/src/containers/Accounting/JournalsLanding/ManualJournalsDataTable.tsx
@@ -142,6 +142,7 @@ function ManualJournalsDataTableInner({
         columns={columns}
         data={manualJournals ?? []}
         manualSortBy={true}
+        rowTestId={'manual-journal-row'}
         selectionColumn={true}
         sticky={true}
         loading={isManualJournalsLoading}

--- a/packages/webapp/src/containers/Accounting/MakeJournal/MakeJournalEntriesHeaderFields.tsx
+++ b/packages/webapp/src/containers/Accounting/MakeJournal/MakeJournalEntriesHeaderFields.tsx
@@ -1,4 +1,4 @@
-import { Position } from '@blueprintjs/core';
+import { Position, type InputGroupProps2 } from '@blueprintjs/core';
 import { css } from '@emotion/css';
 import { useTheme } from '@emotion/react';
 import { Theme } from '@xstyled/emotion';
@@ -66,9 +66,12 @@ export function MakeJournalEntriesHeader() {
             minimal: true,
             fill: true,
           }}
-          inputProps={{
-            leftIcon: <Icon icon={'date-range'} />,
-          }}
+          inputProps={
+            {
+              leftIcon: <Icon icon={'date-range'} />,
+              'data-testId': 'journal-date-input',
+            } as InputGroupProps2
+          }
           fill
           fastField
         />
@@ -91,7 +94,11 @@ export function MakeJournalEntriesHeader() {
         inline
         fastField
       >
-        <FInputGroup name={'reference'} fill />
+        <FInputGroup
+          name={'reference'}
+          data-testId={'journal-reference-input'}
+          fill
+        />
       </FFormGroup>
 
       {/*------------ Journal type  ----------- */}
@@ -101,7 +108,11 @@ export function MakeJournalEntriesHeader() {
         inline
         fastField
       >
-        <FInputGroup name={'journalType'} fill />
+        <FInputGroup
+          name={'journalType'}
+          data-testId={'journal-type-input'}
+          fill
+        />
       </FFormGroup>
 
       {/*------------ Currency  -----------*/}

--- a/packages/webapp/src/containers/Accounting/MakeJournal/MakeJournalEntriesTable.tsx
+++ b/packages/webapp/src/containers/Accounting/MakeJournal/MakeJournalEntriesTable.tsx
@@ -76,6 +76,9 @@ export function MakeJournalEntriesTable({
       data={entries}
       sticky={true}
       totalRow={true}
+      cellTestId={(row, cell) =>
+        cell.column.id === 'accountId' ? 'journal-account-cell' : undefined
+      }
       payload={{
         accounts,
         errors: error,

--- a/packages/webapp/src/containers/Accounting/MakeJournal/MakeJournalFormFooterLeft.tsx
+++ b/packages/webapp/src/containers/Accounting/MakeJournal/MakeJournalFormFooterLeft.tsx
@@ -11,12 +11,14 @@ export function MakeJournalFormFooterLeft() {
         label={intl.get('description')}
         name={'description'}
       >
-        <FEditableText
-          name={'description'}
-          placeholder={intl.get('make_jorunal.decscrption.placeholder')}
-          multiline
-          fastField
-        />
+        <div data-testId={'journal-description-input'}>
+          <FEditableText
+            name={'description'}
+            placeholder={intl.get('make_jorunal.decscrption.placeholder')}
+            multiline
+            fastField
+          />
+        </div>
       </DescriptionFormGroup>
     </React.Fragment>
   );

--- a/packages/webapp/src/containers/Accounting/MakeJournal/MakeJournalTransactionNoField.tsx
+++ b/packages/webapp/src/containers/Accounting/MakeJournal/MakeJournalTransactionNoField.tsx
@@ -68,6 +68,7 @@ export const MakeJournalTransactionNoField = compose(withDialogActions)(({
       <ControlGroup fill={true}>
         <FInputGroup
           name={'journalNumber'}
+          data-testId={'journal-number-input'}
           fill={true}
           asyncControl={true}
           onBlur={handleJournalNoBlur}

--- a/packages/webapp/src/containers/Accounting/MakeJournal/components.tsx
+++ b/packages/webapp/src/containers/Accounting/MakeJournal/components.tsx
@@ -130,6 +130,7 @@ export const useJournalTableEntriesColumns = () => {
         disableSortBy: true,
         width: 100,
         align: Align.Right,
+        moneyInputGroupProps: { 'data-testId': 'journal-debit-input' },
       },
       {
         Header: CreditHeaderCell,
@@ -138,6 +139,7 @@ export const useJournalTableEntriesColumns = () => {
         disableSortBy: true,
         width: 100,
         align: Align.Right,
+        moneyInputGroupProps: { 'data-testId': 'journal-credit-input' },
       },
       {
         Header: ContactHeaderCell,

--- a/packages/webapp/src/containers/Alerts/ManualJournals/JournalDeleteAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/ManualJournals/JournalDeleteAlert.tsx
@@ -74,7 +74,7 @@ function JournalDeleteAlertInner({
       onConfirm={handleConfirmManualJournalDelete}
       loading={isLoading}
     >
-      <p>
+      <p data-testId={'journal-delete-alert'}>
         <T id={'once_delete_this_journal_you_will_able_to_restore_it'} />
       </p>
     </Alert>

--- a/packages/webapp/src/containers/Alerts/ManualJournals/JournalPublishAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/ManualJournals/JournalPublishAlert.tsx
@@ -65,7 +65,7 @@ function JournalPublishAlertInner({
       onConfirm={handleConfirm}
       loading={isLoading}
     >
-      <p>
+      <p data-testId={'journal-publish-alert'}>
         <T id={'are_sure_to_publish_this_manual_journal'} />
       </p>
     </Alert>

--- a/packages/webapp/src/containers/Drawers/ManualJournalDrawer/ManualJournalDrawerDetails.tsx
+++ b/packages/webapp/src/containers/Drawers/ManualJournalDrawer/ManualJournalDrawerDetails.tsx
@@ -11,7 +11,7 @@ import { CommercialDocBox } from '@/components';
  */
 export function ManualJournalDrawerDetails() {
   return (
-    <ManualJournalDetailsRoot>
+    <ManualJournalDetailsRoot data-testId={'journal-details-drawer'}>
       <ManualJournalDrawerActionBar />
 
       <CommercialDocBox>


### PR DESCRIPTION
## Description

Adds Playwright e2e coverage for the manual journals module (CRUD), mirroring the existing `e2e/expenses.spec.ts` / `e2e/_expenses.ts` patterns.

- Adds `e2e/_journals.ts` helper: page waits, account selection, debit/credit entry fills, and a `createJournal` helper that reads the auto-incremented journal number.
- Adds `e2e/manual-journals.spec.ts` covering: list page load, unbalanced credit/debit validation, create draft, create and publish, publish a draft, journal details drawer, edit, and delete.
- Adds the `data-testId` hooks the specs rely on, scoped to the journal module only (list row, form header fields, journal number, entries debit/credit inputs, account cell, delete/publish alerts, details drawer, description field).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Ran the full manual-journals spec against a locally running server (`:3000`) and webapp (`:4000`):

```bash
pnpm run e2e:webapp --grep "manual journals"
```

All 8 tests pass (8 passed, 3.5m). Verified no new TypeScript errors in the touched webapp files and `eslint` passes with no new warnings.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>