### PR TITLE
fix(webapp): Preferences → Users & Roles UI fixes (blank role column, Edit→Save, roles actions menu)

### DIFF
--- a/packages/webapp/src/containers/Dialogs/UserFormDialog/UserFormContent.tsx
+++ b/packages/webapp/src/containers/Dialogs/UserFormDialog/UserFormContent.tsx
@@ -99,7 +99,7 @@ function UserFormContentInner({
             loading={isSubmitting}
             style={{ minWidth: '85px' }}
           >
-            <T id={'edit'} />
+            <T id={'save'} />
           </Button>
         </div>
       </div>

--- a/packages/webapp/src/containers/Preferences/Users/Roles/RolesLanding/components.tsx
+++ b/packages/webapp/src/containers/Preferences/Users/Roles/RolesLanding/components.tsx
@@ -1,4 +1,12 @@
-import { Intent, Menu, MenuItem, MenuDivider } from '@blueprintjs/core';
+import {
+  Intent,
+  Menu,
+  MenuItem,
+  MenuDivider,
+  Button,
+  Popover,
+  Position,
+} from '@blueprintjs/core';
 import React from 'react';
 import intl from 'react-intl-universal';
 import { Icon } from '@/components';
@@ -37,6 +45,21 @@ export function ActionsMenu({
 }
 
 /**
+ * Actions cell — renders the row's contextual menu behind a "more" button,
+ * mirroring the users table so roles are actionable without a right-click.
+ */
+function ActionsCell(props: ActionsMenuProps) {
+  return (
+    <Popover
+      content={<ActionsMenu {...props} />}
+      position={Position.RIGHT_BOTTOM}
+    >
+      <Button icon={<Icon icon="more-h-16" iconSize={16} />} />
+    </Popover>
+  );
+}
+
+/**
  * Retrieve Roles table columns.
  * @returns
  */
@@ -58,6 +81,14 @@ export function useRolesTableColumns() {
         className: 'description',
         width: '180',
         textOverview: true,
+      },
+      {
+        id: 'actions',
+        Header: '',
+        Cell: ActionsCell,
+        className: 'actions',
+        width: 50,
+        disableResizing: true,
       },
     ],
     [],

--- a/packages/webapp/src/containers/Preferences/Users/components.tsx
+++ b/packages/webapp/src/containers/Preferences/Users/components.tsx
@@ -160,7 +160,7 @@ export const useUsersListColumns = () => {
       {
         id: 'role_name',
         Header: intl.get('users.column.role_name'),
-        accessor: 'role_name',
+        accessor: 'roleName',
         width: 120,
       },
       {


### PR DESCRIPTION
## What

Three small fixes in **Preferences → Users** and **Preferences → Roles**, all found while administering a self-hosted instance.

### 1. Users list — Role column is always blank

`useUsersListColumns` defines the role column with `accessor: 'role_name'`, but the users API response exposes the role as **`roleName`** (`UserTransformer.includeAttributes` → `['roleName', 'roleDescription', 'roleSlug']`, and `UserDto.roleName`). So the column never resolves a value and renders empty for every user.

Fix: `accessor: 'roleName'`.

### 2. Edit-user dialog — submit button says "Edit"

`UserFormContent` labels the primary button `<T id={'edit'} />` → "Edit". The dialog is edit-only (title is "Edit User", and `UserForm` only ever calls `EditUserMutate`), so the button should read "Save".

Fix: `<T id={'save'} />` (key already exists in all locale files).

### 3. Roles list — no visible actions menu

`RolesDataTable` passes `ActionsMenu` as `ContextMenu`, so edit/delete a role is only reachable by right-clicking the row — there's no visible affordance, unlike the users list which also has a trailing actions column with a "more" button.

Fix: add an `actions` column to `useRolesTableColumns` that renders the same contextual menu behind a `more-h-16` button, mirroring `Preferences/Users/components.tsx`. Predefined-role guards in `RolesDataTable` (`handleEditRole` / `handleDeleteRole`) are unchanged, so admin/staff still can't be edited or deleted.

## Testing

Manual, against a self-hosted `develop` build:
- Users list now shows "Administrator" / custom role names in the Role column.
- Edit-user dialog button reads "Save".
- Roles list rows show a "more" button opening Edit / Delete; predefined roles still show the "cannot edit/delete predefined roles" toast.

No API or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
