### PR TITLE
feat: add ClickHouse to the production compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -139,9 +139,13 @@ AUTO_UPDATE_INTERVAL=3600
 # Set CLICKHOUSE_ENABLED=true to compute organization totals from ClickHouse.
 # With an empty password, the clickhouse-server image entrypoint restricts
 # the `default` user to localhost connections only, which would reject
-# connections through the published port. The docker-compose service sets
-# CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1 to keep the passwordless user
-# unrestricted in development. Set a non-empty password for production.
+# connections through the published port. The dev docker-compose.yml service
+# sets CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1 to keep the passwordless user
+# unrestricted in development.
+# The production docker-compose.prod.yml requires a non-empty password
+# (it refuses to start otherwise) and hardcodes CLICKHOUSE_HOST to the
+# `clickhouse` service, so the host value below only applies to development.
+# Generate a password with: openssl rand -base64 32
 CLICKHOUSE_ENABLED=false
 CLICKHOUSE_HOST=localhost
 CLICKHOUSE_PORT=8123

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -72,6 +72,14 @@ services:
       # Tenants databases
       - TENANT_DB_NAME_PERFIX=${TENANT_DB_NAME_PERFIX}
 
+      # ClickHouse analytics store
+      - CLICKHOUSE_ENABLED=${CLICKHOUSE_ENABLED:-false}
+      - CLICKHOUSE_HOST=clickhouse
+      - CLICKHOUSE_PORT=8123
+      - CLICKHOUSE_USER=${CLICKHOUSE_USER:-default}
+      - CLICKHOUSE_PASSWORD=${CLICKHOUSE_PASSWORD:?CLICKHOUSE_PASSWORD is required in .env - generate one with openssl rand -base64 32}
+      - CLICKHOUSE_DATABASE=${CLICKHOUSE_DATABASE:-bigcapital_analytics}
+
       # Authentication
       - 'APP_JWT_SECRET=${APP_JWT_SECRET:?APP_JWT_SECRET is required in .env - generate one with openssl rand -base64 48}'
 
@@ -212,9 +220,24 @@ services:
     networks:
       - bigcapital_network
 
+  clickhouse:
+    container_name: bigcapital-clickhouse
+    image: clickhouse/clickhouse-server:24.8
+    restart: on-failure
+    environment:
+      - CLICKHOUSE_USER=${CLICKHOUSE_USER:-default}
+      - CLICKHOUSE_PASSWORD=${CLICKHOUSE_PASSWORD:?CLICKHOUSE_PASSWORD is required in .env - generate one with openssl rand -base64 32}
+      - CLICKHOUSE_DB=${CLICKHOUSE_DATABASE:-bigcapital_analytics}
+    expose:
+      - '8123'
+    volumes:
+      - clickhouse:/var/lib/clickhouse
+    networks:
+      - bigcapital_network
+
   # Auto-updates the containers labelled "com.centurylinklabs.watchtower.enable=true"
   # (webapp and server) by polling the registry for newer :latest images.
-  # Everything else (mysql, redis, gotenberg, proxy) is untouched.
+  # Everything else (mysql, redis, gotenberg, garage, clickhouse, proxy) is untouched.
   auto-update:
     container_name: bigcapital-auto-update
     image: containrrr/watchtower:1.7.1
@@ -237,6 +260,10 @@ volumes:
 
   garage:
     name: bigcapital_prod_garage
+    driver: local
+
+  clickhouse:
+    name: bigcapital_prod_clickhouse
     driver: local
 
 # Networks


### PR DESCRIPTION
## Description

The production docker compose (`docker-compose.prod.yml`) had no ClickHouse configuration, so deployments that enable the analytics store (`CLICKHOUSE_ENABLED=true`) had no ClickHouse service to connect to. This PR adds:

- A `clickhouse` service (`clickhouse/clickhouse-server:24.8`) with a persistent `bigcapital_prod_clickhouse` volume, exposed only on the internal docker network (no host port published), mirroring the dev compose but hardened for production.
- `CLICKHOUSE_*` environment variables passed through to the `server` service, with `CLICKHOUSE_HOST` hardcoded to the `clickhouse` service name, following the existing pattern (`DB_HOST=mysql`, `REDIS_HOST=redis`). The store stays disabled by default (`CLICKHOUSE_ENABLED=false`).
- A fail-fast guard: `docker compose up` refuses to start without `CLICKHOUSE_PASSWORD` set in `.env`, because the clickhouse-server image entrypoint restricts the passwordless `default` user to localhost connections, which would otherwise silently break the server's connection over the docker network.
- Updated the watchtower auto-update comment to list garage and clickhouse among the containers it does not touch.
- Updated the ClickHouse section in `.env.example` to document the production requirements (non-empty password, hardcoded host).

No application code changes: the server already creates the analytics database/tables on bootstrap and retries on failure (`LedgerAnalyticsBootstrap`), so compose only needs to provide the ClickHouse server.

Note for existing deployments pulling this change: `CLICKHOUSE_PASSWORD` becomes a required `.env` variable (one line to add), even when the analytics integration is disabled.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

- Rendered validation with a throwaway sample env file:
  - `docker compose -f docker-compose.prod.yml config --quiet` renders cleanly when `CLICKHOUSE_PASSWORD` is set.
  - The same command fails fast with the instructive `required variable CLICKHOUSE_PASSWORD is missing a value` error when it is not set.
  - `docker compose -f docker-compose.yml config --quiet` still renders cleanly (dev compose is unchanged and still works with an empty password).
- Confirmed the rendered config contains the clickhouse service, the `CLICKHOUSE_*` env vars on the server service, and the `bigcapital_prod_clickhouse` volume.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!-- Generated by PR-Agent -->

<pr_agent:summary>
</pr_agent:summary>

<pr_agent:walkthrough>
</pr_agent:walkthrough>
