### PR TITLE
fix(server): remove hard-coded JWT secret fallback and harden token claims (GHSA-6g8f-59w9-gpfv)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 # App
-APP_JWT_SECRET=123123
+# Required secret used to sign authentication JWTs.
+# Generate one with: openssl rand -base64 48
+APP_JWT_SECRET=
 
 # Twilio (global fallback for SMS)
 TWILIO_ACCOUNT_SID=
@@ -38,7 +40,6 @@ TENANT_DB_NAME_PERFIX=bigcapital_tenant_
 
 # Application
 BASE_URL=http://example.com
-JWT_SECRET=b0JDZW56RnV6aEthb0RGPXVEcUI
 
 # App proxy
 PUBLIC_PROXY_PORT=80

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -96,7 +96,6 @@ jobs:
 
           # Application
           BASE_URL=http://localhost:3000
-          JWT_SECRET=test-jwt-secret-for-e2e-testing
           APP_JWT_SECRET=test-app-jwt-secret
 
           # Sign-up

--- a/.github/workflows/generate-openapi.yml
+++ b/.github/workflows/generate-openapi.yml
@@ -32,7 +32,6 @@ env:
   QUEUE_PORT: 6379
   # App configuration
   APP_JWT_SECRET: test-jwt-secret-for-openapi-generation
-  JWT_SECRET: test-jwt-secret-for-openapi-generation
   BASE_URL: http://localhost:3000
   # Feature flags
   SIGNUP_DISABLED: 'false'

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -97,7 +97,6 @@ jobs:
 
           # Application
           BASE_URL=http://localhost:3000
-          JWT_SECRET=test-jwt-secret-for-server-testing
           APP_JWT_SECRET=test-app-jwt-secret
 
           # Sign-up

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -73,7 +73,7 @@ services:
       - TENANT_DB_NAME_PERFIX=${TENANT_DB_NAME_PERFIX}
 
       # Authentication
-      - JWT_SECRET=${JWT_SECRET}
+      - 'APP_JWT_SECRET=${APP_JWT_SECRET:?APP_JWT_SECRET is required in .env - generate one with openssl rand -base64 48}'
 
       # Application
       - BASE_URL=${BASE_URL}

--- a/packages/server/src/common/config/jwt.ts
+++ b/packages/server/src/common/config/jwt.ts
@@ -1,5 +1,5 @@
 import { registerAs } from '@nestjs/config';
 
 export default registerAs('jwt', () => ({
-  secret: process.env.APP_JWT_SECRET || '123123',
+  secret: process.env.APP_JWT_SECRET,
 }));

