### PR TITLE
fix(webapp): dialogs wider than the viewport force the page into horizontal scroll

### DIFF
--- a/packages/webapp/src/style/components/Dialog/Dialog.scss
+++ b/packages/webapp/src/style/components/Dialog/Dialog.scss
@@ -4,6 +4,12 @@
 .#{$ns}-dialog{
   background: #fff;
 
+  // Individual dialogs set their own fixed pixel width (e.g. 650px, 1000px)
+  // with nothing capping it to the viewport, so on a narrow screen the
+  // dialog itself forces the page into horizontal scroll. Clamp every
+  // dialog to the viewport width, leaving a small gutter either side.
+  max-width: calc(100vw - 32px);
+
   &-header{
     background: #ebf1f5;
   }


### PR DESCRIPTION
## Bug

Individual dialogs set their own fixed pixel width — `AllocateLandedCostForm` (700px), `BranchFormDialog` (650px), the PDF preview dialog (1000px), and others — with nothing capping that width to the viewport. On any screen narrower than the dialog, the dialog itself overflows and pushes the whole page into horizontal scroll, independent of anything else on the page.

## Fix

Cap every dialog at the viewport width, minus a small gutter, in the one shared `Dialog.scss` that every dialog renders through:

```diff
 .bp4-dialog {
   background: #fff;
+
+  max-width: calc(100vw - 32px);
```

A dialog that already fits (the normal desktop case, since 100vw is huge there) is unaffected — `width` and `max-width` both apply to the box and only the smaller one binds. A dialog whose own width exceeds the viewport now shrinks to fit instead of forcing a scrollbar.

## Scope

One rule, one file. Doesn't change dialog *layout* (form fields inside a shrunk dialog may still be tight until those get their own responsive pass) — it just stops the dialog from being wider than the screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
