### PR TITLE
fix(webapp): restore role-form permission checkbox handlers

### DIFF
--- a/packages/webapp/src/containers/Preferences/Users/Roles/RolesForm/utils.tsx
+++ b/packages/webapp/src/containers/Preferences/Users/Roles/RolesForm/utils.tsx
@@ -244,9 +244,7 @@ export function isServiceFullUnchecked(
  * Handles permission checkbox change.
  */
 export const handleCheckboxPermissionChange =
-  (form: FormLike) =>
-  (permission: PermissionItem) =>
-  (service: PermissionService) =>
+  (form: FormLike, permission: PermissionItem, service: PermissionService) =>
   (event: React.ChangeEvent<HTMLInputElement>) => {
     const { subject } = service;
     const isChecked = event.currentTarget.checked;
@@ -309,8 +307,7 @@ export function getServiceAllPermissionsPaths(subject: string): string[] {
  * Handle full access service checkbox change.
  */
 export const handleCheckboxFullAccessChange =
-  (service: PermissionService) =>
-  (form: FormLike) =>
+  (service: PermissionService, form: FormLike) =>
   (event: React.ChangeEvent<HTMLInputElement>) => {
     const isChecked = event.currentTarget.checked;
     const permsPaths = getServiceAllPermissionsPaths(service.subject);


### PR DESCRIPTION
## Description

Fixes #1372.

In **Preferences → Roles**, none of the permission checkboxes (nor the per-service **Full access** checkbox) respond to clicks, so a custom role can't be created or edited from the UI.

### Root cause

Regression from #1366 (`refactor(webapp): migrate ramda to fp-ts`, commit 3a707d362). `handleCheckboxPermissionChange` and `handleCheckboxFullAccessChange` in `RolesForm/utils.tsx` were converted from `R.curry((form, permission, service, event) => …)` to hand-rolled curried arrows `(form) => (permission) => (service) => (event) => …`.

The call sites in `RolesForm/components.tsx` were not changed — they still apply all arguments at once:

```js
onChange={handleCheckboxPermissionChange(form as FormState, permission, service)}
onChange={handleCheckboxFullAccessChange(service, form as FormState)}
```

`R.curry` tolerated that and returned a function awaiting `event`. Plain curried arrows drop the extra arguments, so `onChange` ends up bound to a partially-applied function; the change event is passed as `permission` and `form.setFieldValue` is never called.

### Fix

Collapse each handler's leading parameters into a single argument list:

```js
export const handleCheckboxPermissionChange =
  (form, permission, service) => (event) => { … };

export const handleCheckboxFullAccessChange =
  (service, form) => (event) => { … };
```

All four existing call sites now work unchanged and the original runtime behaviour is restored. One-file change, no call-site edits.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

1. Preferences → Roles → New role.
2. Tick individual permission checkboxes — they toggle, and dependent permissions / the Full access tri-state update.
3. Toggle a service **Full access** checkbox — every permission in that service follows.
4. Save, reopen — values persist.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
