### PR TITLE
fix(server): restore net income horiz PP/PY composer order after fp-ts migration

### DIFF
--- a/packages/server/src/modules/FinancialStatements/modules/BalanceSheet/BalanceSheetNetIncomeDatePeriodsPP.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/BalanceSheet/BalanceSheetNetIncomeDatePeriodsPP.ts
@@ -98,24 +98,24 @@ export const BalanceSheetNetIncomeDatePeriodsPP = <
       (horiontalTotalNode): IBalanceSheetTotal => {
         return flow(
           when(
-            this.query.isPreviousPeriodPercentageActive,
-            this.assocPreviousPeriodTotalPercentageNode,
-          ),
-          when(
-            this.query.isPreviousPeriodChangeActive,
-            this.assocPreviousPeriodTotalChangeNode,
+            this.query.isPreviousPeriodActive,
+            this.assocPreviousPeriodHorizNodeFromToDates(
+              this.query.displayColumnsBy as IFinancialDatePeriodsUnit,
+            ),
           ),
           when(
             this.query.isPreviousPeriodActive,
             this.assocPreviousPeriodNetIncomeHorizTotal(node),
           ),
           when(
-            this.query.isPreviousPeriodActive,
-            this.assocPreviousPeriodHorizNodeFromToDates(
-              this.query.displayColumnsBy as IFinancialDatePeriodsUnit,
-            ),
+            this.query.isPreviousPeriodChangeActive,
+            this.assocPreviousPeriodTotalChangeNode,
           ),
-        )(horiontalTotalNode);
+          when(
+            this.query.isPreviousPeriodPercentageActive,
+            this.assocPreviousPeriodTotalPercentageNode,
+          ),
+        )(horiontalTotalNode) as IBalanceSheetTotal;
       };
 
     /**

--- a/packages/server/src/modules/FinancialStatements/modules/BalanceSheet/BalanceSheetNetIncomeDatePeriodsPY.ts
+++ b/packages/server/src/modules/FinancialStatements/modules/BalanceSheet/BalanceSheetNetIncomeDatePeriodsPY.ts
@@ -94,20 +94,20 @@ export const BalanceSheetNetIncomeDatePeriodsPY = <
       (horiontalTotalNode): IBalanceSheetTotal => {
         return flow(
           when(
-            this.query.isPreviousYearPercentageActive,
-            this.assocPreviousYearTotalPercentageNode,
-          ),
-          when(
-            this.query.isPreviousYearChangeActive,
-            this.assocPreviousYearTotalChangeNode,
+            this.query.isPreviousYearActive,
+            this.assocPreviousYearHorizNodeFromToDates as any,
           ),
           when(
             this.query.isPreviousYearActive,
             this.assocPreviousYearNetIncomeHorizTotal(node),
           ),
           when(
-            this.query.isPreviousYearActive,
-            this.assocPreviousYearHorizNodeFromToDates as any,
+            this.query.isPreviousYearChangeActive,
+            this.assocPreviousYearTotalChangeNode,
+          ),
+          when(
+            this.query.isPreviousYearPercentageActive,
+            this.assocPreviousYearTotalPercentageNode,
           ),
         )(horiontalTotalNode) as IBalanceSheetTotal;
       };

--- a/packages/server/test/_utils/balance-sheet.ts
+++ b/packages/server/test/_utils/balance-sheet.ts
@@ -58,6 +58,7 @@ export interface BSQuery {
   previousYearAmountChange?: boolean;
   previousYearPercentageChange?: boolean;
   previousPeriodAmountChange?: boolean;
+  previousPeriodPercentageChange?: boolean;
   percentageOfColumn?: boolean;
   percentageOfRow?: boolean;
 }

--- a/packages/server/test/balance-sheet.e2e-spec.ts
+++ b/packages/server/test/balance-sheet.e2e-spec.ts
@@ -504,6 +504,84 @@ describe('Balance Sheet (e2e)', () => {
     });
   });
 
+  describe('Date periods with previous period/year comparison', () => {
+    it('attaches previous period totals to the net income period columns', async () => {
+      const { data } = await fetchBalanceSheet({
+        ...YEARS_2022_2023,
+        displayColumnsType: 'date_periods',
+        displayColumnsBy: 'year',
+        previousPeriod: true,
+        previousPeriodAmountChange: true,
+        previousPeriodPercentageChange: true,
+      });
+
+      const netIncome = findNode(data, 'NET_INCOME');
+
+      for (const totalNode of netIncome.horizontal_totals) {
+        expect(totalNode.previous_period).toBeDefined();
+        expect(totalNode.previous_period_change).toBeDefined();
+        expect(totalNode.previous_period_percentage).toBeDefined();
+        expect(totalNode.previous_period_from_date).toBeDefined();
+        expect(totalNode.previous_period_to_date).toBeDefined();
+        expect(totalNode.previous_period_change.amount).toBeCloseTo(
+          totalNode.total.amount - totalNode.previous_period.amount,
+          2,
+        );
+      }
+
+      // The previous period of the 2023 column is the 2022 net income.
+      expect(netIncome.horizontal_totals[1].previous_period.amount).toBeCloseTo(
+        netIncome.horizontal_totals[0].total.amount,
+        2,
+      );
+    });
+
+    it('attaches previous period totals to account period columns', async () => {
+      const { data } = await fetchBalanceSheet({
+        ...YEARS_2022_2023,
+        displayColumnsType: 'date_periods',
+        displayColumnsBy: 'year',
+        previousPeriod: true,
+      });
+
+      const bank = findNode(data, bankId);
+      expect(bank.horizontal_totals[1].previous_period.amount).toBeCloseTo(
+        bank.horizontal_totals[0].total.amount,
+        2,
+      );
+    });
+
+    it('attaches previous year totals to the net income period columns', async () => {
+      const { data } = await fetchBalanceSheet({
+        ...YEARS_2022_2023,
+        displayColumnsType: 'date_periods',
+        displayColumnsBy: 'year',
+        previousYear: true,
+        previousYearAmountChange: true,
+        previousYearPercentageChange: true,
+      });
+
+      const netIncome = findNode(data, 'NET_INCOME');
+
+      for (const totalNode of netIncome.horizontal_totals) {
+        expect(totalNode.previous_year).toBeDefined();
+        expect(totalNode.previous_year_change).toBeDefined();
+        expect(totalNode.previous_year_percentage).toBeDefined();
+        expect(totalNode.previous_year_from_date).toBeDefined();
+        expect(totalNode.previous_year_to_date).toBeDefined();
+        expect(totalNode.previous_year_change.amount).toBeCloseTo(
+          totalNode.total.amount - totalNode.previous_year.amount,
+          2,
+        );
+      }
+
+      expect(netIncome.horizontal_totals[1].previous_year.amount).toBeCloseTo(
+        netIncome.horizontal_totals[0].total.amount,
+        2,
+      );
+    });
+  });
+
   describe('Previous year comparison', () => {
     let data: BSNode[];
     let beforePY: Record<string | number, number>;


### PR DESCRIPTION
## Description

Restores the execution order of the net income horizontal totals composers for the previous period (PP) and previous year (PY) balance sheet columns, which was silently reversed by the ramda → fp-ts migration (commit `e08bef83c`).

`R.compose` executes right-to-left while fp-ts `flow` executes left-to-right. The migration codemod reversed the step order of every converted `R.compose`, but missed the two net income horizontal composers, which kept their original textual order when converted to `flow`:

- `previousPeriodNetIncomeHorizNodeComposer` (`BalanceSheetNetIncomeDatePeriodsPP.ts`)
- `previousYearNetIncomeHorizNodeComposer` (`BalanceSheetNetIncomeDatePeriodsPY.ts`)

As a result, the percentage and amount-change steps ran **before** the step that associates `previousPeriod`/`previousYear` and the from/to dates to each horizontal total node, crashing the balance sheet endpoint with `TypeError: Cannot read properties of undefined (reading 'amount')` whenever date periods columns were combined with the previous period/year comparison:

```
at assocPreviousPeriodTotalPercentageNode (.../common/FinancialPreviousPeriod.ts:70:36)
```

The fix restores the canonical step order used by every other horizontal composer (e.g. `previousPeriodAggregateHorizNodeComposer` in `BalanceSheetComparsionPreviousPeriod.ts`): from/to dates → previous period/year total → amount change → percentage.

An e2e regression test was added for the previously uncovered (and crashing) combinations: `displayColumnsType: date_periods` combined with `previousPeriod` / `previousYear` including the amount change and percentage flags.

Dependencies: none.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- `pnpm run typecheck` passes for all packages.
- Added three e2e cases to `packages/server/test/balance-sheet.e2e-spec.ts` covering the crashing combinations (`date_periods` + `previousPeriod`/`previousYear` with change/percentage flags); run with `cd packages/server && pnpm run test:e2e -- balance-sheet` (requires the docker compose dev database).
- Full unit/e2e suites were not re-run locally; CI will cover them.

To reproduce the original crash: request `GET /reports/balance-sheet` with `displayColumnsType=date_periods`, `displayColumnsBy=year`, `previousPeriod=true`, `previousPeriodAmountChange=true`, `previousPeriodPercentageChange=true` — it returned a 500 before this fix.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>
