### PR TITLE
fix(server): correct sale/purchase GL entries for tax, adjustment and exchange rate

### DIFF
--- a/packages/server/src/modules/Bills/commands/BillsGL.ts
+++ b/packages/server/src/modules/Bills/commands/BillsGL.ts
@@ -142,7 +142,7 @@ export class BillGL {
 
     return {
       ...commonJournalMeta,
-      debit: entry.taxAmount,
+      debit: entry.taxAmount * (this.bill.exchangeRate || 1),
       index,
       indexGroup: 30,
       accountId: this.taxPayableAccountId,

--- a/packages/server/src/modules/Bills/models/Bill.ts
+++ b/packages/server/src/modules/Bills/models/Bill.ts
@@ -1,5 +1,4 @@
 import * as moment from 'moment';
-import * as R from 'ramda';
 import type { Knex } from 'knex';
 import { Model, raw } from 'objection';
 import { castArray, difference, defaultTo } from 'lodash';
@@ -183,12 +182,11 @@ export class Bill extends TenantBaseModel {
    */
   get total(): number {
     const adjustmentAmount = defaultTo(this.adjustment, 0);
+    const totalTax = this.isInclusiveTax
+      ? 0
+      : defaultTo(this.taxAmountWithheld, 0);
 
-    return R.compose(
-      R.add(adjustmentAmount),
-      R.subtract(R.__, this.discountAmount),
-      R.when(R.always(this.isInclusiveTax), R.add(this.taxAmountWithheld)),
-    )(this.subtotal);
+    return this.subtotal - this.discountAmount + adjustmentAmount + totalTax;
   }
 
   /**

--- a/packages/server/src/modules/SaleInvoices/commands/writeoff/SaleInvoiceWriteoffGL.ts
+++ b/packages/server/src/modules/SaleInvoices/commands/writeoff/SaleInvoiceWriteoffGL.ts
@@ -77,7 +77,7 @@ export class SaleInvoiceWriteoffGL {
 
     return {
       ...commontEntry,
-      debit: this.saleInvoiceModel.writtenoffAmount,
+      debit: this.saleInvoiceModel.writtenoffAmountLocal,
       accountId: this.saleInvoiceModel.writtenoffExpenseAccountId,
       credit: 0,
       index: 2,

--- a/packages/server/src/modules/SaleInvoices/ledger/InvoiceGL.ts
+++ b/packages/server/src/modules/SaleInvoices/ledger/InvoiceGL.ts
@@ -134,7 +134,7 @@ export class InvoiceGL {
 
     return {
       ...commonEntry,
-      credit: entry.taxAmount,
+      credit: entry.taxAmount * this.saleInvoice.exchangeRate,
       accountId: this.taxPayableAccountId,
       index: index + 1,
       indexGroup: 30,

--- a/packages/server/src/modules/SaleInvoices/models/SaleInvoice.ts
+++ b/packages/server/src/modules/SaleInvoices/models/SaleInvoice.ts
@@ -1,5 +1,4 @@
 import * as moment from 'moment';
-import * as R from 'ramda';
 import { Model, raw } from 'objection';
 import { castArray } from 'lodash';
 import { MomentInput, unitOfTime } from 'moment';
@@ -213,13 +212,12 @@ export class SaleInvoice extends TenantBaseModel {
    * @returns {number}
    */
   get total() {
-    const adjustmentAmount = defaultTo(this.adjustment, 0);
+    const adjustmentAmount = defaultTo(0, this.adjustment);
+    const totalTax = this.isInclusiveTax
+      ? 0
+      : defaultTo(0, this.taxAmountWithheld);
 
-    return R.compose(
-      R.add(adjustmentAmount),
-      R.subtract(R.__, this.discountAmount),
-      R.when(R.always(this.isInclusiveTax), R.add(this.taxAmountWithheld)),
-    )(this.subtotal);
+    return this.subtotal - this.discountAmount + adjustmentAmount + totalTax;
   }
 
   /**

--- a/packages/server/test/_utils/gl.ts
+++ b/packages/server/test/_utils/gl.ts
@@ -1,0 +1,219 @@
+import request = require('supertest');
+import { faker } from '@faker-js/faker';
+import { app, AuthorizationHeader, orgainzationId } from '../init-app-test';
+
+/**
+ * GL test helpers that assert on the `accounts_transactions` legs posted for a
+ * given transaction, read back through `GET /reports/transactions-by-reference`.
+ */
+
+export interface GLTestLeg {
+  accountId: number;
+  accountCode: string;
+  accountName: string;
+  contactId: number;
+  contactType: string;
+  credit: { amount: number };
+  debit: { amount: number };
+  referenceType: string;
+  referenceId: number;
+}
+
+export interface RawGLTestLeg {
+  account_id?: number;
+  account_code?: string;
+  account_name?: string;
+  contact_id?: number;
+  contact_type?: string;
+  credit?: { amount?: number } | number;
+  debit?: { amount?: number } | number;
+  reference_type?: string;
+  reference_id?: number;
+}
+
+export const authHeaders = () => ({
+  'organization-id': orgainzationId,
+  Authorization: AuthorizationHeader,
+});
+
+export const cancelTransactionsLock = () =>
+  request(app.getHttpServer())
+    .put('/transactions-locking/cancel-lock')
+    .set(authHeaders())
+    .send({ reason: 'Cancel lock for GL e2e test' })
+    .expect(200);
+
+/**
+ * Retrieves the organization base currency so tests can create contacts in the
+ * tenant's base currency (which uses the seeded chart of accounts).
+ */
+export const getBaseCurrency = async (): Promise<string> => {
+  const res = await request(app.getHttpServer())
+    .get('/organization/current')
+    .set(authHeaders())
+    .expect(200);
+
+  return res.body.metadata.base_currency;
+};
+
+const legAmount = (amount: any): number =>
+  Number(amount?.amount ?? amount ?? 0);
+
+/**
+ * Fetches the GL legs posted for a transaction reference.
+ * The report endpoint serializes camelCase DTO keys to snake_case on the wire,
+ * so the raw legs are normalized here for convenient assertions.
+ */
+export const fetchLegs = async (
+  referenceType: string,
+  referenceId: number,
+): Promise<GLTestLeg[]> => {
+  const res = await request(app.getHttpServer())
+    .get('/reports/transactions-by-reference')
+    .set(authHeaders())
+    .query({ referenceType, referenceId })
+    .expect(200);
+
+  return (res.body.transactions as RawGLTestLeg[]).map((t) => ({
+    accountId: t.account_id,
+    accountCode: t.account_code,
+    accountName: t.account_name,
+    contactId: t.contact_id,
+    contactType: t.contact_type,
+    credit: { amount: legAmount(t.credit) },
+    debit: { amount: legAmount(t.debit) },
+    referenceType: t.reference_type,
+    referenceId: t.reference_id,
+  }));
+};
+
+export const sumDebits = (legs: GLTestLeg[]) =>
+  legs.reduce((sum, leg) => sum + legAmount(leg.debit), 0);
+
+export const sumCredits = (legs: GLTestLeg[]) =>
+  legs.reduce((sum, leg) => sum + legAmount(leg.credit), 0);
+
+/**
+ * Asserts the journal is balanced (total debits equal total credits).
+ */
+export const expectBalanced = (legs: GLTestLeg[]) => {
+  const debits = sumDebits(legs);
+  const credits = sumCredits(legs);
+
+  expect(debits).toBeCloseTo(credits, 2);
+};
+
+export interface GLExpectLeg {
+  accountCode?: string;
+  contactId?: number;
+  debit?: number;
+  credit?: number;
+}
+
+/**
+ * Asserts a leg exists matching the given account code and/or contact id and
+ * carries the expected debit/credit amount (close to two decimal places).
+ */
+export const expectLeg = (
+  legs: GLTestLeg[],
+  expected: GLExpectLeg,
+  label = '',
+) => {
+  const { accountCode, contactId, debit, credit } = expected;
+  const leg = legs.find(
+    (l) =>
+      (accountCode !== undefined ? l.accountCode === accountCode : true) &&
+      (contactId !== undefined ? l.contactId === contactId : true),
+  );
+
+  if (!leg) {
+    throw new Error(`Missing GL leg for ${label} ${JSON.stringify(expected)}`);
+  }
+
+  if (debit !== undefined) {
+    expect(legAmount(leg.debit)).toBeCloseTo(debit, 2);
+  }
+  if (credit !== undefined) {
+    expect(legAmount(leg.credit)).toBeCloseTo(credit, 2);
+  }
+};
+
+/**
+ * Asserts the journal contains only the expected legs (matched by account code
+ * for non-contact legs and by contact id for contact legs), ignoring any
+ * zero-amount legs.
+ */
+export const expectLegs = (
+  legs: GLTestLeg[],
+  expected: GLExpectLeg[],
+  referenceLabel = '',
+) => {
+  const nonZeroLegs = legs.filter(
+    (leg) => legAmount(leg.debit) !== 0 || legAmount(leg.credit) !== 0,
+  );
+
+  expect(nonZeroLegs.length).toBe(expected.length);
+
+  expected.forEach((exp) => expectLeg(nonZeroLegs, exp, referenceLabel));
+};
+
+export const createCustomer = async (currencyCode: string) => {
+  const res = await request(app.getHttpServer())
+    .post('/customers')
+    .set(authHeaders())
+    .send({
+      displayName: `GL Test Customer ${Date.now()}-${faker.string.alphanumeric({ length: 4 })}`,
+      customerType: 'business',
+      currencyCode,
+    })
+    .expect(201);
+
+  return res.body.id;
+};
+
+export const createVendor = async (currencyCode: string) => {
+  const res = await request(app.getHttpServer())
+    .post('/vendors')
+    .set(authHeaders())
+    .send({
+      displayName: `GL Test Vendor ${Date.now()}-${faker.string.alphanumeric({ length: 4 })}`,
+      currencyCode,
+    })
+    .expect(201);
+
+  return res.body.id;
+};
+
+export const createServiceItem = async () => {
+  const res = await request(app.getHttpServer())
+    .post('/items')
+    .set(authHeaders())
+    .send({
+      name: `${faker.commerce.productName()} ${Date.now()}-${faker.string.alphanumeric({ length: 4 })}`,
+      type: 'service',
+      sellable: true,
+      purchasable: true,
+      sellAccountId: 1026,
+      costAccountId: 1019,
+      costPrice: 100,
+      sellPrice: 100,
+    })
+    .expect(201);
+
+  return parseInt(res.body.id, 10);
+};
+
+export const createTaxRate = async (rate: number) => {
+  const res = await request(app.getHttpServer())
+    .post('/tax-rates')
+    .set(authHeaders())
+    .send({
+      name: `GL Tax ${rate}% ${faker.string.alphanumeric({ length: 4 })}`,
+      rate,
+      code: faker.string.uuid(),
+      active: true,
+    })
+    .expect(201);
+
+  return res.body.id;
+};

--- a/packages/server/test/gl-purchases.e2e-spec.ts
+++ b/packages/server/test/gl-purchases.e2e-spec.ts
@@ -1,0 +1,287 @@
+import request = require('supertest');
+import { faker } from '@faker-js/faker';
+import { app } from './init-app-test';
+import {
+  authHeaders,
+  cancelTransactionsLock,
+  createServiceItem,
+  createTaxRate,
+  createVendor,
+  expectBalanced,
+  expectLegs,
+  fetchLegs,
+  getBaseCurrency,
+} from './_utils/gl';
+
+describe('GL entries — Purchases transactions (e2e)', () => {
+  let baseCurrency: string;
+  let vendorId: number;
+  let foreignVendorId: number;
+  let itemId: number;
+  let taxRate10: number;
+
+  beforeAll(async () => {
+    await cancelTransactionsLock();
+
+    baseCurrency = await getBaseCurrency();
+    vendorId = await createVendor(baseCurrency);
+    foreignVendorId = await createVendor('EUR');
+    itemId = await createServiceItem();
+    taxRate10 = await createTaxRate(10);
+  });
+
+  describe('Bill', () => {
+    const createBill = async (overrides: Record<string, any> = {}) => {
+      const res = await request(app.getHttpServer())
+        .post('/bills')
+        .set(authHeaders())
+        .send({
+          vendorId,
+          billDate: '2023-01-01',
+          dueDate: '2023-02-01',
+          billNumber: faker.string.alphanumeric(10),
+          referenceNo: 'REF-000201',
+          open: true,
+          discountType: 'percentage',
+          discount: 10,
+          branchId: 1,
+          warehouseId: 1,
+          entries: [
+            {
+              index: 1,
+              itemId,
+              quantity: 2,
+              rate: 1000,
+              description: 'Item description...',
+            },
+          ],
+          ...overrides,
+        })
+        .expect(201);
+
+      return res.body.id;
+    };
+
+    it('posts a balanced journal for a plain opened bill with discount', async () => {
+      const billId = await createBill();
+
+      const legs = await fetchLegs('Bill', billId);
+
+      expectBalanced(legs);
+      expectLegs(
+        legs,
+        [
+          { accountCode: '20001', contactId: vendorId, credit: 1800 },
+          { accountCode: '40002', debit: 2000 },
+          { accountCode: '40009', credit: 200 },
+        ],
+        'Bill',
+      );
+    });
+
+    it('posts a balanced journal for a tax-exclusive bill', async () => {
+      const billId = await createBill({
+        entries: [
+          {
+            index: 1,
+            itemId,
+            quantity: 2,
+            rate: 1000,
+            taxRateId: taxRate10,
+            description: 'Item description...',
+          },
+        ],
+      });
+
+      const legs = await fetchLegs('Bill', billId);
+
+      expectBalanced(legs);
+      expectLegs(
+        legs,
+        [
+          { accountCode: '20001', contactId: vendorId, credit: 2000 },
+          { accountCode: '40002', debit: 2000 },
+          { accountCode: '20006', debit: 200 },
+          { accountCode: '40009', credit: 200 },
+        ],
+        'Bill',
+      );
+    });
+
+    it('posts a balanced journal for a tax-inclusive bill', async () => {
+      const billId = await createBill({
+        isInclusiveTax: true,
+        entries: [
+          {
+            index: 1,
+            itemId,
+            quantity: 2,
+            rate: 1000,
+            taxRateId: taxRate10,
+            description: 'Item description...',
+          },
+        ],
+      });
+
+      const legs = await fetchLegs('Bill', billId);
+
+      expectBalanced(legs);
+      expectLegs(
+        legs,
+        [
+          { accountCode: '20001', contactId: vendorId, credit: 1800 },
+          { accountCode: '40002', debit: 1818.18 },
+          { accountCode: '20006', debit: 181.82 },
+          { accountCode: '40009', credit: 200 },
+        ],
+        'Bill',
+      );
+    });
+
+    it('posts a balanced journal for a bill with adjustment', async () => {
+      const billId = await createBill({
+        adjustment: 50,
+      });
+
+      const legs = await fetchLegs('Bill', billId);
+
+      expectBalanced(legs);
+      expectLegs(
+        legs,
+        [
+          { accountCode: '20001', contactId: vendorId, credit: 1850 },
+          { accountCode: '40002', debit: 2000 },
+          { accountCode: '40009', credit: 200 },
+          { accountCode: '40011', debit: 50 },
+        ],
+        'Bill',
+      );
+    });
+
+    it('posts a balanced journal for a multi-currency tax-exclusive bill', async () => {
+      const billId = await createBill({
+        vendorId: foreignVendorId,
+        exchangeRate: 1.2,
+        entries: [
+          {
+            index: 1,
+            itemId,
+            quantity: 1,
+            rate: 1000,
+            taxRateId: taxRate10,
+            description: 'Item description...',
+          },
+        ],
+      });
+
+      const legs = await fetchLegs('Bill', billId);
+
+      expectBalanced(legs);
+      expectLegs(
+        legs,
+        [
+          { contactId: foreignVendorId, credit: 1200 },
+          { accountCode: '40002', debit: 1200 },
+          { accountCode: '20006', debit: 120 },
+          { accountCode: '40009', credit: 120 },
+        ],
+        'Bill',
+      );
+    });
+  });
+
+  describe('Bill Payment', () => {
+    it('posts a balanced journal for a bill payment', async () => {
+      const billRes = await request(app.getHttpServer())
+        .post('/bills')
+        .set(authHeaders())
+        .send({
+          vendorId,
+          billDate: '2023-01-01',
+          dueDate: '2023-02-01',
+          billNumber: faker.string.alphanumeric(10),
+          referenceNo: 'REF-000201',
+          open: true,
+          branchId: 1,
+          warehouseId: 1,
+          entries: [
+            {
+              index: 1,
+              itemId,
+              quantity: 1,
+              rate: 1000,
+              description: 'Item description...',
+            },
+          ],
+        })
+        .expect(201);
+
+      const paymentRes = await request(app.getHttpServer())
+        .post('/bill-payments')
+        .set(authHeaders())
+        .send({
+          vendorId,
+          paymentAccountId: 1000,
+          paymentDate: '2023-01-01',
+          paymentNumber: faker.string.alphanumeric(10),
+          branchId: 1,
+          entries: [{ billId: billRes.body.id, paymentAmount: 1000 }],
+        })
+        .expect(201);
+
+      const legs = await fetchLegs('BillPayment', paymentRes.body.id);
+
+      expectBalanced(legs);
+      expectLegs(
+        legs,
+        [
+          { accountCode: '20001', contactId: vendorId, debit: 1000 },
+          { accountCode: '10001', credit: 1000 },
+        ],
+        'BillPayment',
+      );
+    });
+  });
+
+  describe('Vendor Credit', () => {
+    it('posts a balanced journal for an opened vendor credit with discount', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/vendor-credits')
+        .set(authHeaders())
+        .send({
+          vendorId,
+          exchangeRate: 1,
+          vendorCreditNumber: faker.string.uuid(),
+          vendorCreditDate: '2025-01-01',
+          open: true,
+          entries: [
+            {
+              index: 1,
+              itemId,
+              quantity: 1,
+              rate: 1000,
+              description: "It's description here.",
+            },
+          ],
+          discount: '100',
+          discountType: 'amount',
+          branchId: 1,
+          warehouseId: 1,
+        })
+        .expect(201);
+
+      const legs = await fetchLegs('VendorCredit', res.body.id);
+
+      expectBalanced(legs);
+      expectLegs(
+        legs,
+        [
+          { accountCode: '20001', contactId: vendorId, debit: 900 },
+          { accountCode: '40002', credit: 1000 },
+          { accountCode: '40009', debit: 100 },
+        ],
+        'VendorCredit',
+      );
+    });
+  });
+});

--- a/packages/server/test/gl-sales.e2e-spec.ts
+++ b/packages/server/test/gl-sales.e2e-spec.ts
@@ -1,0 +1,383 @@
+import request = require('supertest');
+import { faker } from '@faker-js/faker';
+import { app } from './init-app-test';
+import {
+  authHeaders,
+  cancelTransactionsLock,
+  createCustomer,
+  createServiceItem,
+  createTaxRate,
+  expectBalanced,
+  expectLegs,
+  fetchLegs,
+  getBaseCurrency,
+} from './_utils/gl';
+
+describe('GL entries — Sales transactions (e2e)', () => {
+  let baseCurrency: string;
+  let customerId: number;
+  let foreignCustomerId: number;
+  let itemId: number;
+  let taxRate10: number;
+
+  beforeAll(async () => {
+    await cancelTransactionsLock();
+
+    baseCurrency = await getBaseCurrency();
+    customerId = await createCustomer(baseCurrency);
+    foreignCustomerId = await createCustomer('EUR');
+    itemId = await createServiceItem();
+    taxRate10 = await createTaxRate(10);
+  });
+
+  describe('Sale Invoice', () => {
+    const createInvoice = async (overrides: Record<string, any> = {}) => {
+      const res = await request(app.getHttpServer())
+        .post('/sale-invoices')
+        .set(authHeaders())
+        .send({
+          customerId,
+          invoiceDate: '2023-01-01',
+          dueDate: '2023-02-01',
+          invoiceNo: faker.string.uuid(),
+          referenceNo: 'REF-000201',
+          delivered: true,
+          discountType: 'percentage',
+          discount: 10,
+          branchId: 1,
+          warehouseId: 1,
+          entries: [
+            {
+              index: 1,
+              itemId,
+              quantity: 1,
+              rate: 1000,
+              description: 'Item description...',
+            },
+          ],
+          ...overrides,
+        })
+        .expect(201);
+
+      return res.body.id;
+    };
+
+    it('posts a balanced journal for a plain delivered invoice with discount', async () => {
+      const invoiceId = await createInvoice();
+
+      const legs = await fetchLegs('SaleInvoice', invoiceId);
+
+      expectBalanced(legs);
+      expectLegs(
+        legs,
+        [
+          { accountCode: '10007', contactId: customerId, debit: 900 },
+          { accountCode: '50002', credit: 1000 },
+          { accountCode: '40008', debit: 100 },
+        ],
+        'SaleInvoice',
+      );
+    });
+
+    it('posts a balanced journal for a tax-exclusive invoice', async () => {
+      const invoiceId = await createInvoice({
+        entries: [
+          {
+            index: 1,
+            itemId,
+            quantity: 1,
+            rate: 1000,
+            taxRateId: taxRate10,
+            description: 'Item description...',
+          },
+        ],
+      });
+
+      const legs = await fetchLegs('SaleInvoice', invoiceId);
+
+      expectBalanced(legs);
+      expectLegs(
+        legs,
+        [
+          { accountCode: '10007', contactId: customerId, debit: 1000 },
+          { accountCode: '50002', credit: 1000 },
+          { accountCode: '20006', credit: 100 },
+          { accountCode: '40008', debit: 100 },
+        ],
+        'SaleInvoice',
+      );
+    });
+
+    it('posts a balanced journal for a tax-inclusive invoice', async () => {
+      const invoiceId = await createInvoice({
+        isInclusiveTax: true,
+        entries: [
+          {
+            index: 1,
+            itemId,
+            quantity: 1,
+            rate: 1000,
+            taxRateId: taxRate10,
+            description: 'Item description...',
+          },
+        ],
+      });
+
+      const legs = await fetchLegs('SaleInvoice', invoiceId);
+
+      expectBalanced(legs);
+      expectLegs(
+        legs,
+        [
+          { accountCode: '10007', contactId: customerId, debit: 900 },
+          { accountCode: '50002', credit: 909.09 },
+          { accountCode: '20006', credit: 90.91 },
+          { accountCode: '40008', debit: 100 },
+        ],
+        'SaleInvoice',
+      );
+    });
+
+    it('posts a balanced journal for an invoice with adjustment', async () => {
+      const invoiceId = await createInvoice({
+        adjustment: 50,
+      });
+
+      const legs = await fetchLegs('SaleInvoice', invoiceId);
+
+      expectBalanced(legs);
+      expectLegs(
+        legs,
+        [
+          { accountCode: '10007', contactId: customerId, debit: 950 },
+          { accountCode: '50002', credit: 1000 },
+          { accountCode: '40008', debit: 100 },
+          { accountCode: '40010', credit: 50 },
+        ],
+        'SaleInvoice',
+      );
+    });
+
+    it('posts a balanced journal for a multi-currency tax-exclusive invoice', async () => {
+      const invoiceId = await createInvoice({
+        customerId: foreignCustomerId,
+        exchangeRate: 1.2,
+        entries: [
+          {
+            index: 1,
+            itemId,
+            quantity: 1,
+            rate: 1000,
+            taxRateId: taxRate10,
+            description: 'Item description...',
+          },
+        ],
+      });
+
+      const legs = await fetchLegs('SaleInvoice', invoiceId);
+
+      expectBalanced(legs);
+      expectLegs(
+        legs,
+        [
+          { contactId: foreignCustomerId, debit: 1200 },
+          { accountCode: '50002', credit: 1200 },
+          { accountCode: '20006', credit: 120 },
+          { accountCode: '40008', debit: 120 },
+        ],
+        'SaleInvoice',
+      );
+    });
+  });
+
+  describe('Sale Receipt', () => {
+    it('posts a balanced journal for a closed sale receipt with discount', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/sale-receipts')
+        .set(authHeaders())
+        .send({
+          customerId,
+          depositAccountId: 1000,
+          receiptDate: '2022-02-02',
+          receiptNumber: faker.string.uuid(),
+          referenceNo: '123',
+          closed: true,
+          discount: 100,
+          discountType: 'amount',
+          branchId: 1,
+          warehouseId: 1,
+          entries: [
+            {
+              index: 1,
+              itemId,
+              quantity: 1,
+              rate: 2000,
+              description: 'asdfsadf',
+            },
+          ],
+        })
+        .expect(201);
+
+      const legs = await fetchLegs('SaleReceipt', res.body.id);
+
+      expectBalanced(legs);
+      expectLegs(
+        legs,
+        [
+          { accountCode: '10001', debit: 1900 },
+          { accountCode: '50002', credit: 2000 },
+          { accountCode: '40008', debit: 100 },
+        ],
+        'SaleReceipt',
+      );
+    });
+  });
+
+  describe('Payment Received', () => {
+    it('posts a balanced journal for a payment received against an invoice', async () => {
+      const invoiceRes = await request(app.getHttpServer())
+        .post('/sale-invoices')
+        .set(authHeaders())
+        .send({
+          customerId,
+          invoiceDate: '2023-01-01',
+          dueDate: '2023-02-01',
+          invoiceNo: faker.string.uuid(),
+          referenceNo: 'REF-000201',
+          delivered: true,
+          branchId: 1,
+          warehouseId: 1,
+          entries: [
+            {
+              index: 1,
+              itemId,
+              quantity: 1,
+              rate: 1000,
+              description: 'Item description...',
+            },
+          ],
+        })
+        .expect(201);
+
+      const paymentRes = await request(app.getHttpServer())
+        .post('/payments-received')
+        .set(authHeaders())
+        .send({
+          customerId,
+          paymentDate: '2023-01-01',
+          exchangeRate: 1,
+          referenceNo: faker.string.uuid(),
+          depositAccountId: 1000,
+          paymentReceiveNo: faker.string.uuid(),
+          statement: 'Payment received for invoice',
+          entries: [
+            { index: 1, invoiceId: invoiceRes.body.id, paymentAmount: 1000 },
+          ],
+          branchId: 1,
+        })
+        .expect(201);
+
+      const legs = await fetchLegs('PaymentReceive', paymentRes.body.id);
+
+      expectBalanced(legs);
+      expectLegs(
+        legs,
+        [
+          { accountCode: '10001', debit: 1000 },
+          { accountCode: '10007', contactId: customerId, credit: 1000 },
+        ],
+        'PaymentReceive',
+      );
+    });
+  });
+
+  describe('Credit Note', () => {
+    it('posts a balanced journal for an opened credit note with discount', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/credit-notes')
+        .set(authHeaders())
+        .send({
+          customerId,
+          creditNoteDate: '2020-02-02',
+          open: true,
+          branchId: 1,
+          warehouseId: 1,
+          entries: [
+            {
+              index: 1,
+              itemId,
+              quantity: 1,
+              rate: 1000,
+              description: "It's description here.",
+            },
+          ],
+          discount: '100',
+          discountType: 'amount',
+        })
+        .expect(201);
+
+      const legs = await fetchLegs('CreditNote', res.body.id);
+
+      expectBalanced(legs);
+      expectLegs(
+        legs,
+        [
+          { accountCode: '10007', contactId: customerId, credit: 900 },
+          { accountCode: '50002', debit: 1000 },
+          { accountCode: '40008', credit: 100 },
+        ],
+        'CreditNote',
+      );
+    });
+  });
+
+  describe('Sale Invoice Write-off', () => {
+    it('posts a balanced journal for an invoice write-off', async () => {
+      const invoiceRes = await request(app.getHttpServer())
+        .post('/sale-invoices')
+        .set(authHeaders())
+        .send({
+          customerId,
+          invoiceDate: '2023-01-01',
+          dueDate: '2023-02-01',
+          invoiceNo: faker.string.uuid(),
+          referenceNo: 'REF-000201',
+          delivered: true,
+          branchId: 1,
+          warehouseId: 1,
+          entries: [
+            {
+              index: 1,
+              itemId,
+              quantity: 1,
+              rate: 1000,
+              description: 'Item description...',
+            },
+          ],
+        })
+        .expect(201);
+
+      await request(app.getHttpServer())
+        .post(`/sale-invoices/${invoiceRes.body.id}/writeoff`)
+        .set(authHeaders())
+        .send({
+          expenseAccountId: 1024,
+          date: '2023-01-01',
+          reason: 'Write off reason',
+        })
+        .expect(200);
+
+      const legs = await fetchLegs('InvoiceWriteOff', invoiceRes.body.id);
+
+      expectBalanced(legs);
+      expectLegs(
+        legs,
+        [
+          { accountCode: '40007', debit: 1000 },
+          { accountCode: '10007', contactId: customerId, credit: 1000 },
+        ],
+        'InvoiceWriteOff',
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Description

Fixes GL (general ledger) entries posted when creating sales and purchases transactions so the journals are always balanced and economically correct.

Review of the GL generators (`InvoiceGL`, `BillsGL`, `SaleInvoiceWriteoffGL`) and the transaction `total` getters found several correctness bugs:

1. **Tax inversion in `total`/`totalLocal`** (`SaleInvoice`/`Bill` models): tax was added to the total only for *inclusive* tax, but `subtotal` already includes the tax when inclusive. This made the A/R and A/P legs wrong and the journal unbalanced whenever a tax was present. Tax is now added only for **tax-exclusive** transactions, matching the webapp's total computation.
2. **Adjustment dropped from `SaleInvoice.total`**: it used Ramda's `defaultTo(this.adjustment, 0)`, which always returns `0` due to the inverted argument order, so invoice adjustments were ignored by the total (and the A/R leg).
3. **Tax GL legs ignored the exchange rate** (`InvoiceGL.getInvoiceTaxEntry`, `BillsGL.getBillTaxEntry`): the tax amount was posted unconverted while the income/inventory legs were converted, so multi-currency journals did not balance.
4. **Invoice write-off expense leg used the foreign-currency amount** instead of the local (base-currency) amount used by the matching A/R credit leg.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Added HTTP e2e specs that assert the exact `accounts_transactions` legs posted for each transaction (read back through `GET /reports/transactions-by-reference`) and verify every journal is balanced:

- `packages/server/test/gl-sales.e2e-spec.ts` — sale invoice (plain, tax-exclusive, tax-inclusive, multi-currency, adjustment), sale receipt, payment received, credit note, invoice write-off.
- `packages/server/test/gl-purchases.e2e-spec.ts` — bill (plain, tax-exclusive, tax-inclusive, multi-currency, adjustment), bill payment, vendor credit.
- `packages/server/test/_utils/gl.ts` — shared helper (fetch legs, balanced/leg assertions, fixture builders).

Run with: `cd packages/server && pnpm run test:e2e -- gl-sales gl-purchases` (16 tests, all passing).

Also verified no regressions in the related suites: `sale-invoices`, `sale-receipts`, `credit-notes`, `payment-received`, `vendor-credits`, `bills`, `bill-payments`, `bill-landed-costs`, `vendor-credits-apply-bill`, `credit-notes-apply-invoice`, `manual-journal`, `financial-statements`, `tax-rates`. Lint and `tsc --noEmit` are clean.

Note: the pre-commit hook (`npm run format`) could not run because the shell's default Node is v14 (project requires 18.12+); the committed files were verified with `prettier --check` before committing.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>