### PR TITLE
fix(docker): pass THROTTLE_* env vars through to the server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,7 +53,9 @@ SIGNUP_ALLOWED_EMAILS=
 # Sign-up Email Confirmation
 SIGNUP_EMAIL_CONFIRMATION=false
 
-# API throttling
+# API throttling. GLOBAL applies to all endpoints; AUTH only to the auth routes.
+# Raise THROTTLE_GLOBAL_LIMIT temporarily when doing a bulk import / API-scripted
+# data migration against the REST API.
 THROTTLE_GLOBAL_TTL=60000
 THROTTLE_GLOBAL_LIMIT=300
 THROTTLE_AUTH_TTL=60000

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -133,6 +133,12 @@ services:
       - STRIPE_PAYMENT_WEBHOOKS_SECRET=${STRIPE_PAYMENT_WEBHOOKS_SECRET}
       - STRIPE_PAYMENT_REDIRECT_URL=${STRIPE_PAYMENT_REDIRECT_URL}
 
+      # API rate limiting (see .env.example)
+      - THROTTLE_GLOBAL_TTL=${THROTTLE_GLOBAL_TTL}
+      - THROTTLE_GLOBAL_LIMIT=${THROTTLE_GLOBAL_LIMIT}
+      - THROTTLE_AUTH_TTL=${THROTTLE_AUTH_TTL}
+      - THROTTLE_AUTH_LIMIT=${THROTTLE_AUTH_LIMIT}
+
   database_migration:
     container_name: bigcapital-database-migration
     build:


### PR DESCRIPTION
## Problem

`.env.example` documents four throttle knobs:

```
THROTTLE_GLOBAL_TTL=60000
THROTTLE_GLOBAL_LIMIT=300
THROTTLE_AUTH_TTL=60000
THROTTLE_AUTH_LIMIT=30
```

and `packages/server/src/common/config/throttle.ts` reads them
(`process.env.THROTTLE_GLOBAL_LIMIT ?? '300'`, etc.), wired into
`AppThrottleModule`.

But `docker-compose.prod.yml`'s `server` service uses an explicit
`environment:` allow-list and **none of the `THROTTLE_*` vars are in it**. So on
a standard Docker deployment, setting them in `.env` does nothing — the API is
pinned to the compiled-in defaults (300/min global, 30/min auth), with no
feedback that the override was ignored.

This bites anyone doing an initial data migration: a bulk import or an
API-scripted load hits 300/min and there's no supported way to lift it.

## Change

- `docker-compose.prod.yml`: forward the four `THROTTLE_*` vars to the `server`
  service, same `${VAR}` pattern as every other setting in that block.
- `.env.example`: one comment noting that raising `THROTTLE_GLOBAL_LIMIT` is the
  way to get a bulk import / migration through.

No default behaviour changes — the shipped values are identical to today's
hardcoded defaults. This only makes the already-documented overrides actually work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
