### PR TITLE
fix(webapp): financial reports lose the selected date range when navigating between them

### DIFF
--- a/packages/webapp/src/containers/FinancialStatements/APAgingSummary/APAgingSummary.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/APAgingSummary/APAgingSummary.tsx
@@ -1,5 +1,6 @@
 import moment from 'moment';
 import { useCallback, useEffect } from 'react';
+import { writeReportingPeriod } from '../reportingPeriod';
 import { APAgingSummaryActionsBar } from './APAgingSummaryActionsBar';
 import { APAgingSummaryBody } from './APAgingSummaryBody';
 import { APAgingSummaryHeader } from './APAgingSummaryHeader';
@@ -31,6 +32,7 @@ function APAgingSummaryInner({
         ...filter,
         asDate: moment(filter.asDate as string).format('YYYY-MM-DD'),
       };
+      writeReportingPeriod({ toDate: _filter.asDate });
       setLocationQuery(_filter);
     },
     [setLocationQuery],

--- a/packages/webapp/src/containers/FinancialStatements/APAgingSummary/common.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/APAgingSummary/common.tsx
@@ -2,6 +2,7 @@ import { castArray } from 'lodash';
 import moment from 'moment';
 import { useMemo } from 'react';
 import * as Yup from 'yup';
+import { withRememberedPeriod } from '../reportingPeriod';
 import { useAppQueryString } from '@/hooks';
 import { transformToCamelCase, flatObject, transformToForm } from '@/utils';
 
