### PR TITLE
feat(webapp): open invoice/bill detail drawer from payment form entry links

### DIFF
--- a/packages/webapp/src/containers/Purchases/PaymentsMade/PaymentForm/PaymentMadeEntriesTable.tsx
+++ b/packages/webapp/src/containers/Purchases/PaymentsMade/PaymentForm/PaymentMadeEntriesTable.tsx
@@ -4,15 +4,18 @@ import React, { useCallback } from 'react';
 import { usePaymentMadeEntriesTableColumns } from './components';
 import { usePaymentMadeInnerContext } from './PaymentMadeInnerProvider';
 import type { PaymentMadeEntry, PaymentMadeFormValues } from './utils';
+import type { WithDrawerActionsProps } from '@/containers/Drawer/withDrawerActions';
 import {
   DataTableEditable,
   CloudLoadingIndicator,
   FormattedMessage as T,
 } from '@/components';
 import { CLASSES } from '@/constants/classes';
+import { DRAWERS } from '@/constants/drawers';
+import { withDrawerActions } from '@/containers/Drawer/withDrawerActions';
 import { compose, updateTableCell } from '@/utils';
 
-type PaymentMadeEntriesTableProps = {
+type PaymentMadeEntriesTableProps = WithDrawerActionsProps & {
   onUpdateData: (entries: PaymentMadeEntry[]) => void;
   entries: PaymentMadeEntry[];
   currencyCode: string;
@@ -21,16 +24,24 @@ type PaymentMadeEntriesTableProps = {
 /**
  * Payment made items table.
  */
-export function PaymentMadeEntriesTable({
+function PaymentMadeEntriesTableInner({
   onUpdateData,
   entries,
   currencyCode,
+
+  // #withDrawerActions
+  openDrawer,
 }: PaymentMadeEntriesTableProps) {
   // Payment made inner context.
   const { isNewEntriesFetching } = usePaymentMadeInnerContext();
 
+  // Opens the bill detail drawer of the given bill.
+  const handleViewBillDetail = (billId: number) => {
+    openDrawer(DRAWERS.BILL_DETAILS, { billId });
+  };
+
   // Payment entries table columns.
-  const columns = usePaymentMadeEntriesTableColumns();
+  const columns = usePaymentMadeEntriesTableColumns(handleViewBillDetail);
 
   // Formik context.
   const {
@@ -77,3 +88,7 @@ export function PaymentMadeEntriesTable({
     </CloudLoadingIndicator>
   );
 }
+
+export const PaymentMadeEntriesTable = compose(withDrawerActions)(
+  PaymentMadeEntriesTableInner,
+);

--- a/packages/webapp/src/containers/Purchases/PaymentsMade/PaymentForm/PaymentMadeFormPage.tsx
+++ b/packages/webapp/src/containers/Purchases/PaymentsMade/PaymentForm/PaymentMadeFormPage.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { useParams } from 'react-router-dom';
 import { PaymentMadeForm } from './PaymentMadeForm';
 import { PaymentMadeFormProvider } from './PaymentMadeFormProvider';
+import { DRAWERS } from '@/constants/drawers';
+import { index as BillDrawer } from '@/containers/Drawers/BillDrawer';
 
 import '@/style/pages/PaymentMade/PageForm.scss';
 
@@ -15,6 +17,7 @@ export function PaymentMadeFormPage() {
   return (
     <PaymentMadeFormProvider paymentMadeId={paymentMadeId}>
       <PaymentMadeForm />
+      <BillDrawer name={DRAWERS.BILL_DETAILS} />
     </PaymentMadeFormProvider>
   );
 }

--- a/packages/webapp/src/containers/Purchases/PaymentsMade/PaymentForm/components.tsx
+++ b/packages/webapp/src/containers/Purchases/PaymentsMade/PaymentForm/components.tsx
@@ -8,20 +8,96 @@ import {
 } from './utils';
 import { Money, ExchangeRateInputGroup } from '@/components';
 import { MoneyFieldCell } from '@/components/DataTableCells';
+import { CLASSES } from '@/constants/classes';
 import { useCurrentOrganizationBaseCurrency } from '@/hooks/query';
 
 type Row = {
+  billId?: string | number;
   billNo?: string;
   currencyCode?: string;
 };
+
+type OnViewBillDetail = (billId: number) => void;
+
+/**
+ * Creates a click handler that opens the bill detail drawer of the
+ * given bill.
+ */
+const createBillClickHandler =
+  (billId: number, onViewBillDetail?: OnViewBillDetail) =>
+  (event: React.MouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+    onViewBillDetail?.(billId);
+  };
 
 function BillNumberAccessor(row: Row): string {
   return row?.billNo ? row?.billNo : '-';
 }
 
-function BillDateCell({ value }: { value: string }) {
-  return <span>{moment(value).format('YYYY MMM DD')}</span>;
-}
+type BillDateCellProps = {
+  row: { original: Row };
+  value: string;
+};
+
+/**
+ * Bill date cell - renders the date as a link that opens the bill detail
+ * drawer when the row references an existing bill.
+ */
+const createBillDateCell = (onViewBillDetail?: OnViewBillDetail) => {
+  return function BillDateCell({
+    row: { original },
+    value,
+  }: BillDateCellProps) {
+    const formattedDate = moment(value).format('YYYY MMM DD');
+
+    if (!original?.billId) {
+      return <span>{formattedDate}</span>;
+    }
+    return (
+      <a
+        className={CLASSES.TEXT_LINK}
+        onClick={createBillClickHandler(
+          original.billId as number,
+          onViewBillDetail,
+        )}
+      >
+        {formattedDate}
+      </a>
+    );
+  };
+};
+
+type BillNumberCellProps = {
+  row: { original: Row };
+  value: string;
+};
+
+/**
+ * Bill number cell - renders the bill number as a link that opens the
+ * bill detail drawer when the row references an existing bill.
+ */
+const createBillNumberCell = (onViewBillDetail?: OnViewBillDetail) => {
+  return function BillNumberCell({
+    row: { original },
+    value,
+  }: BillNumberCellProps) {
+    if (!original?.billId) {
+      return <span>{value}</span>;
+    }
+    return (
+      <a
+        className={CLASSES.TEXT_LINK}
+        onClick={createBillClickHandler(
+          original.billId as number,
+          onViewBillDetail,
+        )}
+      >
+        {value}
+      </a>
+    );
+  };
+};
 
 /**
  * Money table cell.
@@ -39,20 +115,23 @@ function MoneyTableCell({
 /**
  * Payment made entries table columns
  */
-export function usePaymentMadeEntriesTableColumns() {
+export function usePaymentMadeEntriesTableColumns(
+  onViewBillDetail?: OnViewBillDetail,
+) {
   return React.useMemo(
     () => [
       {
         Header: 'Bill date',
         id: 'billDate',
         accessor: 'billDate',
-        Cell: BillDateCell,
+        Cell: createBillDateCell(onViewBillDetail),
         disableSortBy: true,
         width: 120,
       },
       {
         Header: intl.get('bill_number'),
         accessor: BillNumberAccessor,
+        Cell: createBillNumberCell(onViewBillDetail),
         disableSortBy: true,
         width: 120,
       },
@@ -78,7 +157,7 @@ export function usePaymentMadeEntriesTableColumns() {
         width: 150,
       },
     ],
-    [],
+    [onViewBillDetail],
   );
 }
 

--- a/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentReceiveForm/PaymentReceiveFormPage.tsx
+++ b/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentReceiveForm/PaymentReceiveFormPage.tsx
@@ -7,6 +7,8 @@ import {
   usePaymentReceiveFormContext,
 } from './PaymentReceiveFormProvider';
 import { DashboardInsider } from '@/components';
+import { DRAWERS } from '@/constants/drawers';
+import { index as InvoiceDetailDrawer } from '@/containers/Drawers/InvoiceDetailDrawer';
 
 /**
  * Payment received form page.
@@ -34,6 +36,7 @@ function PaymentReceivedFormPageContent() {
       `}
     >
       <PaymentReceivedForm />
+      <InvoiceDetailDrawer name={DRAWERS.INVOICE_DETAILS} />
     </DashboardInsider>
   );
 }

--- a/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentReceiveForm/PaymentReceiveItemsTable.tsx
+++ b/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentReceiveForm/PaymentReceiveItemsTable.tsx
@@ -4,12 +4,15 @@ import React, { useCallback } from 'react';
 import { usePaymentReceiveEntriesColumns } from './components';
 import { usePaymentReceiveInnerContext } from './PaymentReceiveInnerProvider';
 import type { PaymentReceiveEntry, PaymentReceiveFormValues } from './utils';
+import type { WithDrawerActionsProps } from '@/containers/Drawer/withDrawerActions';
 import { CloudLoadingIndicator, FormattedMessage as T } from '@/components';
 import { DataTableEditable } from '@/components';
 import { CLASSES } from '@/constants/classes';
+import { DRAWERS } from '@/constants/drawers';
+import { withDrawerActions } from '@/containers/Drawer/withDrawerActions';
 import { compose, updateTableCell } from '@/utils';
 
-type PaymentReceiveItemsTableProps = {
+type PaymentReceiveItemsTableProps = WithDrawerActionsProps & {
   entries: PaymentReceiveEntry[];
   onUpdateData: (entries: PaymentReceiveEntry[]) => void;
   currencyCode: string;
@@ -18,14 +21,22 @@ type PaymentReceiveItemsTableProps = {
 /**
  * Payment receive items table.
  */
-export function PaymentReceiveItemsTable({
+function PaymentReceiveItemsTableInner({
   entries,
   onUpdateData,
   currencyCode,
+
+  // #withDrawerActions
+  openDrawer,
 }: PaymentReceiveItemsTableProps) {
   const { isDueInvoicesFetching } = usePaymentReceiveInnerContext();
 
-  const columns = usePaymentReceiveEntriesColumns();
+  // Opens the invoice detail drawer of the given invoice.
+  const handleViewInvoiceDetail = (invoiceId: number) => {
+    openDrawer(DRAWERS.INVOICE_DETAILS, { invoiceId });
+  };
+
+  const columns = usePaymentReceiveEntriesColumns(handleViewInvoiceDetail);
 
   const {
     values: { customerId },
@@ -67,3 +78,7 @@ export function PaymentReceiveItemsTable({
     </CloudLoadingIndicator>
   );
 }
+
+export const PaymentReceiveItemsTable = compose(withDrawerActions)(
+  PaymentReceiveItemsTableInner,
+);

--- a/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentReceiveForm/components.tsx
+++ b/packages/webapp/src/containers/Sales/PaymentsReceived/PaymentReceiveForm/components.tsx
@@ -10,19 +10,56 @@ import {
   type PaymentReceiveFormValues,
 } from './utils';
 import { Money, ExchangeRateInputGroup, MoneyFieldCell } from '@/components';
+import { CLASSES } from '@/constants/classes';
 import { useCurrentOrganizationBaseCurrency } from '@/hooks/query';
 import { transactionNumber } from '@/utils';
 
+type OnViewInvoiceDetail = (invoiceId: number) => void;
+
+/**
+ * Creates a click handler that opens the invoice detail drawer of the
+ * given invoice.
+ */
+const createInvoiceClickHandler =
+  (invoiceId: number, onViewInvoiceDetail?: OnViewInvoiceDetail) =>
+  (event: React.MouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+    onViewInvoiceDetail?.(invoiceId);
+  };
+
 type InvoiceDateCellProps = {
+  row: { original: PaymentReceiveEntry };
   value?: string | number | Date | null;
 };
 
 /**
- * Invoice date cell.
+ * Invoice date cell - renders the date as a link that opens the invoice
+ * detail drawer when the row references an existing invoice.
  */
-function InvoiceDateCell({ value }: InvoiceDateCellProps) {
-  return <span>{moment(value).format('YYYY MMM DD')}</span>;
-}
+const createInvoiceDateCell = (onViewInvoiceDetail?: OnViewInvoiceDetail) => {
+  return function InvoiceDateCell({
+    row: { original },
+    value,
+  }: InvoiceDateCellProps) {
+    const formattedDate = moment(value).format('YYYY MMM DD');
+
+    if (!original?.invoiceId) {
+      return <span>{formattedDate}</span>;
+    }
+    return (
+      <a
+        className={CLASSES.TEXT_LINK}
+        onClick={createInvoiceClickHandler(
+          original.invoiceId as number,
+          onViewInvoiceDetail,
+        )}
+      >
+        {formattedDate}
+      </a>
+    );
+  };
+};
 
 /**
  * Invoice number table cell accessor.
@@ -30,6 +67,37 @@ function InvoiceDateCell({ value }: InvoiceDateCellProps) {
 function InvNumberCellAccessor(row: PaymentReceiveEntry): string {
   return row?.invoiceNo ? `#${row?.invoiceNo || ''}` : '-';
 }
+
+type InvoiceNumberCellProps = {
+  row: { original: PaymentReceiveEntry };
+  value: string;
+};
+
+/**
+ * Invoice number cell - renders the invoice number as a link that opens
+ * the invoice detail drawer when the row references an existing invoice.
+ */
+const createInvoiceNumberCell = (onViewInvoiceDetail?: OnViewInvoiceDetail) => {
+  return function InvoiceNumberCell({
+    row: { original },
+    value,
+  }: InvoiceNumberCellProps) {
+    if (!original?.invoiceId) {
+      return <span>{value}</span>;
+    }
+    return (
+      <a
+        className={CLASSES.TEXT_LINK}
+        onClick={createInvoiceClickHandler(
+          original.invoiceId as number,
+          onViewInvoiceDetail,
+        )}
+      >
+        {value}
+      </a>
+    );
+  };
+};
 
 type MoneyTableCellProps = {
   row: { original: PaymentReceiveEntry };
@@ -46,14 +114,16 @@ function MoneyTableCell({ row: { original }, value }: MoneyTableCellProps) {
 /**
  * Retrieve payment receive form entries columns.
  */
-export const usePaymentReceiveEntriesColumns = () => {
+export const usePaymentReceiveEntriesColumns = (
+  onViewInvoiceDetail?: OnViewInvoiceDetail,
+) => {
   return React.useMemo(
     () => [
       {
         Header: 'Invoice date',
         id: 'invoiceDate',
         accessor: 'invoiceDate',
-        Cell: InvoiceDateCell,
+        Cell: createInvoiceDateCell(onViewInvoiceDetail),
         disableSortBy: true,
         disableResizing: true,
         width: 250,
@@ -62,6 +132,7 @@ export const usePaymentReceiveEntriesColumns = () => {
       {
         Header: intl.get('invocie_number'),
         accessor: InvNumberCellAccessor,
+        Cell: createInvoiceNumberCell(onViewInvoiceDetail),
         disableSortBy: true,
         className: 'invoice_number',
       },
@@ -90,7 +161,7 @@ export const usePaymentReceiveEntriesColumns = () => {
         className: 'payment_amount',
       },
     ],
-    [],
+    [onViewInvoiceDetail],
   );
 };
 


### PR DESCRIPTION
## Description

Adds clickable links in the Payment Received and Payment Made form entries tables that open the underlying invoice/bill detail drawer without leaving the form:

- Payment Received: the invoice number and invoice date cells now open the invoice detail drawer (`DRAWERS.INVOICE_DETAILS`).
- Payment Made: the bill number and bill date cells now open the bill detail drawer (`DRAWERS.BILL_DETAILS`).
- Rows without an invoice/bill reference fall back to plain text (no link).
- Follows the same pattern recently added to the journal/general-ledger report columns: `text-link` styled anchors dispatching `openDrawer` via `withDrawerActions`, with `InvoiceDetailDrawer` / `BillDrawer` mounted on the respective form pages.

No server or SDK changes are required.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- `pnpm run typecheck` (webapp) passes.
- `eslint` on the changed files: 0 errors; 4 new `jsx-a11y/anchor-is-valid` warnings consistent with existing usage across the codebase (177 pre-existing warnings).
- `prettier --check` on the changed files passes.
- Manual verification instructions:
  1. Open a new or existing Payment Received form and select a customer.
  2. Click an invoice number or invoice date cell in the entries table.
  3. The invoice detail drawer opens over the form with the form state intact.
  4. Repeat on a Payment Made form with a vendor: bill number/date cells open the bill detail drawer.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>
