### PR TITLE
fix(server): prevent activating/inactivating the current user

### DIFF
--- a/packages/server/src/modules/UsersModule/Users.controller.ts
+++ b/packages/server/src/modules/UsersModule/Users.controller.ts
@@ -4,6 +4,7 @@ import {
   Delete,
   Get,
   Param,
+  ParseIntPipe,
   Put,
   Query,
 } from '@nestjs/common';
@@ -117,7 +118,7 @@ export class UsersController {
       example: { id: 1, message: 'The user has been activated successfully.' },
     },
   })
-  async activateUser(@Param('id') userId: number) {
+  async activateUser(@Param('id', ParseIntPipe) userId: number) {
     await this.usersApplication.activateUser(userId);
 
     return {
@@ -141,7 +142,7 @@ export class UsersController {
       },
     },
   })
-  async inactivateUser(@Param('id') userId: number) {
+  async inactivateUser(@Param('id', ParseIntPipe) userId: number) {
     await this.usersApplication.inactivateUser(userId);
 
     return {

--- a/packages/server/src/modules/UsersModule/commands/ActivateUser.service.ts
+++ b/packages/server/src/modules/UsersModule/commands/ActivateUser.service.ts
@@ -7,7 +7,6 @@ import { Inject, Injectable } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { ERRORS } from '../Users.constants';
 import { ModelObject } from 'objection';
-import { SystemUser } from '@/modules/System/models/SystemUser';
 import { ITenantUserActivatedPayload } from '../Users.types';
 
 @Injectable()
@@ -26,9 +25,13 @@ export class ActivateUserService {
    */
   public async activateUser(userId: number): Promise<void> {
     const authorizedUser = await this.tenancyContext.getSystemUser();
+    const authorizedTenantUser = await this.tenantUserModel()
+      .query()
+      .findOne({ systemUserId: authorizedUser.id })
+      .throwIfNotFound();
 
     // Throw service error if the given user is equals the authorized user.
-    this.throwErrorIfUserSameAuthorizedUser(userId, authorizedUser);
+    this.throwErrorIfUserSameAuthorizedUser(userId, authorizedTenantUser);
 
     // Retrieve the user or throw not found service error.
     const tenantUser = await this.tenantUserModel().query().findById(userId);
@@ -67,9 +70,9 @@ export class ActivateUserService {
    */
   private throwErrorIfUserSameAuthorizedUser(
     userId: number,
-    authorizedUser: ModelObject<SystemUser>,
+    authorizedUser: ModelObject<TenantUser>,
   ) {
-    if (userId === authorizedUser.id) {
+    if (Number(userId) === authorizedUser.id) {
       throw new ServiceError(ERRORS.USER_SAME_THE_AUTHORIZED_USER);
     }
   }

--- a/packages/server/src/modules/UsersModule/commands/InactivateUser.service.ts
+++ b/packages/server/src/modules/UsersModule/commands/InactivateUser.service.ts
@@ -65,7 +65,7 @@ export class InactivateUserService {
     userId: number,
     authorizedUser: ModelObject<TenantUser>,
   ) {
-    if (userId === authorizedUser.id) {
+    if (Number(userId) === authorizedUser.id) {
       throw new ServiceError(ERRORS.USER_SAME_THE_AUTHORIZED_USER);
     }
   }

--- a/packages/server/test/init-app-test.ts
+++ b/packages/server/test/init-app-test.ts
@@ -11,6 +11,7 @@ const password = '1231231230';
 let orgainzationId = '';
 let authenticationToken = '';
 let AuthorizationHeader = '';
+let authenticatedUserId: number | undefined;
 
 beforeAll(async () => {
   const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -27,6 +28,7 @@ beforeAll(async () => {
   authenticationToken = signinResponse.body.access_token;
   AuthorizationHeader = `Bearer ${authenticationToken}`;
   orgainzationId = signinResponse.body.organization_id;
+  authenticatedUserId = signinResponse.body.user_id;
 });
 
 afterAll(async () => {
@@ -34,4 +36,10 @@ afterAll(async () => {
 });
 jest.retryTimes(3, { logErrorsBeforeRetry: true });
 
-export { app, orgainzationId, authenticationToken, AuthorizationHeader };
+export {
+  app,
+  orgainzationId,
+  authenticationToken,
+  AuthorizationHeader,
+  authenticatedUserId,
+};

--- a/packages/server/test/users.e2e-spec.ts
+++ b/packages/server/test/users.e2e-spec.ts
@@ -1,6 +1,11 @@
 import request = require('supertest');
 import { faker } from '@faker-js/faker';
-import { app, AuthorizationHeader, orgainzationId } from './init-app-test';
+import {
+  app,
+  AuthorizationHeader,
+  authenticatedUserId,
+  orgainzationId,
+} from './init-app-test';
 
 let userId;
 
@@ -15,6 +20,25 @@ describe('Users (e2e)', () => {
       userId = usersResponse.body[0].id;
     }
   });
+
+  /**
+   * Retrieves the tenant user id of the currently authenticated user by
+   * matching the `system_user_id` of the users list against the system user
+   * id returned by the sign-in response.
+   * @returns {Promise<number | undefined>}
+   */
+  const getAuthenticatedUserTenantId = async () => {
+    const usersResponse = await request(app.getHttpServer())
+      .get('/users')
+      .set('organization-id', orgainzationId)
+      .set('Authorization', AuthorizationHeader);
+
+    const currentUser = usersResponse.body.find(
+      (user) => user.system_user_id === authenticatedUserId,
+    );
+
+    return currentUser?.id;
+  };
 
   it('/users (GET)', () => {
     return request(app.getHttpServer())
@@ -76,45 +100,31 @@ describe('Users (e2e)', () => {
     }
   });
 
-  // it('/users/:id/activate (PUT)', async () => {
-  //   if (!userId) {
-  //     const usersResponse = await request(app.getHttpServer())
-  //       .get('/users')
-  //       .set('organization-id', orgainzationId)
-  //       .set('Authorization', AuthorizationHeader);
+  it('/users/:id/activate (PUT) - cannot activate the current user', async () => {
+    const currentUserTenantId = await getAuthenticatedUserTenantId();
+    expect(currentUserTenantId).toBeDefined();
 
-  //     if (usersResponse.body.length > 0) {
-  //       userId = usersResponse.body[0].id;
-  //     }
-  //   }
+    return request(app.getHttpServer())
+      .put(`/users/${currentUserTenantId}/activate`)
+      .set('organization-id', orgainzationId)
+      .set('Authorization', AuthorizationHeader)
+      .expect(400)
+      .expect((res) => {
+        expect(res.body.errors[0].type).toBe('USER_SAME_THE_AUTHORIZED_USER');
+      });
+  });
 
-  //   if (userId) {
-  //     return request(app.getHttpServer())
-  //       .put(`/users/${userId}/activate`)
-  //       .set('organization-id', orgainzationId)
-  //       .set('Authorization', AuthorizationHeader)
-  //       .expect(200);
-  //   }
-  // });
+  it('/users/:id/inactivate (PUT) - cannot inactivate the current user', async () => {
+    const currentUserTenantId = await getAuthenticatedUserTenantId();
+    expect(currentUserTenantId).toBeDefined();
 
-  // it('/users/:id/inactivate (PUT)', async () => {
-  //   if (!userId) {
-  //     const usersResponse = await request(app.getHttpServer())
-  //       .get('/users')
-  //       .set('organization-id', orgainzationId)
-  //       .set('Authorization', AuthorizationHeader);
-
-  //     if (usersResponse.body.length > 0) {
-  //       userId = usersResponse.body[0].id;
-  //     }
-  //   }
-
-  //   if (userId) {
-  //     return request(app.getHttpServer())
-  //       .put(`/users/${userId}/inactivate`)
-  //       .set('organization-id', orgainzationId)
-  //       .set('Authorization', AuthorizationHeader)
-  //       .expect(200);
-  //   }
-  // });
+    return request(app.getHttpServer())
+      .put(`/users/${currentUserTenantId}/inactivate`)
+      .set('organization-id', orgainzationId)
+      .set('Authorization', AuthorizationHeader)
+      .expect(400)
+      .expect((res) => {
+        expect(res.body.errors[0].type).toBe('USER_SAME_THE_AUTHORIZED_USER');
+      });
+  });
 });

--- a/packages/webapp/src/containers/Alerts/Users/UserActivateAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Users/UserActivateAlert.tsx
@@ -18,6 +18,14 @@ interface UserActivateAlertProps extends WithAlertActionsProps {
   payload: UserActivateAlertPayload;
 }
 
+interface UserActivateError {
+  type: string;
+}
+
+interface UserActivateErrorResponse {
+  data: { errors?: UserActivateError[] };
+}
+
 /**
  * User activate alert.
  */
@@ -38,12 +46,14 @@ function UserActivateAlertInner({
           intent: Intent.SUCCESS,
         });
       })
-      .catch((error: Error) => {
-        // Bugfix: original @ts-nocheck silently closed the alert on error without surfacing the failure.
-        AppToaster.show({
-          message: error.message,
-          intent: Intent.DANGER,
-        });
+      .catch((error: UserActivateErrorResponse) => {
+        const errors = error?.data?.errors ?? [];
+        if (errors.find((e) => e.type === 'USER_SAME_THE_AUTHORIZED_USER')) {
+          AppToaster.show({
+            message: intl.get('cannot_toggle_authorized_user'),
+            intent: Intent.DANGER,
+          });
+        }
       })
       .finally(() => {
         closeAlert(name);

--- a/packages/webapp/src/containers/Alerts/Users/UserInactivateAlert.tsx
+++ b/packages/webapp/src/containers/Alerts/Users/UserInactivateAlert.tsx
@@ -22,6 +22,10 @@ interface UserInactivateError {
   type: string;
 }
 
+interface UserInactivateErrorResponse {
+  data: { errors?: UserInactivateError[] };
+}
+
 /**
  * User inactivate alert.
  */
@@ -42,21 +46,15 @@ function UserInactivateAlertInner({
           intent: Intent.SUCCESS,
         });
       })
-      .catch(
-        ({ data: { errors } }: { data: { errors: UserInactivateError[] } }) => {
-          if (
-            errors.find(
-              (e) => e.type === 'CANNOT.TOGGLE.ACTIVATE.AUTHORIZED.USER',
-            )
-          ) {
-            AppToaster.show({
-              message:
-                'You could not activate/inactivate the same authorized user.',
-              intent: Intent.DANGER,
-            });
-          }
-        },
-      )
+      .catch((error: UserInactivateErrorResponse) => {
+        const errors = error?.data?.errors ?? [];
+        if (errors.find((e) => e.type === 'USER_SAME_THE_AUTHORIZED_USER')) {
+          AppToaster.show({
+            message: intl.get('cannot_toggle_authorized_user'),
+            intent: Intent.DANGER,
+          });
+        }
+      })
       .finally(() => {
         closeAlert(name);
       });

--- a/packages/webapp/src/lang/ar/index.json
+++ b/packages/webapp/src/lang/ar/index.json
@@ -285,6 +285,8 @@
   "delete_user": "حذف المستخدم",
   "full_name": "الاسم بالكامل",
   "the_user_has_been_inactivated_successfully": "تم تعطيل المستخدم بنجاح.",
+  "the_user_has_been_activated_successfully": "تم تفعيل المستخدم بنجاح.",
+  "cannot_toggle_authorized_user": "لا يمكنك تفعيل أو تعطيل حسابك الخاص.",
   "the_user_has_been_deleted_successfully": "تم حذف المستخدم بنجاح.",
   "customize_report": "تخصيص التقرير",
   "print": "طباعة",

--- a/packages/webapp/src/lang/en/index.json
+++ b/packages/webapp/src/lang/en/index.json
@@ -357,6 +357,8 @@
   "delete_user": "Delete User",
   "full_name": "Full Name",
   "the_user_has_been_inactivated_successfully": "The user has been inactivated successfully.",
+  "the_user_has_been_activated_successfully": "The user has been activated successfully.",
+  "cannot_toggle_authorized_user": "You cannot activate or inactivate your own account.",
   "the_user_has_been_deleted_successfully": "The user has been deleted successfully.",
   "customize_report": "Customize Report",
   "print": "Print",

--- a/packages/webapp/src/lang/es/index.json
+++ b/packages/webapp/src/lang/es/index.json
@@ -282,6 +282,8 @@
   "delete_user": "Eliminar usuario",
   "full_name": "Nombre completo",
   "the_user_has_been_inactivated_successfully": "El usuario ha sido inactivado exitosamente.",
+  "the_user_has_been_activated_successfully": "El usuario ha sido activado exitosamente.",
+  "cannot_toggle_authorized_user": "No puedes activar o inactivar tu propia cuenta.",
   "the_user_has_been_deleted_successfully": "El usuario ha sido eliminado exitosamente.",
   "customize_report": "Personalizar informe",
   "print": "Imprimir",

--- a/packages/webapp/src/lang/sv/index.json
+++ b/packages/webapp/src/lang/sv/index.json
@@ -276,6 +276,8 @@
   "delete_user": "Ta bort användare",
   "full_name": "Fullständigt namn",
   "the_user_has_been_inactivated_successfully": "Användaren har inaktiverats framgångsrikt.",
+  "the_user_has_been_activated_successfully": "Användaren har aktiverats framgångsrikt.",
+  "cannot_toggle_authorized_user": "Du kan inte aktivera eller inaktivera ditt eget konto.",
   "the_user_has_been_deleted_successfully": "Användaren har tagits bort framgångsrikt.",
   "customize_report": "Anpassa rapporten",
   "print": "Tryck",


### PR DESCRIPTION
## Description

Prevents a user from activating or inactivating their own account in the Users preferences.

The server-side guard (`USER_SAME_THE_AUTHORIZED_USER`) existed for both endpoints but never fired: the `:id` URL param arrived as a string and was compared with strict equality against the numeric authorized tenant user id, so `"1" === 1` was always false and the current user could be toggled successfully. This surfaced as an empty toast (activate) or no feedback (inactivate).

Changes:
- Add `ParseIntPipe` to the activate/inactivate endpoints and coerce the comparison in both services so the guard actually triggers.
- Surface the `USER_SAME_THE_AUTHORIZED_USER` error in `UserActivateAlert` and `UserInactivateAlert` with a localized danger toast instead of an empty message.
- Add the missing activate-success translation (`the_user_has_been_activated_successfully`) and a `cannot_toggle_authorized_user` message in en/es/ar/sv.
- Add e2e coverage asserting that activating/inactivating the current user returns `400` with `USER_SAME_THE_AUTHORIZED_USER`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Manually verified against a running dev stack: `PUT /users/:id/activate` and `PUT /users/:id/inactivate` on the current user return `400` with `{"errors":[{"type":"USER_SAME_THE_AUTHORIZED_USER"}]}`.
- Server e2e: `users.e2e-spec.ts` passes all tests (including the two new current-user rejection cases).
- Server typecheck and ESLint pass for the changed files.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>