### PR TITLE
refactor(webapp): remove @ts-nocheck from first wave of modules

### DIFF
--- a/packages/webapp/src/components/ErrorMessage/index.tsx
+++ b/packages/webapp/src/components/ErrorMessage/index.tsx
@@ -1,10 +1,14 @@
-// @ts-nocheck
 import { get } from 'lodash';
-import React from 'react';
+import type { ReactNode } from 'react';
 
-const hasErrorMessage = ({}) => {};
+interface ErrorMessageProps {
+  touched?: unknown;
+  errors?: unknown;
+  name: string;
+  children?: ReactNode;
+}
 
-export function ErrorMessage({ touched, errors, name, children }) {
+export function ErrorMessage({ touched, errors, name }: ErrorMessageProps) {
   const error = get(errors, name);
   const touch = get(touched, name);
 

--- a/packages/webapp/src/components/Typo/Paragraph.tsx
+++ b/packages/webapp/src/components/Typo/Paragraph.tsx
@@ -1,7 +1,12 @@
-// @ts-nocheck
 import clsx from 'classnames';
 import React from 'react';
+import type { ReactNode } from 'react';
 
-export function Paragraph({ className, children }) {
+export interface ParagraphProps {
+  className?: string;
+  children?: ReactNode;
+}
+
+export function Paragraph({ className, children }: ParagraphProps) {
   return <p className={clsx('paragraph', className)}>{children}</p>;
 }

--- a/packages/webapp/src/components/UniversalSearch/UniversalSearch.tsx
+++ b/packages/webapp/src/components/UniversalSearch/UniversalSearch.tsx
@@ -27,13 +27,13 @@ import { RESOURCES_TYPES } from '@/constants/resourcesTypes';
 type ResourceType = string;
 
 // Search type option item
-interface SearchTypeOption {
+export interface SearchTypeOption {
   key: ResourceType;
   label: string;
 }
 
 // Universal search item
-interface UniversalSearchItem {
+export interface UniversalSearchItem {
   id: number | string;
   _type: ResourceType;
   text: string;
@@ -411,7 +411,7 @@ export interface UniversalSearchProps {
   /** Controlled search resource type */
   searchResource?: ResourceType;
   /** Overlay props */
-  overlayProps?: OverlayProps;
+  overlayProps?: Partial<OverlayProps>;
   /** Whether the search overlay is open */
   isOpen: boolean;
   /** Whether the search is loading */

--- a/packages/webapp/src/components/Utils/For.tsx
+++ b/packages/webapp/src/components/Utils/For.tsx
@@ -1,10 +1,10 @@
-// @ts-nocheck
-import PropTypes from 'prop-types';
+import React from 'react';
 
-export const For = ({ render, of }) =>
-  of.map((item, index) => render(item, index));
+export interface ForProps<T> {
+  render: (item: T, index: number) => React.ReactNode;
+  of: T[];
+}
 
-For.propTypes = {
-  of: PropTypes.array.isRequired,
-  render: PropTypes.func.isRequired,
-};
+export function For<T>({ render, of }: ForProps<T>) {
+  return <>{of.map((item, index) => render(item, index))}</>;
+}

--- a/packages/webapp/src/containers/Attachments/UploadAttachmentButton.tsx
+++ b/packages/webapp/src/containers/Attachments/UploadAttachmentButton.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import {
   Button,
   Classes,
@@ -9,17 +8,28 @@ import clsx from 'classnames';
 import { Field, useFormikContext } from 'formik';
 import styles from './UploadAttachmentButton.module.scss';
 import { UploadAttachmentsPopoverContent } from './UploadAttachmentsPopoverContent';
+import type { AttachmentFile } from './UploadAttachmentsPopoverContent';
+import type { FieldProps } from 'formik';
 import { FFormGroup } from '@/components';
 import { transformToCamelCase, transfromToSnakeCase } from '@/utils';
+
+interface AttachmentFormValues {
+  attachments?: unknown[];
+}
 
 function UploadAttachmentButtonButtonContentField() {
   return (
     <Field name={'attachments'}>
-      {({ form: { setFieldValue }, field: { value } }) => (
+      {({ form: { setFieldValue }, field: { value } }: FieldProps) => (
         <UploadAttachmentsPopoverContent
-          value={transformToCamelCase(value)}
+          value={transformToCamelCase(value) as AttachmentFile[]}
           onChange={(changedValue) => {
-            setFieldValue('attachments', transfromToSnakeCase(changedValue));
+            setFieldValue(
+              'attachments',
+              transfromToSnakeCase(
+                changedValue as unknown as Record<string, unknown>,
+              ),
+            );
           }}
         />
       )}
@@ -28,7 +38,7 @@ function UploadAttachmentButtonButtonContentField() {
 }
 
 export function UploadAttachmentButton() {
-  const { values } = useFormikContext();
+  const { values } = useFormikContext<AttachmentFormValues>();
   const uploadedFiles = values?.attachments?.length || 0;
 
   return (

--- a/packages/webapp/src/containers/Attachments/UploadAttachmentsPopoverContent.tsx
+++ b/packages/webapp/src/containers/Attachments/UploadAttachmentsPopoverContent.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Button, Intent, Text, Spinner } from '@blueprintjs/core';
 import { isEmpty } from 'lodash';
 import { useState } from 'react';
@@ -16,17 +15,16 @@ import {
 import { useUncontrolled } from '@/hooks/useUncontrolled';
 import { formatBytes } from '@/utils/format-bytes';
 
-interface AttachmentFileCommon {
+export interface AttachmentFile {
   originName: string;
   key: string;
   size: number;
   mimeType: string;
+  loading?: boolean;
 }
-interface AttachmentFileLoaded extends AttachmentFileCommon {}
-interface AttachmentFileLoading extends AttachmentFileCommon {
-  loading: boolean;
-}
-type AttachmentFile = AttachmentFileLoaded | AttachmentFileLoading;
+export type AttachmentFileCommon = AttachmentFile;
+export type AttachmentFileLoaded = AttachmentFile;
+export type AttachmentFileLoading = AttachmentFile & { loading: boolean };
 
 interface UploadAttachmentsPopoverContentProps {
   initialValue?: AttachmentFile[];
@@ -57,11 +55,11 @@ export function UploadAttachmentsPopoverContent({
   // Stops loading of the given attachment key and updates it to new key,
   // that came from the server-side after uploading is done.
   const stopLoadingAttachment = (
-    localFiles: AttachmentFile[],
+    files: AttachmentFile[],
     internalKey: string,
     newKey: string,
   ) => {
-    return localFiles.map((localFile) => {
+    return files.map((localFile) => {
       if (localFile.key === internalKey) {
         return {
           ...localFile,
@@ -74,25 +72,32 @@ export function UploadAttachmentsPopoverContent({
   };
   // Uploads the attachments.
   const { mutateAsync: uploadAttachments } = useUploadAttachments({
-    onSuccess: (data, formData) => {
+    onSuccess: (data, variables) => {
+      const internalKey =
+        variables instanceof FormData
+          ? String(variables.get('internalKey') ?? '')
+          : '';
       const newLocalFiles = stopLoadingAttachment(
         localFiles,
-        formData.get('internalKey'),
+        internalKey,
         data.key,
       );
       handleFilesChange(newLocalFiles);
-      onUploadedChange && onUploadedChange(newLocalFiles);
+      onUploadedChange?.(newLocalFiles);
     },
   });
   // Deletes the attachment of the given file key.
   const handleClick = (key: string) => () => {
-    const updatedFiles = localFiles.filter((file, i) => file.key !== key);
+    const updatedFiles = localFiles.filter((file) => file.key !== key);
     handleFilesChange(updatedFiles);
-    onUploadedChange && onUploadedChange(updatedFiles);
+    onUploadedChange?.(updatedFiles);
   };
 
   // Handle change dropzone.
-  const handleChangeDropzone = (file: File) => {
+  const handleChangeDropzone = (file: File | null) => {
+    if (!file) {
+      return;
+    }
     const formData = new FormData();
     const key = Date.now().toString();
 
@@ -103,6 +108,7 @@ export function UploadAttachmentsPopoverContent({
       {
         originName: file.name,
         size: file.size,
+        mimeType: file.type,
         key,
         loading: true,
       },
@@ -143,7 +149,7 @@ export function UploadAttachmentsPopoverContent({
           <Stack spacing={0} className={styles.attachments}>
             {localFiles.map((localFile: AttachmentFile, index: number) => (
               <Group
-                position={'space-between'}
+                position={'apart'}
                 className={styles.attachmentItem}
                 key={index}
               >
@@ -206,7 +212,7 @@ const ViewButton = ({ fileKey }: { fileKey: string }) => {
     setLoading(true);
 
     getAttachmentPresignedUrl(key).then((data) => {
-      window.open(data.presigned_url);
+      window.open(data.presignedUrl);
       setLoading(false);
     });
   };

--- a/packages/webapp/src/containers/Attachments/utils.ts
+++ b/packages/webapp/src/containers/Attachments/utils.ts
@@ -1,19 +1,40 @@
-// @ts-nocheck
 import { transformToForm } from '@/utils';
+
+export interface AttachmentFormValue {
+  key: string;
+  size: number;
+  originName: string;
+  mimeType: string;
+}
+
+interface AttachmentsLike {
+  attachments?: unknown[];
+}
+
+const getAttachments = (values: unknown): unknown[] | undefined =>
+  (values as AttachmentsLike | null | undefined)?.attachments;
 
 const attachmentReqSchema = {
   key: '',
-  size: '',
+  size: 0,
   originName: '',
   mimeType: '',
 };
 
-export const transformAttachmentsToForm = (values) => {
-  return values.attachments?.map((attachment) =>
-    transformToForm(attachment, attachmentReqSchema),
+export const transformAttachmentsToForm = (
+  values: unknown,
+): Array<Record<string, unknown>> => {
+  return (
+    getAttachments(values)?.map((attachment) =>
+      transformToForm(attachment, attachmentReqSchema),
+    ) ?? []
   );
 };
 
-export const transformAttachmentsToRequest = (values) => {
-  return values.attachments?.map((attachment) => ({ key: attachment.key }));
+export const transformAttachmentsToRequest = (
+  values: unknown,
+): Array<{ key: string }> | undefined => {
+  return getAttachments(values)?.map((attachment) => ({
+    key: (attachment as AttachmentFormValue).key,
+  }));
 };

--- a/packages/webapp/src/containers/Drawers/CreditNoteDetailDrawer/JournalEntriesTransactions/components.tsx
+++ b/packages/webapp/src/containers/Drawers/CreditNoteDetailDrawer/JournalEntriesTransactions/components.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import intl from 'react-intl-universal';
+import type { DataTableColumn } from '@/components/Datatable/types';
+import type { GLTransactionRow } from '@/containers/JournalEntriesTable/utils';
 import { FormatDateCell } from '@/components';
 
 import '@/style/pages/JournalEntries/List.scss';
@@ -7,46 +9,48 @@ import '@/style/pages/JournalEntries/List.scss';
 /**
  * Retrieve journal entries transactions table columns.
  */
-export const useJournalEntriesTransactionsColumns = () => {
-  return React.useMemo(
-    () => [
-      {
-        Header: intl.get('date'),
-        accessor: 'date.formattedDate',
-        Cell: FormatDateCell,
-        width: 140,
-        className: 'date',
-        textOverview: true,
-      },
-      {
-        Header: intl.get('account_name'),
-        accessor: 'accountName',
-        width: 140,
-        className: 'account_name',
-        textOverview: true,
-      },
-      {
-        Header: intl.get('contact'),
-        accessor: 'formattedContactType',
-        width: 140,
-      },
-      {
-        Header: intl.get('credit'),
-        accessor: (row: { credit?: { formattedAmount?: string } }) =>
-          row.credit?.formattedAmount,
-        width: 100,
-        className: 'credit',
-        align: 'right',
-      },
-      {
-        Header: intl.get('debit'),
-        accessor: (row: { debit?: { formattedAmount?: string } }) =>
-          row.debit?.formattedAmount,
-        width: 100,
-        className: 'debit',
-        align: 'right',
-      },
-    ],
-    [],
-  );
-};
+export const useJournalEntriesTransactionsColumns =
+  (): DataTableColumn<GLTransactionRow>[] => {
+    return React.useMemo(
+      () =>
+        [
+          {
+            Header: intl.get('date'),
+            accessor: 'date.formattedDate',
+            Cell: FormatDateCell,
+            width: 140,
+            className: 'date',
+            textOverview: true,
+          },
+          {
+            Header: intl.get('account_name'),
+            accessor: 'accountName',
+            width: 140,
+            className: 'account_name',
+            textOverview: true,
+          },
+          {
+            Header: intl.get('contact'),
+            accessor: 'formattedContactType',
+            width: 140,
+          },
+          {
+            Header: intl.get('credit'),
+            accessor: (row: { credit?: { formattedAmount?: string } }) =>
+              row.credit?.formattedAmount,
+            width: 100,
+            className: 'credit',
+            align: 'right',
+          },
+          {
+            Header: intl.get('debit'),
+            accessor: (row: { debit?: { formattedAmount?: string } }) =>
+              row.debit?.formattedAmount,
+            width: 100,
+            className: 'debit',
+            align: 'right',
+          },
+        ] as DataTableColumn<GLTransactionRow>[],
+      [],
+    );
+  };

--- a/packages/webapp/src/containers/Drawers/VendorCreditDetailDrawer/JournalEntriesTransactions/components.tsx
+++ b/packages/webapp/src/containers/Drawers/VendorCreditDetailDrawer/JournalEntriesTransactions/components.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import intl from 'react-intl-universal';
+import type { DataTableColumn } from '@/components/Datatable/types';
+import type { GLTransactionRow } from '@/containers/JournalEntriesTable/utils';
 import { FormatDateCell } from '@/components';
 
 import '@/style/pages/JournalEntries/List.scss';
@@ -7,44 +9,46 @@ import '@/style/pages/JournalEntries/List.scss';
 /**
  * Retrieve journal entries transactions table columns.
  */
-export const useJournalEntriesTransactionsColumns = () => {
-  return React.useMemo(
-    () => [
-      {
-        Header: intl.get('date'),
-        accessor: 'date.formattedDate',
-        Cell: FormatDateCell,
-        width: 140,
-        className: 'date',
-        textOverview: true,
-      },
-      {
-        Header: intl.get('account_name'),
-        accessor: 'accountName',
-        width: 140,
-        className: 'account_name',
-        textOverview: true,
-      },
-      {
-        Header: intl.get('contact'),
-        accessor: 'formattedContactType',
-        width: 140,
-      },
-      {
-        Header: intl.get('credit'),
-        accessor: 'credit.formattedAmount',
-        width: 100,
-        className: 'credit',
-        align: 'right',
-      },
-      {
-        Header: intl.get('debit'),
-        accessor: 'debit.formattedAmount',
-        width: 100,
-        className: 'debit',
-        align: 'right',
-      },
-    ],
-    [],
-  );
-};
+export const useJournalEntriesTransactionsColumns =
+  (): DataTableColumn<GLTransactionRow>[] => {
+    return React.useMemo(
+      () =>
+        [
+          {
+            Header: intl.get('date'),
+            accessor: 'date.formattedDate',
+            Cell: FormatDateCell,
+            width: 140,
+            className: 'date',
+            textOverview: true,
+          },
+          {
+            Header: intl.get('account_name'),
+            accessor: 'accountName',
+            width: 140,
+            className: 'account_name',
+            textOverview: true,
+          },
+          {
+            Header: intl.get('contact'),
+            accessor: 'formattedContactType',
+            width: 140,
+          },
+          {
+            Header: intl.get('credit'),
+            accessor: 'credit.formattedAmount',
+            width: 100,
+            className: 'credit',
+            align: 'right',
+          },
+          {
+            Header: intl.get('debit'),
+            accessor: 'debit.formattedAmount',
+            width: 100,
+            className: 'debit',
+            align: 'right',
+          },
+        ] as DataTableColumn<GLTransactionRow>[],
+      [],
+    );
+  };

--- a/packages/webapp/src/containers/ElementCustomize/ElementCustomize.tsx
+++ b/packages/webapp/src/containers/ElementCustomize/ElementCustomize.tsx
@@ -10,11 +10,12 @@ import {
   ElementCustomizeFormProps,
 } from './ElementCustomizerForm';
 import { ElementCustomizeTabsControllerProvider } from './ElementCustomizeTabsController';
+import type { FormikValues } from 'formik';
 import { Group } from '@/components';
 import { extractChildren } from '@/utils/extract-children';
 
-export interface ElementCustomizeProps<T, Y>
-  extends ElementCustomizeFormProps<T, Y> {
+export interface ElementCustomizeProps<T extends FormikValues, Y>
+  extends ElementCustomizeFormProps<T> {
   brandingState?: Y;
   children?: React.ReactNode;
 }
@@ -49,7 +50,10 @@ export function ElementCustomizeContent({
   );
 }
 
-export function ElementCustomize<T, Y extends ElementPreviewState>({
+export function ElementCustomize<
+  T extends FormikValues,
+  Y extends ElementPreviewState,
+>({
   initialValues,
   validationSchema,
   onSubmit,

--- a/packages/webapp/src/containers/ElementCustomize/ElementCustomizeFields.tsx
+++ b/packages/webapp/src/containers/ElementCustomize/ElementCustomizeFields.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Button, Intent } from '@blueprintjs/core';
 import { useFormikContext } from 'formik';
 import * as FF from 'fp-ts/function';
@@ -8,6 +7,7 @@ import { ElementCustomizeHeader } from './ElementCustomizeHeader';
 import { useElementCustomizeContext } from './ElementCustomizeProvider';
 import { ElementCustomizeTabs } from './ElementCustomizeTabs';
 import { useElementCustomizeTabsController } from './ElementCustomizeTabsController';
+import type { WithDrawerActionsProps } from '@/containers/Drawer/withDrawerActions';
 import { Box, Group, Stack } from '@/components';
 import { useDrawerContext } from '@/components/Drawer/DrawerProvider';
 import { withDrawerActions } from '@/containers/Drawer/withDrawerActions';
@@ -28,8 +28,11 @@ export function ElementCustomizeFieldsMain() {
   const CustomizeTabPanel = React.useMemo(
     () =>
       React.Children.map(CustomizeTabs, (tab) => {
-        return tab.props.id === currentTabId ? tab : null;
-      }).filter(Boolean),
+        if (React.isValidElement(tab) && tab.props.id === currentTabId) {
+          return tab;
+        }
+        return null;
+      })?.filter(Boolean),
     [CustomizeTabs, currentTabId],
   );
 
@@ -47,7 +50,9 @@ export function ElementCustomizeFieldsMain() {
   );
 }
 
-function ElementCustomizeFooterActionsRoot({ closeDrawer }) {
+function ElementCustomizeFooterActionsRoot({
+  closeDrawer,
+}: WithDrawerActionsProps) {
   const { name } = useDrawerContext();
   const { submitForm, isSubmitting } = useFormikContext();
 

--- a/packages/webapp/src/containers/ElementCustomize/ElementCustomizeFieldsGroup.tsx
+++ b/packages/webapp/src/containers/ElementCustomize/ElementCustomizeFieldsGroup.tsx
@@ -1,16 +1,15 @@
-// @ts-nocheck
-import { InputGroupProps, SwitchProps } from '@blueprintjs/core';
+import type { ComponentProps, ReactNode } from 'react';
 import { FInputGroup, FSwitch, Group, Stack } from '@/components';
 import { CLASSES } from '@/constants';
 
 interface ElementCustomizeFieldsGroupProps {
   label: string;
-  children: React.ReactNode;
+  children: ReactNode;
 }
 
 interface ElementCustomizeContentItemFieldGroupProps {
-  inputGroupProps: InputGroupProps & { name?: string; label?: string };
-  switchProps?: SwitchProps;
+  inputGroupProps: ComponentProps<typeof FSwitch>;
+  switchProps?: Partial<ComponentProps<typeof FInputGroup>>;
 }
 
 export function ElementCustomizeFieldsGroup({
@@ -37,7 +36,11 @@ export function ElementCustomizeContentItemFieldGroup({
       <FSwitch {...inputGroupProps} fastField />
 
       {switchProps?.name && (
-        <FInputGroup {...switchProps} style={{ maxWidth: 150 }} fastField />
+        <FInputGroup
+          {...(switchProps as ComponentProps<typeof FInputGroup>)}
+          style={{ maxWidth: 150 }}
+          fastField
+        />
       )}
     </Group>
   );

--- a/packages/webapp/src/containers/ElementCustomize/ElementCustomizePreview.tsx
+++ b/packages/webapp/src/containers/ElementCustomize/ElementCustomizePreview.tsx
@@ -1,12 +1,12 @@
-// @ts-nocheck
 import * as FF from 'fp-ts/function';
 import { ElementCustomizeHeader } from './ElementCustomizeHeader';
 import { ElementCustomizePreviewContent } from './ElementCustomizePreviewContent';
+import type { WithDrawerActionsProps } from '@/containers/Drawer/withDrawerActions';
 import { Stack } from '@/components';
 import { useDrawerContext } from '@/components/Drawer/DrawerProvider';
 import { withDrawerActions } from '@/containers/Drawer/withDrawerActions';
 
-function ElementCustomizePreviewRoot({ closeDrawer }) {
+function ElementCustomizePreviewRoot({ closeDrawer }: WithDrawerActionsProps) {
   const { name } = useDrawerContext();
 
   const handleCloseBtnClick = () => {

--- a/packages/webapp/src/containers/ElementCustomize/ElementCustomizePreviewContent.tsx
+++ b/packages/webapp/src/containers/ElementCustomize/ElementCustomizePreviewContent.tsx
@@ -1,5 +1,5 @@
 import { useElementCustomizeContext } from './ElementCustomizeProvider';
-import { Box, Stack } from '@/components';
+import { Stack } from '@/components';
 
 export function ElementCustomizePreviewContent() {
   const { PaperTemplate } = useElementCustomizeContext();

--- a/packages/webapp/src/containers/ElementCustomize/ElementCustomizerForm.tsx
+++ b/packages/webapp/src/containers/ElementCustomize/ElementCustomizerForm.tsx
@@ -1,15 +1,15 @@
-// @ts-nocheck
-import { Formik, Form, FormikHelpers } from 'formik';
+import { Formik, Form } from 'formik';
 import React from 'react';
+import type { FormikConfig, FormikHelpers, FormikValues } from 'formik';
 
-export interface ElementCustomizeFormProps<T, Y> {
+export interface ElementCustomizeFormProps<T extends FormikValues> {
   initialValues?: T;
-  validationSchema?: any;
+  validationSchema?: FormikConfig<T>['validationSchema'];
   onSubmit?: (values: T, formikHelpers: FormikHelpers<T>) => void;
   children?: React.ReactNode;
 }
 
-export function ElementCustomizeForm<T>({
+export function ElementCustomizeForm<T extends FormikValues>({
   initialValues,
   validationSchema,
   onSubmit,
@@ -17,7 +17,7 @@ export function ElementCustomizeForm<T>({
 }: ElementCustomizeFormProps<T>) {
   return (
     <Formik<T>
-      initialValues={{ ...initialValues }}
+      initialValues={{ ...initialValues } as T}
       validationSchema={validationSchema}
       onSubmit={(value, helpers) => onSubmit && onSubmit(value, helpers)}
     >

--- a/packages/webapp/src/containers/ElementCustomize/components/BrandingCompanyLogoUploadField.tsx
+++ b/packages/webapp/src/containers/ElementCustomize/components/BrandingCompanyLogoUploadField.tsx
@@ -1,10 +1,16 @@
-// @ts-nocheck
 import { useFormikContext } from 'formik';
 import { CompanyLogoUpload } from './CompanyLogoUpload';
 import { FFormGroup } from '@/components';
 
+interface BrandingCompanyLogoFormValues {
+  companyLogoUri?: string;
+  companyLogoKey?: string;
+  _companyLogoFile?: File | null;
+}
+
 export function BrandingCompanyLogoUploadField() {
-  const { setFieldValue, values } = useFormikContext();
+  const { setFieldValue, values } =
+    useFormikContext<BrandingCompanyLogoFormValues>();
 
   return (
     <FFormGroup name={'companyLogo'} label={''} fastField>

--- a/packages/webapp/src/containers/ElementCustomize/components/CompanyLogoUpload.tsx
+++ b/packages/webapp/src/containers/ElementCustomize/components/CompanyLogoUpload.tsx
@@ -1,12 +1,18 @@
-// @ts-nocheck
 import { Button, Intent } from '@blueprintjs/core';
 import clsx from 'classnames';
 import { useRef, useState } from 'react';
 import styles from './CompanyLogoUpload.module.scss';
+import type { ComponentType, PropsWithChildren, ReactNode } from 'react';
 import { Icon, Stack } from '@/components';
 import { Dropzone, DropzoneProps } from '@/components/Dropzone';
 import { MIME_TYPES } from '@/components/Dropzone/mine-types';
 import { useUncontrolled } from '@/hooks/useUncontrolled';
+
+const DropzoneWithChildren = Dropzone as unknown as ComponentType<
+  PropsWithChildren<DropzoneProps> & {
+    classNames?: { root?: string; content?: string };
+  }
+>;
 
 export interface CompanyLogoUploadProps {
   /** Initial preview uri. */
@@ -19,13 +25,13 @@ export interface CompanyLogoUploadProps {
   value?: File;
 
   /** Function called when the file is changed */
-  onChange?: (file: File) => void;
+  onChange?: (file: File | null) => void;
 
   /** Props for the Dropzone component */
-  dropzoneProps?: DropzoneProps;
+  dropzoneProps?: Partial<DropzoneProps>;
 
   /** Icon element for the upload button */
-  uploadIcon?: JSX.Element;
+  uploadIcon?: ReactNode;
 
   /** Title displayed in the component */
   title?: string;
@@ -64,7 +70,7 @@ export function CompanyLogoUpload({
     : initialLocalPreview || '';
 
   return (
-    <Dropzone
+    <DropzoneWithChildren
       onDrop={(files) => handleChange(files[0])}
       onReject={(files) => console.log('rejected files', files)}
       maxSize={5 * 1024 ** 2}
@@ -103,6 +109,6 @@ export function CompanyLogoUpload({
           </Button>
         </Stack>
       )}
-    </Dropzone>
+    </DropzoneWithChildren>
   );
 }

--- a/packages/webapp/src/containers/FinancialStatements/FilterFinancialReports.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/FilterFinancialReports.tsx
@@ -3,9 +3,11 @@ import type { ReactNode } from 'react';
 import { useAbilityContext } from '@/hooks';
 
 export interface FinancialReport {
+  title: ReactNode;
+  desc: ReactNode;
+  link: string;
   ability: string;
   subject: string;
-  [key: string]: unknown;
 }
 
 export interface FinancialSection {

--- a/packages/webapp/src/containers/FinancialStatements/FinancialReports.tsx
+++ b/packages/webapp/src/containers/FinancialStatements/FinancialReports.tsx
@@ -7,8 +7,8 @@ import { financialReportMenus } from '@/constants/financialReportsMenu';
 import '@/style/pages/FinancialStatements/FinancialSheets.scss';
 
 interface FinancialReportsItemProps {
-  title: string;
-  desc: string;
+  title: React.ReactNode;
+  desc: React.ReactNode;
   link: string;
 }
 
@@ -28,7 +28,7 @@ function FinancialReportsItem({
 }
 
 interface FinancialReportsSectionProps {
-  sectionTitle: string;
+  sectionTitle: React.ReactNode;
   reports: FinancialReportsItemProps[];
 }
 

--- a/packages/webapp/src/containers/GlobalErrors/GlobalErrors.tsx
+++ b/packages/webapp/src/containers/GlobalErrors/GlobalErrors.tsx
@@ -1,14 +1,20 @@
-// @ts-nocheck
 import { Intent } from '@blueprintjs/core';
 import * as FF from 'fp-ts/function';
 import intl from 'react-intl-universal';
 import { withGlobalErrors } from './withGlobalErrors';
 import { withGlobalErrorsActions } from './withGlobalErrorsActions';
+import type { WithGlobalErrorsProps } from './withGlobalErrors';
+import type { WithGlobalErrorsActionsProps } from './withGlobalErrorsActions';
 import { AppToaster } from '@/components';
 
-let toastKeySessionExpired;
-let toastKeySomethingWrong;
-let toastTooManyRequests;
+let toastKeySomethingWrong: string | undefined;
+let toastKeySessionExpired: string | undefined;
+let toastKeyTooManyRequests: string | undefined;
+let toastKeyAccessDenied: string | undefined;
+
+interface GlobalErrorsInnerProps
+  extends WithGlobalErrorsProps,
+    WithGlobalErrorsActionsProps {}
 
 function GlobalErrorsInner({
   // #withGlobalErrors
@@ -16,9 +22,9 @@ function GlobalErrorsInner({
 
   // #withGlobalErrorsActions
   globalErrorsSet,
-}) {
+}: GlobalErrorsInnerProps) {
   if (globalErrors.something_wrong) {
-    toastKeySessionExpired = AppToaster.show(
+    toastKeySomethingWrong = AppToaster.show(
       {
         message: intl.get('ops_something_went_wrong'),
         intent: Intent.DANGER,
@@ -26,11 +32,11 @@ function GlobalErrorsInner({
           globalErrorsSet({ something_wrong: false });
         },
       },
-      toastKeySessionExpired,
+      toastKeySomethingWrong,
     );
   }
   if (globalErrors.session_expired) {
-    toastKeySomethingWrong = AppToaster.show(
+    toastKeySessionExpired = AppToaster.show(
       {
         message: intl.get('session_expired'),
         intent: Intent.DANGER,
@@ -38,11 +44,11 @@ function GlobalErrorsInner({
           globalErrorsSet({ session_expired: false });
         },
       },
-      toastKeySomethingWrong,
+      toastKeySessionExpired,
     );
   }
   if (globalErrors.too_many_requests) {
-    toastTooManyRequests = AppToaster.show(
+    toastKeyTooManyRequests = AppToaster.show(
       {
         message: intl.get('global_error.too_many_requests'),
         intent: Intent.DANGER,
@@ -50,21 +56,21 @@ function GlobalErrorsInner({
           globalErrorsSet({ too_many_requests: false });
         },
       },
-      toastTooManyRequests,
+      toastKeyTooManyRequests,
     );
   }
   if (globalErrors.access_denied) {
-    toastKeySomethingWrong = AppToaster.show(
+    toastKeyAccessDenied = AppToaster.show(
       {
         message:
           globalErrors.access_denied.message ||
           intl.get('global_error.you_dont_have_permissions'),
         intent: Intent.DANGER,
         onDismiss: () => {
-          globalErrorsSet({ access_denied: false });
+          globalErrorsSet({ access_denied: undefined });
         },
       },
-      toastKeySomethingWrong,
+      toastKeyAccessDenied,
     );
   }
   if (globalErrors.transactionsLocked) {
@@ -74,7 +80,7 @@ function GlobalErrorsInner({
       }),
       intent: Intent.DANGER,
       onDismiss: () => {
-        globalErrorsSet({ transactionsLocked: false });
+        globalErrorsSet({ transactionsLocked: undefined });
       },
     });
   }
@@ -83,7 +89,7 @@ function GlobalErrorsInner({
       message: `You can't add new data to Bigcapital because your subscription is inactive. Make sure your billing information is up-to-date from Preferences > Billing page.`,
       intent: Intent.DANGER,
       onDismiss: () => {
-        globalErrorsSet({ subscriptionInactive: false });
+        globalErrorsSet({ subscriptionInactive: undefined });
       },
     });
   }
@@ -92,7 +98,7 @@ function GlobalErrorsInner({
       message: intl.get('global_error.authorized_user_inactive'),
       intent: Intent.DANGER,
       onDismiss: () => {
-        globalErrorsSet({ userInactive: false });
+        globalErrorsSet({ userInactive: undefined });
       },
     });
   }

--- a/packages/webapp/src/containers/GlobalErrors/withGlobalErrors.tsx
+++ b/packages/webapp/src/containers/GlobalErrors/withGlobalErrors.tsx
@@ -1,9 +1,10 @@
 import { connect } from 'react-redux';
+import type { GlobalErrorsData } from '@/store/global-errors/global-errors.reducer';
 import type { ComponentType } from 'react';
 import { ApplicationState } from '@/store/reducers';
 
 export interface WithGlobalErrorsProps {
-  globalErrors: Record<string, unknown>;
+  globalErrors: GlobalErrorsData;
 }
 
 const mapStateToProps = (state: ApplicationState): WithGlobalErrorsProps => {

--- a/packages/webapp/src/containers/GlobalErrors/withGlobalErrorsActions.tsx
+++ b/packages/webapp/src/containers/GlobalErrors/withGlobalErrorsActions.tsx
@@ -1,16 +1,17 @@
 import { connect } from 'react-redux';
 import { Dispatch } from 'redux';
+import type { GlobalErrorsData } from '@/store/global-errors/global-errors.reducer';
 import type { ComponentType } from 'react';
 import { setGlobalErrors } from '@/store/global-errors/global-errors.actions';
 
 export interface WithGlobalErrorsActionsProps {
-  globalErrorsSet: (errors: Record<string, unknown>) => void;
+  globalErrorsSet: (errors: Partial<GlobalErrorsData>) => void;
 }
 
 export const mapDispatchToProps = (
   dispatch: Dispatch,
 ): WithGlobalErrorsActionsProps => ({
-  globalErrorsSet: (errors: Record<string, unknown>) =>
+  globalErrorsSet: (errors: Partial<GlobalErrorsData>) =>
     dispatch(setGlobalErrors(errors)),
 });
 

--- a/packages/webapp/src/containers/Homepage/AccountsPayableSection.tsx
+++ b/packages/webapp/src/containers/Homepage/AccountsPayableSection.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import React from 'react';
 import { ShortcutBoxesSection } from './ShortcutBoxesSection';
 import { accountsPayable } from '@/constants/homepageOptions';

--- a/packages/webapp/src/containers/Homepage/AccountsReceivableSection.tsx
+++ b/packages/webapp/src/containers/Homepage/AccountsReceivableSection.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import React from 'react';
 import { ShortcutBoxesSection } from './ShortcutBoxesSection';
 import { accountsReceivable } from '@/constants/homepageOptions';

--- a/packages/webapp/src/containers/Homepage/FinancialAccountingSection.tsx
+++ b/packages/webapp/src/containers/Homepage/FinancialAccountingSection.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import React from 'react';
 import { ShortcutBoxesSection } from './ShortcutBoxesSection';
 import { financialAccounting } from '@/constants/homepageOptions';

--- a/packages/webapp/src/containers/Homepage/Homepage.tsx
+++ b/packages/webapp/src/containers/Homepage/Homepage.tsx
@@ -1,9 +1,11 @@
-// @ts-nocheck
 import React, { useEffect } from 'react';
 import { HomepageContent } from './HomepageContent';
+import type { WithDashboardActionsProps } from '@/containers/Dashboard/withDashboardActions';
 import { DashboardInsider } from '@/components/Dashboard';
 import { withDashboardActions } from '@/containers/Dashboard/withDashboardActions';
 import { useCurrentOrganizationName } from '@/hooks/query';
+
+type DashboardHomepageProps = WithDashboardActionsProps;
 
 /**
  * Dashboard homepage.
@@ -11,7 +13,7 @@ import { useCurrentOrganizationName } from '@/hooks/query';
 function DashboardHomepage({
   // #withDashboardActions
   changePageTitle,
-}) {
+}: DashboardHomepageProps) {
   const organizationName = useCurrentOrganizationName();
 
   useEffect(() => {

--- a/packages/webapp/src/containers/Homepage/HomepageContent.tsx
+++ b/packages/webapp/src/containers/Homepage/HomepageContent.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import React from 'react';
 import { AccountsPayableSection } from './AccountsPayableSection';
 import { AccountsReceivableSection } from './AccountsReceivableSection';

--- a/packages/webapp/src/containers/Homepage/ProductsServicesSection.tsx
+++ b/packages/webapp/src/containers/Homepage/ProductsServicesSection.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import React from 'react';
 import { ShortcutBoxesSection } from './ShortcutBoxesSection';
 import { productsServices } from '@/constants/homepageOptions';

--- a/packages/webapp/src/containers/Homepage/ShortcutBoxesSection.tsx
+++ b/packages/webapp/src/containers/Homepage/ShortcutBoxesSection.tsx
@@ -1,11 +1,20 @@
-// @ts-nocheck
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { useFilterShortcutBoxesSection } from './components';
+import type {
+  HomepageSectionOption,
+  HomepageShortcutOption,
+} from '@/constants/types';
 import { For } from '@/components';
 import '@/style/pages/FinancialStatements/FinancialSheets.scss';
 
-function ShortcutBox({ title, link, description }) {
+interface ShortcutBoxProps {
+  title: React.ReactNode;
+  link: string;
+  description: React.ReactNode;
+}
+
+function ShortcutBox({ title, link, description }: ShortcutBoxProps) {
   return (
     <div className={'financial-reports__item'}>
       <Link className="title" to={link}>
@@ -16,7 +25,12 @@ function ShortcutBox({ title, link, description }) {
   );
 }
 
-function ShortcutBoxes({ sectionTitle, shortcuts }) {
+interface ShortcutBoxesProps {
+  sectionTitle: React.ReactNode;
+  shortcuts: HomepageShortcutOption[];
+}
+
+function ShortcutBoxes({ sectionTitle, shortcuts }: ShortcutBoxesProps) {
   return (
     <div className="financial-reports__section">
       <div className="section-title">{sectionTitle}</div>
@@ -27,7 +41,11 @@ function ShortcutBoxes({ sectionTitle, shortcuts }) {
   );
 }
 
-export function ShortcutBoxesSection({ section }) {
+interface ShortcutBoxesSectionProps {
+  section: HomepageSectionOption[];
+}
+
+export function ShortcutBoxesSection({ section }: ShortcutBoxesSectionProps) {
   const BoxSection = useFilterShortcutBoxesSection(section);
   return <For render={ShortcutBoxes} of={BoxSection} />;
 }

--- a/packages/webapp/src/containers/Homepage/components.tsx
+++ b/packages/webapp/src/containers/Homepage/components.tsx
@@ -1,18 +1,22 @@
-// @ts-nocheck
 import { isEmpty } from 'lodash';
+import type { HomepageSectionOption } from '@/constants/types';
 import { useAbilityContext } from '@/hooks';
 
-export const useFilterShortcutBoxesSection = (section) => {
+export const useFilterShortcutBoxesSection = (
+  section: HomepageSectionOption[],
+): HomepageSectionOption[] => {
   const ability = useAbilityContext();
 
   return section
     .map(({ sectionTitle, shortcuts }) => {
-      const shortcut = shortcuts.filter((shortcuts) => {
-        return ability.can(shortcuts.ability, shortcuts.subject);
+      const filteredShortcuts = shortcuts.filter((shortcut) => {
+        return shortcut.ability != null && shortcut.subject != null
+          ? ability.can(shortcut.ability, shortcut.subject)
+          : false;
       });
       return {
         sectionTitle: sectionTitle,
-        shortcuts: shortcut,
+        shortcuts: filteredShortcuts,
       };
     })
     .filter(({ shortcuts }) => !isEmpty(shortcuts));

--- a/packages/webapp/src/containers/Import/ImportDropzoneFile.tsx
+++ b/packages/webapp/src/containers/Import/ImportDropzoneFile.tsx
@@ -27,7 +27,7 @@ export interface ImportDropzoneFieldProps {
   initialValue?: File | null;
   value?: File | null;
   onChange?: (file: File | null) => void;
-  dropzoneProps?: DropzoneProps;
+  dropzoneProps?: Partial<DropzoneProps>;
   uploadIcon?: ReactNode;
   title?: string;
   subtitle?: string;

--- a/packages/webapp/src/containers/JournalEntriesTable/JournalEntriesTable.tsx
+++ b/packages/webapp/src/containers/JournalEntriesTable/JournalEntriesTable.tsx
@@ -1,21 +1,33 @@
-// @ts-nocheck
 import React from 'react';
 import intl from 'react-intl-universal';
 import styled from 'styled-components';
 import { useGLEntriesTableColumns } from './utils';
+import type { GLTransactionRow } from './utils';
+import type { DataTableColumn } from '@/components/Datatable/types';
 import { DataTable, CurrencyTag, TableSkeletonRows } from '@/components';
 import { TableStyle } from '@/constants';
 import { useCurrentOrganizationBaseCurrency } from '@/hooks/query';
 
+interface JournalEntriesTableProps {
+  transactions: GLTransactionRow[];
+  columns?: DataTableColumn<GLTransactionRow>[];
+  loading?: boolean;
+  className?: string;
+}
+
 /**
  * Journal entries table.
  */
-export function JournalEntriesTable({ transactions, ...restProps }) {
-  const columns = useGLEntriesTableColumns();
+export function JournalEntriesTable({
+  transactions,
+  columns: columnsProp,
+  ...restProps
+}: JournalEntriesTableProps) {
+  const defaultColumns = useGLEntriesTableColumns();
 
   return (
     <DataTable
-      columns={columns}
+      columns={columnsProp ?? defaultColumns}
       data={transactions}
       styleName={TableStyle.Constrant}
       TableLoadingRenderer={TableSkeletonRows}

--- a/packages/webapp/src/containers/JournalEntriesTable/utils.tsx
+++ b/packages/webapp/src/containers/JournalEntriesTable/utils.tsx
@@ -1,47 +1,53 @@
-// @ts-nocheck
 import React from 'react';
 import intl from 'react-intl-universal';
+import type { DataTableColumn } from '@/components/Datatable/types';
+import type { TransactionsByReferenceJsonResponse } from '@bigcapital/sdk-ts';
 
-export const useGLEntriesTableColumns = () => {
-  return React.useMemo(
-    () => [
-      {
-        Header: intl.get('date'),
-        accessor: 'date.formattedDate',
-        width: 140,
-        className: 'date',
-        textOverview: true,
-      },
-      {
-        Header: intl.get('account_name'),
-        accessor: 'accountName',
-        width: 140,
-        className: 'account_name',
-        textOverview: true,
-      },
-      {
-        Header: intl.get('contact'),
-        accessor: 'formattedContactType',
-        width: 140,
-        textOverview: true,
-      },
-      {
-        Header: intl.get('debit'),
-        accessor: ({ debit }) => debit.formattedAmount,
-        width: 100,
-        className: 'debit',
-        textOverview: true,
-        align: 'right',
-      },
-      {
-        Header: intl.get('credit'),
-        accessor: ({ credit }) => credit.formattedAmount,
-        width: 100,
-        className: 'credit',
-        align: 'right',
-        textOverview: true,
-      },
-    ],
-    [],
-  );
-};
+export type GLTransactionRow =
+  TransactionsByReferenceJsonResponse['transactions'][number];
+
+export const useGLEntriesTableColumns =
+  (): DataTableColumn<GLTransactionRow>[] => {
+    return React.useMemo(
+      () =>
+        [
+          {
+            Header: intl.get('date'),
+            accessor: 'date.formattedDate',
+            width: 140,
+            className: 'date',
+            textOverview: true,
+          },
+          {
+            Header: intl.get('account_name'),
+            accessor: 'accountName',
+            width: 140,
+            className: 'account_name',
+            textOverview: true,
+          },
+          {
+            Header: intl.get('contact'),
+            accessor: 'formattedContactType',
+            width: 140,
+            textOverview: true,
+          },
+          {
+            Header: intl.get('debit'),
+            accessor: ({ debit }) => debit.formattedAmount,
+            width: 100,
+            className: 'debit',
+            textOverview: true,
+            align: 'right',
+          },
+          {
+            Header: intl.get('credit'),
+            accessor: ({ credit }) => credit.formattedAmount,
+            width: 100,
+            className: 'credit',
+            align: 'right',
+            textOverview: true,
+          },
+        ] as DataTableColumn<GLTransactionRow>[],
+      [],
+    );
+  };

--- a/packages/webapp/src/containers/NotifyViaSMS/NotifyViaSMSForm.schema.tsx
+++ b/packages/webapp/src/containers/NotifyViaSMS/NotifyViaSMSForm.schema.tsx
@@ -1,5 +1,3 @@
-// @ts-nocheck
-import intl from 'react-intl-universal';
 import * as Yup from 'yup';
 import { DATATYPES_LENGTH } from '@/constants/dataTypes';
 

--- a/packages/webapp/src/containers/NotifyViaSMS/NotifyViaSMSForm.tsx
+++ b/packages/webapp/src/containers/NotifyViaSMS/NotifyViaSMSForm.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Callout, Classes, Intent } from '@blueprintjs/core';
 import { Formik, Form, useFormikContext } from 'formik';
 import { castArray, includes } from 'lodash';
@@ -10,10 +9,38 @@ import { CreateNotifyViaSMSFormSchema } from './NotifyViaSMSForm.schema';
 import { NotifyViaSMSFormFields } from './NotifyViaSMSFormFields';
 import { NotifyViaSMSFormFloatingActions } from './NotifyViaSMSFormFloatingActions';
 import { getSMSUnits } from './utils';
+import type { FormikHelpers } from 'formik';
 import { FormObserver, SMSMessagePreview } from '@/components';
-import { transformToForm, safeInvoke } from '@/utils';
+import { transformToForm } from '@/utils';
 
-const defaultInitialValues = {
+export interface NotifyViaSMSFormValues {
+  notificationKey: string;
+  customerName: string;
+  customerPhoneNumber: string;
+  smsMessage: string;
+}
+
+export interface NotifyViaSMSNotificationType {
+  key: string;
+  label: string;
+}
+
+export interface NotifyViaSMSFormProps {
+  initialValues?: Partial<NotifyViaSMSFormValues>;
+  notificationTypes?:
+    | NotifyViaSMSNotificationType
+    | NotifyViaSMSNotificationType[];
+  onSubmit?: (
+    values: NotifyViaSMSFormValues,
+    helpers: FormikHelpers<NotifyViaSMSFormValues>,
+  ) => void;
+  onCancel?: () => void;
+  onValuesChange?: (values: NotifyViaSMSFormValues) => void;
+  calloutCodes?: number[];
+  formikProps?: Record<string, unknown>;
+}
+
+const defaultInitialValues: NotifyViaSMSFormValues = {
   notificationKey: '',
   customerName: '',
   customerPhoneNumber: '',
@@ -26,7 +53,7 @@ const defaultInitialValues = {
 function SMSMessagePreviewSection() {
   const {
     values: { smsMessage },
-  } = useFormikContext();
+  } = useFormikContext<NotifyViaSMSFormValues>();
 
   // Calculates the SMS units of message.
   const messagesUnits = getSMSUnits(smsMessage);
@@ -56,10 +83,9 @@ export function NotifyViaSMSForm({
   onCancel,
   onValuesChange,
   calloutCodes,
-  formikProps,
-}) {
+}: NotifyViaSMSFormProps) {
   // Initial form values
-  const initialValues = {
+  const initialValues: NotifyViaSMSFormValues = {
     ...defaultInitialValues,
     ...transformToForm(initialValuesComponent, defaultInitialValues),
   };
@@ -74,7 +100,7 @@ export function NotifyViaSMSForm({
       enableReinitialize={true}
       validationSchema={CreateNotifyViaSMSFormSchema}
       initialValues={initialValues}
-      onSubmit={onSubmit}
+      onSubmit={(values, helpers) => onSubmit?.(values, helpers)}
     >
       <Form>
         <div className={Classes.DIALOG_BODY}>
@@ -97,35 +123,49 @@ export function NotifyViaSMSForm({
   );
 }
 
+interface NotifyObserveValuesChangeProps {
+  onChange?: (values: NotifyViaSMSFormValues) => void;
+}
+
 /**
  * Observes the values change of notify form.
  */
-function NotifyObserveValuesChange({ onChange }) {
-  const { values } = useFormikContext();
+function NotifyObserveValuesChange({
+  onChange,
+}: NotifyObserveValuesChangeProps) {
+  const { values } = useFormikContext<NotifyViaSMSFormValues>();
 
   // Handle the form change observe.
   const handleChange = () => {
-    safeInvoke(onChange, values);
+    onChange?.(values);
   };
   return <FormObserver values={values} onChange={handleChange} />;
+}
+
+interface NotifyViaSMSAlertsProps {
+  calloutCodes?: number[];
 }
 
 /**
  * Notify via SMS form alerts.
  */
-function NotifyViaSMSAlerts({ calloutCodes }) {
-  return [
-    includes(calloutCodes, 100) && (
-      <Callout icon={null} intent={Intent.DANGER}>
-        {intl.get('notify_Via_sms.dialog.customer_phone_number_does_not_eixst')}
-      </Callout>
-    ),
-    includes(calloutCodes, 200) && (
-      <Callout icon={null} intent={Intent.DANGER}>
-        {intl.get('notify_Via_sms.dialog.customer_phone_number_invalid')}
-      </Callout>
-    ),
-  ];
+function NotifyViaSMSAlerts({ calloutCodes }: NotifyViaSMSAlertsProps) {
+  return (
+    <>
+      {includes(calloutCodes, 100) && (
+        <Callout icon={null} intent={Intent.DANGER}>
+          {intl.get(
+            'notify_Via_sms.dialog.customer_phone_number_does_not_eixst',
+          )}
+        </Callout>
+      )}
+      {includes(calloutCodes, 200) && (
+        <Callout icon={null} intent={Intent.DANGER}>
+          {intl.get('notify_Via_sms.dialog.customer_phone_number_invalid')}
+        </Callout>
+      )}
+    </>
+  );
 }
 const NotifyContent = styled.div`
   display: flex;

--- a/packages/webapp/src/containers/NotifyViaSMS/NotifyViaSMSFormFields.tsx
+++ b/packages/webapp/src/containers/NotifyViaSMS/NotifyViaSMSFormFields.tsx
@@ -1,15 +1,22 @@
-// @ts-nocheck
 import { FormGroup, InputGroup } from '@blueprintjs/core';
 import classNames from 'classnames';
 import { FastField, ErrorMessage } from 'formik';
 import React from 'react';
 import intl from 'react-intl-universal';
 import styled from 'styled-components';
+import type { NotifyViaSMSNotificationType } from './NotifyViaSMSForm';
+import type { FieldProps } from 'formik';
 import { FFormGroup, FSelect, FieldRequiredHint } from '@/components';
 import { CLASSES } from '@/constants/classes';
 import { inputIntent } from '@/utils';
 
-export function NotifyViaSMSFormFields({ notificationTypes }) {
+interface NotifyViaSMSFormFieldsProps {
+  notificationTypes: NotifyViaSMSNotificationType[];
+}
+
+export function NotifyViaSMSFormFields({
+  notificationTypes,
+}: NotifyViaSMSFormFieldsProps) {
   return (
     <NotifyViaSMSFormFieldsRoot>
       <FFormGroup
@@ -32,16 +39,16 @@ export function NotifyViaSMSFormFields({ notificationTypes }) {
 
       {/* ----------- Send Notification to ----------- */}
       <FastField name={'customerName'}>
-        {({ form, field, meta: { error, touched } }) => (
+        {({ field, meta: { error, touched } }: FieldProps) => (
           <FormGroup
             label={intl.get('notify_via_sms.dialog.send_notification_to')}
             className={classNames('form-group--customer-name', CLASSES.FILL)}
             labelInfo={<FieldRequiredHint />}
-            intent={inputIntent({ error, touched })}
+            intent={inputIntent({ error, touched }) || undefined}
             helperText={<ErrorMessage name={'customerName'} />}
           >
             <InputGroup
-              intent={inputIntent({ error, touched })}
+              intent={inputIntent({ error, touched }) || undefined}
               disabled={true}
               {...field}
             />
@@ -51,11 +58,11 @@ export function NotifyViaSMSFormFields({ notificationTypes }) {
 
       {/* ----------- Phone number ----------- */}
       <FastField name={'customerPhoneNumber'}>
-        {({ form, field, meta: { error, touched } }) => (
+        {({ field, meta: { error, touched } }: FieldProps) => (
           <FormGroup
             label={intl.get('phone_number')}
             labelInfo={<FieldRequiredHint />}
-            intent={inputIntent({ error, touched })}
+            intent={inputIntent({ error, touched }) || undefined}
             helperText={<ErrorMessage name="customerPhoneNumber" />}
             className={classNames(
               'form-group--customer_phone_number',
@@ -63,7 +70,7 @@ export function NotifyViaSMSFormFields({ notificationTypes }) {
             )}
           >
             <InputGroup
-              intent={inputIntent({ error, touched })}
+              intent={inputIntent({ error, touched }) || undefined}
               disabled={true}
               {...field}
             />

--- a/packages/webapp/src/containers/NotifyViaSMS/NotifyViaSMSFormFloatingActions.tsx
+++ b/packages/webapp/src/containers/NotifyViaSMS/NotifyViaSMSFormFloatingActions.tsx
@@ -1,23 +1,26 @@
-// @ts-nocheck
 import { Intent, Button } from '@blueprintjs/core';
 import { useFormikContext } from 'formik';
 import React from 'react';
+import type { NotifyViaSMSFormValues } from './NotifyViaSMSForm';
 import {
   DialogFooter,
   DialogFooterActions,
   FormattedMessage as T,
 } from '@/components';
 
-/**
- *
- */
-export function NotifyViaSMSFormFloatingActions({ onCancel }) {
+interface NotifyViaSMSFormFloatingActionsProps {
+  onCancel?: (event: React.MouseEvent<HTMLElement>) => void;
+}
+
+export function NotifyViaSMSFormFloatingActions({
+  onCancel,
+}: NotifyViaSMSFormFloatingActionsProps) {
   // Formik context.
-  const { isSubmitting } = useFormikContext();
+  const { isSubmitting } = useFormikContext<NotifyViaSMSFormValues>();
 
   // Handle close button click.
-  const handleCancelBtnClick = (event) => {
-    onCancel && onCancel(event);
+  const handleCancelBtnClick = (event: React.MouseEvent<HTMLElement>) => {
+    onCancel?.(event);
   };
 
   return (

--- a/packages/webapp/src/containers/NotifyViaSMS/utils.tsx
+++ b/packages/webapp/src/containers/NotifyViaSMS/utils.tsx
@@ -1,7 +1,18 @@
-// @ts-nocheck
 import intl from 'react-intl-universal';
 
-export const transformErrors = (errors, { setErrors, setCalloutCode }) => {
+export interface SMSNotifyApiError {
+  type: string;
+}
+
+export interface TransformErrorsHelpers {
+  setErrors: (errors: Record<string, string>) => void;
+  setCalloutCode: (codes: number[]) => void;
+}
+
+export const transformErrors = (
+  errors: SMSNotifyApiError[],
+  { setErrors, setCalloutCode }: TransformErrorsHelpers,
+) => {
   if (errors.some((e) => e.type === 'CUSTOMER_SMS_NOTIFY_PHONE_INVALID')) {
     setCalloutCode([200]);
     setErrors({
@@ -18,6 +29,6 @@ export const transformErrors = (errors, { setErrors, setCalloutCode }) => {
   }
 };
 
-export const getSMSUnits = (message, threshold = 140) => {
+export const getSMSUnits = (message: string, threshold = 140): number => {
   return Math.ceil(message.length / threshold);
 };

--- a/packages/webapp/src/containers/PaymentPortal/drawers/PaymentInvoicePreviewDrawer/PaymentInvoicePreviewContent.tsx
+++ b/packages/webapp/src/containers/PaymentPortal/drawers/PaymentInvoicePreviewDrawer/PaymentInvoicePreviewContent.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { usePaymentPortalBoot } from '../../PaymentPortalBoot';
 import { Box, DrawerBody, DrawerHeaderContent } from '@/components';
 import { InvoicePaperTemplate } from '@/containers/Sales/Invoices/InvoiceCustomize/InvoicePaperTemplate';
@@ -22,7 +21,7 @@ export function PaymentInvoicePreviewContent() {
             paymentMade={sharableLinkMeta?.paymentAmountFormatted}
             termsConditions={sharableLinkMeta?.termsConditions}
             statement={sharableLinkMeta?.invoiceMessage}
-            companyName={sharableLinkMeta?.companyName}
+            companyName={sharableLinkMeta?.organization?.name}
             primaryColor={sharableLinkMeta?.brandingTemplate?.primaryColor}
             secondaryColor={sharableLinkMeta?.brandingTemplate?.secondaryColor}
             lines={sharableLinkMeta?.entries?.map((entry) => ({

--- a/packages/webapp/src/containers/PaymentPortal/drawers/PaymentInvoicePreviewDrawer/PaymentInvoicePreviewDrawer.tsx
+++ b/packages/webapp/src/containers/PaymentPortal/drawers/PaymentInvoicePreviewDrawer/PaymentInvoicePreviewDrawer.tsx
@@ -1,10 +1,14 @@
-// @ts-nocheck
 import { Position } from '@blueprintjs/core';
 import * as FF from 'fp-ts/function';
 import React from 'react';
 import { PaymentInvoicePreviewContent } from './PaymentInvoicePreviewContent';
+import type { WithDrawersProps } from '@/containers/Drawer/withDrawers';
 import { Drawer, DrawerSuspense } from '@/components';
 import { withDrawers } from '@/containers/Drawer/withDrawers';
+
+interface PaymentInvoicePreviewDrawerRootProps extends WithDrawersProps {
+  name: string;
+}
 
 /**
  *
@@ -15,7 +19,7 @@ function PaymentInvoicePreviewDrawerRoot({
   // #withDrawer
   isOpen,
   payload,
-}) {
+}: PaymentInvoicePreviewDrawerRootProps) {
   return (
     <Drawer
       isOpen={isOpen}

--- a/packages/webapp/src/containers/SendMailNotification/MailNotificationForm.tsx
+++ b/packages/webapp/src/containers/SendMailNotification/MailNotificationForm.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { SelectOptionProps } from '@blueprintjs-formik/select';
 import styled from 'styled-components';
 import {
@@ -9,17 +8,19 @@ import {
   FRichEditor,
 } from '@/components';
 
+type MailOption = SelectOptionProps & { mail?: string };
+
 interface MailNotificationFormProps {
-  fromAddresses: SelectOptionProps[];
-  toAddresses: SelectOptionProps[];
+  fromAddresses: MailOption[];
+  toAddresses: MailOption[];
 }
 
 const commonAddressSelect = {
   placeholder: '',
-  labelAccessor: '',
+  labelAccessor: 'label',
   valueAccessor: 'mail',
-  tagAccessor: (item) => `<${item.label}> (${item.mail})`,
-  textAccessor: (item) => `<${item.label}> (${item.mail})`,
+  tagAccessor: 'mail',
+  textAccessor: 'mail',
 };
 
 export function MailNotificationForm({
@@ -46,7 +47,6 @@ export function MailNotificationForm({
           <FMultiSelect
             items={toAddresses}
             name={'to'}
-            placeholder=""
             popoverProps={{ minimal: true, fill: true }}
             tagInputProps={{
               tagProps: { round: true, minimal: true, large: true },

--- a/packages/webapp/src/containers/SendMailNotification/utils.ts
+++ b/packages/webapp/src/containers/SendMailNotification/utils.ts
@@ -12,7 +12,7 @@ export interface MailNotificationFormValues {
   from: string[];
   to: string[];
   subject: string;
-  body: string;
+  message: string;
 }
 
 export const transformMailFormToRequest = (

--- a/packages/webapp/src/containers/TransactionsLocking/TransactionsLockingAlerts.tsx
+++ b/packages/webapp/src/containers/TransactionsLocking/TransactionsLockingAlerts.tsx
@@ -1,16 +1,23 @@
-// @ts-nocheck
 import React from 'react';
+import type { ComponentType, LazyExoticComponent } from 'react';
 
-const cancelUnlockingPartialAlert = React.lazy(() =>
+const cancelUnlockingPartialAlert: LazyExoticComponent<
+  ComponentType<{ name: string }>
+> = React.lazy(() =>
   import(
     '@/containers/Alerts/TransactionLocking/cancelUnlockingPartialAlert'
   ).then((m) => ({ default: m.cancelUnlockingPartialAlert })),
 );
 
+interface TransactionsLockingAlertEntry {
+  name: string;
+  component: LazyExoticComponent<ComponentType<{ name: string }>>;
+}
+
 /**
  * Transactions alerts.
  */
-export const TransactionsLockingAlerts = [
+export const TransactionsLockingAlerts: TransactionsLockingAlertEntry[] = [
   {
     name: 'cancel-unlocking-partail',
     component: cancelUnlockingPartialAlert,

--- a/packages/webapp/src/containers/TransactionsLocking/TransactionsLockingBody.tsx
+++ b/packages/webapp/src/containers/TransactionsLocking/TransactionsLockingBody.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import * as FF from 'fp-ts/function';
 import React from 'react';
 import {
@@ -7,8 +6,14 @@ import {
   TransactionLockingSkeletonList,
 } from './components';
 import { useTransactionsLockingContext } from './TransactionsLockingProvider';
+import type { WithAlertActionsProps } from '@/containers/Alert/withAlertActions';
+import type { WithDialogActionsProps } from '@/containers/Dialog/withDialogActions';
 import { withAlertActions } from '@/containers/Alert/withAlertActions';
 import { withDialogActions } from '@/containers/Dialog/withDialogActions';
+
+interface TransactionsLockingBodyProps
+  extends WithDialogActionsProps,
+    WithAlertActionsProps {}
 
 /**
  * Transactions locking body.
@@ -20,42 +25,46 @@ function TransactionsLockingBodyJsx({
 
   // #withAlertActions
   openAlert,
-}) {
+}: TransactionsLockingBodyProps) {
   const { isTransactionLockingLoading, transactionLockingType } =
     useTransactionsLockingContext();
 
   // Handle locking transactions.
-  const handleLockingTransactions = (module, {}, isEnabled) => {
+  const handleLockTransactions = (module: string) => {
+    openDialog('locking-transactions', { module: module });
+  };
+  // Handle editing the locking transactions.
+  const handleEditLockTransactions = (module: string, isEnabled: boolean) => {
     openDialog('locking-transactions', {
       isEnabled: isEnabled,
       module: module,
     });
   };
   // Handle unlocking transactions
-  const handleUnlockTransactions = (module) => {
+  const handleUnlockTransactions = (module: string) => {
     openDialog('unlocking-transactions', { module: module });
   };
   // Handle unlocking transactions
-  const handleUnlockingPartial = (module) => {
+  const handleUnlockingPartial = (module: string) => {
     openDialog('unlocking-partial-transactions', { module: module });
   };
   // Handle cancel partial unlocking.
-  const handleCancelUnlockingPartail = (module) => {
+  const handleCancelUnlockingPartail = (module: string) => {
     openAlert('cancel-unlocking-partail', { module: module });
   };
 
   return !isTransactionLockingLoading ? (
     transactionLockingType === 'partial' ? (
       <TransactionsLockingList
-        onLock={handleLockingTransactions}
-        onEditLock={handleLockingTransactions}
+        onLock={handleLockTransactions}
+        onEditLock={handleEditLockTransactions}
         onCancelLock={handleUnlockTransactions}
         onUnlockPartial={handleUnlockingPartial}
         onCancelUnlockPartial={handleCancelUnlockingPartail}
       />
     ) : (
       <TransactionsLockingFull
-        onLock={handleLockingTransactions}
+        onLock={handleLockTransactions}
         onCancelLock={handleUnlockTransactions}
         onUnlockPartial={handleUnlockingPartial}
         onCancelUnlockPartial={handleCancelUnlockingPartail}

--- a/packages/webapp/src/containers/TransactionsLocking/TransactionsLockingHeader.tsx
+++ b/packages/webapp/src/containers/TransactionsLocking/TransactionsLockingHeader.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Intent } from '@blueprintjs/core';
 import React from 'react';
 import intl from 'react-intl-universal';
@@ -31,10 +30,10 @@ export function TransactionsLockingHeader() {
   // Handle all lock link click.
   const handleAllLockClick = () => {
     const activeModules = validateMoveToFullLocking(
-      transactionsLocking.modules,
+      transactionsLocking?.modules ?? [],
     );
     const modulesStrong = activeModules.map((module) => (
-      <strong>{module.formattedModule}</strong>
+      <strong key={module.module}>{module.formattedModule}</strong>
     ));
     if (activeModules.length > 0) {
       AppToaster.show({
@@ -52,9 +51,9 @@ export function TransactionsLockingHeader() {
   };
 
   const handleUndividualLockClick = () => {
-    const isAllLockingActive = validateMoveToPartialLocking(
-      transactionsLocking.all,
-    );
+    const isAllLockingActive = transactionsLocking
+      ? validateMoveToPartialLocking(transactionsLocking.all)
+      : false;
 
     if (isAllLockingActive) {
       AppToaster.show({

--- a/packages/webapp/src/containers/TransactionsLocking/TransactionsLockingList.tsx
+++ b/packages/webapp/src/containers/TransactionsLocking/TransactionsLockingList.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import React from 'react';
 import styled from 'styled-components';
 import { TransactionsLockingBody } from './TransactionsLockingBody';

--- a/packages/webapp/src/containers/TransactionsLocking/TransactionsLockingPage.tsx
+++ b/packages/webapp/src/containers/TransactionsLocking/TransactionsLockingPage.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import React from 'react';
 import { TransactionsLockingListPage as TransactionsLockingList } from './TransactionsLockingList';
 import { TransactionsLockingProvider } from './TransactionsLockingProvider';

--- a/packages/webapp/src/containers/TransactionsLocking/TransactionsLockingProvider.tsx
+++ b/packages/webapp/src/containers/TransactionsLocking/TransactionsLockingProvider.tsx
@@ -1,15 +1,36 @@
-// @ts-nocheck
 import React from 'react';
+import type {
+  TransactionsLockingListResponse,
+  TransactionsLockingType,
+} from '@bigcapital/sdk-ts';
 import { DashboardInsider } from '@/components/Dashboard';
 import { useTransactionsLocking } from '@/hooks/query';
 import { useWatchImmediate } from '@/hooks/utils/useWatch';
 
-const TransactionsLockingContext = React.createContext();
+export interface TransactionsLockingContextValue {
+  transactionsLocking: TransactionsLockingListResponse | undefined;
+  isTransactionLockingFetching: boolean;
+  isTransactionLockingLoading: boolean;
+  transactionLockingType: TransactionsLockingType;
+  setTransactionLockingType: React.Dispatch<
+    React.SetStateAction<TransactionsLockingType>
+  >;
+}
+
+const TransactionsLockingContext = React.createContext<
+  TransactionsLockingContextValue | undefined
+>(undefined);
+
+interface TransactionsLockingProviderProps {
+  children?: React.ReactNode;
+}
 
 /**
  * Transactions locking data provider.
  */
-function TransactionsLockingProvider({ ...props }) {
+function TransactionsLockingProvider({
+  children,
+}: TransactionsLockingProviderProps) {
   // Fetch transaction locking modules list.
   const {
     data: transactionsLocking,
@@ -19,7 +40,7 @@ function TransactionsLockingProvider({ ...props }) {
 
   // Transactions locking type.
   const [transactionLockingType, setTransactionLockingType] =
-    React.useState('partial');
+    React.useState<TransactionsLockingType>('partial');
 
   // Locking type controlled from response.
   useWatchImmediate(() => {
@@ -29,7 +50,7 @@ function TransactionsLockingProvider({ ...props }) {
   }, transactionsLocking?.lockingType);
 
   // Provider
-  const provider = {
+  const provider: TransactionsLockingContextValue = {
     transactionsLocking,
     isTransactionLockingFetching,
     isTransactionLockingLoading,
@@ -40,12 +61,22 @@ function TransactionsLockingProvider({ ...props }) {
 
   return (
     <DashboardInsider>
-      <TransactionsLockingContext.Provider value={provider} {...props} />
+      <TransactionsLockingContext.Provider value={provider}>
+        {children}
+      </TransactionsLockingContext.Provider>
     </DashboardInsider>
   );
 }
 
-const useTransactionsLockingContext = () =>
-  React.useContext(TransactionsLockingContext);
+const useTransactionsLockingContext = (): TransactionsLockingContextValue => {
+  const context = React.useContext(TransactionsLockingContext);
+
+  if (!context) {
+    throw new Error(
+      'useTransactionsLockingContext must be used within a TransactionsLockingProvider',
+    );
+  }
+  return context;
+};
 
 export { TransactionsLockingProvider, useTransactionsLockingContext };

--- a/packages/webapp/src/containers/TransactionsLocking/components.tsx
+++ b/packages/webapp/src/containers/TransactionsLocking/components.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import {
   Button,
   Position,
@@ -13,14 +12,48 @@ import React from 'react';
 import intl from 'react-intl-universal';
 import styled from 'styled-components';
 import { useTransactionsLockingContext } from './TransactionsLockingProvider';
+import type { TransactionsLockingMeta } from '@bigcapital/sdk-ts';
 import { Hint, Icon, If, FormattedMessage as T } from '@/components';
-import { safeInvoke } from '@/utils';
+
+export interface TransactionLockingHandlers {
+  onLock?: (module: string, event: React.MouseEvent) => void;
+  onEditLock?: (
+    module: string,
+    isEnabled: boolean,
+    event: React.MouseEvent,
+  ) => void;
+  onCancelLock?: (module: string, event: React.MouseEvent) => void;
+  onUnlockPartial?: (module: string, event: React.MouseEvent) => void;
+  onCancelUnlockPartial?: (module: string, event: React.MouseEvent) => void;
+}
+
+export interface TransactionsLockingItemModuleProps
+  extends TransactionLockingHandlers {
+  module: TransactionsLockingMeta;
+}
+
+export interface TransactionLockingContentProps
+  extends TransactionLockingHandlers {
+  name: string;
+  module: string;
+  description: string;
+  isEnabled: boolean;
+  isPartialUnlock: boolean;
+  lockToDate: string;
+  lockReason: string;
+  unlockReason: string;
+  unlockFromDate: string;
+  unlockToDate: string;
+}
 
 /**
  * Transaction locking module item.
  * @returns {React.JSX}
  */
-export function TransactionsLockingItemModule({ module, ...rest }) {
+export function TransactionsLockingItemModule({
+  module,
+  ...rest
+}: TransactionsLockingItemModuleProps) {
   return (
     <TransactionLockingContent
       name={module.formattedModule}
@@ -42,26 +75,40 @@ export function TransactionsLockingItemModule({ module, ...rest }) {
  * Transactions locking items modules list.
  * @returns {React.JSX}
  */
-export function TransactionsLockingList({ ...rest }) {
-  const {
-    transactionsLocking: { modules },
-  } = useTransactionsLockingContext();
+export function TransactionsLockingList({
+  ...rest
+}: Omit<TransactionsLockingItemModuleProps, 'module'>) {
+  const { transactionsLocking } = useTransactionsLockingContext();
+  const modules = transactionsLocking?.modules ?? [];
 
-  return modules.map((module) => (
-    <TransactionsLockingItemModule module={module} {...rest} />
-  ));
+  return (
+    <>
+      {modules.map((module) => (
+        <TransactionsLockingItemModule
+          key={module.module}
+          module={module}
+          {...rest}
+        />
+      ))}
+    </>
+  );
 }
 
 /**
  * Transactions locking full module item.
  * @returns {React.JSX}
  */
-export function TransactionsLockingFull({ ...rest }) {
-  const {
-    transactionsLocking: { all },
-  } = useTransactionsLockingContext();
+export function TransactionsLockingFull({
+  ...rest
+}: Omit<TransactionsLockingItemModuleProps, 'module'>) {
+  const { transactionsLocking } = useTransactionsLockingContext();
 
-  return <TransactionsLockingItemModule module={all} {...rest} />;
+  if (!transactionsLocking) {
+    return null;
+  }
+  return (
+    <TransactionsLockingItemModule module={transactionsLocking.all} {...rest} />
+  );
 }
 
 /**
@@ -82,9 +129,9 @@ export function TransactionLockingSkeletonList() {
  * Transactions locking skeleton item.
  * @returns {React.JSX}
  */
-export const TransactionLockingItemSkeleton = ({}) => {
+export const TransactionLockingItemSkeleton = () => {
   return (
-    <TransactionLockingWrapp>
+    <TransactionLockingWrapp isEnabled={false}>
       <TransLockingInner>
         <TransLockingIcon>
           <Icon icon="lock" iconSize={24} />
@@ -104,37 +151,30 @@ export const TransactionLockingItemSkeleton = ({}) => {
   );
 };
 
-const TransactionsLockingItemContext = React.createContext();
+const TransactionsLockingItemContext = React.createContext<
+  TransactionLockingContentProps | undefined
+>(undefined);
 
-const useTransactionsLockingItemContext = () =>
-  React.useContext(TransactionsLockingItemContext);
+const useTransactionsLockingItemContext =
+  (): TransactionLockingContentProps => {
+    const context = React.useContext(TransactionsLockingItemContext);
+
+    if (!context) {
+      throw new Error(
+        'useTransactionsLockingItemContext must be used within a TransactionLockingContent',
+      );
+    }
+    return context;
+  };
 
 /**
  * Transactions locking item.
  * @returns {React.JSX}
  */
-export const TransactionLockingContent = (props) => {
-  const {
-    name,
-    description,
-    module,
-
-    isEnabled,
-    lockToDate,
-    lockReason,
-
-    // Unlock props.
-    isPartialUnlock,
-    unlockToDate,
-    unlockFromDate,
-    unlockReason,
-
-    onLock,
-    onCancelLock,
-    onEditLock,
-    onUnlockPartial,
-    onCancelUnlockPartial,
-  } = props;
+export const TransactionLockingContent = (
+  props: TransactionLockingContentProps,
+) => {
+  const { isEnabled } = props;
 
   return (
     <TransactionsLockingItemContext.Provider value={props}>
@@ -195,7 +235,7 @@ function TransactionsLockingItemContent() {
             )}
           </TransLockingItemDesc>
 
-          <If condition={lockReason}>
+          <If condition={!!lockReason}>
             <TransLockingReason>
               {intl.formatHTMLMessage(
                 { id: 'transactions_locking.lock_reason' },
@@ -218,7 +258,7 @@ function TransactionsLockingItemContent() {
             )}
           </TransLockingItemDesc>
 
-          <If condition={unlockReason}>
+          <If condition={!!unlockReason}>
             <TransLockingReason>
               {intl.formatHTMLMessage(
                 { id: 'transactions_locking.unlock_reason' },
@@ -250,21 +290,21 @@ function TransactionsLockingItemActions() {
     onCancelUnlockPartial,
   } = useTransactionsLockingItemContext();
 
-  const handleLockClick = (event) => {
-    safeInvoke(onLock, module, event);
+  const handleLockClick = (event: React.MouseEvent) => {
+    onLock?.(module, event);
   };
-  const handleEditBtn = (event) => {
-    safeInvoke(onEditLock, module, isEnabled, event);
+  const handleEditBtn = (event: React.MouseEvent) => {
+    onEditLock?.(module, isEnabled, event);
   };
-  const handleUnlockPartial = (event) => {
-    safeInvoke(onUnlockPartial, module, event);
+  const handleUnlockPartial = (event: React.MouseEvent) => {
+    onUnlockPartial?.(module, event);
   };
 
-  const handleUnlockFull = (event) => {
-    safeInvoke(onCancelLock, module, event);
+  const handleUnlockFull = (event: React.MouseEvent) => {
+    onCancelLock?.(module, event);
   };
-  const handleCancelPartialUnlock = (event) => {
-    safeInvoke(onCancelUnlockPartial, module, event);
+  const handleCancelPartialUnlock = (event: React.MouseEvent) => {
+    onCancelUnlockPartial?.(module, event);
   };
 
   return (
@@ -324,7 +364,7 @@ function TransactionsLockingItemActions() {
   );
 }
 
-const TransactionLockingWrapp = styled.div`
+const TransactionLockingWrapp = styled.div<{ isEnabled: boolean }>`
   display: flex;
   align-items: center;
   border-radius: 6px;

--- a/packages/webapp/src/containers/TransactionsLocking/utils.tsx
+++ b/packages/webapp/src/containers/TransactionsLocking/utils.tsx
@@ -1,13 +1,37 @@
-// @ts-nocheck
-export const validateMoveToPartialLocking = (all) => {
+import type {
+  TransactionsLockingListResponse,
+  TransactionsLockingMeta,
+} from '@bigcapital/sdk-ts';
+
+export const validateMoveToPartialLocking = (
+  all: TransactionsLockingMeta,
+): boolean => {
   return all.isEnabled;
 };
 
-export const validateMoveToFullLocking = (modules) => {
+export const validateMoveToFullLocking = (
+  modules: TransactionsLockingMeta[],
+): TransactionsLockingMeta[] => {
   return modules.filter((module) => module.isEnabled);
 };
 
-export const transformItem = (item) => {
+export interface TransactionsLockingViewItem {
+  name: string;
+  module: string;
+  description: string;
+  isEnabled: boolean;
+  isPartialUnlock: boolean;
+  lockToDate: string;
+  lockReason: string;
+  unlockFromDate: string;
+  unlockToDate: string;
+  unlockReason: string;
+  partialUnlockReason: string;
+}
+
+export const transformItem = (
+  item: TransactionsLockingMeta,
+): TransactionsLockingViewItem => {
   return {
     name: item.formattedModule,
     module: item.module,
@@ -23,7 +47,14 @@ export const transformItem = (item) => {
   };
 };
 
-export const transformList = (res) => {
+export interface TransactionsLockingViewList {
+  all: TransactionsLockingViewItem;
+  modules: TransactionsLockingViewItem[];
+}
+
+export const transformList = (
+  res: TransactionsLockingListResponse,
+): TransactionsLockingViewList => {
   return {
     all: transformItem(res.all),
     modules: res.modules.map((module) => transformItem(module)),

--- a/packages/webapp/src/containers/UniversalSearch/DashboardUniversalSearch.tsx
+++ b/packages/webapp/src/containers/UniversalSearch/DashboardUniversalSearch.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import * as FF from 'fp-ts/function';
 import { debounce } from 'lodash';
 import { isUndefined } from 'lodash';
@@ -9,9 +8,22 @@ import { DashboardUniversalSearchItemActions } from './DashboardUniversalSearchI
 import { useGetUniversalSearchTypeOptions } from './utils';
 import { withUniversalSearch } from './withUniversalSearch';
 import { withUniversalSearchActions } from './withUniversalSearchActions';
+import type { WithUniversalSearchActionsProps } from './withUniversalSearchActions';
+import type {
+  SearchTypeOption,
+  UniversalSearchItem,
+} from '@/components/UniversalSearch/UniversalSearch';
 import { UniversalSearch } from '@/components';
 import { RESOURCES_TYPES } from '@/constants/resourcesTypes';
 import { useUniversalSearch } from '@/hooks/query';
+
+interface DashboardUniversalSearchInnerProps {
+  setSelectedItemUniversalSearch: WithUniversalSearchActionsProps['setSelectedItemUniversalSearch'];
+  closeGlobalSearch: WithUniversalSearchActionsProps['closeGlobalSearch'];
+
+  globalSearchShow: boolean;
+  defaultUniversalResourceType: string;
+}
 
 /**
  * Dashboard universal search.
@@ -19,12 +31,12 @@ import { useUniversalSearch } from '@/hooks/query';
 function DashboardUniversalSearchInner({
   // #withUniversalSearchActions
   setSelectedItemUniversalSearch,
+  closeGlobalSearch,
 
   // #withUniversalSearch
   globalSearchShow,
-  closeGlobalSearch,
   defaultUniversalResourceType,
-}) {
+}: DashboardUniversalSearchInnerProps) {
   const searchTypeOptions = useGetUniversalSearchTypeOptions();
 
   // Search keyword.
@@ -51,9 +63,7 @@ function DashboardUniversalSearchInner({
   // Fetch accounts list according to the given custom view id.
   const {
     data,
-    remove,
     isFetching: isSearchFetching,
-    isLoading: isSearchLoading,
     refetch,
   } = useUniversalSearch(searchType, searchKeyword, {
     keepPreviousData: true,
@@ -61,12 +71,11 @@ function DashboardUniversalSearchInner({
   });
 
   // Handle query change.
-  const handleQueryChange = (query) => {
+  const handleQueryChange = (query: string) => {
     setSearchKeyword(query);
   };
   // Handle search type change.
-  const handleSearchTypeChange = (type) => {
-    remove();
+  const handleSearchTypeChange = (type: SearchTypeOption) => {
     setSearchType(type.key);
   };
   // Handle overlay of universal search close.
@@ -74,7 +83,7 @@ function DashboardUniversalSearchInner({
     closeGlobalSearch();
   };
   // Handle universal search item select.
-  const handleItemSelect = (item) => {
+  const handleItemSelect = (item: UniversalSearchItem) => {
     setSelectedItemUniversalSearch(searchType, item.id);
     closeGlobalSearch();
     setSearchKeyword('');
@@ -101,7 +110,7 @@ function DashboardUniversalSearchInner({
   }
 
   return (
-    <div class="dashboard__universal-search">
+    <div className="dashboard__universal-search">
       <UniversalSearch
         isOpen={globalSearchShow}
         isLoading={isSearchFetching}

--- a/packages/webapp/src/containers/UniversalSearch/DashboardUniversalSearchBinds.tsx
+++ b/packages/webapp/src/containers/UniversalSearch/DashboardUniversalSearchBinds.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { universalSearchJournalBind } from '../Accounting/ManualJournalUniversalSearch';
 import { universalSearchAccountBind } from '../Accounts/AccountUniversalSearch';
 import { universalSearchCustomerBind } from '../Customers/CustomersUniversalSearch';
@@ -12,8 +11,11 @@ import { universalSearchInvoiceBind } from '../Sales/Invoices/InvoiceUniversalSe
 import { universalSearchPaymentReceiveBind } from '../Sales/PaymentsReceived/PaymentReceiveUniversalSearch';
 import { universalSearchReceiptBind } from '../Sales/Receipts/ReceiptUniversalSearch';
 import { universalSearchVendorBind } from '../Vendors/VendorsUniversalSearch';
+import type { UniversalSearchBind } from './types';
 
-// Universal search binds.
+// Universal search binds. Each bind is authored next to its resource module
+// with resource-specific item/renderer types, so the aggregation boundary
+// widens to the common consumer contract.
 export const universalSearchBinds = [
   universalSearchItemBind,
   universalSearchAccountBind,
@@ -28,4 +30,4 @@ export const universalSearchBinds = [
   universalSearchJournalBind,
   universalSearchCreditNoteBind,
   universalSearchVendorCreditBind,
-];
+] as unknown as Array<() => UniversalSearchBind>;

--- a/packages/webapp/src/containers/UniversalSearch/DashboardUniversalSearchHotkeys.tsx
+++ b/packages/webapp/src/containers/UniversalSearch/DashboardUniversalSearchHotkeys.tsx
@@ -1,13 +1,15 @@
-// @ts-nocheck
 import * as FF from 'fp-ts/function';
 import { useHotkeys } from 'react-hotkeys-hook';
 import { withUniversalSearchActions } from './withUniversalSearchActions';
+import type { WithUniversalSearchActionsProps } from './withUniversalSearchActions';
 
 /**
  * Universal search hotkey.
  */
-function DashboardUniversalSearchHotkey({ openGlobalSearch }) {
-  useHotkeys('shift+p', (event, handle) => {
+function DashboardUniversalSearchHotkey({
+  openGlobalSearch,
+}: WithUniversalSearchActionsProps) {
+  useHotkeys('shift+p', () => {
     openGlobalSearch();
   });
 

--- a/packages/webapp/src/containers/UniversalSearch/DashboardUniversalSearchItemActions.tsx
+++ b/packages/webapp/src/containers/UniversalSearch/DashboardUniversalSearchItemActions.tsx
@@ -1,9 +1,20 @@
-// @ts-nocheck
 import * as FF from 'fp-ts/function';
 import React from 'react';
 import { getUniversalSearchItemsActions } from './utils';
 import { withUniversalSearch } from './withUniversalSearch';
 import { withUniversalSearchActions } from './withUniversalSearchActions';
+import type { WithUniversalSearchProps } from './withUniversalSearch';
+import type { WithUniversalSearchActionsProps } from './withUniversalSearchActions';
+
+interface DashboardUniversalSearchItemActionsInnerProps
+  extends Pick<
+      WithUniversalSearchActionsProps,
+      'resetSelectedItemUniversalSearch'
+    >,
+    Pick<
+      WithUniversalSearchProps,
+      'searchSelectedResourceType' | 'searchSelectedResourceId'
+    > {}
 
 /**
  * Universal search selected item action based on each resource type.
@@ -14,7 +25,7 @@ function DashboardUniversalSearchItemActionsInner({
 
   // #with
   resetSelectedItemUniversalSearch,
-}) {
+}: DashboardUniversalSearchItemActionsInnerProps) {
   const components = getUniversalSearchItemsActions();
 
   // Handle action execuation.
@@ -22,13 +33,18 @@ function DashboardUniversalSearchItemActionsInner({
     resetSelectedItemUniversalSearch();
   }, [resetSelectedItemUniversalSearch]);
 
-  return components.map((COMPONENT) => (
-    <COMPONENT
-      resourceId={searchSelectedResourceId}
-      resourceType={searchSelectedResourceType}
-      onAction={handleActionExec}
-    />
-  ));
+  return (
+    <>
+      {components.map((COMPONENT, index) => (
+        <COMPONENT
+          key={index}
+          resourceId={searchSelectedResourceId as number}
+          resourceType={String(searchSelectedResourceType)}
+          onAction={handleActionExec}
+        />
+      ))}
+    </>
+  );
 }
 
 export const DashboardUniversalSearchItemActions = FF.pipe(

--- a/packages/webapp/src/containers/UniversalSearch/components.tsx
+++ b/packages/webapp/src/containers/UniversalSearch/components.tsx
@@ -1,13 +1,17 @@
-// @ts-nocheck
 import { MenuItem } from '@blueprintjs/core';
 import React from 'react';
 import { getUniversalSearchBind } from './utils';
+import type { UniversalSearchItem } from '@/components/UniversalSearch/UniversalSearch';
+import type { IItemRendererProps, ItemRenderer } from '@blueprintjs/select';
 import { highlightText } from '@/utils';
 
 /**
  * Default univesal search item component.
  */
-function UniversalSearchItemDetail(item, { handleClick, modifiers, query }) {
+function UniversalSearchItemDetail(
+  item: UniversalSearchItem,
+  { handleClick, modifiers, query }: IItemRendererProps,
+) {
   return (
     <MenuItem
       active={modifiers.active}
@@ -17,25 +21,29 @@ function UniversalSearchItemDetail(item, { handleClick, modifiers, query }) {
           <div>{highlightText(item.text, query)}</div>
 
           {item.subText && (
-            <span class="bp4-text-muted">
+            <span className="bp4-text-muted">
               {highlightText(item.subText, query)}
             </span>
           )}
         </div>
       }
-      label={item.label ? highlightText(item.label, query) : ''}
+      label={
+        item.label
+          ? (highlightText(item.label, query) as unknown as string)
+          : ''
+      }
       onClick={handleClick}
     />
   );
 }
 
 /**
- *
- * @param {*} props
- * @param {*} actions
- * @returns
+ * Dashboard universal search item.
  */
-export const DashboardUniversalSearchItem = (props, actions) => {
+export const DashboardUniversalSearchItem: ItemRenderer<UniversalSearchItem> = (
+  props,
+  actions,
+) => {
   const itemRenderer = getUniversalSearchBind(props._type, 'itemRenderer');
 
   return typeof itemRenderer !== 'undefined'

--- a/packages/webapp/src/containers/UniversalSearch/types.ts
+++ b/packages/webapp/src/containers/UniversalSearch/types.ts
@@ -1,0 +1,26 @@
+import type { UniversalSearchItem } from '@/components/UniversalSearch/UniversalSearch';
+import type { IItemRendererProps } from '@blueprintjs/select';
+import type { ComponentType } from 'react';
+
+export interface UniversalSearchSelectActionProps {
+  resourceType: string;
+  resourceId: number;
+  onAction?: () => void;
+}
+
+export interface UniversalSearchPermission {
+  ability: string;
+  subject: string;
+}
+
+export interface UniversalSearchBind {
+  resourceType: string;
+  optionItemLabel: string;
+  selectItemAction?: ComponentType<UniversalSearchSelectActionProps>;
+  itemRenderer?(
+    item: UniversalSearchItem,
+    modifiers: IItemRendererProps,
+  ): React.ReactElement | null;
+  itemSelect?(item: unknown): UniversalSearchItem;
+  permission?: UniversalSearchPermission;
+}

--- a/packages/webapp/src/containers/UniversalSearch/utils.tsx
+++ b/packages/webapp/src/containers/UniversalSearch/utils.tsx
@@ -1,35 +1,42 @@
-// @ts-nocheck
 import * as FF from 'fp-ts/function';
 import { get } from 'lodash';
 import React from 'react';
 import { universalSearchBinds } from './DashboardUniversalSearchBinds';
+import type { UniversalSearchBind } from './types';
+import type { SearchTypeOption } from '@/components/UniversalSearch/UniversalSearch';
 import { useAbilitiesFilter } from '@/hooks/utils';
 
 /**
- *
- * @returns
+ * Retrieves the universal search binds.
  */
-export const getUniversalSearchBinds = () => {
+export const getUniversalSearchBinds = (): UniversalSearchBind[] => {
   return universalSearchBinds.map((binder) => binder());
 };
 
 /**
- *
- * @param {*} resourceType
- * @param {*} key
- * @returns
+ * Retrieves the universal search bind by the given resource type.
  */
-export const getUniversalSearchBind = (resourceType, key) => {
+export function getUniversalSearchBind(
+  resourceType: string,
+): UniversalSearchBind | undefined;
+export function getUniversalSearchBind<K extends keyof UniversalSearchBind>(
+  resourceType: string,
+  key: K,
+): UniversalSearchBind[K] | undefined;
+export function getUniversalSearchBind(
+  resourceType: string,
+  key?: keyof UniversalSearchBind,
+) {
   const resourceConfig = getUniversalSearchBinds().find(
     (meta) => meta.resourceType === resourceType,
   );
   return key ? get(resourceConfig, key) : resourceConfig;
-};
+}
 
 /**
  * Retrieve universal search type options.
  */
-export const useGetUniversalSearchTypeOptions = () => {
+export const useGetUniversalSearchTypeOptions = (): SearchTypeOption[] => {
   const abilityFilter = useAbilitiesFilter();
 
   const momerizedBinds = React.useMemo(() => {
@@ -49,6 +56,11 @@ export const useGetUniversalSearchTypeOptions = () => {
  */
 export const getUniversalSearchItemsActions = () => {
   return getUniversalSearchBinds()
-    .filter((bind) => bind.selectItemAction)
-    .map((bind) => bind.selectItemAction);
+    .map((bind) => bind.selectItemAction)
+    .filter(
+      (
+        action,
+      ): action is NonNullable<UniversalSearchBind['selectItemAction']> =>
+        !!action,
+    );
 };

--- a/packages/webapp/src/containers/Views/ViewForm.container.tsx
+++ b/packages/webapp/src/containers/Views/ViewForm.container.tsx
@@ -1,25 +1,42 @@
-// @ts-nocheck
 import * as FF from 'fp-ts/function';
 import { connect } from 'react-redux';
+import type { ApplicationState } from '@/store/reducers';
+import type { ComponentType } from 'react';
 import { withDashboardActions } from '@/containers/Dashboard/withDashboardActions';
-import { withResourceDetail } from '@/containers/Resources/withResourceDetails';
-import { withViewsDetails } from '@/containers/Views/withViewDetails';
+import { withResourceDetails } from '@/containers/Resources/withResourceDetails';
+import { withViewDetails } from '@/containers/Views/withViewDetails';
 import { withViewsActions } from '@/containers/Views/withViewsActions';
 
-const mapStateToProps = (state, ownProps) => {
+interface ViewFormOwnProps {
+  viewId?: string | number;
+  viewMeta?: { resource?: { name?: string } } | null;
+  resourceName?: string;
+}
+
+const mapStateToProps = (
+  _state: ApplicationState,
+  ownProps: ViewFormOwnProps,
+) => {
   return {
     resourceName: ownProps.viewId
-      ? ownProps.viewMeta.resource?.name
+      ? ownProps.viewMeta?.resource?.name
       : ownProps.resourceName,
   };
 };
 
-const viewFormConnect = connect(mapStateToProps);
+function withViewFormResourceName<P>(
+  WrappedComponent: ComponentType<P>,
+): ComponentType<P> {
+  const Connected = connect(mapStateToProps)(
+    WrappedComponent as ComponentType<any>,
+  );
+  return Connected as unknown as ComponentType<P>;
+}
 
 export const ViewFormContainer = FF.flow(
-  withResourceDetail(),
-  viewFormConnect,
-  withViewsDetails,
+  withResourceDetails(),
+  withViewFormResourceName,
+  withViewDetails(),
   withViewsActions,
   withDashboardActions,
 );

--- a/packages/webapp/src/containers/Views/ViewForm.tsx
+++ b/packages/webapp/src/containers/Views/ViewForm.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import {
   InputGroup,
   FormGroup,
@@ -21,16 +20,84 @@ import { ReactSortable } from 'react-sortablejs';
 import * as Yup from 'yup';
 import { FormattedMessage as T } from '@/components';
 import { If, Icon, AppToaster } from '@/components';
-import ErrorMessage from '@/components/ErrorMessage';
+import { ErrorMessage } from '@/components/ErrorMessage';
 import { ViewFormContainer } from '@/containers/Views/ViewForm.container';
 import { transfromToSnakeCase } from '@/utils';
+
+export interface ViewRole {
+  fieldKey: string;
+  comparator: string;
+  value: string;
+  index: number;
+}
+
+export interface ViewRoleMeta extends ViewRole {
+  field?: { key: string };
+}
+
+export interface ViewColumnItem {
+  id: string | number;
+  key: string;
+  label: string;
+}
+
+export interface ViewMeta {
+  id?: string | number;
+  name?: string;
+  columns?: ViewColumnItem[];
+  roles?: ViewRoleMeta[];
+  roles_logic_expression?: string;
+  logicExpression?: string;
+  resource?: { name?: string };
+}
+
+export interface ResourceField {
+  key: string;
+  label_name: string;
+}
+
+export interface ResourceMetadata {
+  label: string;
+  baseRoute: string;
+}
+
+export interface ViewFormValues {
+  resourceName: string;
+  name: string;
+  logicExpression: string;
+  roles: ViewRole[];
+  columns: Array<{ key: string; index: number }>;
+}
+
+const Sortable = ReactSortable as unknown as React.ComponentType<
+  React.PropsWithChildren<{
+    list: ViewColumnItem[];
+    setList: React.Dispatch<React.SetStateAction<ViewColumnItem[]>>;
+    group: string;
+  }>
+>;
+
+interface ViewFormInnerProps {
+  requestSubmitView: (form: unknown) => Promise<unknown>;
+  requestEditView: (id: string | number, form: unknown) => Promise<unknown>;
+  onDelete?: (view: ViewMeta | null) => void;
+
+  viewId?: string | number;
+  viewMeta?: ViewMeta | null;
+
+  resourceName?: string;
+  resourceColumns: ViewColumnItem[];
+  resourceFields: ResourceField[];
+  resourceMetadata: ResourceMetadata;
+
+  changePageSubtitle: (subtitle: string) => void;
+}
 
 function ViewFormInner({
   requestSubmitView,
   requestEditView,
   onDelete,
 
-  viewId,
   viewMeta,
 
   resourceName,
@@ -39,8 +106,7 @@ function ViewFormInner({
   resourceMetadata,
 
   changePageSubtitle,
-}) {
-  const intl = useIntl();
+}: ViewFormInnerProps) {
   const history = useHistory();
 
   useEffect(() => {
@@ -50,7 +116,7 @@ function ViewFormInner({
     };
   }, [changePageSubtitle, resourceMetadata.label]);
 
-  const [draggedColumns, setDraggedColumn] = useState([
+  const [draggedColumns, setDraggedColumn] = useState<ViewColumnItem[]>([
     ...(viewMeta && viewMeta.columns ? viewMeta.columns : []),
   ]);
 
@@ -59,7 +125,7 @@ function ViewFormInner({
     [draggedColumns],
   );
 
-  const [availableColumns, setAvailableColumns] = useState([
+  const [availableColumns, setAvailableColumns] = useState<ViewColumnItem[]>([
     ...(viewMeta && viewMeta.columns
       ? resourceColumns.filter(
           (column) => draggedColumnsIds.indexOf(column.id) === -1,
@@ -107,23 +173,21 @@ function ViewFormInner({
       name: '',
       logicExpression: '',
       roles: [defaultViewRole],
-      columns: [],
+      columns: [] as Array<{ key: string; index: number }>,
     }),
     [defaultViewRole, resourceName],
   );
 
-  const initialForm = useMemo(
-    () => ({
+  const initialForm = useMemo((): ViewFormValues & {
+    roles_logic_expression?: string;
+  } => {
+    const meta = (viewMeta ?? {}) as ViewMeta;
+    return {
       ...initialEmptyForm,
-      ...(viewMeta
-        ? {
-            ...viewMeta,
-            resourceName: viewMeta.resource?.name || resourceName,
-          }
-        : {}),
-    }),
-    [initialEmptyForm, viewMeta, resourceName],
-  );
+      ...meta,
+      resourceName: meta.resource?.name || resourceName || '',
+    } as ViewFormValues & { roles_logic_expression?: string };
+  }, [initialEmptyForm, viewMeta, resourceName]);
 
   const {
     values,
@@ -133,19 +197,22 @@ function ViewFormInner({
     getFieldProps,
     handleSubmit,
     isSubmitting,
-  } = useFormik({
+  } = useFormik<ViewFormValues>({
     enableReinitialize: true,
     validationSchema: validationSchema,
     initialValues: {
-      roles: [],
-      ...pick(initialForm, Object.keys(initialEmptyForm)),
+      ...initialEmptyForm,
+      ...(pick(
+        initialForm,
+        Object.keys(initialEmptyForm),
+      ) as Partial<ViewFormValues>),
       // The view API returns `roles_logic_expression` in snake_case.
       logicExpression: initialForm.roles_logic_expression || '',
       roles: [
-        ...initialForm.roles.map((role) => {
+        ...(initialForm.roles ?? []).map((role): ViewRole => {
           return {
-            ...pick(role, Object.keys(defaultViewRole)),
-            fieldKey: role.field ? role.field.key : '',
+            ...(pick(role, Object.keys(defaultViewRole)) as ViewRole),
+            fieldKey: (role as ViewRoleMeta).field?.key ?? '',
           };
         }),
       ],
@@ -155,7 +222,7 @@ function ViewFormInner({
       const payload = transfromToSnakeCase(values);
 
       if (viewMeta && viewMeta.id) {
-        requestEditView(viewMeta.id, payload).then((response) => {
+        requestEditView(viewMeta.id, payload).then(() => {
           AppToaster.show({
             message: 'the_view_has_been_edited',
             intent: Intent.SUCCESS,
@@ -166,13 +233,13 @@ function ViewFormInner({
           setSubmitting(false);
         });
       } else {
-        requestSubmitView(payload).then((response) => {
+        requestSubmitView(payload).then(() => {
           AppToaster.show({
             message: 'the_view_has_been_submit',
             intent: Intent.SUCCESS,
           });
           history.push(
-            `${resourceMetadata.baseRoute}/${viewMeta.id}/custom_view`,
+            `${resourceMetadata.baseRoute}/${viewMeta?.id}/custom_view`,
           );
           setSubmitting(false);
         });
@@ -227,10 +294,6 @@ function ViewFormInner({
     [resourceFields],
   );
 
-  // Account item of select accounts field.
-  const selectItem = (item, { handleClick, modifiers, query }) => {
-    return <MenuItem text={item.label} key={item.key} onClick={handleClick} />;
-  };
   // Handle click new condition button.
   const onClickNewRole = useCallback(() => {
     setFieldValue('roles', [
@@ -244,8 +307,8 @@ function ViewFormInner({
 
   // Handle click remove view role button.
   const onClickRemoveRole = useCallback(
-    (viewRole, index) => {
-      let viewRoles = [...values.roles];
+    (_viewRole: ViewRole, index: number) => {
+      const viewRoles = [...values.roles];
 
       // Can't continue if view roles equals or less than 1.
       if (viewRoles.length > 1) {
@@ -263,33 +326,40 @@ function ViewFormInner({
   );
 
   const onClickDeleteView = useCallback(() => {
-    onDelete && onDelete(viewMeta);
+    onDelete?.(viewMeta ?? null);
   }, [onDelete, viewMeta]);
 
-  const hasError = (path) => get(errors, path) && get(touched, path);
+  const hasError = (path: string) => get(errors, path) && get(touched, path);
+
+  const getSelectFieldProps = (name: string) => {
+    const { value, onChange, onBlur } = getFieldProps(name);
+
+    return { value, onChange, onBlur };
+  };
 
   const handleClickCancelBtn = () => {
     history.goBack();
   };
 
   return (
-    <div class="view-form">
+    <div className="view-form">
       <form onSubmit={handleSubmit}>
-        <div class="view-form--name-section">
+        <div className="view-form--name-section">
           <Row>
             <Col sm={8}>
               <FormGroup
                 label={intl.get('view_name')}
                 className={'form-group--name'}
-                intent={errors.name && touched.name && Intent.DANGER}
+                intent={errors.name && touched.name ? Intent.DANGER : undefined}
                 helperText={
                   <ErrorMessage {...{ errors, touched }} name={'name'} />
                 }
                 inline={true}
-                fill={true}
               >
                 <InputGroup
-                  intent={errors.name && touched.name && Intent.DANGER}
+                  intent={
+                    errors.name && touched.name ? Intent.DANGER : undefined
+                  }
                   fill={true}
                   {...getFieldProps('name')}
                 />
@@ -301,9 +371,9 @@ function ViewFormInner({
         <H5 className="mb2">Define the conditionals</H5>
 
         {values.roles.map((role, index) => (
-          <Row class="view-form__role-conditional">
-            <Col sm={2} class="flex">
-              <div class="mr2 pt1 condition-number">{index + 1}</div>
+          <Row key={index} className="view-form__role-conditional">
+            <Col sm={2} className="flex">
+              <div className="mr2 pt1 condition-number">{index + 1}</div>
               {index === 0 ? (
                 <HTMLSelect
                   options={whenConditionalsItems}
@@ -319,33 +389,41 @@ function ViewFormInner({
 
             <Col sm={2}>
               <FormGroup
-                intent={hasError(`roles[${index}].fieldKey`) && Intent.DANGER}
+                intent={
+                  hasError(`roles[${index}].fieldKey`)
+                    ? Intent.DANGER
+                    : undefined
+                }
               >
                 <HTMLSelect
                   options={resourceFieldsOptions}
-                  value={role.fieldKey}
                   className={Classes.FILL}
-                  {...getFieldProps(`roles[${index}].fieldKey`)}
+                  {...getSelectFieldProps(`roles[${index}].fieldKey`)}
                 />
               </FormGroup>
             </Col>
 
             <Col sm={2}>
               <FormGroup
-                intent={hasError(`roles[${index}].comparator`) && Intent.DANGER}
+                intent={
+                  hasError(`roles[${index}].comparator`)
+                    ? Intent.DANGER
+                    : undefined
+                }
               >
                 <HTMLSelect
                   options={compatatorsItems}
-                  value={role.comparator}
                   className={Classes.FILL}
-                  {...getFieldProps(`roles[${index}].comparator`)}
+                  {...getSelectFieldProps(`roles[${index}].comparator`)}
                 />
               </FormGroup>
             </Col>
 
-            <Col sm={5} class="flex">
+            <Col sm={5} className="flex">
               <FormGroup
-                intent={hasError(`roles[${index}].value`) && Intent.DANGER}
+                intent={
+                  hasError(`roles[${index}].value`) ? Intent.DANGER : undefined
+                }
               >
                 <InputGroup
                   placeholder={intl.get('value')}
@@ -355,7 +433,6 @@ function ViewFormInner({
 
               <Button
                 icon={<Icon icon="times-circle" iconSize={14} />}
-                iconSize={14}
                 className="ml2"
                 minimal={true}
                 intent={Intent.DANGER}
@@ -375,16 +452,16 @@ function ViewFormInner({
           </Button>
         </div>
 
-        <div class="view-form--logic-expression-section">
+        <div className="view-form--logic-expression-section">
           <Row>
             <Col sm={8}>
               <FormGroup
                 label={intl.get('Logic Expression')}
                 className={'form-group--logic-expression'}
                 intent={
-                  errors.logicExpression &&
-                  touched.logicExpression &&
-                  Intent.DANGER
+                  errors.logicExpression && touched.logicExpression
+                    ? Intent.DANGER
+                    : undefined
                 }
                 helperText={
                   <ErrorMessage
@@ -393,13 +470,12 @@ function ViewFormInner({
                   />
                 }
                 inline={true}
-                fill={true}
               >
                 <InputGroup
                   intent={
-                    errors.logicExpression &&
-                    touched.logicExpression &&
-                    Intent.DANGER
+                    errors.logicExpression && touched.logicExpression
+                      ? Intent.DANGER
+                      : undefined
                   }
                   fill={true}
                   {...getFieldProps('logicExpression')}
@@ -411,16 +487,16 @@ function ViewFormInner({
 
         <H5 className={'mb2'}>Columns Preferences</H5>
 
-        <div class="dragable-columns">
+        <div className="dragable-columns">
           <Row gutterWidth={14}>
             <Col sm={4} className="dragable-columns__column">
               <H6 className="dragable-columns__title">Available Columns</H6>
 
               <InputGroup placeholder={intl.get('search')} leftIcon="search" />
 
-              <div class="dragable-columns__items">
+              <div className="dragable-columns__items">
                 <Menu>
-                  <ReactSortable
+                  <Sortable
                     list={availableColumns}
                     setList={setAvailableColumns}
                     group="shared-group-name"
@@ -428,13 +504,13 @@ function ViewFormInner({
                     {availableColumns.map((field) => (
                       <MenuItem key={field.id} text={field.label} />
                     ))}
-                  </ReactSortable>
+                  </Sortable>
                 </Menu>
               </div>
             </Col>
 
             <Col sm={1}>
-              <div class="dragable-columns__arrows">
+              <div className="dragable-columns__arrows">
                 <div>
                   <Icon
                     icon="arrow-circle-left"
@@ -442,7 +518,7 @@ function ViewFormInner({
                     color="#cecece"
                   />
                 </div>
-                <div class="mt2">
+                <div className="mt2">
                   <Icon
                     icon="arrow-circle-right"
                     iconSize={30}
@@ -456,9 +532,9 @@ function ViewFormInner({
               <H6 className="dragable-columns__title">Selected Columns</H6>
               <InputGroup placeholder={intl.get('search')} leftIcon="search" />
 
-              <div class="dragable-columns__items">
+              <div className="dragable-columns__items">
                 <Menu>
-                  <ReactSortable
+                  <Sortable
                     list={draggedColumns}
                     setList={setDraggedColumn}
                     group="shared-group-name"
@@ -466,14 +542,14 @@ function ViewFormInner({
                     {draggedColumns.map((field) => (
                       <MenuItem key={field.id} text={field.label} />
                     ))}
-                  </ReactSortable>
+                  </Sortable>
                 </Menu>
               </div>
             </Col>
           </Row>
         </div>
 
-        <div class="form__floating-footer">
+        <div className="form__floating-footer">
           <Button intent={Intent.PRIMARY} type="submit" disabled={isSubmitting}>
             <T id={'submit'} />
           </Button>
@@ -486,7 +562,7 @@ function ViewFormInner({
             <T id={'cancel'} />
           </Button>
 
-          <If condition={viewMeta && viewMeta.id}>
+          <If condition={!!(viewMeta && viewMeta.id)}>
             <Button
               intent={Intent.DANGER}
               onClick={onClickDeleteView}

--- a/packages/webapp/src/containers/Views/ViewFormPage.tsx
+++ b/packages/webapp/src/containers/Views/ViewFormPage.tsx
@@ -1,27 +1,33 @@
-// @ts-nocheck
 import { Intent, Alert } from '@blueprintjs/core';
 import * as FF from 'fp-ts/function';
 import React, { useEffect, useState, useCallback } from 'react';
+import intl from 'react-intl-universal';
 import { useParams } from 'react-router-dom';
 import { useAsync } from 'react-use';
+import type { WithDashboardActionsProps } from '@/containers/Dashboard/withDashboardActions';
+import type { WithResourcesActionsProps } from '@/containers/Resources/withResourcesActions';
+import type { ViewMeta } from '@/containers/Views/ViewForm';
+import type { WithViewsActionsProps } from '@/containers/Views/withViewsActions';
 import {
   If,
   AppToaster,
   DashboardInsider,
   DashboardPageContent,
   FormattedMessage as T,
-  FormattedHTMLMessage,
 } from '@/components';
 import { withDashboardActions } from '@/containers/Dashboard/withDashboardActions';
 import { withResourcesActions } from '@/containers/Resources/withResourcesActions';
 import { ViewForm } from '@/containers/Views/ViewForm';
 import { withViewsActions } from '@/containers/Views/withViewsActions';
 
-// @flow
+interface ViewFormPageProps
+  extends WithDashboardActionsProps,
+    WithResourcesActionsProps,
+    WithViewsActionsProps {}
+
 function ViewFormPageInner({
   // #withDashboardActions
   changePageTitle,
-  changePageSubtitle,
 
   requestFetchResourceFields,
   requestFetchResourceColumns,
@@ -29,9 +35,12 @@ function ViewFormPageInner({
 
   requestFetchView,
   requestDeleteView,
-}) {
-  const { resource_slug: resourceSlug, view_id: viewId } = useParams();
-  const [stateDeleteView, setStateDeleteView] = useState(null);
+}: ViewFormPageProps) {
+  const { resource_slug: resourceSlug, view_id: viewId } = useParams<{
+    resource_slug?: string;
+    view_id?: string;
+  }>();
+  const [stateDeleteView, setStateDeleteView] = useState<ViewMeta | null>(null);
 
   const fetchHook = useAsync(async () => {
     return Promise.all([
@@ -59,7 +68,7 @@ function ViewFormPageInner({
   }, [viewId, changePageTitle]);
 
   // Handle delete view button click.
-  const handleDeleteView = useCallback((view) => {
+  const handleDeleteView = useCallback((view: ViewMeta | null) => {
     setStateDeleteView(view);
   }, []);
 
@@ -70,7 +79,10 @@ function ViewFormPageInner({
 
   // Handle confirm delete custom view.
   const handleConfirmDeleteView = useCallback(() => {
-    requestDeleteView(stateDeleteView.id).then((response) => {
+    if (!stateDeleteView?.id) {
+      return;
+    }
+    requestDeleteView(stateDeleteView.id).then(() => {
       setStateDeleteView(null);
       AppToaster.show({
         message: intl.get('the_custom_view_has_been_deleted_successfully'),
@@ -86,7 +98,7 @@ function ViewFormPageInner({
       mount={false}
     >
       <DashboardPageContent>
-        <If condition={fetchHook.value}>
+        <If condition={!!fetchHook.value}>
           <ViewForm
             viewId={viewId}
             resourceName={resourceSlug}
@@ -94,23 +106,23 @@ function ViewFormPageInner({
           />
 
           <Alert
-            cancelButtonText={<T id={'cancel'} />}
-            confirmButtonText={<T id={'delete'} />}
+            cancelButtonText={intl.get('cancel')}
+            confirmButtonText={intl.get('delete')}
             icon="trash"
             intent={Intent.DANGER}
-            isOpen={stateDeleteView}
+            isOpen={stateDeleteView != null}
             onCancel={handleCancelDeleteView}
             onConfirm={handleConfirmDeleteView}
           >
             <p>
-              <FormattedHTMLMessage
-                id={'once_delete_these_views_you_will_not_able_restore_them'}
-              />
+              {intl.formatHTMLMessage({
+                id: 'once_delete_these_views_you_will_not_able_restore_them',
+              })}
             </p>
           </Alert>
         </If>
 
-        <If condition={fetchHook.error}>
+        <If condition={!!fetchHook.error}>
           <h4>
             <T id={'something_wrong'} />
           </h4>

--- a/packages/webapp/src/containers/Views/withViewsActions.tsx
+++ b/packages/webapp/src/containers/Views/withViewsActions.tsx
@@ -13,12 +13,12 @@ import {
 } from '@/store/custom-views/custom-views.actions';
 
 export interface WithViewsActionsProps {
-  requestFetchView: (id: string | number) => unknown;
-  requestSubmitView: (form: unknown) => unknown;
-  requestEditView: (id: string | number, form: unknown) => unknown;
-  requestDeleteView: (id: string | number) => unknown;
-  requestFetchResourceViews: (resourceSlug: string) => unknown;
-  requestFetchViewResource: (id: string | number) => unknown;
+  requestFetchView: (id: string | number) => Promise<unknown>;
+  requestSubmitView: (form: unknown) => Promise<unknown>;
+  requestEditView: (id: string | number, form: unknown) => Promise<unknown>;
+  requestDeleteView: (id: string | number) => Promise<unknown>;
+  requestFetchResourceViews: (resourceSlug: string) => Promise<unknown>;
+  requestFetchViewResource: (id: string | number) => Promise<unknown>;
 }
 
 export const mapDispatchToProps = (

--- a/packages/webapp/src/hooks/query/GenericResource/index.tsx
+++ b/packages/webapp/src/hooks/query/GenericResource/index.tsx
@@ -18,6 +18,7 @@ import { defaultTo } from 'lodash';
 import { useRef } from 'react';
 import { useApiFetcher } from '../../useRequest';
 import type { ApiFetcher } from '@bigcapital/sdk-ts';
+import type { UseQueryResult } from '@tanstack/react-query';
 import { RESOURCES_TYPES } from '@/constants/resourcesTypes';
 
 interface ResourceData {
@@ -65,7 +66,7 @@ export function useResourceData(
     select: transformResourceData(type),
     placeholderData: defaultDataProp ?? { items: [] },
     ...(restProps as object),
-  } as any);
+  } as any) as UseQueryResult<ResourceData, Error>;
   const defaultData = useRef(defaultDataProp ?? { items: [] });
 
   return {

--- a/packages/webapp/src/hooks/query/attachments/queries.ts
+++ b/packages/webapp/src/hooks/query/attachments/queries.ts
@@ -5,6 +5,7 @@ import {
 } from '@bigcapital/sdk-ts';
 import { useMutation, UseMutationOptions } from '@tanstack/react-query';
 import { useApiFetcher } from '../../useRequest';
+import type { AttachmentPresignedUrlResponse } from '@bigcapital/sdk-ts';
 
 type UploadAttachmentResponse = Awaited<ReturnType<typeof uploadAttachment>>;
 
@@ -45,9 +46,9 @@ export function useDeleteAttachment(
 }
 
 export function useGetPresignedUrlAttachment(
-  props?: UseMutationOptions<unknown, Error, string>,
+  props?: UseMutationOptions<AttachmentPresignedUrlResponse, Error, string>,
 ) {
-  const fetcher = useApiFetcher();
+  const fetcher = useApiFetcher({ enableCamelCaseTransform: true });
   return useMutation({
     ...props,
     mutationFn: (key: string) => fetchAttachmentPresignedUrl(fetcher, key),

--- a/packages/webapp/src/hooks/query/transactions-locking/queries.ts
+++ b/packages/webapp/src/hooks/query/transactions-locking/queries.ts
@@ -91,8 +91,12 @@ export function useTransactionsLocking(
     ...props,
     queryKey: transactionsLockingKeys.list(query),
     queryFn: () => fetchTransactionsLocking(fetcher),
-    select: (data) =>
-      Array.isArray(data) ? data : ((data as { data?: unknown })?.data ?? data),
+    select: (data) => {
+      const wrapped = data as TransactionsLockingListResponse & {
+        data?: TransactionsLockingListResponse;
+      };
+      return wrapped.data ?? data;
+    },
   });
 }
 

--- a/packages/webapp/src/hooks/state/globalErrors.tsx
+++ b/packages/webapp/src/hooks/state/globalErrors.tsx
@@ -1,4 +1,5 @@
 import { useCallback } from 'react';
+import type { GlobalErrorsData } from '@/store/global-errors/global-errors.reducer';
 import { setGlobalErrors } from '@/store/global-errors/global-errors.actions';
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
 
@@ -6,7 +7,7 @@ export const useSetGlobalErrors = () => {
   const dispatch = useAppDispatch();
 
   return useCallback(
-    (errors: Record<string, unknown>) => {
+    (errors: Partial<GlobalErrorsData>) => {
       dispatch(setGlobalErrors(errors));
     },
     [dispatch],

--- a/packages/webapp/src/store/global-errors/global-errors.actions.ts
+++ b/packages/webapp/src/store/global-errors/global-errors.actions.ts
@@ -1,4 +1,6 @@
-export const setGlobalErrors = (errors: Record<string, unknown>) => {
+import type { GlobalErrorsData } from './global-errors.reducer';
+
+export const setGlobalErrors = (errors: Partial<GlobalErrorsData>) => {
   return {
     type: 'GLOBAL_ERRORS_SET',
     payload: {

--- a/packages/webapp/src/store/global-errors/global-errors.reducer.ts
+++ b/packages/webapp/src/store/global-errors/global-errors.reducer.ts
@@ -1,7 +1,22 @@
 import { createReducer } from '@reduxjs/toolkit';
 
+export interface TransactionsLockedError {
+  formattedLockedToDate?: string;
+  [key: string]: unknown;
+}
+
+export interface GlobalErrorsData {
+  something_wrong?: boolean;
+  session_expired?: boolean;
+  too_many_requests?: boolean;
+  access_denied?: { message?: string };
+  transactionsLocked?: TransactionsLockedError;
+  subscriptionInactive?: boolean;
+  userInactive?: boolean;
+}
+
 interface GlobalErrorsState {
-  data: Record<string, unknown>;
+  data: GlobalErrorsData;
 }
 
 const initialState: GlobalErrorsState = {
@@ -11,7 +26,7 @@ const initialState: GlobalErrorsState = {
 export const globalErrorsReducer = createReducer(initialState, {
   GLOBAL_ERRORS_SET: (
     state,
-    action: { payload: { errors: Record<string, unknown> } },
+    action: { payload: { errors: Partial<GlobalErrorsData> } },
   ) => {
     const { errors } = action.payload;
 

--- a/packages/webapp/src/types/react-grid-system.d.ts
+++ b/packages/webapp/src/types/react-grid-system.d.ts
@@ -1,0 +1,23 @@
+declare module 'react-grid-system' {
+  import type { ComponentType, HTMLAttributes, ReactNode } from 'react';
+
+  export interface RowProps extends HTMLAttributes<HTMLDivElement> {
+    gutterWidth?: number;
+    children?: ReactNode;
+  }
+
+  export interface ColProps extends HTMLAttributes<HTMLDivElement> {
+    xs?: number;
+    sm?: number;
+    md?: number;
+    lg?: number;
+    xl?: number;
+    children?: ReactNode;
+  }
+
+  export const Row: ComponentType<RowProps>;
+  export const Col: ComponentType<ColProps>;
+  export const Container: ComponentType<HTMLAttributes<HTMLDivElement>>;
+  export const ScreenClassProvider: ComponentType<{ children?: ReactNode }>;
+  export function useScreenClass(): string;
+}

--- a/shared/sdk-ts/src/attachments.ts
+++ b/shared/sdk-ts/src/attachments.ts
@@ -45,11 +45,15 @@ export async function deleteAttachment(fetcher: ApiFetcher, id: string): Promise
   await del({ id });
 }
 
+export interface AttachmentPresignedUrlResponse {
+  presignedUrl: string;
+}
+
 export async function fetchAttachmentPresignedUrl(
   fetcher: ApiFetcher,
   id: string
-): Promise<unknown> {
+): Promise<AttachmentPresignedUrlResponse> {
   const get = fetcher.path(ATTACHMENTS_ROUTES.PRESIGNED_URL).method('get').create();
   const { data } = await get({ id });
-  return data;
+  return data as unknown as AttachmentPresignedUrlResponse;
 }

--- a/shared/sdk-ts/src/transactions-locking.ts
+++ b/shared/sdk-ts/src/transactions-locking.ts
@@ -1,6 +1,5 @@
 import type { ApiFetcher } from './fetch-utils';
 import { paths } from './schema';
-import { OpForPath, OpResponseBody } from './utils';
 
 export const TRANSACTIONS_LOCKING_ROUTES = {
   LOCK: '/api/transactions-locking/lock',
@@ -11,21 +10,49 @@ export const TRANSACTIONS_LOCKING_ROUTES = {
   BY_MODULE: '/api/transactions-locking/{module}',
 } as const satisfies Record<string, keyof paths>;
 
-export type TransactionsLockingListResponse = OpResponseBody<OpForPath<typeof TRANSACTIONS_LOCKING_ROUTES.LIST, 'get'>>;
+export type TransactionsLockingType = 'all' | 'partial';
+
+/**
+ * A single module locking meta as returned by the transactions locking list
+ * endpoint. The OpenAPI response schema for this endpoint is inaccurate, so
+ * the shape is declared explicitly to match the server transformer output.
+ */
+export interface TransactionsLockingMeta {
+  module: string;
+  formattedModule: string;
+  description: string;
+  isEnabled: boolean;
+  isPartialUnlock: boolean;
+  lockToDate: string;
+  unlockFromDate: string;
+  unlockToDate: string;
+  lockReason: string;
+  unlockReason: string;
+  partialUnlockReason: string;
+  formattedLockToDate: string;
+  formattedUnlockFromDate: string;
+  formattedUnlockToDate: string;
+}
+
+export interface TransactionsLockingListResponse {
+  lockingType: TransactionsLockingType;
+  all: TransactionsLockingMeta;
+  modules: TransactionsLockingMeta[];
+}
 
 export async function fetchTransactionsLocking(fetcher: ApiFetcher): Promise<TransactionsLockingListResponse> {
   const get = fetcher.path(TRANSACTIONS_LOCKING_ROUTES.LIST).method('get').create();
   const { data } = await get({});
-  return data;
+  return data as unknown as TransactionsLockingListResponse;
 }
 
 export async function fetchTransactionsLockingByModule(
   fetcher: ApiFetcher,
   module: string
-): Promise<unknown> {
+): Promise<TransactionsLockingMeta> {
   const get = fetcher.path(TRANSACTIONS_LOCKING_ROUTES.BY_MODULE).method('get').create();
   const { data } = await get({ module });
-  return data;
+  return data as unknown as TransactionsLockingMeta;
 }
 
 export async function lockTransactions(


### PR DESCRIPTION
## Description

This continues the webapp TypeScript migration by removing `@ts-nocheck` from the first wave of whole modules and replacing `any`/type suppressions with real types.

45 `@ts-nocheck` directives were removed across 11 modules:

- TransactionsLocking, Homepage, JournalEntriesTable, GlobalErrors
- SendMailNotification, Attachments, Views, ElementCustomize
- NotifyViaSMS, UniversalSearch, PaymentPortal drawers

Supporting changes:

- Typed shared primitives: `Paragraph`, `For`, `ErrorMessage`, `ImportDropzoneFile`, `UniversalSearch` props and the `GenericResource` query hook.
- Corrected stale SDK response types: transactions locking list/meta (`TransactionsLockingMeta`) and attachment presigned URLs.
- Fixed latent bugs surfaced by typing:
  - Views form called undefined `useIntl()` and `ViewFormPage` used undefined `intl`.
  - Views container imported non-existent `withResourceDetail`/`withViewsDetails` and crashed on create via `viewMeta.id`.
  - `GlobalErrors` reused the session-expired toast key for access-denied.
  - Universal search called `remove()`, which no longer exists in react-query v5, on resource-type change.
  - Payment portal drawer read a non-existent `companyName` field (now `organization.name`).
  - Attachments popover had no null guard for the dropzone callback and an invalid `Group position` value.

Motivation: `pnpm typecheck` currently passes only because ~380 files opt out with `@ts-nocheck`. This PR removes the first batch and establishes the per-module recipe for the remaining sweep.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- `pnpm run typecheck` (sdk-ts, server, webapp) — pass
- `pnpm --filter @bigcapital/webapp build` — pass
- ESLint and Prettier on all 68 changed webapp files — clean
- Playwright smoke flow (temporary spec, removed after the run):
  - homepage sections render
  - universal search opens, queries, switches resource type and closes
  - transactions locking renders module rows
  - invoice attachments popover renders
  - result: 4/4 passed

Manual reproduction: run the dev server and open `/`, `Shift+P` for universal search, `/transactions-locking`, and `/invoices/new` (attachments).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>
