### PR TITLE
fix(webapp): app shell forces a 1100px minimum width on every viewport

### DIFF
--- a/packages/webapp/src/style/App.scss
+++ b/packages/webapp/src/style/App.scss
@@ -49,8 +49,16 @@ body {
 }
 // App
 .App {
-  min-width: 1100px;
   min-height: 100vh;
+
+  // Only floor the width on viewports that already have the room for it.
+  // Applying this unconditionally forced every viewport - phones included -
+  // to render at 1100px and rely on the browser to shrink/scroll it back
+  // down, which is what makes the whole app pinch-zoom-and-pan on mobile
+  // instead of laying out at its actual width.
+  @media (min-width: 1100px) {
+    min-width: 1100px;
+  }
 }
 // =======
 


### PR DESCRIPTION
## Bug

`.App` has an unconditional `min-width: 1100px` (`packages/webapp/src/style/App.scss`). Every viewport — phones included — is forced to lay out at 1100px, and the browser is left to shrink/scroll that back down to fit the real screen. That's why the whole app needs pinch-zoom and horizontal panning on any narrow window: it never actually renders at the device's width.

## Fix

Gate the floor behind a matching `@media (min-width: 1100px)`. Above 1100px this is a no-op — the rule only ever had an effect when the viewport was already narrower than 1100px, which is exactly the case it shouldn't apply to. Desktop is byte-identical; narrow viewports get their real width back instead of a forced 1100px canvas.

```diff
 .App {
-  min-width: 1100px;
   min-height: 100vh;
+
+  @media (min-width: 1100px) {
+    min-width: 1100px;
+  }
 }
```

## Scope

This is one rule, not a mobile redesign — individual pages/components still assume a wide screen in places (tables, dialogs) and won't look great narrow yet. But it removes the single most basic blocker: the app currently can't render at less than 1100px at all, regardless of anything else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