@@ -45,7 +46,7 @@ const parseAPAgingSummaryQuery = (locationQuery: Record<string, unknown>) => {
   const defaultQuery = getDefaultAPAgingSummaryQuery();
 
   const transformed = {
-    ...defaultQuery,
+    ...withRememberedPeriod(defaultQuery),
     ...transformToForm(locationQuery, defaultQuery),
   };
   return {

--- a/packages/webapp/src/containers/FinancialStatements/ARAgingSummary/ARAgingSummary.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/ARAgingSummary/ARAgingSummary.tsx
@@ -1,5 +1,6 @@
 import moment from 'moment';
 import { useCallback, useEffect } from 'react';
+import { writeReportingPeriod } from '../reportingPeriod';
 import { ARAgingSummaryActionsBar } from './ARAgingSummaryActionsBar';
 import { ARAgingSummaryBody } from './ARAgingSummaryBody';
 import { ARAgingSummaryHeader } from './ARAgingSummaryHeader';
@@ -31,6 +32,7 @@ function ARAgingSummaryInner({
         ...filter,
         asDate: moment(filter.asDate as string).format('YYYY-MM-DD'),
       };
+      writeReportingPeriod({ toDate: _filter.asDate });
       setLocationQuery(_filter);
     },
     [setLocationQuery],

--- a/packages/webapp/src/containers/FinancialStatements/ARAgingSummary/common.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/ARAgingSummary/common.tsx
@@ -2,6 +2,7 @@ import { castArray } from 'lodash';
 import moment from 'moment';
 import { useMemo } from 'react';
 import * as Yup from 'yup';
+import { withRememberedPeriod } from '../reportingPeriod';
 import { useAppQueryString } from '@/hooks';
 import { transformToCamelCase, flatObject, transformToForm } from '@/utils';
 
@@ -44,7 +45,7 @@ export const getARAgingSummaryQuerySchema = () => {
 const parseARAgingSummaryQuery = (locationQuery: Record<string, unknown>) => {
   const defaultQuery = getDefaultARAgingSummaryQuery();
   const transformed = {
-    ...defaultQuery,
+    ...withRememberedPeriod(defaultQuery),
     ...transformToForm(locationQuery, defaultQuery),
   };
   return {

--- a/packages/webapp/src/containers/FinancialStatements/BalanceSheet/BalanceSheet.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/BalanceSheet/BalanceSheet.tsx
@@ -1,5 +1,6 @@
 import moment from 'moment';
 import { useEffect } from 'react';
+import { writeReportingPeriod } from '../reportingPeriod';
 import { BalanceSheetActionsBar } from './BalanceSheetActionsBar';
 import { BalanceSheetBody } from './BalanceSheetBody';
 import { BalanceSheetDialogs } from './BalanceSheetDialogs';
@@ -38,6 +39,7 @@ function BalanceSheetInner({
       fromDate: moment(filter.fromDate).format('YYYY-MM-DD'),
       toDate: moment(filter.toDate).format('YYYY-MM-DD'),
     };
+    writeReportingPeriod(newFilter);
     setLocationQuery({ ...newFilter });
   };
   // Handle number format submit.

--- a/packages/webapp/src/containers/FinancialStatements/BalanceSheet/utils.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/BalanceSheet/utils.tsx
@@ -4,6 +4,7 @@ import moment from 'moment';
 import React from 'react';
 import intl from 'react-intl-universal';
 import * as Yup from 'yup';
+import { withRememberedPeriod } from '../reportingPeriod';
 import type { FormikContextType } from 'formik';
 import { useAppQueryString } from '@/hooks';
 import { transformToForm } from '@/utils';
@@ -55,7 +56,7 @@ const parseBalanceSheetQuery = (
 ): BalanceSheetFormQuery => {
   const defaultQuery = getDefaultBalanceSheetQuery();
   const transformed = {
-    ...defaultQuery,
+    ...withRememberedPeriod(defaultQuery),
     ...transformToForm(locationQuery, defaultQuery),
   };
   return {

--- a/packages/webapp/src/containers/FinancialStatements/CashFlowStatement/CashFlowStatement.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/CashFlowStatement/CashFlowStatement.tsx
@@ -1,5 +1,6 @@
 import moment from 'moment';
 import React, { useEffect } from 'react';
+import { writeReportingPeriod } from '../reportingPeriod';
 import { CashflowSheetDialogs } from './CashflowSheetDialogs';
 import { CashFlowStatementActionsBar } from './CashFlowStatementActionsBar';
 import { CashFlowStatementBody } from './CashFlowStatementBody';
@@ -33,6 +34,7 @@ function CashFlowStatementInner({
       fromDate: moment(filter.fromDate as string).format('YYYY-MM-DD'),
       toDate: moment(filter.toDate as string).format('YYYY-MM-DD'),
     };
+    writeReportingPeriod(newFilter);
     setLocationQuery({ ...newFilter });
   };
 

--- a/packages/webapp/src/containers/FinancialStatements/CashFlowStatement/utils.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/CashFlowStatement/utils.tsx
@@ -1,6 +1,7 @@
 import { castArray } from 'lodash';
 import moment from 'moment';
 import React from 'react';
+import { withRememberedPeriod } from '../reportingPeriod';
 import { useAppQueryString } from '@/hooks';
 import { transformToForm } from '@/utils';
 
@@ -20,7 +21,7 @@ const parseCashflowQuery = (query: Record<string, unknown>) => {
   const defaultQuery = getDefaultCashFlowSheetQuery();
 
   const transformed = {
-    ...defaultQuery,
+    ...withRememberedPeriod(defaultQuery),
     ...transformToForm(query, defaultQuery),
   };
   return {

--- a/packages/webapp/src/containers/FinancialStatements/CustomersBalanceSummary/CustomersBalanceSummary.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/CustomersBalanceSummary/CustomersBalanceSummary.tsx
@@ -1,6 +1,7 @@
 import * as FF from 'fp-ts/function';
 import moment from 'moment';
 import React, { useEffect } from 'react';
+import { writeReportingPeriod } from '../reportingPeriod';
 import { CustomersBalanceLoadingBar } from './components';
 import { CustomerBalanceSummaryPdfDialog } from './CustomerBalancePdfDialog';
 import { CustomerBalanceSummaryBody } from './CustomerBalanceSummaryBody';
@@ -30,6 +31,7 @@ function CustomersBalanceSummaryInner({
       ...filter,
       asDate: moment(filter.asDate as string).format('YYYY-MM-DD'),
     };
+    writeReportingPeriod({ toDate: _filter.asDate });
     setLocationQuery({ ..._filter });
   };
 

--- a/packages/webapp/src/containers/FinancialStatements/CustomersBalanceSummary/utils.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/CustomersBalanceSummary/utils.tsx
@@ -2,6 +2,7 @@ import { castArray } from 'lodash';
 import moment from 'moment';
 import { useMemo } from 'react';
 import * as Yup from 'yup';
+import { withRememberedPeriod } from '../reportingPeriod';
 import { useAppQueryString } from '@/hooks';
 import { transformToForm } from '@/utils';
 
@@ -34,7 +35,7 @@ const parseCustomersBalanceSummaryQuery = (
   const defaultQuery = getDefaultCustomersBalanceQuery();
 
   const transformed = {
-    ...defaultQuery,
+    ...withRememberedPeriod(defaultQuery),
     ...transformToForm(locationQuery, defaultQuery),
   };
   return {

--- a/packages/webapp/src/containers/FinancialStatements/CustomersTransactions/CustomersTransactions.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/CustomersTransactions/CustomersTransactions.tsx
@@ -1,5 +1,6 @@
 import moment from 'moment';
 import React, { useEffect } from 'react';
+import { writeReportingPeriod } from '../reportingPeriod';
 import { useCustomersTransactionsQuery } from './_utils';
 import { CustomersTransactionsLoadingBar } from './components';
 import { CustomersTransactionsActionsBar } from './CustomersTransactionsActionsBar';
@@ -33,6 +34,7 @@ function CustomersTransactionsInner({
       fromDate: moment(filter.fromDate).format('YYYY-MM-DD'),
       toDate: moment(filter.toDate).format('YYYY-MM-DD'),
     };
+    writeReportingPeriod(_filter);
     setFilter({ ..._filter });
   };
 

--- a/packages/webapp/src/containers/FinancialStatements/CustomersTransactions/_utils.ts
+++ b/packages/webapp/src/containers/FinancialStatements/CustomersTransactions/_utils.ts
@@ -4,6 +4,7 @@ import moment from 'moment';
 import { useMemo } from 'react';
 import intl from 'react-intl-universal';
 import * as Yup from 'yup';
+import { withRememberedPeriod } from '../reportingPeriod';
 import { useAppQueryString } from '@/hooks';
 import { transformToForm } from '@/utils';
 
@@ -42,7 +43,7 @@ const parseCustomersTransactionsQuery = (
   const defaultQuery = getCustomersTransactionsDefaultQuery();
 
   const transformedQuery = {
-    ...defaultQuery,
+    ...withRememberedPeriod(defaultQuery),
     ...transformToForm(query, defaultQuery),
   };
   return {

--- a/packages/webapp/src/containers/FinancialStatements/GeneralLedger/GeneralLedger.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/GeneralLedger/GeneralLedger.tsx
@@ -1,5 +1,6 @@
 import moment from 'moment';
 import React, { useCallback, useEffect } from 'react';
+import { writeReportingPeriod } from '../reportingPeriod';
 import { useGeneralLedgerQuery } from './common';
 import {
   GeneralLedgerSheetAlerts,
@@ -41,6 +42,7 @@ function GeneralLedgerInner({
         fromDate: moment(filter.fromDate).format('YYYY-MM-DD'),
         toDate: moment(filter.toDate).format('YYYY-MM-DD'),
       };
+      writeReportingPeriod(parsedFilter);
       setLocationQuery(parsedFilter);
     },
     [setLocationQuery],

--- a/packages/webapp/src/containers/FinancialStatements/GeneralLedger/common.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/GeneralLedger/common.tsx
@@ -3,6 +3,7 @@ import moment from 'moment';
 import React from 'react';
 import intl from 'react-intl-universal';
 import * as Yup from 'yup';
+import { withRememberedPeriod } from '../reportingPeriod';
 import { useAppQueryString } from '@/hooks';
 import { transformToForm } from '@/utils';
 
@@ -53,7 +54,7 @@ const parseGeneralLedgerQuery = (locationQuery: Record<string, unknown>) => {
   const defaultQuery = getDefaultGeneralLedgerQuery();
 
   const transformed = {
-    ...defaultQuery,
+    ...withRememberedPeriod(defaultQuery),
     ...transformToForm(locationQuery, defaultQuery),
   };
   return {

--- a/packages/webapp/src/containers/FinancialStatements/InventoryItemDetails/InventoryItemDetails.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/InventoryItemDetails/InventoryItemDetails.tsx
@@ -1,5 +1,6 @@
 import moment from 'moment';
 import React, { useEffect } from 'react';
+import { writeReportingPeriod } from '../reportingPeriod';
 import {
   InventoryItemDetailsLoadingBar,
   InventoryItemDetailsAlerts,
@@ -37,6 +38,7 @@ function InventoryItemDetailsInner({
       fromDate: moment(filter.fromDate as string).format('YYYY-MM-DD'),
       toDate: moment(filter.toDate as string).format('YYYY-MM-DD'),
     };
+    writeReportingPeriod(_filter);
     setLocationQuery({ ..._filter });
   };
   // Handle number format submit.

--- a/packages/webapp/src/containers/FinancialStatements/InventoryItemDetails/utils2.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/InventoryItemDetails/utils2.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import intl from 'react-intl-universal';
 import * as Yup from 'yup';
 import { transformFilterFormToQuery } from '../common';
+import { withRememberedPeriod } from '../reportingPeriod';
 import { useAppQueryString } from '@/hooks';
 import { transformToForm } from '@/utils';
 
@@ -42,7 +43,7 @@ const parseInventoryItemDetailsQuery = (
   const defaultQuery = getInventoryItemDetailsDefaultQuery();
 
   const transformed = {
-    ...defaultQuery,
+    ...withRememberedPeriod(defaultQuery),
     ...transformToForm(locationQuery, defaultQuery),
   };
 

--- a/packages/webapp/src/containers/FinancialStatements/InventoryValuation/InventoryValuation.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/InventoryValuation/InventoryValuation.tsx
@@ -1,5 +1,6 @@
 import moment from 'moment';
 import React, { useEffect, useCallback } from 'react';
+import { writeReportingPeriod } from '../reportingPeriod';
 import { InventoryValuationLoadingBar } from './components';
 import { InventoryValuationActionsBar } from './InventoryValuationActionsBar';
 import { InventoryValuationBody } from './InventoryValuationBody';
@@ -36,6 +37,7 @@ function InventoryValuationInner({
         ...filter,
         asDate: moment(filter.asDate as string).format('YYYY-MM-DD'),
       };
+      writeReportingPeriod({ toDate: newFilter.asDate });
       setLocationQuery(newFilter);
     },
     [setLocationQuery],

--- a/packages/webapp/src/containers/FinancialStatements/InventoryValuation/utils.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/InventoryValuation/utils.tsx
@@ -3,6 +3,7 @@ import { castArray } from 'lodash';
 import moment from 'moment';
 import React from 'react';
 import * as Yup from 'yup';
+import { withRememberedPeriod } from '../reportingPeriod';
 import { useAppQueryString } from '@/hooks';
 import { transformToForm } from '@/utils';
 
@@ -35,7 +36,7 @@ const parseInventoryValuationQuery = (
 ): InventoryValuationTableQuery => {
   const defaultQuery = getInventoryValuationQuery();
   const transformed = {
-    ...defaultQuery,
+    ...withRememberedPeriod(defaultQuery),
     ...transformToForm(locationQuery, defaultQuery),
   };
   return {

--- a/packages/webapp/src/containers/FinancialStatements/Journal/Journal.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/Journal/Journal.tsx
@@ -1,5 +1,6 @@
 import moment from 'moment';
 import React, { useCallback, useEffect } from 'react';
+import { writeReportingPeriod } from '../reportingPeriod';
 import { JournalSheetLoadingBar, JournalSheetAlerts } from './components';
 import { JournalActionsBar } from './JournalActionsBar';
 import { JournalBody } from './JournalBody';
@@ -33,6 +34,7 @@ function JournalInner({
         fromDate: moment(filter.fromDate as string).format('YYYY-MM-DD'),
         toDate: moment(filter.toDate as string).format('YYYY-MM-DD'),
       };
+      writeReportingPeriod(_filter);
       setLocationQuery(_filter);
     },
     [setLocationQuery],

--- a/packages/webapp/src/containers/FinancialStatements/Journal/utils.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/Journal/utils.tsx
@@ -1,5 +1,6 @@
 import moment from 'moment';
 import React from 'react';
+import { withRememberedPeriod } from '../reportingPeriod';
 import { useAppQueryString } from '@/hooks';
 import { transformToForm } from '@/utils';
 
@@ -21,7 +22,7 @@ const parseJournalQuery = (locationQuery: Record<string, unknown>) => {
   const defaultQuery = getDefaultJournalQuery();
 
   return {
-    ...defaultQuery,
+    ...withRememberedPeriod(defaultQuery),
     ...transformToForm(locationQuery, defaultQuery),
   };
 };

--- a/packages/webapp/src/containers/FinancialStatements/ProfitLossSheet/ProfitLossSheet.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/ProfitLossSheet/ProfitLossSheet.tsx
@@ -1,5 +1,6 @@
 import moment from 'moment';
 import React from 'react';
+import { writeReportingPeriod } from '../reportingPeriod';
 import { ProfitLossSheetAlerts, ProfitLossSheetLoadingBar } from './components';
 import { ProfitLossActionsBar } from './ProfitLossActionsBar';
 import { ProfitLossBody } from './ProfitLossBody';
@@ -31,6 +32,7 @@ function ProfitLossSheetInner({
       fromDate: moment(filter.fromDate as string).format('YYYY-MM-DD'),
       toDate: moment(filter.toDate as string).format('YYYY-MM-DD'),
     };
+    writeReportingPeriod(newFilter);
     setLocationQuery(newFilter);
   };
 

--- a/packages/webapp/src/containers/FinancialStatements/ProfitLossSheet/utils.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/ProfitLossSheet/utils.tsx
@@ -3,6 +3,7 @@ import moment from 'moment';
 import React from 'react';
 import intl from 'react-intl-universal';
 import * as Yup from 'yup';
+import { withRememberedPeriod } from '../reportingPeriod';
 import type { FormikContextType } from 'formik';
 import { useAppQueryString } from '@/hooks';
 import { transformToForm } from '@/utils';
@@ -39,7 +40,7 @@ const parseProfitLossQuery = (locationQuery: Record<string, unknown>) => {
   const defaultQuery = getDefaultProfitLossQuery();
 
   const transformed = {
-    ...defaultQuery,
+    ...withRememberedPeriod(defaultQuery),
     ...transformToForm(locationQuery, defaultQuery),
   };
 

--- a/packages/webapp/src/containers/FinancialStatements/PurchasesByItems/PurchasesByItems.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/PurchasesByItems/PurchasesByItems.tsx
@@ -1,5 +1,6 @@
 import moment from 'moment';
 import { useEffect, useCallback } from 'react';
+import { writeReportingPeriod } from '../reportingPeriod';
 import { PurchasesByItemsLoadingBar } from './components';
 import { PurchasesByItemsActionsBar } from './PurchasesByItemsActionsBar';
 import { PurchasesByItemsBody } from './PurchasesByItemsBody';
@@ -35,6 +36,7 @@ function PurchasesByItemsInner({
         fromDate: moment(filter.fromDate as string).format('YYYY-MM-DD'),
         toDate: moment(filter.toDate as string).format('YYYY-MM-DD'),
       };
+      writeReportingPeriod(parsedFilter);
       setLocationQuery(parsedFilter);
     },
     [setLocationQuery],

--- a/packages/webapp/src/containers/FinancialStatements/PurchasesByItems/utils.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/PurchasesByItems/utils.tsx
@@ -4,6 +4,7 @@ import moment from 'moment';
 import React from 'react';
 import intl from 'react-intl-universal';
 import * as Yup from 'yup';
+import { withRememberedPeriod } from '../reportingPeriod';
 import { useAppQueryString } from '@/hooks';
 import { transformToForm } from '@/utils';
 
@@ -39,7 +40,7 @@ const parsePurchasesByItemsQuery = (
 ): PurchasesByItemsTableQuery => {
   const defaultQuery = getDefaultPurchasesByItemsQuery();
   const transformed = {
-    ...defaultQuery,
+    ...withRememberedPeriod(defaultQuery),
     ...transformToForm(locationQuery, defaultQuery),
   };
   return {

--- a/packages/webapp/src/containers/FinancialStatements/SalesByItems/SalesByItems.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/SalesByItems/SalesByItems.tsx
@@ -1,5 +1,6 @@
 import moment from 'moment';
 import { useEffect, useCallback } from 'react';
+import { writeReportingPeriod } from '../reportingPeriod';
 import { SalesByItemsLoadingBar } from './components';
 import { SalesByItemProvider } from './SalesByItemProvider';
 import { SalesByItemsActionsBar } from './SalesByItemsActionsBar';
@@ -35,6 +36,7 @@ function SalesByItemsInner({
         fromDate: moment(filter.fromDate as string).format('YYYY-MM-DD'),
         toDate: moment(filter.toDate as string).format('YYYY-MM-DD'),
       };
+      writeReportingPeriod(parsedFilter);
       setLocationQuery(parsedFilter);
     },
     [setLocationQuery],

--- a/packages/webapp/src/containers/FinancialStatements/SalesByItems/utils.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/SalesByItems/utils.tsx
@@ -4,6 +4,7 @@ import moment from 'moment';
 import React from 'react';
 import intl from 'react-intl-universal';
 import * as Yup from 'yup';
+import { withRememberedPeriod } from '../reportingPeriod';
 import { useAppQueryString } from '@/hooks';
 import { transformToForm } from '@/utils';
 
@@ -39,7 +40,7 @@ const parseSalesByItemsQuery = (
 ): SalesByItemsTableQuery => {
   const defaultQuery = getDefaultSalesByItemsQuery();
   const transformed = {
-    ...defaultQuery,
+    ...withRememberedPeriod(defaultQuery),
     ...transformToForm(locationQuery, defaultQuery),
   };
   return {

--- a/packages/webapp/src/containers/FinancialStatements/SalesTaxLiabilitySummary/SalesTaxLiabilitySummary.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/SalesTaxLiabilitySummary/SalesTaxLiabilitySummary.tsx
@@ -1,5 +1,6 @@
 import moment from 'moment';
 import React, { useEffect } from 'react';
+import { writeReportingPeriod } from '../reportingPeriod';
 import { SalesTaxLiabilitySummaryLoadingBar } from './components';
 import { SalesTaxLiabiltiyPdfDialog } from './SalesTaxLiabilityPdfDialog';
 import { SalesTaxLiabilitySummaryActionsBar } from './SalesTaxLiabilitySummaryActionsBar';
@@ -33,6 +34,7 @@ function SalesTaxLiabilitySummaryInner({
       fromDate: moment(filter.fromDate).format('YYYY-MM-DD'),
       toDate: moment(filter.toDate).format('YYYY-MM-DD'),
     };
+    writeReportingPeriod(newFilter);
     setQuery({ ...newFilter });
   };
   // Handle number format submit.

--- a/packages/webapp/src/containers/FinancialStatements/SalesTaxLiabilitySummary/utils.ts
+++ b/packages/webapp/src/containers/FinancialStatements/SalesTaxLiabilitySummary/utils.ts
@@ -3,6 +3,7 @@ import moment from 'moment';
 import React, { useMemo } from 'react';
 import intl from 'react-intl-universal';
 import * as Yup from 'yup';
+import { withRememberedPeriod } from '../reportingPeriod';
 import { salesTaxLiabilitySummaryDynamicColumns } from './dynamicColumns';
 import { useSalesTaxLiabilitySummaryContext } from './SalesTaxLiabilitySummaryBoot';
 import { useAppQueryString } from '@/hooks';
@@ -27,7 +28,7 @@ const parseSalesTaxLiabilitySummaryQuery = (
   const defaultQuery = getDefaultSalesTaxLiablitySummaryQuery();
 
   const transformed = {
-    ...defaultQuery,
+    ...withRememberedPeriod(defaultQuery),
     ...transformToForm(locationQuery, defaultQuery),
   };
   return {

--- a/packages/webapp/src/containers/FinancialStatements/TrialBalanceSheet/TrialBalanceSheet.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/TrialBalanceSheet/TrialBalanceSheet.tsx
@@ -1,5 +1,6 @@
 import moment from 'moment';
 import React, { useCallback, useEffect } from 'react';
+import { writeReportingPeriod } from '../reportingPeriod';
 import {
   TrialBalanceSheetAlerts,
   TrialBalanceSheetLoadingBar,
@@ -39,6 +40,7 @@ function TrialBalanceSheetInner({
         fromDate: moment(filter.fromDate as Date).format('YYYY-MM-DD'),
         toDate: moment(filter.toDate as Date).format('YYYY-MM-DD'),
       };
+      writeReportingPeriod(parsedFilter);
       setLocationQuery(parsedFilter);
     },
     [setLocationQuery],

--- a/packages/webapp/src/containers/FinancialStatements/TrialBalanceSheet/utils.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/TrialBalanceSheet/utils.tsx
@@ -3,6 +3,7 @@ import { castArray } from 'lodash';
 import moment from 'moment';
 import React from 'react';
 import { transformFilterFormToQuery } from '../common';
+import { withRememberedPeriod } from '../reportingPeriod';
 import { useAppQueryString } from '@/hooks';
 import { transformToForm } from '@/utils';
 
@@ -30,7 +31,7 @@ const parseTrialBalanceSheetQuery = (
 ): TrialBalanceQuery => {
   const defaultQuery = getDefaultTrialBalanceQuery();
   const transformed = {
-    ...defaultQuery,
+    ...withRememberedPeriod(defaultQuery),
     ...transformToForm(locationQuery, defaultQuery),
   };
   return {

--- a/packages/webapp/src/containers/FinancialStatements/VendorsBalanceSummary/VendorsBalanceSummary.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/VendorsBalanceSummary/VendorsBalanceSummary.tsx
@@ -1,5 +1,6 @@
 import moment from 'moment';
 import React, { useEffect } from 'react';
+import { writeReportingPeriod } from '../reportingPeriod';
 import { VendorsSummarySheetLoadingBar } from './components';
 import { useVendorsBalanceSummaryQuery } from './utils';
 import { VendorBalanceDialogs } from './VendorBalanceDialogs';
@@ -33,6 +34,7 @@ function VendorsBalanceSummaryInner({
       ...filter,
       asDate: moment(filter.asDate as string).format('YYYY-MM-DD'),
     };
+    writeReportingPeriod({ toDate: _filter.asDate });
     setLocationQuery(_filter);
   };
 

--- a/packages/webapp/src/containers/FinancialStatements/VendorsBalanceSummary/utils.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/VendorsBalanceSummary/utils.tsx
@@ -3,6 +3,7 @@ import { castArray } from 'lodash';
 import moment from 'moment';
 import { useMemo } from 'react';
 import * as Yup from 'yup';
+import { withRememberedPeriod } from '../reportingPeriod';
 import { useAppQueryString } from '@/hooks';
 import { transformToForm } from '@/utils';
 
@@ -27,7 +28,7 @@ export const parseVendorsBalanceSummaryQuery = (
 ): VendorBalanceTableQuery => {
   const defaultQuery = getDefaultVendorsBalanceQuery();
   const transformed = {
-    ...defaultQuery,
+    ...withRememberedPeriod(defaultQuery),
     ...transformToForm(locationQuery, defaultQuery),
   };
   return {

--- a/packages/webapp/src/containers/FinancialStatements/VendorsTransactions/VendorsTransactions.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/VendorsTransactions/VendorsTransactions.tsx
@@ -1,5 +1,6 @@
 import moment from 'moment';
 import React, { useEffect } from 'react';
+import { writeReportingPeriod } from '../reportingPeriod';
 import { useVendorsTransactionsQuery } from './_utils';
 import { VendorsTransactionsLoadingBar } from './components';
 import { VendorsTransactionsActionsBar } from './VendorsTransactionsActionsBar';
@@ -34,6 +35,7 @@ function VendorsTransactionsInner({
       fromDate: moment(filter.fromDate as string).format('YYYY-MM-DD'),
       toDate: moment(filter.toDate as string).format('YYYY-MM-DD'),
     };
+    writeReportingPeriod(_filter);
     setFilter({ ..._filter });
   };
   // Handle number format submit.

--- a/packages/webapp/src/containers/FinancialStatements/VendorsTransactions/_utils.ts
+++ b/packages/webapp/src/containers/FinancialStatements/VendorsTransactions/_utils.ts
@@ -3,6 +3,7 @@ import moment from 'moment';
 import { useMemo } from 'react';
 import intl from 'react-intl-universal';
 import * as Yup from 'yup';
+import { withRememberedPeriod } from '../reportingPeriod';
 import { useAppQueryString } from '@/hooks';
 import { transformToForm } from '@/utils';
 
@@ -38,7 +39,7 @@ const parseVendorsTransactionsQuery = (
 ): TransactionsByVendorsTableQuery => {
   const defaultQuery = getVendorsTransactionsDefaultQuery();
   const transformed = {
-    ...defaultQuery,
+    ...withRememberedPeriod(defaultQuery),
     ...transformToForm(query, defaultQuery),
   };
   return {

--- a/packages/webapp/src/containers/FinancialStatements/reportingPeriod.ts
+++ b/packages/webapp/src/containers/FinancialStatements/reportingPeriod.ts
@@ -1,0 +1,85 @@
+/**
+ * The last date range a user picked on a financial report, remembered so that
+ * moving between reports keeps the same period instead of snapping back to each
+ * report's own default.
+ *
+ * Scope for now is a single localStorage key; a per-user server setting can back
+ * this later without changing callers.
+ */
+const STORAGE_KEY = 'bigcapital:financial-reports:period';
+
+export interface ReportingPeriod {
+  fromDate: string;
+  toDate: string;
+}
+
+const isValid = (value: unknown): value is ReportingPeriod =>
+  typeof value === 'object' &&
+  value !== null &&
+  typeof (value as ReportingPeriod).fromDate === 'string' &&
+  typeof (value as ReportingPeriod).toDate === 'string';
+
+/**
+ * Reads the remembered reporting period, or `null` when nothing is stored or the
+ * value is unusable (private window, cleared storage, older shape).
+ */
+export const readReportingPeriod = (): ReportingPeriod | null => {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+
+    const parsed = JSON.parse(raw);
+    return isValid(parsed)
+      ? { fromDate: parsed.fromDate, toDate: parsed.toDate }
+      : null;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Persists the reporting period. A partial update is merged over what's already
+ * stored, so a point-in-time report (aging, balance summary) can move just the
+ * `toDate` while keeping the range's start. Nothing is written until both ends
+ * are known. Failures (storage disabled/full) are ignored - remembering the
+ * range is a convenience, not correctness.
+ */
+export const writeReportingPeriod = (
+  period: Partial<ReportingPeriod>,
+): void => {
+  const current = readReportingPeriod();
+  const fromDate = period.fromDate ?? current?.fromDate;
+  const toDate = period.toDate ?? current?.toDate;
+
+  if (!fromDate || !toDate) return;
+
+  try {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ fromDate, toDate }),
+    );
+  } catch {
+    /* no-op */
+  }
+};
+
+/**
+ * Overlays the remembered period onto a report's default query, when one is
+ * stored. Only keys the report already declares are touched: a range report
+ * gets `fromDate`/`toDate`, a point-in-time report gets its `asDate` set to the
+ * range's end. A report opened via a URL that already carries these still wins,
+ * because the location query is merged over the defaults downstream.
+ */
+export const withRememberedPeriod = <T extends object>(defaults: T): T => {
+  const remembered = readReportingPeriod();
+
+  if (!remembered) return defaults;
+
+  const overlay: Record<string, string> = {};
+
+  if ('fromDate' in defaults) overlay.fromDate = remembered.fromDate;
+  if ('toDate' in defaults) overlay.toDate = remembered.toDate;
+  if ('asDate' in defaults) overlay.asDate = remembered.toDate;
+
+  return { ...defaults, ...overlay };
+};


### PR DESCRIPTION
## Bug

Financial reports each default their own date range and only read the active
range from the URL query string. Set a range on one report (say, Q3 2025 on
P&L), then open a different report (Balance Sheet) — it resets to that
report's own hardcoded default instead of keeping Q3 2025. Reviewing several
reports for one period means re-entering the dates on every single one.

## Fix

A small `localStorage`-backed helper, `containers/FinancialStatements/reportingPeriod.ts`:

- `withRememberedPeriod(defaultQuery)` — a report falls back to it only when
  it has no date range of its own (i.e. no URL query present — a fresh
  navigation, not a shared link or back button).
- `writeReportingPeriod(...)` — called when a filter is applied.
- `readReportingPeriod()` — tolerant of missing/disabled/stale storage (returns `null`).

A report opened from a URL that already carries `fromDate`/`toDate` is
unaffected — that still wins over the remembered value, exactly as before.

## Scope

Wired into every report that has a working date filter: P&L, Balance Sheet,
Cash Flow, General Ledger, Journal, Trial Balance, AP/AR Aging,
Customers/Vendors Balance Summary, Customers/Vendors Transactions,
Sales/Purchases by Item, Sales Tax Liability, Inventory Valuation, Inventory
Item Details.

**Left out** (not this bug):
- Audit Log — its date range is optional/empty by design.
- Realized/Unrealized Gain or Loss — their filter isn't wired to the query
  at all yet (separate, pre-existing issue).

## Behaviour

- Open P&L, set the range to `2025 Q3`, open Balance Sheet → it opens on `2025 Q3` too.
- Empty/unavailable storage → each report falls back to its existing default. No UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