--- a/packages/server/src/modules/Auth/Auth.constants.ts
+++ b/packages/server/src/modules/Auth/Auth.constants.ts
@@ -1,7 +1,5 @@
-export const jwtConstants = {
-  secret:
-    'DO NOT USE THIS VALUE. INSTEAD, CREATE A COMPLEX SECRET AND KEEP IT SAFE OUTSIDE OF THE SOURCE CODE.',
-};
+export const JWT_ISSUER = 'bigcapital';
+export const JWT_AUDIENCE = 'bigcapital:api';
 
 export const ERRORS = {
   INVALID_DETAILS: 'INVALID_DETAILS',

--- a/packages/server/src/modules/Auth/Auth.interfaces.ts
+++ b/packages/server/src/modules/Auth/Auth.interfaces.ts
@@ -4,7 +4,10 @@ import { TenantModel } from '../System/models/TenantModel';
 import { AuthSignupDto } from './dtos/AuthSignup.dto';
 
 export interface JwtPayload {
+  /** The authenticated user's id. */
   sub: string;
+  iss?: string;
+  aud?: string;
   iat: number;
   exp: number;
 }

--- a/packages/server/src/modules/Auth/Auth.module.ts
+++ b/packages/server/src/modules/Auth/Auth.module.ts
@@ -23,6 +23,8 @@ import { BullModule } from '@nestjs/bullmq';
 import {
   SendResetPasswordMailQueue,
   SendSignupVerificationMailQueue,
+  JWT_ISSUER,
+  JWT_AUDIENCE,
 } from './Auth.constants';
 import { SendResetPasswordMailProcessor } from './processors/SendResetPasswordMail.processor';
 import { SendSignupVerificationMailProcessor } from './processors/SendSignupVerificationMail.processor';
@@ -57,11 +59,28 @@ const models = [
     PassportModule.register({ defaultStrategy: 'jwt' }),
     JwtModule.registerAsync({
       inject: [ConfigService],
-      useFactory: (configService: ConfigService) => ({
-        secret: configService.get('jwt.secret'),
-        signOptions: { expiresIn: '1d', algorithm: 'HS384' },
-        verifyOptions: { algorithms: ['HS384'] },
-      }),
+      useFactory: (configService: ConfigService) => {
+        const secret = configService.get<string>('jwt.secret');
+        if (!secret) {
+          throw new Error(
+            'APP_JWT_SECRET is not configured. The server refuses to sign or verify tokens with a default secret. Generate a strong secret (e.g. `openssl rand -base64 48`) and set it as APP_JWT_SECRET in your environment or .env file.',
+          );
+        }
+        return {
+          secret,
+          signOptions: {
+            expiresIn: '1d',
+            algorithm: 'HS384',
+            issuer: JWT_ISSUER,
+            audience: JWT_AUDIENCE,
+          },
+          verifyOptions: {
+            algorithms: ['HS384'],
+            issuer: JWT_ISSUER,
+            audience: JWT_AUDIENCE,
+          },
+        };
+      },
     }),
     TenantDBManagerModule,
     TenancyModule,

--- a/packages/server/src/modules/Auth/commands/AuthSignin.service.spec.ts
+++ b/packages/server/src/modules/Auth/commands/AuthSignin.service.spec.ts
@@ -1,0 +1,111 @@
+import { UnauthorizedException } from '@nestjs/common';
+import { AuthSigninService } from './AuthSignin.service';
+import { JWT_ISSUER, JWT_AUDIENCE } from '../Auth.constants';
+import { UserNotFoundException } from '../exceptions/UserNotFound.exception';
+
+describe('AuthSigninService token claims', () => {
+  const userId = 42;
+  const user = { id: userId, email: 'owner@corp.com' } as any;
+
+  const createService = (foundUser: any = user) => {
+    const findOne = jest.fn().mockImplementation(() => {
+      const result = Promise.resolve(foundUser);
+      (result as any).throwIfNotFound = () => result;
+      return result;
+    });
+    const query = jest.fn(() => ({ findOne }));
+    const systemUserModel = { query } as any;
+    const clsService = { set: jest.fn() } as any;
+    const jwtService = {
+      sign: jest.fn().mockReturnValue('signed-token'),
+    } as any;
+    const service = new AuthSigninService(
+      systemUserModel,
+      {} as any,
+      {} as any,
+      jwtService,
+      clsService,
+    );
+    return { service, findOne, clsService, jwtService };
+  };
+
+  describe('verifyPayload', () => {
+    it('resolves the user by the id carried in sub, not by email', async () => {
+      const { service, findOne, clsService } = createService();
+      const payload = {
+        sub: String(userId),
+        iss: JWT_ISSUER,
+        aud: JWT_AUDIENCE,
+        iat: 1,
+        exp: 2,
+      };
+
+      await service.verifyPayload(payload);
+
+      expect(findOne).toHaveBeenCalledWith({ id: userId });
+      expect(findOne).not.toHaveBeenCalledWith(
+        expect.objectContaining({ email: expect.anything() }),
+      );
+      expect(clsService.set).toHaveBeenCalledWith('userId', userId);
+    });
+
+    it('throws when the user does not exist', async () => {
+      const { service } = createService(null);
+      const payload = {
+        sub: '999',
+        iss: JWT_ISSUER,
+        aud: JWT_AUDIENCE,
+        iat: 1,
+        exp: 2,
+      };
+
+      await expect(service.verifyPayload(payload)).rejects.toThrow(
+        UserNotFoundException,
+      );
+    });
+
+    it('never resolves identity from a token without the expected issuer/audience', async () => {
+      const { service, findOne } = createService();
+      const claims: Array<Partial<{ iss: string; aud: string }>> = [
+        { iss: 'attacker', aud: JWT_AUDIENCE },
+        { iss: JWT_ISSUER, aud: 'attacker' },
+        {},
+      ];
+
+      for (const partial of claims) {
+        await expect(
+          service.verifyPayload({ sub: String(userId), ...partial } as any),
+        ).rejects.toThrow(UnauthorizedException);
+      }
+      expect(findOne).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('signToken', () => {
+    it('embeds the user id as sub with issuer/audience claims', () => {
+      const { service, jwtService } = createService();
+
+      service.signToken(user);
+
+      expect(jwtService.sign).toHaveBeenCalledWith(
+        { sub: String(userId) },
+        {
+          expiresIn: '1d',
+          issuer: JWT_ISSUER,
+          audience: JWT_AUDIENCE,
+        },
+      );
+    });
+
+    it('extends the lifetime when rememberMe is set', () => {
+      const { service, jwtService } = createService();
+
+      service.signToken(user, true);
+
+      expect(jwtService.sign).toHaveBeenCalledWith(
+        { sub: String(userId) },
+        expect.objectContaining({ expiresIn: '30d' }),
+      );
+    });
+  });
+});

--- a/packages/server/src/modules/Auth/commands/AuthSignin.service.ts
+++ b/packages/server/src/modules/Auth/commands/AuthSignin.service.ts
@@ -1,11 +1,12 @@
 import { ClsService } from 'nestjs-cls';
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, UnauthorizedException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { SystemUser } from '@/modules/System/models/SystemUser';
 import { TenantModel } from '@/modules/System/models/TenantModel';
 import { UserTenant } from '@/modules/System/models/UserTenant.model';
 import { ModelObject } from 'objection';
 import { JwtPayload } from '../Auth.interfaces';
+import { JWT_ISSUER, JWT_AUDIENCE } from '../Auth.constants';
 import { InvalidEmailPasswordException } from '../exceptions/InvalidEmailPassword.exception';
 import { UserNotFoundException } from '../exceptions/UserNotFound.exception';
 
@@ -57,11 +58,14 @@ export class AuthSigninService {
    * @returns {Promise<any>}
    */
   async verifyPayload(payload: JwtPayload): Promise<any> {
+    if (payload.iss !== JWT_ISSUER || payload.aud !== JWT_AUDIENCE) {
+      throw new UnauthorizedException('Invalid token claims.');
+    }
     let user: SystemUser;
     try {
       user = await this.systemUserModel
         .query()
-        .findOne({ email: payload.sub })
+        .findOne({ id: Number(payload.sub) })
         .throwIfNotFound();
 
       this.clsService.set('userId', user.id);
@@ -128,9 +132,13 @@ export class AuthSigninService {
    */
   signToken(user: SystemUser, rememberMe = false): string {
     const payload = {
-      sub: user.email,
+      sub: String(user.id),
     };
     const expiresIn = rememberMe ? '30d' : '1d';
-    return this.jwtService.sign(payload, { expiresIn });
+    return this.jwtService.sign(payload, {
+      expiresIn,
+      issuer: JWT_ISSUER,
+      audience: JWT_AUDIENCE,
+    });
   }
 }

--- a/packages/server/src/modules/Auth/strategies/Jwt.strategy.spec.ts
+++ b/packages/server/src/modules/Auth/strategies/Jwt.strategy.spec.ts
@@ -1,0 +1,12 @@
+import { JwtStrategy } from './Jwt.strategy';
+
+describe('JwtStrategy fail-fast', () => {
+  it('refuses to register when APP_JWT_SECRET is missing', () => {
+    const configService = { get: jest.fn().mockReturnValue(undefined) } as any;
+    const authSigninService = {} as any;
+
+    expect(() => new JwtStrategy(authSigninService, configService)).toThrow(
+      /APP_JWT_SECRET is not configured/,
+    );
+  });
+});

--- a/packages/server/src/modules/Auth/strategies/Jwt.strategy.ts
+++ b/packages/server/src/modules/Auth/strategies/Jwt.strategy.ts
@@ -4,6 +4,7 @@ import { ExtractJwt, Strategy } from 'passport-jwt';
 import { AuthSigninService } from '../commands/AuthSignin.service';
 import { JwtPayload } from '../Auth.interfaces';
 import { ConfigService } from '@nestjs/config';
+import { JWT_ISSUER, JWT_AUDIENCE } from '../Auth.constants';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
@@ -11,10 +12,19 @@ export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
     private readonly authSigninService: AuthSigninService,
     private readonly configService: ConfigService,
   ) {
+    const secretOrKey = configService.get<string>('jwt.secret');
+    if (!secretOrKey) {
+      throw new Error(
+        'APP_JWT_SECRET is not configured. Generate a strong secret (e.g. `openssl rand -base64 48`) and set it as APP_JWT_SECRET in your environment or .env file.',
+      );
+    }
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: false,
-      secretOrKey: configService.get('jwt.secret'),
+      secretOrKey,
+      issuer: JWT_ISSUER,
+      audience: JWT_AUDIENCE,
+      algorithms: ['HS384'],
     });
   }
 

--- a/setup.sh
+++ b/setup.sh
@@ -75,6 +75,21 @@ setup_env() {
         cp "$CURRENT/.env.example" "$DOCKER_ENV_PATH"
     fi
 
+    # Generate a strong JWT signing secret when the .env does not define one.
+    # The server refuses to boot without it.
+    if ! grep -qE '^APP_JWT_SECRET=.+$' "$DOCKER_ENV_PATH" 2>/dev/null;
+    then
+        if command -v openssl &> /dev/null;
+        then
+            GENERATED_JWT_SECRET=$(openssl rand -base64 48 | tr -d '\n')
+        else
+            GENERATED_JWT_SECRET=$(head -c 48 /dev/urandom | base64 | tr -d '\n')
+        fi
+        # Remove any empty APP_JWT_SECRET line, then append the generated value.
+        sed -i.bak '/^APP_JWT_SECRET=/d' "$DOCKER_ENV_PATH" && rm -f "${DOCKER_ENV_PATH}.bak"
+        printf '\n# Auto-generated JWT signing secret (see APP_JWT_SECRET docs)\nAPP_JWT_SECRET=%s\n' "$GENERATED_JWT_SECRET" >> "$DOCKER_ENV_PATH"
+        echo "A random APP_JWT_SECRET has been generated in $DOCKER_ENV_PATH"
+    fi
 }
 # Prints the main actions men.
 function askForAction() {


### PR DESCRIPTION
## Description

Fixes [GHSA-6g8f-59w9-gpfv](https://github.com/bigcapitalhq/bigcapital/security/advisories/GHSA-6g8f-59w9-gpfv) — hard-coded JWT secret `123123` in the official deployment (CVSS 10.0 Critical, CWE-798).

**The chain**

- `common/config/jwt.ts` fell back to `process.env.APP_JWT_SECRET || '123123'`.
- `docker-compose.prod.yml` forwarded `JWT_SECRET`, a name the application never reads, so official deployments always ran on the public `'123123'` secret; `.env.example` shipped it too (`setup.sh` copies `.env.example` → `.env` verbatim).
- The token payload carried nothing but `{ sub: user.email }`, and `verifyPayload` resolved the account purely by that email. Anyone knowing a registered user's email could forge an HS384 token offline and fully impersonate them (owners included) across the victim's financial data.

**The fix (all four advisory remediation items)**

- **No default secret, fail fast**: `jwt.ts` returns `APP_JWT_SECRET` as-is; `AuthModule` and `JwtStrategy` throw a descriptive error at boot when it is unset. This lives in `AuthModule` (server only) on purpose — the migration CLI (`CLIModule`) eagerly evaluates the shared `config` factories and must keep booting without a JWT secret.
- **Compose wiring**: `docker-compose.prod.yml` now forwards `APP_JWT_SECRET` and interpolates with `:?` so `docker compose` itself refuses to start without it, printing generation instructions.
- **No shipped secrets**: `.env.example` ships an empty `APP_JWT_SECRET` with `openssl rand -base64 48` instructions; the dead public `JWT_SECRET=b0JDZW56RnV6aEthb0RGPXVEcUI` line is removed (nothing ever read it), and stale `JWT_SECRET` env entries are dropped from CI workflows (each already sets `APP_JWT_SECRET`).
- **Token hardening**: `signToken` now issues `{ sub: String(user.id) }` with `issuer: bigcapital` / `audience: bigcapital:api`; `verifyPayload` resolves the user by id and rejects wrong claims; passport-jwt additionally validates issuer/audience/HS384 on every request. Identity no longer depends on the email claim, and `cls.userId` (the input to all tenant-membership and RBAC checks) is still set from the DB record.
- **setup.sh**: auto-generates a random `APP_JWT_SECRET` into `.env` on install when one is not present (idempotent; keeps `openssl`-less fallback), so the official install path works with zero manual steps.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

> Note for self-hosters (documented in the commit): upgrading requires setting `APP_JWT_SECRET` in `.env` (fresh installs get it auto-generated) and invalidates all existing sessions — required, since every old token was signed with a publicly-known key.

## How Has This Been Tested?

- [x] `npx jest src/modules/Auth` — 14 tests pass, including new `AuthSignin.service.spec.ts` (id-based lookup, claim validation, rememberMe lifetime) and `Jwt.strategy.spec.ts` (boot refuses without secret)
- [x] `tsc --noEmit` (server) clean; ESLint clean on changed files
- [x] `docker compose -f docker-compose.prod.yml --env-file /dev/null config` → exits 1 with `required variable APP_JWT_SECRET is missing a value` ; with the var set → parses
- [x] `setup.sh` generation logic exercised in isolation: empty `APP_JWT_SECRET` replaced with a 64-char random value; re-run is a no-op
- [x] `bash -n setup.sh` clean
- [x] CLI/migration path unaffected: `CLIModule` never reads `jwt.secret`, and `jwt.ts` no longer throws

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
